### PR TITLE
Refactoring which numeric interface exposes which methods to match latest API review decisions

### DIFF
--- a/src/libraries/Common/tests/System/GenericMathHelpers.cs
+++ b/src/libraries/Common/tests/System/GenericMathHelpers.cs
@@ -42,6 +42,18 @@ namespace System
         public static bool TryWriteBigEndian(TSelf value, Span<byte> destination, out int bytesWritten) => value.TryWriteBigEndian(destination, out bytesWritten);
 
         public static bool TryWriteLittleEndian(TSelf value, Span<byte> destination, out int bytesWritten) => value.TryWriteLittleEndian(destination, out bytesWritten);
+
+        public static int WriteBigEndian(TSelf value, byte[] destination) => value.WriteBigEndian(destination);
+
+        public static int WriteBigEndian(TSelf value, byte[] destination, int startIndex) => value.WriteBigEndian(destination, startIndex);
+
+        public static int WriteBigEndian(TSelf value, Span<byte> destination) => value.WriteBigEndian(destination);
+
+        public static int WriteLittleEndian(TSelf value, byte[] destination) => value.WriteLittleEndian(destination);
+
+        public static int WriteLittleEndian(TSelf value, byte[] destination, int startIndex) => value.WriteLittleEndian(destination, startIndex);
+
+        public static int WriteLittleEndian(TSelf value, Span<byte> destination) => value.WriteLittleEndian(destination);
     }
 
     public static class BinaryNumberHelper<TSelf>
@@ -100,9 +112,39 @@ namespace System
         public static bool op_Inequality(TSelf left, TOther right) => left != right;
     }
 
+    public static class ExponentialFunctionsHelper<TSelf>
+        where TSelf : IExponentialFunctions<TSelf>
+    {
+        public static TSelf Exp(TSelf x) => TSelf.Exp(x);
+
+        public static TSelf ExpM1(TSelf x) => TSelf.ExpM1(x);
+
+        public static TSelf Exp2(TSelf x) => TSelf.Exp2(x);
+
+        public static TSelf Exp2M1(TSelf x) => TSelf.Exp2M1(x);
+
+        public static TSelf Exp10(TSelf x) => TSelf.Exp10(x);
+
+        public static TSelf Exp10M1(TSelf x) => TSelf.Exp10M1(x);
+    }
+
     public static class FloatingPointHelper<TSelf>
         where TSelf : IFloatingPoint<TSelf>
     {
+        public static TSelf Ceiling(TSelf x) => TSelf.Ceiling(x);
+
+        public static TSelf Floor(TSelf x) => TSelf.Floor(x);
+
+        public static TSelf Round(TSelf x) => TSelf.Round(x);
+
+        public static TSelf Round(TSelf x, int digits) => TSelf.Round(x, digits);
+
+        public static TSelf Round(TSelf x, MidpointRounding mode) => TSelf.Round(x, mode);
+
+        public static TSelf Round(TSelf x, int digits, MidpointRounding mode) => TSelf.Round(x, digits, mode);
+
+        public static TSelf Truncate(TSelf x) => TSelf.Truncate(x);
+
         public static int GetExponentByteCount(TSelf value) => value.GetExponentByteCount();
 
         public static int GetExponentShortestBitLength(TSelf value) => value.GetExponentShortestBitLength();
@@ -118,6 +160,82 @@ namespace System
         public static bool TryWriteSignificandBigEndian(TSelf value, Span<byte> destination, out int bytesWritten) => value.TryWriteSignificandBigEndian(destination, out bytesWritten);
 
         public static bool TryWriteSignificandLittleEndian(TSelf value, Span<byte> destination, out int bytesWritten) => value.TryWriteSignificandLittleEndian(destination, out bytesWritten);
+
+        public static int WriteExponentBigEndian(TSelf value, byte[] destination) => value.WriteExponentBigEndian(destination);
+
+        public static int WriteExponentBigEndian(TSelf value, byte[] destination, int startIndex) => value.WriteExponentBigEndian(destination, startIndex);
+
+        public static int WriteExponentBigEndian(TSelf value, Span<byte> destination) => value.WriteExponentBigEndian(destination);
+
+        public static int WriteExponentLittleEndian(TSelf value, byte[] destination) => value.WriteExponentLittleEndian(destination);
+
+        public static int WriteExponentLittleEndian(TSelf value, byte[] destination, int startIndex) => value.WriteExponentLittleEndian(destination, startIndex);
+
+        public static int WriteExponentLittleEndian(TSelf value, Span<byte> destination) => value.WriteExponentLittleEndian(destination);
+
+        public static int WriteSignificandBigEndian(TSelf value, byte[] destination) => value.WriteSignificandBigEndian(destination);
+
+        public static int WriteSignificandBigEndian(TSelf value, byte[] destination, int startIndex) => value.WriteSignificandBigEndian(destination, startIndex);
+
+        public static int WriteSignificandBigEndian(TSelf value, Span<byte> destination) => value.WriteSignificandBigEndian(destination);
+
+        public static int WriteSignificandLittleEndian(TSelf value, byte[] destination) => value.WriteSignificandLittleEndian(destination);
+
+        public static int WriteSignificandLittleEndian(TSelf value, byte[] destination, int startIndex) => value.WriteSignificandLittleEndian(destination, startIndex);
+
+        public static int WriteSignificandLittleEndian(TSelf value, Span<byte> destination) => value.WriteSignificandLittleEndian(destination);
+    }
+
+    public static class FloatingPointIeee754Helper<TSelf>
+        where TSelf : IFloatingPointIeee754<TSelf>
+    {
+        public static TSelf E => TSelf.E;
+
+        public static TSelf Epsilon => TSelf.Epsilon;
+
+        public static TSelf NaN => TSelf.NaN;
+
+        public static TSelf NegativeInfinity => TSelf.NegativeInfinity;
+
+        public static TSelf NegativeZero => TSelf.NegativeZero;
+
+        public static TSelf Pi => TSelf.Pi;
+
+        public static TSelf PositiveInfinity => TSelf.PositiveInfinity;
+
+        public static TSelf Tau => TSelf.Tau;
+
+        public static TSelf BitDecrement(TSelf x) => TSelf.BitDecrement(x);
+
+        public static TSelf BitIncrement(TSelf x) => TSelf.BitIncrement(x);
+
+        public static TSelf FusedMultiplyAdd(TSelf left, TSelf right, TSelf addend) => TSelf.FusedMultiplyAdd(left, right, addend);
+
+        public static TSelf Ieee754Remainder(TSelf left, TSelf right) => TSelf.Ieee754Remainder(left, right);
+
+        public static int ILogB(TSelf x) => TSelf.ILogB(x);
+
+        public static TSelf ReciprocalEstimate(TSelf x) => TSelf.ReciprocalEstimate(x);
+
+        public static TSelf ReciprocalSqrtEstimate(TSelf x) => TSelf.ReciprocalSqrtEstimate(x);
+
+        public static TSelf ScaleB(TSelf x, int n) => TSelf.ScaleB(x, n);
+    }
+
+    public static class HyperbolicFunctionsHelper<TSelf>
+        where TSelf : IHyperbolicFunctions<TSelf>
+    {
+        public static TSelf Acosh(TSelf x) => TSelf.Acosh(x);
+
+        public static TSelf Asinh(TSelf x) => TSelf.Asinh(x);
+
+        public static TSelf Atanh(TSelf x) => TSelf.Atanh(x);
+
+        public static TSelf Cosh(TSelf x) => TSelf.Cosh(x);
+
+        public static TSelf Sinh(TSelf x) => TSelf.Sinh(x);
+
+        public static TSelf Tanh(TSelf x) => TSelf.Tanh(x);
     }
 
     public static class IncrementOperatorsHelper<TSelf>
@@ -126,6 +244,24 @@ namespace System
         public static TSelf op_Increment(TSelf value) => ++value;
 
         public static TSelf op_CheckedIncrement(TSelf value) => checked(++value);
+    }
+
+    public static class LogarithmicFunctionsHelper<TSelf>
+        where TSelf : ILogarithmicFunctions<TSelf>
+    {
+        public static TSelf Log(TSelf x) => TSelf.Log(x);
+
+        public static TSelf Log(TSelf x, TSelf newBase) => TSelf.Log(x, newBase);
+
+        public static TSelf LogP1(TSelf x) => TSelf.LogP1(x);
+
+        public static TSelf Log2(TSelf x) => TSelf.Log2(x);
+
+        public static TSelf Log2P1(TSelf x) => TSelf.Log2P1(x);
+
+        public static TSelf Log10(TSelf x) => TSelf.Log10(x);
+
+        public static TSelf Log10P1(TSelf x) => TSelf.Log10P1(x);
     }
 
     public static class MinMaxValueHelper<TSelf>
@@ -162,56 +298,70 @@ namespace System
         public static TSelf One => TSelf.One;
 
         public static TSelf Zero => TSelf.Zero;
+
+        public static TSelf Abs(TSelf value) => TSelf.Abs(value);
+
+        public static TSelf CreateChecked<TOther>(TOther value)
+            where TOther : INumberBase<TOther> => TSelf.CreateChecked(value);
+
+        public static TSelf CreateSaturating<TOther>(TOther value)
+            where TOther : INumberBase<TOther> => TSelf.CreateSaturating(value);
+
+        public static TSelf CreateTruncating<TOther>(TOther value)
+            where TOther : INumberBase<TOther> => TSelf.CreateTruncating(value);
+
+        public static bool IsFinite(TSelf value) => TSelf.IsFinite(value);
+
+        public static bool IsInfinity(TSelf value) => TSelf.IsInfinity(value);
+
+        public static bool IsNaN(TSelf value) => TSelf.IsNaN(value);
+
+        public static bool IsNegative(TSelf value) => TSelf.IsNegative(value);
+
+        public static bool IsNegativeInfinity(TSelf value) => TSelf.IsNegativeInfinity(value);
+
+        public static bool IsNormal(TSelf value) => TSelf.IsNormal(value);
+
+        public static bool IsPositiveInfinity(TSelf value) => TSelf.IsPositiveInfinity(value);
+
+        public static bool IsSubnormal(TSelf value) => TSelf.IsSubnormal(value);
+
+        public static TSelf MaxMagnitude(TSelf x, TSelf y) => TSelf.MaxMagnitude(x, y);
+
+        public static TSelf MaxMagnitudeNumber(TSelf x, TSelf y) => TSelf.MaxMagnitudeNumber(x, y);
+
+        public static TSelf MinMagnitude(TSelf x, TSelf y) => TSelf.MinMagnitude(x, y);
+
+        public static TSelf MinMagnitudeNumber(TSelf x, TSelf y) => TSelf.MinMagnitudeNumber(x, y);
+
+        public static TSelf Parse(string s, NumberStyles style, IFormatProvider provider) => TSelf.Parse(s, style, provider);
+
+        public static TSelf Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider) => TSelf.Parse(s, style, provider);
+
+        public static bool TryCreate<TOther>(TOther value, out TSelf result)
+            where TOther : INumberBase<TOther> => TSelf.TryCreate(value, out result);
+
+        public static bool TryParse(string s, NumberStyles style, IFormatProvider provider, out TSelf result) => TSelf.TryParse(s, style, provider, out result);
+
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider, out TSelf result) => TSelf.TryParse(s, style, provider, out result);
     }
 
     public static class NumberHelper<TSelf>
         where TSelf : INumber<TSelf>
     {
-        public static TSelf Abs(TSelf value) => TSelf.Abs(value);
-
         public static TSelf Clamp(TSelf value, TSelf min, TSelf max) => TSelf.Clamp(value, min, max);
 
         public static TSelf CopySign(TSelf value, TSelf sign) => TSelf.CopySign(value, sign);
 
-        public static TSelf CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther> => TSelf.CreateChecked(value);
-
-        public static TSelf CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther> => TSelf.CreateSaturating(value);
-
-        public static TSelf CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther> => TSelf.CreateTruncating(value);
-
-        public static bool IsNegative(TSelf value) => TSelf.IsNegative(value);
-
         public static TSelf Max(TSelf x, TSelf y) => TSelf.Max(x, y);
 
-        public static TSelf MaxMagnitude(TSelf x, TSelf y) => TSelf.MaxMagnitude(x, y);
+        public static TSelf MaxNumber(TSelf x, TSelf y) => TSelf.MaxNumber(x, y);
 
         public static TSelf Min(TSelf x, TSelf y) => TSelf.Min(x, y);
 
-        public static TSelf MinMagnitude(TSelf x, TSelf y) => TSelf.MinMagnitude(x, y);
-
-        public static TSelf Parse(string s, IFormatProvider provider) => TSelf.Parse(s, provider);
-
-        public static TSelf Parse(string s, NumberStyles style, IFormatProvider provider) => TSelf.Parse(s, style, provider);
-
-        public static TSelf Parse(ReadOnlySpan<char> s, IFormatProvider provider) => TSelf.Parse(s, provider);
-
-        public static TSelf Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider) => TSelf.Parse(s, style, provider);
+        public static TSelf MinNumber(TSelf x, TSelf y) => TSelf.MinNumber(x, y);
 
         public static int Sign(TSelf value) => TSelf.Sign(value);
-
-        public static bool TryCreate<TOther>(TOther value, out TSelf result)
-            where TOther : INumber<TOther> => TSelf.TryCreate(value, out result);
-
-        public static bool TryParse(string s, IFormatProvider provider, out TSelf result) => TSelf.TryParse(s, provider, out result);
-
-        public static bool TryParse(string s, NumberStyles style, IFormatProvider provider, out TSelf result) => TSelf.TryParse(s, style, provider, out result);
-
-        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out TSelf result) => TSelf.TryParse(s, provider, out result);
-
-        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider, out TSelf result) => TSelf.TryParse(s, style, provider, out result);
     }
 
     public static class ParsableHelper<TSelf>
@@ -220,6 +370,20 @@ namespace System
         public static TSelf Parse(string s, IFormatProvider provider) => TSelf.Parse(s, provider);
 
         public static bool TryParse(string s, IFormatProvider provider, out TSelf result) => TSelf.TryParse(s, provider, out result);
+    }
+
+    public static class PowerFunctionsHelper<TSelf>
+        where TSelf : IPowerFunctions<TSelf>
+    {
+        public static TSelf Pow(TSelf x, TSelf y) => TSelf.Pow(x, y);
+    }
+
+    public static class RootFunctionsHelper<TSelf>
+        where TSelf : IRootFunctions<TSelf>
+    {
+        public static TSelf Cbrt(TSelf x) => TSelf.Cbrt(x);
+
+        public static TSelf Sqrt(TSelf x) => TSelf.Sqrt(x);
     }
 
     public static class ShiftOperatorsHelper<TSelf, TResult>
@@ -252,6 +416,26 @@ namespace System
         public static TResult op_Subtraction(TSelf left, TOther right) => left - right;
 
         public static TResult op_CheckedSubtraction(TSelf left, TOther right) => checked(left - right);
+    }
+
+    public static class TrigonometricFunctionsHelper<TSelf>
+        where TSelf : ITrigonometricFunctions<TSelf>
+    {
+        public static TSelf Acos(TSelf x) => TSelf.Acos(x);
+
+        public static TSelf Asin(TSelf x) => TSelf.Asin(x);
+
+        public static TSelf Atan(TSelf x) => TSelf.Atan(x);
+
+        public static TSelf Atan2(TSelf y, TSelf x) => TSelf.Atan2(y, x);
+
+        public static TSelf Cos(TSelf x) => TSelf.Cos(x);
+
+        public static TSelf Sin(TSelf x) => TSelf.Sin(x);
+
+        public static (TSelf Sin, TSelf Cos) SinCos(TSelf x) => TSelf.SinCos(x);
+
+        public static TSelf Tan(TSelf x) => TSelf.Tan(x);
     }
 
     public static class UnaryNegationOperatorsHelper<TSelf, TResult>

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -494,19 +494,44 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        static byte INumber<byte>.Abs(byte value) => value;
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static byte Clamp(byte value, byte min, byte max) => Math.Clamp(value, min, max);
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         static byte INumber<byte>.CopySign(byte value, byte sign) => value;
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static byte Max(byte x, byte y) => Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static byte INumber<byte>.MaxNumber(byte x, byte y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static byte Min(byte x, byte y) => Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static byte INumber<byte>.MinNumber(byte x, byte y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(byte value) => (value == 0) ? 0 : 1;
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static byte INumberBase<byte>.One => One;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static byte INumberBase<byte>.Zero => Zero;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        static byte INumberBase<byte>.Abs(byte value) => value;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -571,10 +596,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -659,10 +684,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -727,28 +752,46 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
-        static bool INumber<byte>.IsNegative(byte value) => false;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<byte>.IsFinite(byte value) => true;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static byte Max(byte x, byte y) => Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<byte>.IsInfinity(byte value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        static byte INumber<byte>.MaxMagnitude(byte x, byte y) => Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<byte>.IsNaN(byte value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static byte Min(byte x, byte y) => Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
+        static bool INumberBase<byte>.IsNegative(byte value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        static byte INumber<byte>.MinMagnitude(byte x, byte y) => Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<byte>.IsNegativeInfinity(byte value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(byte value) => (value == 0) ? 0 : 1;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<byte>.IsNormal(byte value) => value != 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<byte>.IsPositiveInfinity(byte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<byte>.IsSubnormal(byte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        static byte INumberBase<byte>.MaxMagnitude(byte x, byte y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static byte INumberBase<byte>.MaxMagnitudeNumber(byte x, byte y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        static byte INumberBase<byte>.MinMagnitude(byte x, byte y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static byte INumberBase<byte>.MinMagnitudeNumber(byte x, byte y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out byte result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -931,16 +974,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static byte INumberBase<byte>.One => One;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static byte INumberBase<byte>.Zero => Zero;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -1345,18 +1345,43 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        static char INumber<char>.Abs(char value) => value;
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         static char INumber<char>.Clamp(char value, char min, char max) => (char)Math.Clamp(value, min, max);
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         static char INumber<char>.CopySign(char value, char sign) => value;
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        static char INumber<char>.Max(char x, char y) => (char)Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static char INumber<char>.MaxNumber(char x, char y) => (char)Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        static char INumber<char>.Min(char x, char y) => (char)Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static char INumber<char>.MinNumber(char x, char y) => (char)Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        static int INumber<char>.Sign(char value) => (value == 0) ? 0 : 1;
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static char INumberBase<char>.One => (char)1;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static char INumberBase<char>.Zero => (char)0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        static char INumberBase<char>.Abs(char value) => value;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static char INumber<char>.CreateChecked<TOther>(TOther value)
+        static char INumberBase<char>.CreateChecked<TOther>(TOther value)
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1421,9 +1446,9 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static char INumber<char>.CreateSaturating<TOther>(TOther value)
+        static char INumberBase<char>.CreateSaturating<TOther>(TOther value)
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1505,9 +1530,9 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static char INumber<char>.CreateTruncating<TOther>(TOther value)
+        static char INumberBase<char>.CreateTruncating<TOther>(TOther value)
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1572,27 +1597,45 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
-        static bool INumber<char>.IsNegative(char value) => false;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<char>.IsFinite(char value) => true;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        static char INumber<char>.Max(char x, char y) => (char)Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<char>.IsInfinity(char value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        static char INumber<char>.MaxMagnitude(char x, char y) => (char)Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<char>.IsNaN(char value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        static char INumber<char>.Min(char x, char y) => (char)Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
+        static bool INumberBase<char>.IsNegative(char value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        static char INumber<char>.MinMagnitude(char x, char y) => (char)Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<char>.IsNegativeInfinity(char value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        static int INumber<char>.Sign(char value) => (value == 0) ? 0 : 1;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<char>.IsNormal(char value) => value != 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<char>.IsPositiveInfinity(char value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<char>.IsSubnormal(char value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        static char INumberBase<char>.MaxMagnitude(char x, char y) => (char)Math.Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static char INumberBase<char>.MaxMagnitudeNumber(char x, char y) => (char)Math.Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        static char INumberBase<char>.MinMagnitude(char x, char y) => (char)Math.Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static char INumberBase<char>.MinMagnitudeNumber(char x, char y) => (char)Math.Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<char>.TryCreate<TOther>(TOther value, out char result)
+        static bool INumberBase<char>.TryCreate<TOther>(TOther value, out char result)
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1768,9 +1811,9 @@ namespace System
             }
         }
 
-        static char INumber<char>.Parse(string s, NumberStyles style, IFormatProvider? provider) => Parse(s);
+        static char INumberBase<char>.Parse(string s, NumberStyles style, IFormatProvider? provider) => Parse(s);
 
-        static char INumber<char>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
+        static char INumberBase<char>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
         {
             if (s.Length != 1)
             {
@@ -1779,9 +1822,9 @@ namespace System
             return s[0];
         }
 
-        static bool INumber<char>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out char result) => TryParse(s, out result);
+        static bool INumberBase<char>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out char result) => TryParse(s, out result);
 
-        static bool INumber<char>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out char result)
+        static bool INumberBase<char>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out char result)
         {
             if (s.Length != 1)
             {
@@ -1791,16 +1834,6 @@ namespace System
             result = s[0];
             return true;
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static char INumberBase<char>.One => (char)1;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static char INumberBase<char>.Zero => (char)0;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
@@ -1295,12 +1295,6 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        public static decimal Abs(decimal value)
-        {
-            return new decimal(in value, value._flags & ~SignMask);
-        }
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static decimal Clamp(decimal value, decimal min, decimal max) => Math.Clamp(value, min, max);
 
@@ -1310,10 +1304,47 @@ namespace System
             return new decimal(in value, (value._flags & ~SignMask) | (sign._flags & SignMask));
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static decimal Max(decimal x, decimal y)
+        {
+            return DecCalc.VarDecCmp(in x, in y) >= 0 ? x : y;
+        }
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static decimal INumber<decimal>.MaxNumber(decimal x, decimal y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static decimal Min(decimal x, decimal y)
+        {
+            return DecCalc.VarDecCmp(in x, in y) < 0 ? x : y;
+        }
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static decimal INumber<decimal>.MinNumber(decimal x, decimal y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(decimal d) => (d.Low64 | d.High) == 0 ? 0 : (d._flags >> 31) | 1;
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static decimal INumberBase<decimal>.One => One;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static decimal INumberBase<decimal>.Zero => Zero;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        public static decimal Abs(decimal value)
+        {
+            return new decimal(in value, value._flags & ~SignMask);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static decimal CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1386,10 +1417,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static decimal CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1465,10 +1496,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static decimal CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1554,34 +1585,78 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<decimal>.IsFinite(decimal value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<decimal>.IsInfinity(decimal value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<decimal>.IsNaN(decimal value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
         public static bool IsNegative(decimal value) => value._flags < 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static decimal Max(decimal x, decimal y)
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<decimal>.IsNegativeInfinity(decimal value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<decimal>.IsNormal(decimal value) => value != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<decimal>.IsPositiveInfinity(decimal value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<decimal>.IsSubnormal(decimal value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        public static decimal MaxMagnitude(decimal x, decimal y)
         {
-            return DecCalc.VarDecCmp(in x, in y) >= 0 ? x : y;
+            decimal ax = Abs(x);
+            decimal ay = Abs(y);
+
+            if (ax > ay)
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        public static decimal MaxMagnitude(decimal x, decimal y) => (Abs(x) >= Abs(y)) ? x : y;
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static decimal INumberBase<decimal>.MaxMagnitudeNumber(decimal x, decimal y) => MaxMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static decimal Min(decimal x, decimal y)
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        public static decimal MinMagnitude(decimal x, decimal y)
         {
-            return DecCalc.VarDecCmp(in x, in y) < 0 ? x : y;
+            decimal ax = Abs(x);
+            decimal ay = Abs(y);
+
+            if (ax < ay)
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        public static decimal MinMagnitude(decimal x, decimal y) => (Abs(x) <= Abs(y)) ? x : y;
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static decimal INumberBase<decimal>.MinMagnitudeNumber(decimal x, decimal y) => MinMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(decimal d) => (d.Low64 | d.High) == 0 ? 0 : (d._flags >> 31) | 1;
-
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out decimal result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1686,16 +1761,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static decimal INumberBase<decimal>.One => One;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static decimal INumberBase<decimal>.Zero => Zero;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -824,100 +824,6 @@ namespace System
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ILogB(TSelf)" />
         public static int ILogB(double x) => Math.ILogB(x);
 
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
-        public static double MaxMagnitudeNumber(double x, double y)
-        {
-            // This matches the IEEE 754:2019 `maximumMagnitudeNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
-
-            double ax = Abs(x);
-            double ay = Abs(y);
-
-            if ((ax > ay) || IsNaN(ay))
-            {
-                return x;
-            }
-
-            if (ax == ay)
-            {
-                return IsNegative(x) ? y : x;
-            }
-
-            return y;
-        }
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
-        public static double MaxNumber(double x, double y)
-        {
-            // This matches the IEEE 754:2019 `maximumNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
-
-            if (x != y)
-            {
-                if (!IsNaN(y))
-                {
-                    return y < x ? x : y;
-                }
-
-                return x;
-            }
-
-            return IsNegative(y) ? x : y;
-        }
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
-        public static double MinMagnitudeNumber(double x, double y)
-        {
-            // This matches the IEEE 754:2019 `minimumMagnitudeNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
-
-            double ax = Abs(x);
-            double ay = Abs(y);
-
-            if ((ax < ay) || IsNaN(ay))
-            {
-                return x;
-            }
-
-            if (ax == ay)
-            {
-                return IsNegative(x) ? x : y;
-            }
-
-            return y;
-        }
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
-        public static double MinNumber(double x, double y)
-        {
-            // This matches the IEEE 754:2019 `minimumNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
-
-            if (x != y)
-            {
-                if (!IsNaN(y))
-                {
-                    return x < y ? x : y;
-                }
-
-                return x;
-            }
-
-            return IsNegative(x) ? x : y;
-        }
-
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalEstimate(TSelf)" />
         public static double ReciprocalEstimate(double x) => Math.ReciprocalEstimate(x);
 
@@ -1022,350 +928,64 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        public static double Abs(double value) => Math.Abs(value);
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static double Clamp(double value, double min, double max) => Math.Clamp(value, min, max);
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         public static double CopySign(double x, double y) => Math.CopySign(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                return (byte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                return (char)(object)value;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                return (double)(decimal)(object)value;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                return (double)(object)value;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                return (short)(object)value;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                return (int)(object)value;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                return (long)(object)value;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                return (double)(Int128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                return (nint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                return (sbyte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                return (float)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                return (ushort)(object)value;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                return (uint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                return (ulong)(object)value;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                return (double)(UInt128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                return (nuint)(object)value;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                return default;
-            }
-        }
-
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                return (byte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                return (char)(object)value;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                return (double)(decimal)(object)value;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                return (double)(object)value;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                return (short)(object)value;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                return (int)(object)value;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                return (long)(object)value;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                return (double)(Int128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                return (nint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                return (sbyte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                return (float)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                return (ushort)(object)value;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                return (uint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                return (ulong)(object)value;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                return (double)(UInt128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                return (nuint)(object)value;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                return default;
-            }
-        }
-
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                return (byte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                return (char)(object)value;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                return (double)(decimal)(object)value;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                return (double)(object)value;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                return (short)(object)value;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                return (int)(object)value;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                return (long)(object)value;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                return (double)(Int128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                return (nint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                return (sbyte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                return (float)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                return (ushort)(object)value;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                return (uint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                return (ulong)(object)value;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                return (double)(UInt128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                return (nuint)(object)value;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                return default;
-            }
-        }
-
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
         public static double Max(double x, double y) => Math.Max(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        public static double MaxMagnitude(double x, double y) => Math.MaxMagnitude(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        public static double MaxNumber(double x, double y)
+        {
+            // This matches the IEEE 754:2019 `maximumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return y < x ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(y) ? x : y;
+        }
 
         /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
         public static double Min(double x, double y) => Math.Min(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        public static double MinMagnitude(double x, double y) => Math.MinMagnitude(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        public static double MinNumber(double x, double y)
+        {
+            // This matches the IEEE 754:2019 `minimumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return x < y ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(x) ? x : y;
+        }
 
         /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
         public static int Sign(double value) => Math.Sign(value);
-
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryCreate<TOther>(TOther value, out double result)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                result = (byte)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                result = (char)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                result = (double)(decimal)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                result = (double)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                result = (short)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                result = (int)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                result = (long)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                result = (double)(Int128)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                result = (nint)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                result = (sbyte)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                result = (float)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                result = (ushort)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                result = (uint)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                result = (ulong)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                result = (double)(UInt128)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                result = (nuint)(object)value;
-                return true;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                result = default;
-                return false;
-            }
-        }
 
         //
         // INumberBase
@@ -1376,6 +996,166 @@ namespace System
 
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static double INumberBase<double>.Zero => Zero;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        public static double Abs(double value) => Math.Abs(value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double CreateChecked<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            return CreateSaturating(value);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double CreateSaturating<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            if (typeof(TOther) == typeof(byte))
+            {
+                return (byte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(char))
+            {
+                return (char)(object)value;
+            }
+            else if (typeof(TOther) == typeof(decimal))
+            {
+                return (double)(decimal)(object)value;
+            }
+            else if (typeof(TOther) == typeof(double))
+            {
+                return (double)(object)value;
+            }
+            else if (typeof(TOther) == typeof(short))
+            {
+                return (short)(object)value;
+            }
+            else if (typeof(TOther) == typeof(int))
+            {
+                return (int)(object)value;
+            }
+            else if (typeof(TOther) == typeof(long))
+            {
+                return (long)(object)value;
+            }
+            else if (typeof(TOther) == typeof(Int128))
+            {
+                return (double)(Int128)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nint))
+            {
+                return (nint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(sbyte))
+            {
+                return (sbyte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(float))
+            {
+                return (float)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ushort))
+            {
+                return (ushort)(object)value;
+            }
+            else if (typeof(TOther) == typeof(uint))
+            {
+                return (uint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ulong))
+            {
+                return (ulong)(object)value;
+            }
+            else if (typeof(TOther) == typeof(UInt128))
+            {
+                return (double)(UInt128)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nuint))
+            {
+                return (nuint)(object)value;
+            }
+            else
+            {
+                ThrowHelper.ThrowNotSupportedException();
+                return default;
+            }
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double CreateTruncating<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            return CreateSaturating(value);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        public static double MaxMagnitude(double x, double y) => Math.MaxMagnitude(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        public static double MaxMagnitudeNumber(double x, double y)
+        {
+            // This matches the IEEE 754:2019 `maximumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            double ax = Abs(x);
+            double ay = Abs(y);
+
+            if ((ax > ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        public static double MinMagnitude(double x, double y) => Math.MinMagnitude(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        public static double MinMagnitudeNumber(double x, double y)
+        {
+            // This matches the IEEE 754:2019 `minimumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            double ax = Abs(x);
+            double ay = Abs(y);
+
+            if ((ax < ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryCreate<TOther>(TOther value, out double result)
+            where TOther : INumberBase<TOther>
+        {
+            result = CreateSaturating(value);
+            return true;
+        }
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -1021,100 +1021,6 @@ namespace System
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ILogB(TSelf)" />
         public static int ILogB(Half x) => MathF.ILogB((float)x);
 
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
-        public static Half MaxMagnitudeNumber(Half x, Half y)
-        {
-            // This matches the IEEE 754:2019 `maximumMagnitudeNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
-
-            Half ax = Abs(x);
-            Half ay = Abs(y);
-
-            if ((ax > ay) || IsNaN(ay))
-            {
-                return x;
-            }
-
-            if (ax == ay)
-            {
-                return IsNegative(x) ? y : x;
-            }
-
-            return y;
-        }
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
-        public static Half MaxNumber(Half x, Half y)
-        {
-            // This matches the IEEE 754:2019 `maximumNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
-
-            if (x != y)
-            {
-                if (!IsNaN(y))
-                {
-                    return y < x ? x : y;
-                }
-
-                return x;
-            }
-
-            return IsNegative(y) ? x : y;
-        }
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
-        public static Half MinMagnitudeNumber(Half x, Half y)
-        {
-            // This matches the IEEE 754:2019 `minimumMagnitudeNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
-
-            Half ax = Abs(x);
-            Half ay = Abs(y);
-
-            if ((ax < ay) || IsNaN(ay))
-            {
-                return x;
-            }
-
-            if (ax == ay)
-            {
-                return IsNegative(x) ? x : y;
-            }
-
-            return y;
-        }
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
-        public static Half MinNumber(Half x, Half y)
-        {
-            // This matches the IEEE 754:2019 `minimumNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
-
-            if (x != y)
-            {
-                if (!IsNaN(y))
-                {
-                    return x < y ? x : y;
-                }
-
-                return x;
-            }
-
-            return IsNegative(x) ? x : y;
-        }
-
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalEstimate(TSelf)" />
         public static Half ReciprocalEstimate(Half x) => (Half)MathF.ReciprocalEstimate((float)x);
 
@@ -1214,350 +1120,64 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        public static Half Abs(Half value) => (Half)MathF.Abs((float)value);
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static Half Clamp(Half value, Half min, Half max) => (Half)Math.Clamp((float)value, (float)min, (float)max);
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         public static Half CopySign(Half x, Half y) => (Half)MathF.CopySign((float)x, (float)y);
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Half CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                return (Half)(byte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                return (Half)(char)(object)value;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                return (Half)(float)(decimal)(object)value;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                return (Half)(double)(object)value;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                return (Half)(short)(object)value;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                return (Half)(int)(object)value;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                return (Half)(long)(object)value;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                return (Half)(Int128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                return (Half)(long)(nint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                return (Half)(sbyte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                return (Half)(float)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                return (Half)(ushort)(object)value;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                return (Half)(uint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                return (Half)(ulong)(object)value;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                return (Half)(UInt128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                return (Half)(ulong)(nuint)(object)value;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                return default;
-            }
-        }
-
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Half CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                return (Half)(byte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                return (Half)(char)(object)value;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                return (Half)(float)(decimal)(object)value;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                return (Half)(double)(object)value;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                return (Half)(short)(object)value;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                return (Half)(int)(object)value;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                return (Half)(long)(object)value;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                return (Half)(Int128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                return (Half)(long)(nint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                return (Half)(sbyte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                return (Half)(float)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                return (Half)(ushort)(object)value;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                return (Half)(uint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                return (Half)(ulong)(object)value;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                return (Half)(UInt128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                return (Half)(ulong)(nuint)(object)value;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                return default;
-            }
-        }
-
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Half CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                return (Half)(byte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                return (Half)(char)(object)value;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                return (Half)(float)(decimal)(object)value;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                return (Half)(double)(object)value;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                return (Half)(short)(object)value;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                return (Half)(int)(object)value;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                return (Half)(long)(object)value;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                return (Half)(Int128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                return (Half)(long)(nint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                return (Half)(sbyte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                return (Half)(float)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                return (Half)(ushort)(object)value;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                return (Half)(uint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                return (Half)(ulong)(object)value;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                return (Half)(UInt128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                return (Half)(ulong)(nuint)(object)value;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                return default;
-            }
-        }
-
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
         public static Half Max(Half x, Half y) => (Half)MathF.Max((float)x, (float)y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        public static Half MaxMagnitude(Half x, Half y) => (Half)MathF.MaxMagnitude((float)x, (float)y);
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        public static Half MaxNumber(Half x, Half y)
+        {
+            // This matches the IEEE 754:2019 `maximumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return y < x ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(y) ? x : y;
+        }
 
         /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
         public static Half Min(Half x, Half y) => (Half)MathF.Min((float)x, (float)y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        public static Half MinMagnitude(Half x, Half y) => (Half)MathF.MinMagnitude((float)x, (float)y);
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        public static Half MinNumber(Half x, Half y)
+        {
+            // This matches the IEEE 754:2019 `minimumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return x < y ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(x) ? x : y;
+        }
 
         /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
         public static int Sign(Half value) => MathF.Sign((float)value);
-
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryCreate<TOther>(TOther value, out Half result)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                result = (Half)(byte)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                result = (Half)(char)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                result = (Half)(float)(decimal)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                result = (Half)(double)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                result = (Half)(short)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                result = (Half)(int)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                result = (Half)(long)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                result = (Half)(Int128)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                result = (Half)(long)(nint)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                result = (Half)(sbyte)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                result = (Half)(float)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                result = (Half)(ushort)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                result = (Half)(uint)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                result = (Half)(ulong)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                result = (Half)(UInt128)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                result = (Half)(ulong)(nuint)(object)value;
-                return true;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                result = default;
-                return false;
-            }
-        }
 
         //
         // INumberBase
@@ -1568,6 +1188,166 @@ namespace System
 
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         public static Half Zero => new Half(PositiveZeroBits);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        public static Half Abs(Half value) => (Half)MathF.Abs((float)value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half CreateChecked<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            return CreateSaturating(value);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half CreateSaturating<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            if (typeof(TOther) == typeof(byte))
+            {
+                return (Half)(byte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(char))
+            {
+                return (Half)(char)(object)value;
+            }
+            else if (typeof(TOther) == typeof(decimal))
+            {
+                return (Half)(float)(decimal)(object)value;
+            }
+            else if (typeof(TOther) == typeof(double))
+            {
+                return (Half)(double)(object)value;
+            }
+            else if (typeof(TOther) == typeof(short))
+            {
+                return (Half)(short)(object)value;
+            }
+            else if (typeof(TOther) == typeof(int))
+            {
+                return (Half)(int)(object)value;
+            }
+            else if (typeof(TOther) == typeof(long))
+            {
+                return (Half)(long)(object)value;
+            }
+            else if (typeof(TOther) == typeof(Int128))
+            {
+                return (Half)(Int128)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nint))
+            {
+                return (Half)(long)(nint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(sbyte))
+            {
+                return (Half)(sbyte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(float))
+            {
+                return (Half)(float)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ushort))
+            {
+                return (Half)(ushort)(object)value;
+            }
+            else if (typeof(TOther) == typeof(uint))
+            {
+                return (Half)(uint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ulong))
+            {
+                return (Half)(ulong)(object)value;
+            }
+            else if (typeof(TOther) == typeof(UInt128))
+            {
+                return (Half)(UInt128)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nuint))
+            {
+                return (Half)(ulong)(nuint)(object)value;
+            }
+            else
+            {
+                ThrowHelper.ThrowNotSupportedException();
+                return default;
+            }
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half CreateTruncating<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            return CreateSaturating(value);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        public static Half MaxMagnitude(Half x, Half y) => (Half)MathF.MaxMagnitude((float)x, (float)y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        public static Half MaxMagnitudeNumber(Half x, Half y)
+        {
+            // This matches the IEEE 754:2019 `maximumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            Half ax = Abs(x);
+            Half ay = Abs(y);
+
+            if ((ax > ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        public static Half MinMagnitude(Half x, Half y) => (Half)MathF.MinMagnitude((float)x, (float)y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        public static Half MinMagnitudeNumber(Half x, Half y)
+        {
+            // This matches the IEEE 754:2019 `minimumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            Half ax = Abs(x);
+            Half ay = Abs(y);
+
+            if ((ax < ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryCreate<TOther>(TOther value, out Half result)
+            where TOther : INumberBase<TOther>
+        {
+            result = CreateSaturating(value);
+            return true;
+        }
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -1188,21 +1188,6 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        public static Int128 Abs(Int128 value)
-        {
-            if (IsNegative(value))
-            {
-                value = -value;
-
-                if (IsNegative(value))
-                {
-                    Math.ThrowNegateTwosCompOverflow();
-                }
-            }
-            return value;
-        }
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static Int128 Clamp(Int128 value, Int128 min, Int128 max)
         {
@@ -1244,10 +1229,64 @@ namespace System
             return -absValue;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static Int128 Max(Int128 x, Int128 y) => (x >= y) ? x : y;
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static Int128 INumber<Int128>.MaxNumber(Int128 x, Int128 y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static Int128 Min(Int128 x, Int128 y) => (x <= y) ? x : y;
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static Int128 INumber<Int128>.MinNumber(Int128 x, Int128 y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(Int128 value)
+        {
+            if (IsNegative(value))
+            {
+                return -1;
+            }
+            else if (value != default)
+            {
+                return 1;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        public static Int128 One => new Int128(0, 1);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        public static Int128 Zero => default;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        public static Int128 Abs(Int128 value)
+        {
+            if (IsNegative(value))
+            {
+                value = -value;
+
+                if (IsNegative(value))
+                {
+                    Math.ThrowNegateTwosCompOverflow();
+                }
+            }
+            return value;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Int128 CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1316,10 +1355,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Int128 CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1388,10 +1427,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Int128 CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1460,15 +1499,33 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<Int128>.IsFinite(Int128 value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<Int128>.IsInfinity(Int128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<Int128>.IsNaN(Int128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
         public static bool IsNegative(Int128 value) => (long)value._upper < 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<Int128>.IsNegativeInfinity(Int128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<Int128>.IsNormal(Int128 value) => value != 0;
 
         internal static bool IsPositive(Int128 value) => (long)value._upper >= 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static Int128 Max(Int128 x, Int128 y) => (x >= y) ? x : y;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<Int128>.IsPositiveInfinity(Int128 value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<Int128>.IsSubnormal(Int128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static Int128 MaxMagnitude(Int128 x, Int128 y)
         {
             Int128 absX = x;
@@ -1498,10 +1555,10 @@ namespace System
             return (absX >= absY) ? x : y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static Int128 Min(Int128 x, Int128 y) => (x <= y) ? x : y;
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static Int128 INumberBase<Int128>.MaxMagnitudeNumber(Int128 x, Int128 y) => MaxMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
         public static Int128 MinMagnitude(Int128 x, Int128 y)
         {
             Int128 absX = x;
@@ -1531,27 +1588,13 @@ namespace System
             return (absX <= absY) ? x : y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(Int128 value)
-        {
-            if (IsNegative(value))
-            {
-                return -1;
-            }
-            else if (value != default)
-            {
-                return 1;
-            }
-            else
-            {
-                return 0;
-            }
-        }
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static Int128 INumberBase<Int128>.MinMagnitudeNumber(Int128 x, Int128 y) => MinMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out Int128 result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1659,16 +1702,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        public static Int128 One => new Int128(0, 1);
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        public static Int128 Zero => default;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -1552,7 +1552,17 @@ namespace System
                 }
             }
 
-            return (absX >= absY) ? x : y;
+            if (absX > absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
         }
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
@@ -1585,7 +1595,17 @@ namespace System
                 }
             }
 
-            return (absX <= absY) ? x : y;
+            if (absX < absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
         }
 
         /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -520,9 +520,6 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        public static short Abs(short value) => Math.Abs(value);
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static short Clamp(short value, short min, short max) => Math.Clamp(value, min, max);
 
@@ -549,10 +546,38 @@ namespace System
             return (short)(-absValue);
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static short Max(short x, short y) => Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static short INumber<short>.MaxNumber(short x, short y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static short Min(short x, short y) => Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static short INumber<short>.MinNumber(short x, short y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(short value) => Math.Sign(value);
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static short INumberBase<short>.One => One;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static short INumberBase<short>.Zero => Zero;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        public static short Abs(short value) => Math.Abs(value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -617,10 +642,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -702,10 +727,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -770,13 +795,31 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<short>.IsFinite(short value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<short>.IsInfinity(short value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<short>.IsNaN(short value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
         public static bool IsNegative(short value) => value < 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static short Max(short x, short y) => Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<short>.IsNegativeInfinity(short value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<short>.IsNormal(short value) => value != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<short>.IsPositiveInfinity(short value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<short>.IsSubnormal(short value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static short MaxMagnitude(short x, short y)
         {
             short absX = x;
@@ -803,13 +846,23 @@ namespace System
                 }
             }
 
-            return (absX >= absY) ? x : y;
+            if (absX > absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static short Min(short x, short y) => Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static short INumberBase<short>.MaxMagnitudeNumber(short x, short y) => MaxMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
         public static short MinMagnitude(short x, short y)
         {
             short absX = x;
@@ -836,16 +889,26 @@ namespace System
                 }
             }
 
-            return (absX <= absY) ? x : y;
+            if (absX < absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(short value) => Math.Sign(value);
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static short INumberBase<short>.MinMagnitudeNumber(short x, short y) => MinMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out short result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1012,16 +1075,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static short INumberBase<short>.One => One;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static short INumberBase<short>.Zero => Zero;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -512,9 +512,6 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        public static int Abs(int value) => Math.Abs(value);
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static int Clamp(int value, int min, int max) => Math.Clamp(value, min, max);
 
@@ -541,10 +538,38 @@ namespace System
             return -absValue;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static int Max(int x, int y) => Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static int INumber<int>.MaxNumber(int x, int y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static int Min(int x, int y) => Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static int INumber<int>.MinNumber(int x, int y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(int value) => Math.Sign(value);
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static int INumberBase<int>.One => One;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static int INumberBase<int>.Zero => Zero;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        public static int Abs(int value) => Math.Abs(value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -609,10 +634,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -690,10 +715,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -758,13 +783,31 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<int>.IsFinite(int value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<int>.IsInfinity(int value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<int>.IsNaN(int value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
         public static bool IsNegative(int value) => value < 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static int Max(int x, int y) => Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<int>.IsNegativeInfinity(int value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<int>.IsNormal(int value) => value != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<int>.IsPositiveInfinity(int value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<int>.IsSubnormal(int value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static int MaxMagnitude(int x, int y)
         {
             int absX = x;
@@ -791,13 +834,23 @@ namespace System
                 }
             }
 
-            return (absX >= absY) ? x : y;
+            if (absX > absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static int Min(int x, int y) => Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static int INumberBase<int>.MaxMagnitudeNumber(int x, int y) => MaxMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
         public static int MinMagnitude(int x, int y)
         {
             int absX = x;
@@ -824,16 +877,26 @@ namespace System
                 }
             }
 
-            return (absX <= absY) ? x : y;
+            if (absX < absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(int value) => Math.Sign(value);
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static int INumberBase<int>.MinMagnitudeNumber(int x, int y) => MinMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out int result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -976,16 +1039,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static int INumberBase<int>.One => One;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static int INumberBase<int>.Zero => Zero;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -499,9 +499,6 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        public static long Abs(long value) => Math.Abs(value);
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static long Clamp(long value, long min, long max) => Math.Clamp(value, min, max);
 
@@ -528,10 +525,38 @@ namespace System
             return -absValue;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static long Max(long x, long y) => Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static long INumber<long>.MaxNumber(long x, long y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static long Min(long x, long y) => Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static long INumber<long>.MinNumber(long x, long y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(long value) => Math.Sign(value);
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static long INumberBase<long>.One => One;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static long INumberBase<long>.Zero => Zero;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        public static long Abs(long value) => Math.Abs(value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -596,10 +621,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -672,10 +697,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -740,13 +765,31 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<long>.IsFinite(long value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<long>.IsInfinity(long value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<long>.IsNaN(long value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
         public static bool IsNegative(long value) => value < 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static long Max(long x, long y) => Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<long>.IsNegativeInfinity(long value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<long>.IsNormal(long value) => value != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<long>.IsPositiveInfinity(long value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<long>.IsSubnormal(long value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static long MaxMagnitude(long x, long y)
         {
             long absX = x;
@@ -773,13 +816,23 @@ namespace System
                 }
             }
 
-            return (absX >= absY) ? x : y;
+            if (absX > absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static long Min(long x, long y) => Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static long INumberBase<long>.MaxMagnitudeNumber(long x, long y) => MaxMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
         public static long MinMagnitude(long x, long y)
         {
             long absX = x;
@@ -806,16 +859,26 @@ namespace System
                 }
             }
 
-            return (absX <= absY) ? x : y;
+            if (absX < absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(long value) => Math.Sign(value);
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static long INumberBase<long>.MinMagnitudeNumber(long x, long y) => MinMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out long result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -934,16 +997,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static long INumberBase<long>.One => One;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static long INumberBase<long>.Zero => Zero;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -472,9 +472,6 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        public static nint Abs(nint value) => Math.Abs(value);
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static nint Clamp(nint value, nint min, nint max) => Math.Clamp(value, min, max);
 
@@ -501,10 +498,38 @@ namespace System
             return -absValue;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static nint Max(nint x, nint y) => Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static nint INumber<nint>.MaxNumber(nint x, nint y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static nint Min(nint x, nint y) => Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static nint INumber<nint>.MinNumber(nint x, nint y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(nint value) => Math.Sign(value);
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static nint INumberBase<nint>.One => 1;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static nint INumberBase<nint>.Zero => 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        public static nint Abs(nint value) => Math.Abs(value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nint CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -514,9 +539,9 @@ namespace System
             {
                 return (char)(object)value;
             }
-            else if (typeof(TOther) == typeof(decimal))
+            else if (typeof(TOther) == typeof(nint))
             {
-                return checked((nint)(decimal)(object)value);
+                return checked((nint)(nint)(object)value);
             }
             else if (typeof(TOther) == typeof(double))
             {
@@ -569,10 +594,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nint CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -582,9 +607,9 @@ namespace System
             {
                 return (char)(object)value;
             }
-            else if (typeof(TOther) == typeof(decimal))
+            else if (typeof(TOther) == typeof(nint))
             {
-                var actualValue = (decimal)(object)value;
+                var actualValue = (nint)(object)value;
                 return (actualValue > nint.MaxValue) ? MaxValue :
                        (actualValue < nint.MinValue) ? MinValue : (nint)actualValue;
             }
@@ -648,10 +673,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nint CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -661,9 +686,9 @@ namespace System
             {
                 return (char)(object)value;
             }
-            else if (typeof(TOther) == typeof(decimal))
+            else if (typeof(TOther) == typeof(nint))
             {
-                return (nint)(decimal)(object)value;
+                return (nint)(nint)(object)value;
             }
             else if (typeof(TOther) == typeof(double))
             {
@@ -716,13 +741,31 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<nint>.IsFinite(nint value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<nint>.IsInfinity(nint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<nint>.IsNaN(nint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
         public static bool IsNegative(nint value) => value < 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static nint Max(nint x, nint y) => Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<nint>.IsNegativeInfinity(nint value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<nint>.IsNormal(nint value) => value != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<nint>.IsPositiveInfinity(nint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<nint>.IsSubnormal(nint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static nint MaxMagnitude(nint x, nint y)
         {
             nint absX = x;
@@ -749,13 +792,23 @@ namespace System
                 }
             }
 
-            return (absX >= absY) ? x : y;
+            if (absX > absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static nint Min(nint x, nint y) => Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static nint INumberBase<nint>.MaxMagnitudeNumber(nint x, nint y) => MaxMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
         public static nint MinMagnitude(nint x, nint y)
         {
             nint absX = x;
@@ -782,16 +835,26 @@ namespace System
                 }
             }
 
-            return (absX <= absY) ? x : y;
+            if (absX < absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(nint value) => Math.Sign(value);
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static nint INumberBase<nint>.MinMagnitudeNumber(nint x, nint y) => MinMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out nint result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -803,9 +866,9 @@ namespace System
                 result = (char)(object)value;
                 return true;
             }
-            else if (typeof(TOther) == typeof(decimal))
+            else if (typeof(TOther) == typeof(nint))
             {
-                var actualValue = (decimal)(object)value;
+                var actualValue = (nint)(object)value;
 
                 if ((actualValue < nint.MinValue) || (actualValue > nint.MaxValue))
                 {
@@ -926,16 +989,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static nint INumberBase<nint>.One => 1;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static nint INumberBase<nint>.Zero => 0;
 
         //
         // IShiftOperators

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPoint.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPoint.cs
@@ -49,13 +49,13 @@ namespace System.Numerics
         /// <returns>The truncation of <paramref name="x" />.</returns>
         static abstract TSelf Truncate(TSelf x);
 
-        /// <summary>Gets the length, in bits, of the shortest two's complement representation of the current exponent.</summary>
-        /// <returns>The length, in bits, of the shortest two's complement representation of the current exponent.</returns>
-        int GetExponentShortestBitLength();
-
         /// <summary>Gets the number of bytes that will be written as part of <see cref="TryWriteExponentLittleEndian(Span{byte}, out int)" />.</summary>
         /// <returns>The number of bytes that will be written as part of <see cref="TryWriteExponentLittleEndian(Span{byte}, out int)" />.</returns>
         int GetExponentByteCount();
+
+        /// <summary>Gets the length, in bits, of the shortest two's complement representation of the current exponent.</summary>
+        /// <returns>The length, in bits, of the shortest two's complement representation of the current exponent.</returns>
+        int GetExponentShortestBitLength();
 
         /// <summary>Gets the length, in bits, of the current significand.</summary>
         /// <returns>The length, in bits, of the current significand.</returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPointIeee754.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPointIeee754.cs
@@ -67,69 +67,6 @@ namespace System.Numerics
         /// <returns>The integer logarithm of <paramref name="x" />.</returns>
         static abstract int ILogB(TSelf x);
 
-        /// <summary>Determines if a value is finite.</summary>
-        /// <param name="value">The value to be checked.</param>
-        /// <returns><c>true</c> if <paramref name="value" /> is finite; otherwise, <c>false</c>.</returns>
-        static abstract bool IsFinite(TSelf value);
-
-        /// <summary>Determines if a value is infinite.</summary>
-        /// <param name="value">The value to be checked.</param>
-        /// <returns><c>true</c> if <paramref name="value" /> is infinite; otherwise, <c>false</c>.</returns>
-        static abstract bool IsInfinity(TSelf value);
-
-        /// <summary>Determines if a value is NaN.</summary>
-        /// <param name="value">The value to be checked.</param>
-        /// <returns><c>true</c> if <paramref name="value" /> is NaN; otherwise, <c>false</c>.</returns>
-        static abstract bool IsNaN(TSelf value);
-
-        /// <summary>Determines if a value is negative infinity.</summary>
-        /// <param name="value">The value to be checked.</param>
-        /// <returns><c>true</c> if <paramref name="value" /> is negative infinity; otherwise, <c>false</c>.</returns>
-        static abstract bool IsNegativeInfinity(TSelf value);
-
-        /// <summary>Determines if a value is normal.</summary>
-        /// <param name="value">The value to be checked.</param>
-        /// <returns><c>true</c> if <paramref name="value" /> is normal; otherwise, <c>false</c>.</returns>
-        static abstract bool IsNormal(TSelf value);
-
-        /// <summary>Determines if a value is positive infinity.</summary>
-        /// <param name="value">The value to be checked.</param>
-        /// <returns><c>true</c> if <paramref name="value" /> is positive infinity; otherwise, <c>false</c>.</returns>
-        static abstract bool IsPositiveInfinity(TSelf value);
-
-        /// <summary>Determines if a value is subnormal.</summary>
-        /// <param name="value">The value to be checked.</param>
-        /// <returns><c>true</c> if <paramref name="value" /> is subnormal; otherwise, <c>false</c>.</returns>
-        static abstract bool IsSubnormal(TSelf value);
-
-        /// <summary>Compares two values to compute which has the greater magnitude and returning the other value if an input is <c>NaN</c>.</summary>
-        /// <param name="x">The value to compare with <paramref name="y" />.</param>
-        /// <param name="y">The value to compare with <paramref name="x" />.</param>
-        /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
-        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumMagnitudeNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
-        static abstract TSelf MaxMagnitudeNumber(TSelf x, TSelf y);
-
-        /// <summary>Compares two values to compute which is greater and returning the other value if an input is <c>NaN</c>.</summary>
-        /// <param name="x">The value to compare with <paramref name="y" />.</param>
-        /// <param name="y">The value to compare with <paramref name="x" />.</param>
-        /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
-        /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
-        static abstract TSelf MaxNumber(TSelf x, TSelf y);
-
-        /// <summary>Compares two values to compute which has the lesser magnitude and returning the other value if an input is <c>NaN</c>.</summary>
-        /// <param name="x">The value to compare with <paramref name="y" />.</param>
-        /// <param name="y">The value to compare with <paramref name="x" />.</param>
-        /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
-        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumMagnitudeNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
-        static abstract TSelf MinMagnitudeNumber(TSelf x, TSelf y);
-
-        /// <summary>Compares two values to compute which is lesser and returning the other value if an input is <c>NaN</c>.</summary>
-        /// <param name="x">The value to compare with <paramref name="y" />.</param>
-        /// <param name="y">The value to compare with <paramref name="x" />.</param>
-        /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
-        /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
-        static abstract TSelf MinNumber(TSelf x, TSelf y);
-
         /// <summary>Computes an estimate of the reciprocal of a value.</summary>
         /// <param name="x">The value whose estimate of the reciprocal is to be computed.</param>
         /// <returns>An estimate of the reciprocal of <paramref name="x" />.</returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/INumber.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/INumber.cs
@@ -11,16 +11,9 @@ namespace System.Numerics
     public interface INumber<TSelf>
         : IComparisonOperators<TSelf, TSelf>,   // implies IEqualityOperators<TSelf, TSelf>
           IModulusOperators<TSelf, TSelf, TSelf>,
-          INumberBase<TSelf>,
-          ISpanParsable<TSelf>                  // implies IParsable<TSelf>
+          INumberBase<TSelf>
         where TSelf : INumber<TSelf>
     {
-        /// <summary>Computes the absolute of a value.</summary>
-        /// <param name="value">The value for which to get its absolute.</param>
-        /// <returns>The absolute of <paramref name="value" />.</returns>
-        /// <exception cref="OverflowException">The absolute of <paramref name="value" /> is not representable by <typeparamref name="TSelf" />.</exception>
-        static abstract TSelf Abs(TSelf value);
-
         /// <summary>Clamps a value to an inclusive minimum and maximum value.</summary>
         /// <param name="value">The value to clamp.</param>
         /// <param name="min">The inclusive minimum to which <paramref name="value" /> should clamp.</param>
@@ -35,36 +28,6 @@ namespace System.Numerics
         /// <returns>A value with the magnitude of <paramref name="value" /> and the sign of <paramref name="sign" />.</returns>
         static abstract TSelf CopySign(TSelf value, TSelf sign);
 
-        /// <summary>Creates an instance of the current type from a value, throwing an overflow exception for any values that fall outside the representable range of the current type.</summary>
-        /// <typeparam name="TOther">The type of <paramref name="value" />.</typeparam>
-        /// <param name="value">The value which is used to create the instance of <typeparamref name="TSelf" />.</param>
-        /// <returns>An instance of <typeparamref name="TSelf" /> created from <paramref name="value" />.</returns>
-        /// <exception cref="NotSupportedException"><typeparamref name="TOther" /> is not supported.</exception>
-        /// <exception cref="OverflowException"><paramref name="value" /> is not representable by <typeparamref name="TSelf" />.</exception>
-        static abstract TSelf CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>;
-
-        /// <summary>Creates an instance of the current type from a value, saturating any values that fall outside the representable range of the current type.</summary>
-        /// <typeparam name="TOther">The type of <paramref name="value" />.</typeparam>
-        /// <param name="value">The value which is used to create the instance of <typeparamref name="TSelf" />.</param>
-        /// <returns>An instance of <typeparamref name="TSelf" /> created from <paramref name="value" />, saturating if <paramref name="value" /> falls outside the representable range of <typeparamref name="TSelf" />.</returns>
-        /// <exception cref="NotSupportedException"><typeparamref name="TOther" /> is not supported.</exception>
-        static abstract TSelf CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>;
-
-        /// <summary>Creates an instance of the current type from a value, truncating any values that fall outside the representable range of the current type.</summary>
-        /// <typeparam name="TOther">The type of <paramref name="value" />.</typeparam>
-        /// <param name="value">The value which is used to create the instance of <typeparamref name="TSelf" />.</param>
-        /// <returns>An instance of <typeparamref name="TSelf" /> created from <paramref name="value" />, truncating if <paramref name="value" /> falls outside the representable range of <typeparamref name="TSelf" />.</returns>
-        /// <exception cref="NotSupportedException"><typeparamref name="TOther" /> is not supported.</exception>
-        static abstract TSelf CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>;
-
-        /// <summary>Determines if a value is negative.</summary>
-        /// <param name="value">The value to be checked.</param>
-        /// <returns><c>true</c> if <paramref name="value" /> is negative; otherwise, <c>false</c>.</returns>
-        static abstract bool IsNegative(TSelf value);
-
         /// <summary>Compares two values to compute which is greater.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
@@ -72,12 +35,12 @@ namespace System.Numerics
         /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>maximum</c> function. This requires NaN inputs to be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
         static abstract TSelf Max(TSelf x, TSelf y);
 
-        /// <summary>Compares two values to compute which is greater.</summary>
+        /// <summary>Compares two values to compute which is greater and returning the other value if an input is <c>NaN</c>.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
-        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumMagnitude</c> function. This requires NaN inputs to be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
-        static abstract TSelf MaxMagnitude(TSelf x, TSelf y);
+        /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        static abstract TSelf MaxNumber(TSelf x, TSelf y);
 
         /// <summary>Compares two values to compute which is lesser.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
@@ -86,65 +49,17 @@ namespace System.Numerics
         /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>minimum</c> function. This requires NaN inputs to be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
         static abstract TSelf Min(TSelf x, TSelf y);
 
-        /// <summary>Compares two values to compute which is lesser.</summary>
+        /// <summary>Compares two values to compute which is lesser and returning the other value if an input is <c>NaN</c>.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
-        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumMagnitude</c> function. This requires NaN inputs to be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
-        static abstract TSelf MinMagnitude(TSelf x, TSelf y);
-
-        /// <summary>Parses a string into a value.</summary>
-        /// <param name="s">The string to parse.</param>
-        /// <param name="style">A bitwise combination of number styles that can be present in <paramref name="s" />.</param>
-        /// <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
-        /// <returns>The result of parsing <paramref name="s" />.</returns>
-        /// <exception cref="ArgumentException"><paramref name="style" /> is not a supported <see cref="NumberStyles" /> value.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="s" /> is <c>null</c>.</exception>
-        /// <exception cref="FormatException"><paramref name="s" /> is not in the correct format.</exception>
-        /// <exception cref="OverflowException"><paramref name="s" /> is not representable by <typeparamref name="TSelf" />.</exception>
-        static abstract TSelf Parse(string s, NumberStyles style, IFormatProvider? provider);
-
-        /// <summary>Parses a span of characters into a value.</summary>
-        /// <param name="s">The span of characters to parse.</param>
-        /// <param name="style">A bitwise combination of number styles that can be present in <paramref name="s" />.</param>
-        /// <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
-        /// <returns>The result of parsing <paramref name="s" />.</returns>
-        /// <exception cref="ArgumentException"><paramref name="style" /> is not a supported <see cref="NumberStyles" /> value.</exception>
-        /// <exception cref="FormatException"><paramref name="s" /> is not in the correct format.</exception>
-        /// <exception cref="OverflowException"><paramref name="s" /> is not representable by <typeparamref name="TSelf" />.</exception>
-        static abstract TSelf Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider);
+        /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        static abstract TSelf MinNumber(TSelf x, TSelf y);
 
         /// <summary>Computes the sign of a value.</summary>
         /// <param name="value">The value whose sign is to be computed.</param>
         /// <returns>A positive value if <paramref name="value" /> is positive, <see cref="INumberBase{TSelf}.Zero" /> if <paramref name="value" /> is zero, and a negative value if <paramref name="value" /> is negative.</returns>
         /// <remarks>It is recommended that a function return <c>1</c>, <c>0</c>, and <c>-1</c>, respectively.</remarks>
         static abstract int Sign(TSelf value);
-
-        /// <summary>Tries to create an instance of the current type from a value.</summary>
-        /// <typeparam name="TOther">The type of <paramref name="value" />.</typeparam>
-        /// <param name="value">The value which is used to create the instance of <typeparamref name="TSelf" />.</param>
-        /// <param name="result">On return, contains the result of succesfully creating an instance of <typeparamref name="TSelf" /> from <paramref name="value" /> or an undefined value on failure.</param>
-        /// <returns><c>true</c> if <paramref name="value" /> an instance of the current type was succesfully created from <paramref name="value" />; otherwise, <c>false</c>.</returns>
-        /// <exception cref="NotSupportedException"><typeparamref name="TOther" /> is not supported.</exception>
-        static abstract bool TryCreate<TOther>(TOther value, out TSelf result)
-            where TOther : INumber<TOther>;
-
-        /// <summary>Tries to parses a string into a value.</summary>
-        /// <param name="s">The string to parse.</param>
-        /// <param name="style">A bitwise combination of number styles that can be present in <paramref name="s" />.</param>
-        /// <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
-        /// <param name="result">On return, contains the result of succesfully parsing <paramref name="s" /> or an undefined value on failure.</param>
-        /// <returns><c>true</c> if <paramref name="s" /> was successfully parsed; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentException"><paramref name="style" /> is not a supported <see cref="NumberStyles" /> value.</exception>
-        static abstract bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out TSelf result);
-
-        /// <summary>Tries to parses a span of characters into a value.</summary>
-        /// <param name="s">The span of characters to parse.</param>
-        /// <param name="style">A bitwise combination of number styles that can be present in <paramref name="s" />.</param>
-        /// <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
-        /// <param name="result">On return, contains the result of succesfully parsing <paramref name="s" /> or an undefined value on failure.</param>
-        /// <returns><c>true</c> if <paramref name="s" /> was successfully parsed; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentException"><paramref name="style" /> is not a supported <see cref="NumberStyles" /> value.</exception>
-        static abstract bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out TSelf result);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
 namespace System.Numerics
 {
     /// <summary>Defines the base of other number types.</summary>
@@ -15,6 +18,7 @@ namespace System.Numerics
           IMultiplicativeIdentity<TSelf, TSelf>,
           IMultiplyOperators<TSelf, TSelf, TSelf>,
           ISpanFormattable,                     // implies IFormattable
+          ISpanParsable<TSelf>,                 // implies IParsable<TSelf>
           ISubtractionOperators<TSelf, TSelf, TSelf>,
           IUnaryPlusOperators<TSelf, TSelf>,
           IUnaryNegationOperators<TSelf, TSelf>
@@ -25,5 +29,152 @@ namespace System.Numerics
 
         /// <summary>Gets the value <c>0</c> for the type.</summary>
         static abstract TSelf Zero { get; }
+
+        /// <summary>Computes the absolute of a value.</summary>
+        /// <param name="value">The value for which to get its absolute.</param>
+        /// <returns>The absolute of <paramref name="value" />.</returns>
+        /// <exception cref="OverflowException">The absolute of <paramref name="value" /> is not representable by <typeparamref name="TSelf" />.</exception>
+        static abstract TSelf Abs(TSelf value);
+
+        /// <summary>Creates an instance of the current type from a value, throwing an overflow exception for any values that fall outside the representable range of the current type.</summary>
+        /// <typeparam name="TOther">The type of <paramref name="value" />.</typeparam>
+        /// <param name="value">The value which is used to create the instance of <typeparamref name="TSelf" />.</param>
+        /// <returns>An instance of <typeparamref name="TSelf" /> created from <paramref name="value" />.</returns>
+        /// <exception cref="NotSupportedException"><typeparamref name="TOther" /> is not supported.</exception>
+        /// <exception cref="OverflowException"><paramref name="value" /> is not representable by <typeparamref name="TSelf" />.</exception>
+        static abstract TSelf CreateChecked<TOther>(TOther value)
+            where TOther : INumberBase<TOther>;
+
+        /// <summary>Creates an instance of the current type from a value, saturating any values that fall outside the representable range of the current type.</summary>
+        /// <typeparam name="TOther">The type of <paramref name="value" />.</typeparam>
+        /// <param name="value">The value which is used to create the instance of <typeparamref name="TSelf" />.</param>
+        /// <returns>An instance of <typeparamref name="TSelf" /> created from <paramref name="value" />, saturating if <paramref name="value" /> falls outside the representable range of <typeparamref name="TSelf" />.</returns>
+        /// <exception cref="NotSupportedException"><typeparamref name="TOther" /> is not supported.</exception>
+        static abstract TSelf CreateSaturating<TOther>(TOther value)
+            where TOther : INumberBase<TOther>;
+
+        /// <summary>Creates an instance of the current type from a value, truncating any values that fall outside the representable range of the current type.</summary>
+        /// <typeparam name="TOther">The type of <paramref name="value" />.</typeparam>
+        /// <param name="value">The value which is used to create the instance of <typeparamref name="TSelf" />.</param>
+        /// <returns>An instance of <typeparamref name="TSelf" /> created from <paramref name="value" />, truncating if <paramref name="value" /> falls outside the representable range of <typeparamref name="TSelf" />.</returns>
+        /// <exception cref="NotSupportedException"><typeparamref name="TOther" /> is not supported.</exception>
+        static abstract TSelf CreateTruncating<TOther>(TOther value)
+            where TOther : INumberBase<TOther>;
+
+        /// <summary>Determines if a value is finite.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is finite; otherwise, <c>false</c>.</returns>
+        static abstract bool IsFinite(TSelf value);
+
+        /// <summary>Determines if a value is infinite.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is infinite; otherwise, <c>false</c>.</returns>
+        static abstract bool IsInfinity(TSelf value);
+
+        /// <summary>Determines if a value is NaN.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is NaN; otherwise, <c>false</c>.</returns>
+        static abstract bool IsNaN(TSelf value);
+
+        /// <summary>Determines if a value is negative.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is negative; otherwise, <c>false</c>.</returns>
+        static abstract bool IsNegative(TSelf value);
+
+        /// <summary>Determines if a value is negative infinity.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is negative infinity; otherwise, <c>false</c>.</returns>
+        static abstract bool IsNegativeInfinity(TSelf value);
+
+        /// <summary>Determines if a value is normal.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is normal; otherwise, <c>false</c>.</returns>
+        static abstract bool IsNormal(TSelf value);
+
+        /// <summary>Determines if a value is positive infinity.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is positive infinity; otherwise, <c>false</c>.</returns>
+        static abstract bool IsPositiveInfinity(TSelf value);
+
+        /// <summary>Determines if a value is subnormal.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is subnormal; otherwise, <c>false</c>.</returns>
+        static abstract bool IsSubnormal(TSelf value);
+
+        /// <summary>Compares two values to compute which is greater.</summary>
+        /// <param name="x">The value to compare with <paramref name="y" />.</param>
+        /// <param name="y">The value to compare with <paramref name="x" />.</param>
+        /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
+        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumMagnitude</c> function. This requires NaN inputs to be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        static abstract TSelf MaxMagnitude(TSelf x, TSelf y);
+
+        /// <summary>Compares two values to compute which has the greater magnitude and returning the other value if an input is <c>NaN</c>.</summary>
+        /// <param name="x">The value to compare with <paramref name="y" />.</param>
+        /// <param name="y">The value to compare with <paramref name="x" />.</param>
+        /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
+        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumMagnitudeNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        static abstract TSelf MaxMagnitudeNumber(TSelf x, TSelf y);
+
+        /// <summary>Compares two values to compute which is lesser.</summary>
+        /// <param name="x">The value to compare with <paramref name="y" />.</param>
+        /// <param name="y">The value to compare with <paramref name="x" />.</param>
+        /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
+        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumMagnitude</c> function. This requires NaN inputs to be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        static abstract TSelf MinMagnitude(TSelf x, TSelf y);
+
+        /// <summary>Compares two values to compute which has the lesser magnitude and returning the other value if an input is <c>NaN</c>.</summary>
+        /// <param name="x">The value to compare with <paramref name="y" />.</param>
+        /// <param name="y">The value to compare with <paramref name="x" />.</param>
+        /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
+        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumMagnitudeNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        static abstract TSelf MinMagnitudeNumber(TSelf x, TSelf y);
+
+        /// <summary>Parses a string into a value.</summary>
+        /// <param name="s">The string to parse.</param>
+        /// <param name="style">A bitwise combination of number styles that can be present in <paramref name="s" />.</param>
+        /// <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
+        /// <returns>The result of parsing <paramref name="s" />.</returns>
+        /// <exception cref="ArgumentException"><paramref name="style" /> is not a supported <see cref="NumberStyles" /> value.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="s" /> is <c>null</c>.</exception>
+        /// <exception cref="FormatException"><paramref name="s" /> is not in the correct format.</exception>
+        /// <exception cref="OverflowException"><paramref name="s" /> is not representable by <typeparamref name="TSelf" />.</exception>
+        static abstract TSelf Parse(string s, NumberStyles style, IFormatProvider? provider);
+
+        /// <summary>Parses a span of characters into a value.</summary>
+        /// <param name="s">The span of characters to parse.</param>
+        /// <param name="style">A bitwise combination of number styles that can be present in <paramref name="s" />.</param>
+        /// <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
+        /// <returns>The result of parsing <paramref name="s" />.</returns>
+        /// <exception cref="ArgumentException"><paramref name="style" /> is not a supported <see cref="NumberStyles" /> value.</exception>
+        /// <exception cref="FormatException"><paramref name="s" /> is not in the correct format.</exception>
+        /// <exception cref="OverflowException"><paramref name="s" /> is not representable by <typeparamref name="TSelf" />.</exception>
+        static abstract TSelf Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider);
+
+        /// <summary>Tries to create an instance of the current type from a value.</summary>
+        /// <typeparam name="TOther">The type of <paramref name="value" />.</typeparam>
+        /// <param name="value">The value which is used to create the instance of <typeparamref name="TSelf" />.</param>
+        /// <param name="result">On return, contains the result of succesfully creating an instance of <typeparamref name="TSelf" /> from <paramref name="value" /> or an undefined value on failure.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> an instance of the current type was succesfully created from <paramref name="value" />; otherwise, <c>false</c>.</returns>
+        /// <exception cref="NotSupportedException"><typeparamref name="TOther" /> is not supported.</exception>
+        static abstract bool TryCreate<TOther>(TOther value, out TSelf result)
+            where TOther : INumberBase<TOther>;
+
+        /// <summary>Tries to parses a string into a value.</summary>
+        /// <param name="s">The string to parse.</param>
+        /// <param name="style">A bitwise combination of number styles that can be present in <paramref name="s" />.</param>
+        /// <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
+        /// <param name="result">On return, contains the result of succesfully parsing <paramref name="s" /> or an undefined value on failure.</param>
+        /// <returns><c>true</c> if <paramref name="s" /> was successfully parsed; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentException"><paramref name="style" /> is not a supported <see cref="NumberStyles" /> value.</exception>
+        static abstract bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out TSelf result);
+
+        /// <summary>Tries to parses a span of characters into a value.</summary>
+        /// <param name="s">The span of characters to parse.</param>
+        /// <param name="style">A bitwise combination of number styles that can be present in <paramref name="s" />.</param>
+        /// <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
+        /// <param name="result">On return, contains the result of succesfully parsing <paramref name="s" /> or an undefined value on failure.</param>
+        /// <returns><c>true</c> if <paramref name="s" /> was successfully parsed; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentException"><paramref name="style" /> is not a supported <see cref="NumberStyles" /> value.</exception>
+        static abstract bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out TSelf result);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
@@ -1019,18 +1019,6 @@ namespace System.Runtime.InteropServices
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ILogB(TSelf)" />
         public static int ILogB(NFloat x) => NativeType.ILogB(x._value);
 
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
-        public static NFloat MaxMagnitudeNumber(NFloat x, NFloat y) => new NFloat(NativeType.MaxMagnitudeNumber(x._value, y._value));
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
-        public static NFloat MaxNumber(NFloat x, NFloat y) => new NFloat(NativeType.MaxNumber(x._value, y._value));
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
-        public static NFloat MinMagnitudeNumber(NFloat x, NFloat y) => new NFloat(NativeType.MinMagnitudeNumber(x._value, y._value));
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
-        public static NFloat MinNumber(NFloat x, NFloat y) => new NFloat(NativeType.MinNumber(x._value, y._value));
-
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalEstimate(TSelf)" />
         public static NFloat ReciprocalEstimate(NFloat x) => new NFloat(NativeType.ReciprocalEstimate(x._value));
 
@@ -1112,19 +1100,52 @@ namespace System.Runtime.InteropServices
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        public static NFloat Abs(NFloat value) => new NFloat(NativeType.Abs(value._value));
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static NFloat Clamp(NFloat value, NFloat min, NFloat max) => new NFloat(NativeType.Clamp(value._value, min._value, max._value));
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         public static NFloat CopySign(NFloat x, NFloat y) => new NFloat(NativeType.CopySign(x._value, y._value));
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static NFloat Max(NFloat x, NFloat y) => new NFloat(NativeType.Max(x._value, y._value));
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        public static NFloat MaxNumber(NFloat x, NFloat y) => new NFloat(NativeType.MaxNumber(x._value, y._value));
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static NFloat Min(NFloat x, NFloat y) => new NFloat(NativeType.Min(x._value, y._value));
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        public static NFloat MinNumber(NFloat x, NFloat y) => new NFloat(NativeType.MinNumber(x._value, y._value));
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(NFloat value) => NativeType.Sign(value._value);
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static NFloat INumberBase<NFloat>.One => new NFloat(NativeType.One);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static NFloat INumberBase<NFloat>.Zero => new NFloat(NativeType.Zero);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        public static NFloat Abs(NFloat value) => new NFloat(NativeType.Abs(value._value));
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NFloat CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
+        {
+            return CreateSaturating(value);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static NFloat CreateSaturating<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1193,134 +1214,34 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NFloat CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
-        {
-            return CreateChecked(value);
-        }
-
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NFloat CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             return CreateChecked(value);
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static NFloat Max(NFloat x, NFloat y) => new NFloat(NativeType.Max(x._value, y._value));
-
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static NFloat MaxMagnitude(NFloat x, NFloat y) => new NFloat(NativeType.MaxMagnitude(x._value, y._value));
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static NFloat Min(NFloat x, NFloat y) => new NFloat(NativeType.Min(x._value, y._value));
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        public static NFloat MaxMagnitudeNumber(NFloat x, NFloat y) => new NFloat(NativeType.MaxMagnitudeNumber(x._value, y._value));
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
         public static NFloat MinMagnitude(NFloat x, NFloat y) => new NFloat(NativeType.MinMagnitude(x._value, y._value));
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(NFloat value) => NativeType.Sign(value._value);
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        public static NFloat MinMagnitudeNumber(NFloat x, NFloat y) => new NFloat(NativeType.MinMagnitudeNumber(x._value, y._value));
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out NFloat result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
-            if (typeof(TOther) == typeof(byte))
-            {
-                result = (byte)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                result = (char)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                result = (NFloat)(decimal)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                result = (NFloat)(double)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                result = (short)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                result = (int)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                result = (long)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                result = (nint)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                result = (sbyte)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                result = (NFloat)(float)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                result = (ushort)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                result = (uint)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                result = (ulong)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                result = (nuint)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(NFloat))
-            {
-                result = (NFloat)(object)value;
-                return true;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                result = default;
-                return false;
-            }
+            result = CreateSaturating(value);
+            return true;
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static NFloat INumberBase<NFloat>.One => new NFloat(NativeType.One);
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static NFloat INumberBase<NFloat>.Zero => new NFloat(NativeType.Zero);
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -527,9 +527,6 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        public static sbyte Abs(sbyte value) => Math.Abs(value);
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static sbyte Clamp(sbyte value, sbyte min, sbyte max) => Math.Clamp(value, min, max);
 
@@ -556,10 +553,38 @@ namespace System
             return (sbyte)(-absValue);
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static sbyte Max(sbyte x, sbyte y) => Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static sbyte INumber<sbyte>.MaxNumber(sbyte x, sbyte y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static sbyte Min(sbyte x, sbyte y) => Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static sbyte INumber<sbyte>.MinNumber(sbyte x, sbyte y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(sbyte value) => Math.Sign(value);
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static sbyte INumberBase<sbyte>.One => One;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static sbyte INumberBase<sbyte>.Zero => Zero;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        public static sbyte Abs(sbyte value) => Math.Abs(value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static sbyte CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -624,10 +649,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static sbyte CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -712,10 +737,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static sbyte CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -780,13 +805,31 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<sbyte>.IsFinite(sbyte value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<sbyte>.IsInfinity(sbyte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<sbyte>.IsNaN(sbyte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
         public static bool IsNegative(sbyte value) => value < 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static sbyte Max(sbyte x, sbyte y) => Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<sbyte>.IsNegativeInfinity(sbyte value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<sbyte>.IsNormal(sbyte value) => value != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<sbyte>.IsPositiveInfinity(sbyte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<sbyte>.IsSubnormal(sbyte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static sbyte MaxMagnitude(sbyte x, sbyte y)
         {
             sbyte absX = x;
@@ -813,13 +856,23 @@ namespace System
                 }
             }
 
-            return (absX >= absY) ? x : y;
+            if (absX > absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static sbyte Min(sbyte x, sbyte y) => Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static sbyte INumberBase<sbyte>.MaxMagnitudeNumber(sbyte x, sbyte y) => MaxMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
         public static sbyte MinMagnitude(sbyte x, sbyte y)
         {
             sbyte absX = x;
@@ -846,16 +899,26 @@ namespace System
                 }
             }
 
-            return (absX <= absY) ? x : y;
+            if (absX < absY)
+            {
+                return x;
+            }
+
+            if (absX == absY)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(sbyte value) => Math.Sign(value);
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static sbyte INumberBase<sbyte>.MinMagnitudeNumber(sbyte x, sbyte y) => MinMagnitude(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out sbyte result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1038,16 +1101,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static sbyte INumberBase<sbyte>.One => One;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static sbyte INumberBase<sbyte>.Zero => Zero;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -807,100 +807,6 @@ namespace System
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ILogB(TSelf)" />
         public static int ILogB(float x) => MathF.ILogB(x);
 
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
-        public static float MaxMagnitudeNumber(float x, float y)
-        {
-            // This matches the IEEE 754:2019 `maximumMagnitudeNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
-
-            float ax = Abs(x);
-            float ay = Abs(y);
-
-            if ((ax > ay) || IsNaN(ay))
-            {
-                return x;
-            }
-
-            if (ax == ay)
-            {
-                return IsNegative(x) ? y : x;
-            }
-
-            return y;
-        }
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
-        public static float MaxNumber(float x, float y)
-        {
-            // This matches the IEEE 754:2019 `maximumNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
-
-            if (x != y)
-            {
-                if (!IsNaN(y))
-                {
-                    return y < x ? x : y;
-                }
-
-                return x;
-            }
-
-            return IsNegative(y) ? x : y;
-        }
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
-        public static float MinMagnitudeNumber(float x, float y)
-        {
-            // This matches the IEEE 754:2019 `minimumMagnitudeNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
-
-            float ax = Abs(x);
-            float ay = Abs(y);
-
-            if ((ax < ay) || IsNaN(ay))
-            {
-                return x;
-            }
-
-            if (ax == ay)
-            {
-                return IsNegative(x) ? x : y;
-            }
-
-            return y;
-        }
-
-        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
-        public static float MinNumber(float x, float y)
-        {
-            // This matches the IEEE 754:2019 `minimumNumber` function
-            //
-            // It does not propagate NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
-
-            if (x != y)
-            {
-                if (!IsNaN(y))
-                {
-                    return x < y ? x : y;
-                }
-
-                return x;
-            }
-
-            return IsNegative(x) ? x : y;
-        }
-
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalEstimate(TSelf)" />
         public static float ReciprocalEstimate(float x) => MathF.ReciprocalEstimate(x);
 
@@ -1005,350 +911,64 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        public static float Abs(float value) => MathF.Abs(value);
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static float Clamp(float value, float min, float max) => Math.Clamp(value, min, max);
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         public static float CopySign(float x, float y) => MathF.CopySign(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                return (byte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                return (char)(object)value;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                return (float)(decimal)(object)value;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                return (float)(double)(object)value;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                return (short)(object)value;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                return (int)(object)value;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                return (long)(object)value;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                return (float)(Int128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                return (nint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                return (sbyte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                return (float)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                return (ushort)(object)value;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                return (uint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                return (ulong)(object)value;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                return (float)(UInt128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                return (nuint)(object)value;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                return default;
-            }
-        }
-
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                return (byte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                return (char)(object)value;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                return (float)(decimal)(object)value;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                return (float)(double)(object)value;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                return (short)(object)value;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                return (int)(object)value;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                return (long)(object)value;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                return (float)(Int128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                return (nint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                return (sbyte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                return (float)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                return (ushort)(object)value;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                return (uint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                return (ulong)(object)value;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                return (float)(UInt128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                return (nuint)(object)value;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                return default;
-            }
-        }
-
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                return (byte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                return (char)(object)value;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                return (float)(decimal)(object)value;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                return (float)(double)(object)value;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                return (short)(object)value;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                return (int)(object)value;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                return (long)(object)value;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                return (float)(Int128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                return (nint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                return (sbyte)(object)value;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                return (float)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                return (ushort)(object)value;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                return (uint)(object)value;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                return (ulong)(object)value;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                return (float)(UInt128)(object)value;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                return (nuint)(object)value;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                return default;
-            }
-        }
-
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
         public static float Max(float x, float y) => MathF.Max(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        public static float MaxMagnitude(float x, float y) => MathF.MaxMagnitude(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        public static float MaxNumber(float x, float y)
+        {
+            // This matches the IEEE 754:2019 `maximumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return y < x ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(y) ? x : y;
+        }
 
         /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
         public static float Min(float x, float y) => MathF.Min(x, y);
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        public static float MinMagnitude(float x, float y) => MathF.MinMagnitude(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        public static float MinNumber(float x, float y)
+        {
+            // This matches the IEEE 754:2019 `minimumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return x < y ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(x) ? x : y;
+        }
 
         /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
         public static int Sign(float value) => MathF.Sign(value);
-
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryCreate<TOther>(TOther value, out float result)
-            where TOther : INumber<TOther>
-        {
-            if (typeof(TOther) == typeof(byte))
-            {
-                result = (byte)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(char))
-            {
-                result = (char)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(decimal))
-            {
-                result = (float)(decimal)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(double))
-            {
-                result = (float)(double)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(short))
-            {
-                result = (short)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(int))
-            {
-                result = (int)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(long))
-            {
-                result = (long)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(Int128))
-            {
-                result = (float)(Int128)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(nint))
-            {
-                result = (nint)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(sbyte))
-            {
-                result = (sbyte)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(float))
-            {
-                result = (float)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(ushort))
-            {
-                result = (ushort)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(uint))
-            {
-                result = (uint)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(ulong))
-            {
-                result = (ulong)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(UInt128))
-            {
-                result = (float)(UInt128)(object)value;
-                return true;
-            }
-            else if (typeof(TOther) == typeof(nuint))
-            {
-                result = (nuint)(object)value;
-                return true;
-            }
-            else
-            {
-                ThrowHelper.ThrowNotSupportedException();
-                result = default;
-                return false;
-            }
-        }
 
         //
         // INumberBase
@@ -1359,6 +979,158 @@ namespace System
 
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static float INumberBase<float>.Zero => Zero;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        public static float Abs(float value) => MathF.Abs(value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float CreateChecked<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            return CreateSaturating(value);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float CreateSaturating<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            if (typeof(TOther) == typeof(byte))
+            {
+                return (byte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(char))
+            {
+                return (char)(object)value;
+            }
+            else if (typeof(TOther) == typeof(decimal))
+            {
+                return (float)(decimal)(object)value;
+            }
+            else if (typeof(TOther) == typeof(double))
+            {
+                return (float)(double)(object)value;
+            }
+            else if (typeof(TOther) == typeof(short))
+            {
+                return (short)(object)value;
+            }
+            else if (typeof(TOther) == typeof(int))
+            {
+                return (int)(object)value;
+            }
+            else if (typeof(TOther) == typeof(long))
+            {
+                return (long)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nint))
+            {
+                return (nint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(sbyte))
+            {
+                return (sbyte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(float))
+            {
+                return (float)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ushort))
+            {
+                return (ushort)(object)value;
+            }
+            else if (typeof(TOther) == typeof(uint))
+            {
+                return (uint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ulong))
+            {
+                return (ulong)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nuint))
+            {
+                return (nuint)(object)value;
+            }
+            else
+            {
+                ThrowHelper.ThrowNotSupportedException();
+                return default;
+            }
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float CreateTruncating<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            return CreateSaturating(value);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        public static float MaxMagnitude(float x, float y) => MathF.MaxMagnitude(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        public static float MaxMagnitudeNumber(float x, float y)
+        {
+            // This matches the IEEE 754:2019 `maximumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            float ax = Abs(x);
+            float ay = Abs(y);
+
+            if ((ax > ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        public static float MinMagnitude(float x, float y) => MathF.MinMagnitude(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        public static float MinMagnitudeNumber(float x, float y)
+        {
+            // This matches the IEEE 754:2019 `minimumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            float ax = Abs(x);
+            float ay = Abs(y);
+
+            if ((ax < ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryCreate<TOther>(TOther value, out float result)
+            where TOther : INumberBase<TOther>
+        {
+            result = CreateSaturating(value);
+            return true;
+        }
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -1024,6 +1024,10 @@ namespace System
             {
                 return (long)(object)value;
             }
+            else if (typeof(TOther) == typeof(Int128))
+            {
+                return (float)(Int128)(object)value;
+            }
             else if (typeof(TOther) == typeof(nint))
             {
                 return (nint)(object)value;
@@ -1047,6 +1051,10 @@ namespace System
             else if (typeof(TOther) == typeof(ulong))
             {
                 return (ulong)(object)value;
+            }
+            else if (typeof(TOther) == typeof(UInt128))
+            {
+                return (float)(UInt128)(object)value;
             }
             else if (typeof(TOther) == typeof(nuint))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
@@ -1290,9 +1290,6 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        static UInt128 INumber<UInt128>.Abs(UInt128 value) => value;
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static UInt128 Clamp(UInt128 value, UInt128 min, UInt128 max)
         {
@@ -1316,10 +1313,38 @@ namespace System
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         static UInt128 INumber<UInt128>.CopySign(UInt128 value, UInt128 sign) => value;
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static UInt128 Max(UInt128 x, UInt128 y) => (x >= y) ? x : y;
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static UInt128 INumber<UInt128>.MaxNumber(UInt128 x, UInt128 y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static UInt128 Min(UInt128 x, UInt128 y) => (x <= y) ? x : y;
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static UInt128 INumber<UInt128>.MinNumber(UInt128 x, UInt128 y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(UInt128 value) => (value == 0U) ? 0 : 1;
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        public static UInt128 One => new UInt128(0, 1);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        public static UInt128 Zero => default;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        static UInt128 INumberBase<UInt128>.Abs(UInt128 value) => value;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static UInt128 CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1388,10 +1413,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static UInt128 CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1466,10 +1491,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static UInt128 CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1539,28 +1564,46 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
-        static bool INumber<UInt128>.IsNegative(UInt128 value) => false;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<UInt128>.IsFinite(UInt128 value) => true;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static UInt128 Max(UInt128 x, UInt128 y) => (x >= y) ? x : y;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<UInt128>.IsInfinity(UInt128 value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        static UInt128 INumber<UInt128>.MaxMagnitude(UInt128 x, UInt128 y) => Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<UInt128>.IsNaN(UInt128 value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static UInt128 Min(UInt128 x, UInt128 y) => (x <= y) ? x : y;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
+        static bool INumberBase<UInt128>.IsNegative(UInt128 value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        static UInt128 INumber<UInt128>.MinMagnitude(UInt128 x, UInt128 y) => Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<UInt128>.IsNegativeInfinity(UInt128 value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(UInt128 value) => (value == 0U) ? 0 : 1;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<UInt128>.IsNormal(UInt128 value) => value != 0U;
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<UInt128>.IsPositiveInfinity(UInt128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<UInt128>.IsSubnormal(UInt128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        static UInt128 INumberBase<UInt128>.MaxMagnitude(UInt128 x, UInt128 y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static UInt128 INumberBase<UInt128>.MaxMagnitudeNumber(UInt128 x, UInt128 y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        static UInt128 INumberBase<UInt128>.MinMagnitude(UInt128 x, UInt128 y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static UInt128 INumberBase<UInt128>.MinMagnitudeNumber(UInt128 x, UInt128 y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out UInt128 result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1716,16 +1759,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        public static UInt128 One => new UInt128(0, 1);
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        public static UInt128 Zero => default;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -489,19 +489,44 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        static ushort INumber<ushort>.Abs(ushort value) => value;
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static ushort Clamp(ushort value, ushort min, ushort max) => Math.Clamp(value, min, max);
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         static ushort INumber<ushort>.CopySign(ushort value, ushort sign) => value;
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static ushort Max(ushort x, ushort y) => Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static ushort INumber<ushort>.MaxNumber(ushort x, ushort y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static ushort Min(ushort x, ushort y) => Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static ushort INumber<ushort>.MinNumber(ushort x, ushort y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(ushort value) => (value == 0) ? 0 : 1;
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static ushort INumberBase<ushort>.One => One;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static ushort INumberBase<ushort>.Zero => Zero;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        static ushort INumberBase<ushort>.Abs(ushort value) => value;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -566,10 +591,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -651,10 +676,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -719,28 +744,46 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
-        static bool INumber<ushort>.IsNegative(ushort value) => false;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<ushort>.IsFinite(ushort value) => true;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static ushort Max(ushort x, ushort y) => Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<ushort>.IsInfinity(ushort value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        static ushort INumber<ushort>.MaxMagnitude(ushort x, ushort y) => Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<ushort>.IsNaN(ushort value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static ushort Min(ushort x, ushort y) => Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
+        static bool INumberBase<ushort>.IsNegative(ushort value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        static ushort INumber<ushort>.MinMagnitude(ushort x, ushort y) => Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<ushort>.IsNegativeInfinity(ushort value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(ushort value) => (value == 0) ? 0 : 1;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<ushort>.IsNormal(ushort value) => value != 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<ushort>.IsPositiveInfinity(ushort value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<ushort>.IsSubnormal(ushort value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        static ushort INumberBase<ushort>.MaxMagnitude(ushort x, ushort y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static ushort INumberBase<ushort>.MaxMagnitudeNumber(ushort x, ushort y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        static ushort INumberBase<ushort>.MinMagnitude(ushort x, ushort y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static ushort INumberBase<ushort>.MinMagnitudeNumber(ushort x, ushort y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out ushort result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -907,16 +950,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static ushort INumberBase<ushort>.One => One;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static ushort INumberBase<ushort>.Zero => Zero;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -475,19 +475,44 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        static uint INumber<uint>.Abs(uint value) => value;
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static uint Clamp(uint value, uint min, uint max) => Math.Clamp(value, min, max);
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         static uint INumber<uint>.CopySign(uint value, uint sign) => value;
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static uint Max(uint x, uint y) => Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static uint INumber<uint>.MaxNumber(uint x, uint y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static uint Min(uint x, uint y) => Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static uint INumber<uint>.MinNumber(uint x, uint y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(uint value) => (value == 0) ? 0 : 1;
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static uint INumberBase<uint>.One => One;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static uint INumberBase<uint>.Zero => Zero;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        static uint INumberBase<uint>.Abs(uint value) => value;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -552,10 +577,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -635,10 +660,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -703,28 +728,46 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
-        static bool INumber<uint>.IsNegative(uint value) => false;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<uint>.IsFinite(uint value) => true;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static uint Max(uint x, uint y) => Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<uint>.IsInfinity(uint value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        static uint INumber<uint>.MaxMagnitude(uint x, uint y) => Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<uint>.IsNaN(uint value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static uint Min(uint x, uint y) => Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
+        static bool INumberBase<uint>.IsNegative(uint value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        static uint INumber<uint>.MinMagnitude(uint x, uint y) => Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<uint>.IsNegativeInfinity(uint value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(uint value) => (value == 0) ? 0 : 1;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<uint>.IsNormal(uint value) => value != 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<uint>.IsPositiveInfinity(uint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<uint>.IsSubnormal(uint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        static uint INumberBase<uint>.MaxMagnitude(uint x, uint y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static uint INumberBase<uint>.MaxMagnitudeNumber(uint x, uint y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        static uint INumberBase<uint>.MinMagnitude(uint x, uint y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static uint INumberBase<uint>.MinMagnitudeNumber(uint x, uint y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out uint result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -883,16 +926,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static uint INumberBase<uint>.One => One;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static uint INumberBase<uint>.Zero => Zero;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -474,19 +474,44 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        static ulong INumber<ulong>.Abs(ulong value) => value;
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static ulong Clamp(ulong value, ulong min, ulong max) => Math.Clamp(value, min, max);
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         static ulong INumber<ulong>.CopySign(ulong value, ulong sign) => value;
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static ulong Max(ulong x, ulong y) => Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static ulong INumber<ulong>.MaxNumber(ulong x, ulong y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static ulong Min(ulong x, ulong y) => Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static ulong INumber<ulong>.MinNumber(ulong x, ulong y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(ulong value) => (value == 0) ? 0 : 1;
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static ulong INumberBase<ulong>.One => One;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static ulong INumberBase<ulong>.Zero => Zero;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        static ulong INumberBase<ulong>.Abs(ulong value) => value;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -551,10 +576,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -630,10 +655,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -698,28 +723,46 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
-        static bool INumber<ulong>.IsNegative(ulong value) => false;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<ulong>.IsFinite(ulong value) => true;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static ulong Max(ulong x, ulong y) => Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<ulong>.IsInfinity(ulong value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        static ulong INumber<ulong>.MaxMagnitude(ulong x, ulong y) => Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<ulong>.IsNaN(ulong value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static ulong Min(ulong x, ulong y) => Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
+        static bool INumberBase<ulong>.IsNegative(ulong value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        static ulong INumber<ulong>.MinMagnitude(ulong x, ulong y) => Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<ulong>.IsNegativeInfinity(ulong value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(ulong value) => (value == 0) ? 0 : 1;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<ulong>.IsNormal(ulong value) => value != 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<ulong>.IsPositiveInfinity(ulong value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<ulong>.IsSubnormal(ulong value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        static ulong INumberBase<ulong>.MaxMagnitude(ulong x, ulong y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static ulong INumberBase<ulong>.MaxMagnitudeNumber(ulong x, ulong y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        static ulong INumberBase<ulong>.MinMagnitude(ulong x, ulong y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static ulong INumberBase<ulong>.MinMagnitudeNumber(ulong x, ulong y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out ulong result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -862,16 +905,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static ulong INumberBase<ulong>.One => One;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static ulong INumberBase<ulong>.Zero => Zero;
 
         //
         // IParsable

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -449,19 +449,44 @@ namespace System
         // INumber
         //
 
-        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        static nuint INumber<nuint>.Abs(nuint value) => value;
-
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
         public static nuint Clamp(nuint value, nuint min, nuint max) => Math.Clamp(value, min, max);
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         static nuint INumber<nuint>.CopySign(nuint value, nuint sign) => value;
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static nuint Max(nuint x, nuint y) => Math.Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static nuint INumber<nuint>.MaxNumber(nuint x, nuint y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static nuint Min(nuint x, nuint y) => Math.Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static nuint INumber<nuint>.MinNumber(nuint x, nuint y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(nuint value) => (value == 0) ? 0 : 1;
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.One" />
+        static nuint INumberBase<nuint>.One => 1;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
+        static nuint INumberBase<nuint>.Zero => 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        static nuint INumberBase<nuint>.Abs(nuint value) => value;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nuint CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -526,10 +551,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nuint CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -608,10 +633,10 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nuint CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -676,28 +701,46 @@ namespace System
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
-        static bool INumber<nuint>.IsNegative(nuint value) => false;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<nuint>.IsFinite(nuint value) => true;
 
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        public static nuint Max(nuint x, nuint y) => Math.Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<nuint>.IsInfinity(nuint value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        public static nuint MaxMagnitude(nuint x, nuint y) => Max(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<nuint>.IsNaN(nuint value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        public static nuint Min(nuint x, nuint y) => Math.Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
+        static bool INumberBase<nuint>.IsNegative(nuint value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        public static nuint MinMagnitude(nuint x, nuint y) => Min(x, y);
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<nuint>.IsNegativeInfinity(nuint value) => false;
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        public static int Sign(nuint value) => (value == 0) ? 0 : 1;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<nuint>.IsNormal(nuint value) => value != 0;
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<nuint>.IsPositiveInfinity(nuint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<nuint>.IsSubnormal(nuint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        static nuint INumberBase<nuint>.MaxMagnitude(nuint x, nuint y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static nuint INumberBase<nuint>.MaxMagnitudeNumber(nuint x, nuint y) => Max(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        static nuint INumberBase<nuint>.MinMagnitude(nuint x, nuint y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static nuint INumberBase<nuint>.MinMagnitudeNumber(nuint x, nuint y) => Min(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out nuint result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -848,16 +891,6 @@ namespace System
                 return false;
             }
         }
-
-        //
-        // INumberBase
-        //
-
-        /// <inheritdoc cref="INumberBase{TSelf}.One" />
-        static nuint INumberBase<nuint>.One => 1;
-
-        /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
-        static nuint INumberBase<nuint>.Zero => 0;
 
         //
         // IShiftOperators

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -824,13 +824,13 @@ namespace System.Runtime.InteropServices
         public static System.Runtime.InteropServices.NFloat NegativeZero { get { throw null; } }
         public static System.Runtime.InteropServices.NFloat Pi { get { throw null; } }
         public static System.Runtime.InteropServices.NFloat PositiveInfinity { get { throw null; } }
-        public static System.Runtime.InteropServices.NFloat Tau { get { throw null; } }
         public static int Size { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.IAdditiveIdentity<System.Runtime.InteropServices.NFloat,System.Runtime.InteropServices.NFloat>.AdditiveIdentity { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.IMultiplicativeIdentity<System.Runtime.InteropServices.NFloat,System.Runtime.InteropServices.NFloat>.MultiplicativeIdentity { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>.One { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>.Zero { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.ISignedNumber<System.Runtime.InteropServices.NFloat>.NegativeOne { get { throw null; } }
+        public static System.Runtime.InteropServices.NFloat Tau { get { throw null; } }
         public double Value { get { throw null; } }
         public static System.Runtime.InteropServices.NFloat Abs(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static System.Runtime.InteropServices.NFloat Acos(System.Runtime.InteropServices.NFloat x) { throw null; }
@@ -850,9 +850,9 @@ namespace System.Runtime.InteropServices
         public static System.Runtime.InteropServices.NFloat CopySign(System.Runtime.InteropServices.NFloat x, System.Runtime.InteropServices.NFloat y) { throw null; }
         public static System.Runtime.InteropServices.NFloat Cos(System.Runtime.InteropServices.NFloat x) { throw null; }
         public static System.Runtime.InteropServices.NFloat Cosh(System.Runtime.InteropServices.NFloat x) { throw null; }
-        public static System.Runtime.InteropServices.NFloat CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static System.Runtime.InteropServices.NFloat CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static System.Runtime.InteropServices.NFloat CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static System.Runtime.InteropServices.NFloat CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.Runtime.InteropServices.NFloat CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.Runtime.InteropServices.NFloat CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(System.Runtime.InteropServices.NFloat other) { throw null; }
         public static System.Runtime.InteropServices.NFloat Exp(System.Runtime.InteropServices.NFloat x) { throw null; }
@@ -971,12 +971,12 @@ namespace System.Runtime.InteropServices
         static System.Runtime.InteropServices.NFloat System.Numerics.IDivisionOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>.operator checked /(System.Runtime.InteropServices.NFloat left, System.Runtime.InteropServices.NFloat right) { throw null; }
         int System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.GetExponentByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.GetExponentShortestBitLength() { throw null; }
-        int System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.GetSignificandByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.GetSignificandBitLength() { throw null; }
-        bool System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.TryWriteExponentBigEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.TryWriteExponentLittleEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.TryWriteSignificandBigEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.TryWriteSignificandLittleEndian(Span<byte> destination, out int bytesWritten) { throw null; }
+        int System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.GetSignificandByteCount() { throw null; }
+        bool System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.TryWriteExponentBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.TryWriteExponentLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.TryWriteSignificandBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         static System.Runtime.InteropServices.NFloat System.Numerics.IIncrementOperators<System.Runtime.InteropServices.NFloat>.operator checked ++(System.Runtime.InteropServices.NFloat value) { throw null; }
         static System.Runtime.InteropServices.NFloat System.Numerics.IMultiplyOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>.operator checked *(System.Runtime.InteropServices.NFloat left, System.Runtime.InteropServices.NFloat right) { throw null; }
         static System.Runtime.InteropServices.NFloat System.Numerics.ISubtractionOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>.operator checked -(System.Runtime.InteropServices.NFloat left, System.Runtime.InteropServices.NFloat right) { throw null; }
@@ -988,7 +988,7 @@ namespace System.Runtime.InteropServices
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static System.Runtime.InteropServices.NFloat Truncate(System.Runtime.InteropServices.NFloat x) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out System.Runtime.InteropServices.NFloat result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Runtime.InteropServices.NFloat result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Runtime.InteropServices.NFloat result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Runtime.InteropServices.NFloat result) { throw null; }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
@@ -158,47 +158,9 @@ namespace System.Runtime.InteropServices.Tests
             throw new Xunit.Sdk.EqualException(expected, actual);
         }
 
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            AssertBitwiseEqual(PositiveZero, AdditiveIdentityHelper<NFloat, NFloat>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            AssertBitwiseEqual(NFloat.MinValue, MinMaxValueHelper<NFloat>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            AssertBitwiseEqual(NFloat.MaxValue, MinMaxValueHelper<NFloat>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            AssertBitwiseEqual(PositiveOne, MultiplicativeIdentityHelper<NFloat, NFloat>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            Assert.Equal(NegativeOne, SignedNumberHelper<NFloat>.NegativeOne);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -239,6 +201,20 @@ namespace System.Runtime.InteropServices.Tests
             AssertBitwiseEqual(NFloat.MaxValue, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.MaxValue, PositiveOne));
             AssertBitwiseEqual(NFloat.PositiveInfinity, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.PositiveInfinity, PositiveOne));
         }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            AssertBitwiseEqual(PositiveZero, AdditiveIdentityHelper<NFloat, NFloat>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -291,45 +267,9 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.NegativeInfinity, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.MinValue, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NegativeOne, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-MinNormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-NFloat.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NegativeZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.NaN, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(PositiveZero, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(MinNormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(PositiveOne, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.MaxValue, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.PositiveInfinity, PositiveOne));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.NegativeInfinity, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.MinValue, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NegativeOne, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-MinNormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-NFloat.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NegativeZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.NaN, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(PositiveZero, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(MinNormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(PositiveOne, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.MaxValue, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.PositiveInfinity, PositiveOne));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -372,6 +312,50 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.NegativeInfinity, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.MinValue, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NegativeOne, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-MinNormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-MaxSubnormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-NFloat.Epsilon, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NegativeZero, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.NaN, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(PositiveZero, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.Epsilon, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(MaxSubnormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(MinNormal, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(PositiveOne, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.MaxValue, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.NegativeInfinity, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.MinValue, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NegativeOne, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-MinNormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-MaxSubnormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-NFloat.Epsilon, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NegativeZero, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.NaN, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(PositiveZero, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.Epsilon, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(MaxSubnormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(MinNormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(PositiveOne, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.MaxValue, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.PositiveInfinity, PositiveOne));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             AssertBitwiseEqual(NFloat.NegativeInfinity, DecrementOperatorsHelper<NFloat>.op_Decrement(NFloat.NegativeInfinity));
@@ -410,6 +394,10 @@ namespace System.Runtime.InteropServices.Tests
             AssertBitwiseEqual(NFloat.MaxValue, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(NFloat.MaxValue));
             AssertBitwiseEqual(NFloat.PositiveInfinity, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(NFloat.PositiveInfinity));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -477,6 +465,10 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -517,1079 +509,9 @@ namespace System.Runtime.InteropServices.Tests
             Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.PositiveInfinity, PositiveOne));
         }
 
-        [Fact]
-        public static void op_IncrementTest()
-        {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.NegativeInfinity));
-            AssertBitwiseEqual(NFloat.MinValue, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.MinValue));
-            AssertBitwiseEqual(PositiveZero, IncrementOperatorsHelper<NFloat>.op_Increment(NegativeOne));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(-MinNormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(-MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(-NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(NegativeZero));
-            AssertBitwiseEqual(NFloat.NaN, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.NaN));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(PositiveZero));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(MinNormal));
-            AssertBitwiseEqual(PositiveTwo, IncrementOperatorsHelper<NFloat>.op_Increment(PositiveOne));
-            AssertBitwiseEqual(NFloat.MaxValue, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.MaxValue));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.PositiveInfinity));
-        }
-
-        [Fact]
-        public static void op_CheckedIncrementTest()
-        {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.NegativeInfinity));
-            AssertBitwiseEqual(NFloat.MinValue, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.MinValue));
-            AssertBitwiseEqual(PositiveZero, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NegativeOne));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-MinNormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NegativeZero));
-            AssertBitwiseEqual(NFloat.NaN, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.NaN));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(PositiveZero));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(MinNormal));
-            AssertBitwiseEqual(PositiveTwo, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(PositiveOne));
-            AssertBitwiseEqual(NFloat.MaxValue, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.MaxValue));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.PositiveInfinity));
-        }
-
-        [Fact]
-        public static void op_ModulusTest()
-        {
-            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.MinValue, PositiveTwo));
-            AssertBitwiseEqual(NegativeOne, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-MinNormal, PositiveTwo));
-            AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual(-NFloat.Epsilon, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-NFloat.Epsilon, PositiveTwo)); ;
-            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual(NFloat.Epsilon, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.Epsilon, PositiveTwo));
-            AssertBitwiseEqual(MaxSubnormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual(MinNormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(MinNormal, PositiveTwo));
-            AssertBitwiseEqual(PositiveOne, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.MaxValue, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.PositiveInfinity, PositiveTwo));
-        }
-
-        [Fact]
-        public static void op_MultiplyTest()
-        {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.MinValue, PositiveTwo));
-            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NaN, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual(PositiveTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.MaxValue, PositiveTwo));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.PositiveInfinity, PositiveTwo));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)(-4.4501477170144028E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-4.4501477170144018E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-9.8813129168249309E-324), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)9.8813129168249309E-324, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)4.4501477170144018E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)4.4501477170144028E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MinNormal, PositiveTwo));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)(-2.3509887E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-2.35098842E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-2.80259693E-45f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.80259693E-45f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.35098842E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.3509887E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MinNormal, PositiveTwo));
-            }
-        }
-
-        [Fact]
-        public static void op_CheckedMultiplyTest()
-        {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.MinValue, PositiveTwo));
-            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NaN, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual(PositiveTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.MaxValue, PositiveTwo));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.PositiveInfinity, PositiveTwo));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)(-4.4501477170144028E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-4.4501477170144018E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-9.8813129168249309E-324), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)9.8813129168249309E-324, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)4.4501477170144018E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)4.4501477170144028E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MinNormal, PositiveTwo));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)(-2.3509887E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-2.35098842E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-2.80259693E-45f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.80259693E-45f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.35098842E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.3509887E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MinNormal, PositiveTwo));
-            }
-        }
-
-        [Fact]
-        public static void AbsTest()
-        {
-            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberBaseHelper<NFloat>.Abs(NFloat.NegativeInfinity));
-            AssertBitwiseEqual(NFloat.MaxValue, NumberBaseHelper<NFloat>.Abs(NFloat.MinValue));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.Abs(NegativeOne));
-            AssertBitwiseEqual(MinNormal, NumberBaseHelper<NFloat>.Abs(-MinNormal));
-            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<NFloat>.Abs(-MaxSubnormal));
-            AssertBitwiseEqual(NFloat.Epsilon, NumberBaseHelper<NFloat>.Abs(-NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.Abs(NegativeZero));
-            AssertBitwiseEqual(NFloat.NaN, NumberBaseHelper<NFloat>.Abs(NFloat.NaN));
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.Abs(PositiveZero));
-            AssertBitwiseEqual(NFloat.Epsilon, NumberBaseHelper<NFloat>.Abs(NFloat.Epsilon));
-            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<NFloat>.Abs(MaxSubnormal));
-            AssertBitwiseEqual(MinNormal, NumberBaseHelper<NFloat>.Abs(MinNormal));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.Abs(PositiveOne));
-            AssertBitwiseEqual(NFloat.MaxValue, NumberBaseHelper<NFloat>.Abs(NFloat.MaxValue));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberBaseHelper<NFloat>.Abs(NFloat.PositiveInfinity));
-        }
-
-        [Fact]
-        public static void ClampTest()
-        {
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NFloat.NegativeInfinity, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NFloat.MinValue, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NegativeOne, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(-MinNormal, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(-MaxSubnormal, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(-NFloat.Epsilon, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NegativeZero, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Clamp(NFloat.NaN, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(PositiveZero, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NFloat.Epsilon, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(MaxSubnormal, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(MinNormal, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(PositiveOne, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual((NFloat)63.0f, NumberHelper<NFloat>.Clamp(NFloat.MaxValue, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual((NFloat)63.0f, NumberHelper<NFloat>.Clamp(NFloat.PositiveInfinity, PositiveOne, (NFloat)63.0f));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x7F));
-            AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x80));
-            AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0xFF));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromCharTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<short>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<short>(0x7FFF));
-            AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateChecked<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<short>(unchecked((short)0xFFFF)));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<int>(0x00000001));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateChecked<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberBaseHelper<NFloat>.CreateChecked<int>(unchecked((int)0x80000000)));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateChecked<int>(unchecked((int)0x80000000)));
-            }
-        }
-
-        [Fact]
-        public static void CreateCheckedFromInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<long>(0x0000000000000001));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberBaseHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
-            }
-        }
-
-        [Fact]
-        public static void CreateCheckedFromIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
-            }
-        }
-
-        [Fact]
-        public static void CreateCheckedFromSByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x7F));
-            AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromUInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromUInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x00000001));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0, NumberBaseHelper<NFloat>.CreateChecked<uint>(0xFFFFFFFF));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateChecked<uint>(0xFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void CreateCheckedFromUInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x0000000000000001));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void CreateCheckedFromUIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((NFloat)18446744073709551615.0,NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x7F));
-            AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x80));
-            AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0xFF));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromCharTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x7FFF));
-            AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateSaturating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<short>(unchecked((short)0xFFFF)));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x00000001));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberBaseHelper<NFloat>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            }
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x0000000000000001));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberBaseHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            }
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
-            }
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromSByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x7F));
-            AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromUInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromUInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x00000001));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0xFFFFFFFF));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0xFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromUInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000001));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromUIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x7F));
-            AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x80));
-            AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0xFF));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromCharTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x7FFF));
-            AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateTruncating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<short>(unchecked((short)0xFFFF)));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x00000001));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberBaseHelper<NFloat>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            }
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x0000000000000001));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberBaseHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            }
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
-            }
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromSByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x7F));
-            AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromUInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromUInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x00000001));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0xFFFFFFFF));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0xFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromUInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000001));
-
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
-            }
-            else
-            {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromUIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NFloat.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NFloat.MinValue, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(-NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Max(NFloat.NaN, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(NFloat.MaxValue, NumberHelper<NFloat>.Max(NFloat.MaxValue, PositiveOne));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberHelper<NFloat>.Max(NFloat.PositiveInfinity, PositiveOne));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, NumberHelper<NFloat>.Min(NFloat.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(NFloat.MinValue, NumberHelper<NFloat>.Min(NFloat.MinValue, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.Min(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(-MinNormal, NumberHelper<NFloat>.Min(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<NFloat>.Min(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(-NFloat.Epsilon, NumberHelper<NFloat>.Min(-NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(NegativeZero, NumberHelper<NFloat>.Min(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Min(NFloat.NaN, PositiveOne));
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.Min(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(NFloat.Epsilon, NumberHelper<NFloat>.Min(NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<NFloat>.Min(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(MinNormal, NumberHelper<NFloat>.Min(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Min(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Min(NFloat.MaxValue, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Min(NFloat.PositiveInfinity, PositiveOne));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(-1, NumberHelper<NFloat>.Sign(NFloat.NegativeInfinity));
-            Assert.Equal(-1, NumberHelper<NFloat>.Sign(NFloat.MinValue));
-            Assert.Equal(-1, NumberHelper<NFloat>.Sign(NegativeOne));
-            Assert.Equal(-1, NumberHelper<NFloat>.Sign(-MinNormal));
-            Assert.Equal(-1, NumberHelper<NFloat>.Sign(-MaxSubnormal));
-            Assert.Equal(-1, NumberHelper<NFloat>.Sign(-NFloat.Epsilon));
-
-            Assert.Equal(0, NumberHelper<NFloat>.Sign(NegativeZero));
-            Assert.Equal(0, NumberHelper<NFloat>.Sign(PositiveZero));
-
-            Assert.Equal(1, NumberHelper<NFloat>.Sign(NFloat.Epsilon));
-            Assert.Equal(1, NumberHelper<NFloat>.Sign(MaxSubnormal));
-            Assert.Equal(1, NumberHelper<NFloat>.Sign(MinNormal));
-            Assert.Equal(1, NumberHelper<NFloat>.Sign(PositiveOne));
-            Assert.Equal(1, NumberHelper<NFloat>.Sign(NFloat.MaxValue));
-            Assert.Equal(1, NumberHelper<NFloat>.Sign(NFloat.PositiveInfinity));
-
-            Assert.Throws<ArithmeticException>(() => NumberHelper<NFloat>.Sign(NFloat.NaN));
-        }
-
-        [Fact]
-        public static void TryCreateFromByteTest()
-        {
-            NFloat result;
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x00, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x01, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x7F, out result));
-            Assert.Equal((NFloat)127.0f, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x80, out result));
-            Assert.Equal((NFloat)128.0f, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0xFF, out result));
-            Assert.Equal((NFloat)255.0f, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromCharTest()
-        {
-            NFloat result;
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x0000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x0001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x7FFF, out result));
-            Assert.Equal((NFloat)32767.0f, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x8000, out result));
-            Assert.Equal((NFloat)32768.0f, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0xFFFF, out result));
-            Assert.Equal((NFloat)65535.0f, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromInt16Test()
-        {
-            NFloat result;
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x0000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x0001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x7FFF, out result));
-            Assert.Equal((NFloat)32767.0f, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(unchecked((short)0x8000), out result));
-            Assert.Equal((NFloat)(-32768.0f), result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(unchecked((short)0xFFFF), out result));
-            Assert.Equal(NegativeOne, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromInt32Test()
-        {
-            NFloat result;
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x00000000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x00000001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
-            Assert.Equal(NegativeOne, result);
-
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x7FFFFFFF, out result));
-                Assert.Equal((NFloat)2147483647.0, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(unchecked((int)0x80000000), out result));
-                Assert.Equal((NFloat)(-2147483648.0), result);
-            }
-            else
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x7FFFFFFF, out result));
-                Assert.Equal((NFloat)2147483647.0f, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(unchecked((int)0x80000000), out result));
-                Assert.Equal((NFloat)(-2147483648.0f), result);
-            }
-        }
-
-        [Fact]
-        public static void TryCreateFromInt64Test()
-        {
-            NFloat result;
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x0000000000000000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x0000000000000001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
-            Assert.Equal(NegativeOne, result);
-
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
-                Assert.Equal((NFloat)9223372036854775807.0, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
-                Assert.Equal((NFloat)(-9223372036854775808.0), result);
-            }
-            else
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
-                Assert.Equal((NFloat)9223372036854775807.0f, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
-                Assert.Equal((NFloat)(-9223372036854775808.0f), result);
-            }
-        }
-
-        [Fact]
-        public static void TryCreateFromIntPtrTest()
-        {
-            NFloat result;
-
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
-                Assert.Equal(PositiveZero, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
-                Assert.Equal(PositiveOne, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
-                Assert.Equal((NFloat)9223372036854775807.0, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
-                Assert.Equal((NFloat)(-9223372036854775808.0), result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
-                Assert.Equal(NegativeOne, result);
-            }
-            else
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x00000000, out result));
-                Assert.Equal(PositiveZero, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x00000001, out result));
-                Assert.Equal(PositiveOne, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
-                Assert.Equal((NFloat)2147483647.0f, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
-                Assert.Equal((NFloat)(-2147483648.0f), result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
-                Assert.Equal(NegativeOne, result);
-            }
-        }
-
-        [Fact]
-        public static void TryCreateFromSByteTest()
-        {
-            NFloat result;
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x00, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x01, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x7F, out result));
-            Assert.Equal((NFloat)127.0f, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
-            Assert.Equal((NFloat)(-128.0f), result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
-            Assert.Equal(NegativeOne, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromUInt16Test()
-        {
-            NFloat result;
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x0000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x0001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x7FFF, out result));
-            Assert.Equal((NFloat)32767.0f, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x8000, out result));
-            Assert.Equal((NFloat)32768.0f, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0xFFFF, out result));
-            Assert.Equal((NFloat)65535.0f, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromUInt32Test()
-        {
-            NFloat result;
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x00000000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x00000001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x7FFFFFFF, out result));
-                Assert.Equal((NFloat)2147483647.0, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x80000000, out result));
-                Assert.Equal((NFloat)2147483648.0, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0xFFFFFFFF, out result));
-                Assert.Equal((NFloat)4294967295.0, result);
-            }
-            else
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x7FFFFFFF, out result));
-                Assert.Equal((NFloat)2147483647.0f, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x80000000, out result));
-                Assert.Equal((NFloat)2147483648.0f, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0xFFFFFFFF, out result));
-                Assert.Equal((NFloat)4294967295.0f, result);
-            }
-        }
-
-        [Fact]
-        public static void TryCreateFromUInt64Test()
-        {
-            NFloat result;
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x0000000000000000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x0000000000000001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
-                Assert.Equal((NFloat)9223372036854775807.0, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x8000000000000000, out result));
-                Assert.Equal((NFloat)9223372036854775808.0, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
-                Assert.Equal((NFloat)18446744073709551615.0, result);
-            }
-            else
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
-                Assert.Equal((NFloat)9223372036854775807.0f, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x8000000000000000, out result));
-                Assert.Equal((NFloat)9223372036854775808.0f, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
-                Assert.Equal((NFloat)18446744073709551615.0f, result);
-            }
-        }
-
-        [Fact]
-        public static void TryCreateFromUIntPtrTest()
-        {
-            NFloat result;
-
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
-                Assert.Equal(PositiveZero, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
-                Assert.Equal(PositiveOne, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
-                Assert.Equal((NFloat)9223372036854775807.0, result);
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
-                // Assert.Equal((NFloat)9223372036854775808.0, result);
-                //
-                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
-                // Assert.Equal((NFloat)18446744073709551615.0, result);
-            }
-            else
-            {
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x00000000, out result));
-                Assert.Equal(PositiveZero, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x00000001, out result));
-                Assert.Equal(PositiveOne, result);
-
-                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
-                Assert.Equal((NFloat)2147483647.0f, result);
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
-                // Assert.Equal((NFloat)2147483648.0f, result);
-                //
-                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
-                // Assert.Equal((NFloat)4294967295.0f, result);
-            }
-        }
+        //
+        // IFloatingPoint
+        //
 
         [Fact]
         public static void GetExponentByteCountTest()
@@ -2257,6 +1179,1152 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
+        //
+        // IIncrementOperators
+        //
+
+        [Fact]
+        public static void op_IncrementTest()
+        {
+            AssertBitwiseEqual(NFloat.NegativeInfinity, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.NegativeInfinity));
+            AssertBitwiseEqual(NFloat.MinValue, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.MinValue));
+            AssertBitwiseEqual(PositiveZero, IncrementOperatorsHelper<NFloat>.op_Increment(NegativeOne));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(-MinNormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(-MaxSubnormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(-NFloat.Epsilon));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(NegativeZero));
+            AssertBitwiseEqual(NFloat.NaN, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.NaN));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(PositiveZero));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.Epsilon));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(MaxSubnormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(MinNormal));
+            AssertBitwiseEqual(PositiveTwo, IncrementOperatorsHelper<NFloat>.op_Increment(PositiveOne));
+            AssertBitwiseEqual(NFloat.MaxValue, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.MaxValue));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_CheckedIncrementTest()
+        {
+            AssertBitwiseEqual(NFloat.NegativeInfinity, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.NegativeInfinity));
+            AssertBitwiseEqual(NFloat.MinValue, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.MinValue));
+            AssertBitwiseEqual(PositiveZero, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NegativeOne));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-MinNormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-MaxSubnormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-NFloat.Epsilon));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NegativeZero));
+            AssertBitwiseEqual(NFloat.NaN, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.NaN));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(PositiveZero));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.Epsilon));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(MaxSubnormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(MinNormal));
+            AssertBitwiseEqual(PositiveTwo, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(PositiveOne));
+            AssertBitwiseEqual(NFloat.MaxValue, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.MaxValue));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.PositiveInfinity));
+        }
+
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            AssertBitwiseEqual(NFloat.MaxValue, MinMaxValueHelper<NFloat>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            AssertBitwiseEqual(NFloat.MinValue, MinMaxValueHelper<NFloat>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
+        [Fact]
+        public static void op_ModulusTest()
+        {
+            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.NegativeInfinity, PositiveTwo));
+            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.MinValue, PositiveTwo));
+            AssertBitwiseEqual(NegativeOne, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NegativeOne, PositiveTwo));
+            AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-MinNormal, PositiveTwo));
+            AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual(-NFloat.Epsilon, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-NFloat.Epsilon, PositiveTwo)); ;
+            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NegativeZero, PositiveTwo));
+            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.NaN, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(PositiveZero, PositiveTwo));
+            AssertBitwiseEqual(NFloat.Epsilon, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.Epsilon, PositiveTwo));
+            AssertBitwiseEqual(MaxSubnormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual(MinNormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(MinNormal, PositiveTwo));
+            AssertBitwiseEqual(PositiveOne, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(PositiveOne, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.MaxValue, PositiveTwo));
+            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.PositiveInfinity, PositiveTwo));
+        }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            AssertBitwiseEqual(PositiveOne, MultiplicativeIdentityHelper<NFloat, NFloat>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
+
+        [Fact]
+        public static void op_MultiplyTest()
+        {
+            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.NegativeInfinity, PositiveTwo));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.MinValue, PositiveTwo));
+            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NegativeOne, PositiveTwo));
+            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NegativeZero, PositiveTwo));
+            AssertBitwiseEqual(NFloat.NaN, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.NaN, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(PositiveZero, PositiveTwo));
+            AssertBitwiseEqual(PositiveTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(PositiveOne, PositiveTwo));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.MaxValue, PositiveTwo));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.PositiveInfinity, PositiveTwo));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)(-4.4501477170144028E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MinNormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-4.4501477170144018E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MaxSubnormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-9.8813129168249309E-324), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-NFloat.Epsilon, PositiveTwo));
+                AssertBitwiseEqual((NFloat)9.8813129168249309E-324, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.Epsilon, PositiveTwo));
+                AssertBitwiseEqual((NFloat)4.4501477170144018E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MaxSubnormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)4.4501477170144028E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MinNormal, PositiveTwo));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)(-2.3509887E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MinNormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-2.35098842E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MaxSubnormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-2.80259693E-45f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-NFloat.Epsilon, PositiveTwo));
+                AssertBitwiseEqual((NFloat)2.80259693E-45f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.Epsilon, PositiveTwo));
+                AssertBitwiseEqual((NFloat)2.35098842E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MaxSubnormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)2.3509887E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MinNormal, PositiveTwo));
+            }
+        }
+
+        [Fact]
+        public static void op_CheckedMultiplyTest()
+        {
+            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.NegativeInfinity, PositiveTwo));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.MinValue, PositiveTwo));
+            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NegativeOne, PositiveTwo));
+            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NegativeZero, PositiveTwo));
+            AssertBitwiseEqual(NFloat.NaN, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.NaN, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(PositiveZero, PositiveTwo));
+            AssertBitwiseEqual(PositiveTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(PositiveOne, PositiveTwo));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.MaxValue, PositiveTwo));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.PositiveInfinity, PositiveTwo));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)(-4.4501477170144028E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MinNormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-4.4501477170144018E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MaxSubnormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-9.8813129168249309E-324), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-NFloat.Epsilon, PositiveTwo));
+                AssertBitwiseEqual((NFloat)9.8813129168249309E-324, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.Epsilon, PositiveTwo));
+                AssertBitwiseEqual((NFloat)4.4501477170144018E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MaxSubnormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)4.4501477170144028E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MinNormal, PositiveTwo));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)(-2.3509887E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MinNormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-2.35098842E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MaxSubnormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-2.80259693E-45f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-NFloat.Epsilon, PositiveTwo));
+                AssertBitwiseEqual((NFloat)2.80259693E-45f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.Epsilon, PositiveTwo));
+                AssertBitwiseEqual((NFloat)2.35098842E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MaxSubnormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)2.3509887E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MinNormal, PositiveTwo));
+            }
+        }
+
+        //
+        // INumber
+        //
+
+        [Fact]
+        public static void ClampTest()
+        {
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NFloat.NegativeInfinity, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NFloat.MinValue, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NegativeOne, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(-MinNormal, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(-MaxSubnormal, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(-NFloat.Epsilon, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NegativeZero, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Clamp(NFloat.NaN, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(PositiveZero, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NFloat.Epsilon, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(MaxSubnormal, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(MinNormal, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(PositiveOne, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual((NFloat)63.0f, NumberHelper<NFloat>.Clamp(NFloat.MaxValue, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual((NFloat)63.0f, NumberHelper<NFloat>.Clamp(NFloat.PositiveInfinity, PositiveOne, (NFloat)63.0f));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NFloat.NegativeInfinity, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NFloat.MinValue, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NegativeOne, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(-MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(-MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(-NFloat.Epsilon, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NegativeZero, PositiveOne));
+            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Max(NFloat.NaN, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(PositiveZero, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NFloat.Epsilon, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(PositiveOne, PositiveOne));
+            AssertBitwiseEqual(NFloat.MaxValue, NumberHelper<NFloat>.Max(NFloat.MaxValue, PositiveOne));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberHelper<NFloat>.Max(NFloat.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            AssertBitwiseEqual(NFloat.NegativeInfinity, NumberHelper<NFloat>.Min(NFloat.NegativeInfinity, PositiveOne));
+            AssertBitwiseEqual(NFloat.MinValue, NumberHelper<NFloat>.Min(NFloat.MinValue, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.Min(NegativeOne, PositiveOne));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<NFloat>.Min(-MinNormal, PositiveOne));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<NFloat>.Min(-MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(-NFloat.Epsilon, NumberHelper<NFloat>.Min(-NFloat.Epsilon, PositiveOne));
+            AssertBitwiseEqual(NegativeZero, NumberHelper<NFloat>.Min(NegativeZero, PositiveOne));
+            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Min(NFloat.NaN, PositiveOne));
+            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.Min(PositiveZero, PositiveOne));
+            AssertBitwiseEqual(NFloat.Epsilon, NumberHelper<NFloat>.Min(NFloat.Epsilon, PositiveOne));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<NFloat>.Min(MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(MinNormal, NumberHelper<NFloat>.Min(MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Min(PositiveOne, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Min(NFloat.MaxValue, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Min(NFloat.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(-1, NumberHelper<NFloat>.Sign(NFloat.NegativeInfinity));
+            Assert.Equal(-1, NumberHelper<NFloat>.Sign(NFloat.MinValue));
+            Assert.Equal(-1, NumberHelper<NFloat>.Sign(NegativeOne));
+            Assert.Equal(-1, NumberHelper<NFloat>.Sign(-MinNormal));
+            Assert.Equal(-1, NumberHelper<NFloat>.Sign(-MaxSubnormal));
+            Assert.Equal(-1, NumberHelper<NFloat>.Sign(-NFloat.Epsilon));
+
+            Assert.Equal(0, NumberHelper<NFloat>.Sign(NegativeZero));
+            Assert.Equal(0, NumberHelper<NFloat>.Sign(PositiveZero));
+
+            Assert.Equal(1, NumberHelper<NFloat>.Sign(NFloat.Epsilon));
+            Assert.Equal(1, NumberHelper<NFloat>.Sign(MaxSubnormal));
+            Assert.Equal(1, NumberHelper<NFloat>.Sign(MinNormal));
+            Assert.Equal(1, NumberHelper<NFloat>.Sign(PositiveOne));
+            Assert.Equal(1, NumberHelper<NFloat>.Sign(NFloat.MaxValue));
+            Assert.Equal(1, NumberHelper<NFloat>.Sign(NFloat.PositiveInfinity));
+
+            Assert.Throws<ArithmeticException>(() => NumberHelper<NFloat>.Sign(NFloat.NaN));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberBaseHelper<NFloat>.Abs(NFloat.NegativeInfinity));
+            AssertBitwiseEqual(NFloat.MaxValue, NumberBaseHelper<NFloat>.Abs(NFloat.MinValue));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.Abs(NegativeOne));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<NFloat>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<NFloat>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(NFloat.Epsilon, NumberBaseHelper<NFloat>.Abs(-NFloat.Epsilon));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.Abs(NegativeZero));
+            AssertBitwiseEqual(NFloat.NaN, NumberBaseHelper<NFloat>.Abs(NFloat.NaN));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.Abs(PositiveZero));
+            AssertBitwiseEqual(NFloat.Epsilon, NumberBaseHelper<NFloat>.Abs(NFloat.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<NFloat>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<NFloat>.Abs(MinNormal));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.Abs(PositiveOne));
+            AssertBitwiseEqual(NFloat.MaxValue, NumberBaseHelper<NFloat>.Abs(NFloat.MaxValue));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberBaseHelper<NFloat>.Abs(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x7F));
+            AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x80));
+            AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromCharTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<short>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<short>(0x7FFF));
+            AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateChecked<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<int>(0x00000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateChecked<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberBaseHelper<NFloat>.CreateChecked<int>(unchecked((int)0x80000000)));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateChecked<int>(unchecked((int)0x80000000)));
+            }
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<long>(0x0000000000000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberBaseHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            }
+        }
+
+        [Fact]
+        public static void CreateCheckedFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateCheckedFromSByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x7F));
+            AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x00000001));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0, NumberBaseHelper<NFloat>.CreateChecked<uint>(0xFFFFFFFF));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateChecked<uint>(0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x0000000000000001));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((NFloat)18446744073709551615.0,NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x7F));
+            AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x80));
+            AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromCharTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x7FFF));
+            AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateSaturating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x00000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberBaseHelper<NFloat>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x0000000000000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberBaseHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromSByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x7F));
+            AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x00000001));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0xFFFFFFFF));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000001));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x7F));
+            AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x80));
+            AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromCharTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x7FFF));
+            AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateTruncating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x00000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberBaseHelper<NFloat>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x0000000000000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberBaseHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromSByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x7F));
+            AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x00000001));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0xFFFFFFFF));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000001));
+
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            }
+            else
+            {
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromByteTest()
+        {
+            NFloat result;
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x00, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x01, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x7F, out result));
+            Assert.Equal((NFloat)127.0f, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x80, out result));
+            Assert.Equal((NFloat)128.0f, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0xFF, out result));
+            Assert.Equal((NFloat)255.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromCharTest()
+        {
+            NFloat result;
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x0000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x0001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.Equal((NFloat)32767.0f, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x8000, out result));
+            Assert.Equal((NFloat)32768.0f, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.Equal((NFloat)65535.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt16Test()
+        {
+            NFloat result;
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x0000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x0001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x7FFF, out result));
+            Assert.Equal((NFloat)32767.0f, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.Equal((NFloat)(-32768.0f), result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.Equal(NegativeOne, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt32Test()
+        {
+            NFloat result;
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x00000000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x00000001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.Equal(NegativeOne, result);
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x7FFFFFFF, out result));
+                Assert.Equal((NFloat)2147483647.0, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(unchecked((int)0x80000000), out result));
+                Assert.Equal((NFloat)(-2147483648.0), result);
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x7FFFFFFF, out result));
+                Assert.Equal((NFloat)2147483647.0f, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(unchecked((int)0x80000000), out result));
+                Assert.Equal((NFloat)(-2147483648.0f), result);
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromInt64Test()
+        {
+            NFloat result;
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.Equal(NegativeOne, result);
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.Equal((NFloat)9223372036854775807.0, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+                Assert.Equal((NFloat)(-9223372036854775808.0), result);
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.Equal((NFloat)9223372036854775807.0f, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+                Assert.Equal((NFloat)(-9223372036854775808.0f), result);
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromIntPtrTest()
+        {
+            NFloat result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.Equal(PositiveZero, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.Equal(PositiveOne, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal((NFloat)9223372036854775807.0, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.Equal((NFloat)(-9223372036854775808.0), result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.Equal(NegativeOne, result);
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.Equal(PositiveZero, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.Equal(PositiveOne, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.Equal((NFloat)2147483647.0f, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.Equal((NFloat)(-2147483648.0f), result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.Equal(NegativeOne, result);
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromSByteTest()
+        {
+            NFloat result;
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x00, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x01, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x7F, out result));
+            Assert.Equal((NFloat)127.0f, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.Equal((NFloat)(-128.0f), result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.Equal(NegativeOne, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt16Test()
+        {
+            NFloat result;
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x0000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x0001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.Equal((NFloat)32767.0f, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x8000, out result));
+            Assert.Equal((NFloat)32768.0f, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.Equal((NFloat)65535.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt32Test()
+        {
+            NFloat result;
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x00000000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x00000001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x7FFFFFFF, out result));
+                Assert.Equal((NFloat)2147483647.0, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x80000000, out result));
+                Assert.Equal((NFloat)2147483648.0, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0xFFFFFFFF, out result));
+                Assert.Equal((NFloat)4294967295.0, result);
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x7FFFFFFF, out result));
+                Assert.Equal((NFloat)2147483647.0f, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x80000000, out result));
+                Assert.Equal((NFloat)2147483648.0f, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0xFFFFFFFF, out result));
+                Assert.Equal((NFloat)4294967295.0f, result);
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt64Test()
+        {
+            NFloat result;
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.Equal((NFloat)9223372036854775807.0, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x8000000000000000, out result));
+                Assert.Equal((NFloat)9223372036854775808.0, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+                Assert.Equal((NFloat)18446744073709551615.0, result);
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.Equal((NFloat)9223372036854775807.0f, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x8000000000000000, out result));
+                Assert.Equal((NFloat)9223372036854775808.0f, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+                Assert.Equal((NFloat)18446744073709551615.0f, result);
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromUIntPtrTest()
+        {
+            NFloat result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.Equal(PositiveZero, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.Equal(PositiveOne, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal((NFloat)9223372036854775807.0, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                // Assert.Equal((NFloat)9223372036854775808.0, result);
+                //
+                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                // Assert.Equal((NFloat)18446744073709551615.0, result);
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.Equal(PositiveZero, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.Equal(PositiveOne, result);
+
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.Equal((NFloat)2147483647.0f, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                // Assert.Equal((NFloat)2147483648.0f, result);
+                //
+                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                // Assert.Equal((NFloat)4294967295.0f, result);
+            }
+        }
+
+        //
+        // ISignedNumber
+        //
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(NegativeOne, SignedNumberHelper<NFloat>.NegativeOne);
+        }
+
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -2297,6 +2365,10 @@ namespace System.Runtime.InteropServices.Tests
             AssertBitwiseEqual(NFloat.PositiveInfinity, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.PositiveInfinity, PositiveOne));
         }
 
+        //
+        // IUnaryNegationOperators
+        //
+
         [Fact]
         public static void op_UnaryNegationTest()
         {
@@ -2336,6 +2408,10 @@ namespace System.Runtime.InteropServices.Tests
             AssertBitwiseEqual(NFloat.MinValue, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NFloat.MaxValue));
             AssertBitwiseEqual(NFloat.NegativeInfinity, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NFloat.PositiveInfinity));
         }
+
+        //
+        // IUnaryPlusOperators
+        //
 
         [Fact]
         public static void op_UnaryPlusTest()

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
@@ -646,21 +646,21 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void AbsTest()
         {
-            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberHelper<NFloat>.Abs(NFloat.NegativeInfinity));
-            AssertBitwiseEqual(NFloat.MaxValue, NumberHelper<NFloat>.Abs(NFloat.MinValue));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Abs(NegativeOne));
-            AssertBitwiseEqual(MinNormal, NumberHelper<NFloat>.Abs(-MinNormal));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<NFloat>.Abs(-MaxSubnormal));
-            AssertBitwiseEqual(NFloat.Epsilon, NumberHelper<NFloat>.Abs(-NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.Abs(NegativeZero));
-            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Abs(NFloat.NaN));
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.Abs(PositiveZero));
-            AssertBitwiseEqual(NFloat.Epsilon, NumberHelper<NFloat>.Abs(NFloat.Epsilon));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<NFloat>.Abs(MaxSubnormal));
-            AssertBitwiseEqual(MinNormal, NumberHelper<NFloat>.Abs(MinNormal));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Abs(PositiveOne));
-            AssertBitwiseEqual(NFloat.MaxValue, NumberHelper<NFloat>.Abs(NFloat.MaxValue));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberHelper<NFloat>.Abs(NFloat.PositiveInfinity));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberBaseHelper<NFloat>.Abs(NFloat.NegativeInfinity));
+            AssertBitwiseEqual(NFloat.MaxValue, NumberBaseHelper<NFloat>.Abs(NFloat.MinValue));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.Abs(NegativeOne));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<NFloat>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<NFloat>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(NFloat.Epsilon, NumberBaseHelper<NFloat>.Abs(-NFloat.Epsilon));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.Abs(NegativeZero));
+            AssertBitwiseEqual(NFloat.NaN, NumberBaseHelper<NFloat>.Abs(NFloat.NaN));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.Abs(PositiveZero));
+            AssertBitwiseEqual(NFloat.Epsilon, NumberBaseHelper<NFloat>.Abs(NFloat.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<NFloat>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<NFloat>.Abs(MinNormal));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.Abs(PositiveOne));
+            AssertBitwiseEqual(NFloat.MaxValue, NumberBaseHelper<NFloat>.Abs(NFloat.MaxValue));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberBaseHelper<NFloat>.Abs(NFloat.PositiveInfinity));
         }
 
         [Fact]
@@ -686,68 +686,68 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<byte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberHelper<NFloat>.CreateChecked<byte>(0x7F));
-            AssertBitwiseEqual((NFloat)128.0f, NumberHelper<NFloat>.CreateChecked<byte>(0x80));
-            AssertBitwiseEqual((NFloat)255.0f, NumberHelper<NFloat>.CreateChecked<byte>(0xFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x7F));
+            AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x80));
+            AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<char>((char)0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberHelper<NFloat>.CreateChecked<char>((char)0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberHelper<NFloat>.CreateChecked<char>((char)0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberHelper<NFloat>.CreateChecked<char>((char)0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<short>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberHelper<NFloat>.CreateChecked<short>(0x7FFF));
-            AssertBitwiseEqual((NFloat)(-32768.0f), NumberHelper<NFloat>.CreateChecked<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<short>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<short>(0x7FFF));
+            AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateChecked<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<int>(0x00000001));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<int>(0x00000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberHelper<NFloat>.CreateChecked<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberHelper<NFloat>.CreateChecked<int>(unchecked((int)0x80000000)));
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateChecked<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberBaseHelper<NFloat>.CreateChecked<int>(unchecked((int)0x80000000)));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateChecked<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberHelper<NFloat>.CreateChecked<int>(unchecked((int)0x80000000)));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateChecked<int>(unchecked((int)0x80000000)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<long>(0x0000000000000001));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<long>(0x0000000000000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberHelper<NFloat>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberBaseHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
             }
         }
 
@@ -756,79 +756,79 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<nint>((nint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<sbyte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberHelper<NFloat>.CreateChecked<sbyte>(0x7F));
-            AssertBitwiseEqual((NFloat)(-128.0f), NumberHelper<NFloat>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x7F));
+            AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<ushort>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberHelper<NFloat>.CreateChecked<ushort>(0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberHelper<NFloat>.CreateChecked<ushort>(0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberHelper<NFloat>.CreateChecked<ushort>(0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<uint>(0x00000001));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x00000001));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberHelper<NFloat>.CreateChecked<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0, NumberHelper<NFloat>.CreateChecked<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0, NumberHelper<NFloat>.CreateChecked<uint>(0xFFFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0, NumberBaseHelper<NFloat>.CreateChecked<uint>(0xFFFFFFFF));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateChecked<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0f, NumberHelper<NFloat>.CreateChecked<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0f, NumberHelper<NFloat>.CreateChecked<uint>(0xFFFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateChecked<uint>(0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x0000000000000001));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberHelper<NFloat>.CreateChecked<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberHelper<NFloat>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberHelper<NFloat>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberHelper<NFloat>.CreateChecked<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberHelper<NFloat>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
             }
         }
 
@@ -837,91 +837,91 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((NFloat)18446744073709551615.0,NumberHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((NFloat)18446744073709551615.0,NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberHelper<NFloat>.CreateChecked<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberHelper<NFloat>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<byte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberHelper<NFloat>.CreateSaturating<byte>(0x7F));
-            AssertBitwiseEqual((NFloat)128.0f, NumberHelper<NFloat>.CreateSaturating<byte>(0x80));
-            AssertBitwiseEqual((NFloat)255.0f, NumberHelper<NFloat>.CreateSaturating<byte>(0xFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x7F));
+            AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x80));
+            AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<char>((char)0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberHelper<NFloat>.CreateSaturating<char>((char)0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberHelper<NFloat>.CreateSaturating<char>((char)0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberHelper<NFloat>.CreateSaturating<char>((char)0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<short>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberHelper<NFloat>.CreateSaturating<short>(0x7FFF));
-            AssertBitwiseEqual((NFloat)(-32768.0f), NumberHelper<NFloat>.CreateSaturating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x7FFF));
+            AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateSaturating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<int>(0x00000001));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x00000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberHelper<NFloat>.CreateSaturating<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberHelper<NFloat>.CreateSaturating<int>(unchecked((int)0x80000000)));
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberBaseHelper<NFloat>.CreateSaturating<int>(unchecked((int)0x80000000)));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateSaturating<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberHelper<NFloat>.CreateSaturating<int>(unchecked((int)0x80000000)));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateSaturating<int>(unchecked((int)0x80000000)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<long>(0x0000000000000001));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x0000000000000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberHelper<NFloat>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberBaseHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
             }
         }
 
@@ -930,79 +930,79 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<nint>((nint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<sbyte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberHelper<NFloat>.CreateSaturating<sbyte>(0x7F));
-            AssertBitwiseEqual((NFloat)(-128.0f), NumberHelper<NFloat>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x7F));
+            AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<ushort>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberHelper<NFloat>.CreateSaturating<ushort>(0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberHelper<NFloat>.CreateSaturating<ushort>(0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberHelper<NFloat>.CreateSaturating<ushort>(0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<uint>(0x00000001));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x00000001));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberHelper<NFloat>.CreateSaturating<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0, NumberHelper<NFloat>.CreateSaturating<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0, NumberHelper<NFloat>.CreateSaturating<uint>(0xFFFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0xFFFFFFFF));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateSaturating<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0f, NumberHelper<NFloat>.CreateSaturating<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0f, NumberHelper<NFloat>.CreateSaturating<uint>(0xFFFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000001));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberHelper<NFloat>.CreateSaturating<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberHelper<NFloat>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberHelper<NFloat>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberHelper<NFloat>.CreateSaturating<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberHelper<NFloat>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
         }
 
@@ -1011,91 +1011,91 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberHelper<NFloat>.CreateSaturating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberHelper<NFloat>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<byte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberHelper<NFloat>.CreateTruncating<byte>(0x7F));
-            AssertBitwiseEqual((NFloat)128.0f, NumberHelper<NFloat>.CreateTruncating<byte>(0x80));
-            AssertBitwiseEqual((NFloat)255.0f, NumberHelper<NFloat>.CreateTruncating<byte>(0xFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x7F));
+            AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x80));
+            AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<char>((char)0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberHelper<NFloat>.CreateTruncating<char>((char)0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberHelper<NFloat>.CreateTruncating<char>((char)0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberHelper<NFloat>.CreateTruncating<char>((char)0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<short>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberHelper<NFloat>.CreateTruncating<short>(0x7FFF));
-            AssertBitwiseEqual((NFloat)(-32768.0f), NumberHelper<NFloat>.CreateTruncating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x7FFF));
+            AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateTruncating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<int>(0x00000001));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x00000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberHelper<NFloat>.CreateTruncating<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberHelper<NFloat>.CreateTruncating<int>(unchecked((int)0x80000000)));
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0), NumberBaseHelper<NFloat>.CreateTruncating<int>(unchecked((int)0x80000000)));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateTruncating<int>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberHelper<NFloat>.CreateTruncating<int>(unchecked((int)0x80000000)));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateTruncating<int>(unchecked((int)0x80000000)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<long>(0x0000000000000001));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x0000000000000001));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberHelper<NFloat>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0f), NumberBaseHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
             }
         }
 
@@ -1104,79 +1104,79 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<nint>((nint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<sbyte>(0x01));
-            AssertBitwiseEqual((NFloat)127.0f, NumberHelper<NFloat>.CreateTruncating<sbyte>(0x7F));
-            AssertBitwiseEqual((NFloat)(-128.0f), NumberHelper<NFloat>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x01));
+            AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x7F));
+            AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<ushort>(0x0001));
-            AssertBitwiseEqual((NFloat)32767.0f, NumberHelper<NFloat>.CreateTruncating<ushort>(0x7FFF));
-            AssertBitwiseEqual((NFloat)32768.0f, NumberHelper<NFloat>.CreateTruncating<ushort>(0x8000));
-            AssertBitwiseEqual((NFloat)65535.0f, NumberHelper<NFloat>.CreateTruncating<ushort>(0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x0001));
+            AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x7FFF));
+            AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x8000));
+            AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<uint>(0x00000001));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x00000001));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)2147483647.0, NumberHelper<NFloat>.CreateTruncating<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0, NumberHelper<NFloat>.CreateTruncating<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0, NumberHelper<NFloat>.CreateTruncating<uint>(0xFFFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483647.0, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0xFFFFFFFF));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateTruncating<uint>(0x7FFFFFFF));
-                AssertBitwiseEqual((NFloat)2147483648.0f, NumberHelper<NFloat>.CreateTruncating<uint>(0x80000000));
-                AssertBitwiseEqual((NFloat)4294967295.0f, NumberHelper<NFloat>.CreateTruncating<uint>(0xFFFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x7FFFFFFF));
+                AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x80000000));
+                AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000001));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberHelper<NFloat>.CreateTruncating<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberHelper<NFloat>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberHelper<NFloat>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberHelper<NFloat>.CreateTruncating<ulong>(0x8000000000000000));
-                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberHelper<NFloat>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0f, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+                AssertBitwiseEqual((NFloat)9223372036854775808.0f, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x8000000000000000));
+                AssertBitwiseEqual((NFloat)18446744073709551615.0f, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
         }
 
@@ -1185,23 +1185,23 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual((NFloat)9223372036854775808.0, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((NFloat)18446744073709551615.0, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((NFloat)2147483647.0f, NumberHelper<NFloat>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberHelper<NFloat>.CreateTruncating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberHelper<NFloat>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual((NFloat)2147483648.0f, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((NFloat)4294967295.0f, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -1273,19 +1273,19 @@ namespace System.Runtime.InteropServices.Tests
         {
             NFloat result;
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x00, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x01, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((NFloat)127.0f, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x80, out result));
             Assert.Equal((NFloat)128.0f, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((NFloat)255.0f, result);
         }
 
@@ -1294,19 +1294,19 @@ namespace System.Runtime.InteropServices.Tests
         {
             NFloat result;
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((NFloat)32767.0f, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((NFloat)32768.0f, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((NFloat)65535.0f, result);
         }
 
@@ -1315,19 +1315,19 @@ namespace System.Runtime.InteropServices.Tests
         {
             NFloat result;
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x0000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x0001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((NFloat)32767.0f, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal((NFloat)(-32768.0f), result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1336,29 +1336,29 @@ namespace System.Runtime.InteropServices.Tests
         {
             NFloat result;
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x00000000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x00000001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(NegativeOne, result);
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<int>(0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x7FFFFFFF, out result));
                 Assert.Equal((NFloat)2147483647.0, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<int>(unchecked((int)0x80000000), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(unchecked((int)0x80000000), out result));
                 Assert.Equal((NFloat)(-2147483648.0), result);
             }
             else
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<int>(0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x7FFFFFFF, out result));
                 Assert.Equal((NFloat)2147483647.0f, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<int>(unchecked((int)0x80000000), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(unchecked((int)0x80000000), out result));
                 Assert.Equal((NFloat)(-2147483648.0f), result);
             }
         }
@@ -1368,29 +1368,29 @@ namespace System.Runtime.InteropServices.Tests
         {
             NFloat result;
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
             Assert.Equal(NegativeOne, result);
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal((NFloat)9223372036854775807.0, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
                 Assert.Equal((NFloat)(-9223372036854775808.0), result);
             }
             else
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal((NFloat)9223372036854775807.0f, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
                 Assert.Equal((NFloat)(-9223372036854775808.0f), result);
             }
         }
@@ -1402,36 +1402,36 @@ namespace System.Runtime.InteropServices.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal(PositiveZero, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal(PositiveOne, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((NFloat)9223372036854775807.0, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal((NFloat)(-9223372036854775808.0), result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(NegativeOne, result);
             }
             else
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal(PositiveZero, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal(PositiveOne, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((NFloat)2147483647.0f, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal((NFloat)(-2147483648.0f), result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(NegativeOne, result);
             }
         }
@@ -1441,19 +1441,19 @@ namespace System.Runtime.InteropServices.Tests
         {
             NFloat result;
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((NFloat)127.0f, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal((NFloat)(-128.0f), result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1462,19 +1462,19 @@ namespace System.Runtime.InteropServices.Tests
         {
             NFloat result;
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((NFloat)32767.0f, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((NFloat)32768.0f, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((NFloat)65535.0f, result);
         }
 
@@ -1483,32 +1483,32 @@ namespace System.Runtime.InteropServices.Tests
         {
             NFloat result;
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal(PositiveOne, result);
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<uint>(0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x7FFFFFFF, out result));
                 Assert.Equal((NFloat)2147483647.0, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<uint>(0x80000000, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x80000000, out result));
                 Assert.Equal((NFloat)2147483648.0, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<uint>(0xFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0xFFFFFFFF, out result));
                 Assert.Equal((NFloat)4294967295.0, result);
             }
             else
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<uint>(0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x7FFFFFFF, out result));
                 Assert.Equal((NFloat)2147483647.0f, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<uint>(0x80000000, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x80000000, out result));
                 Assert.Equal((NFloat)2147483648.0f, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<uint>(0xFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0xFFFFFFFF, out result));
                 Assert.Equal((NFloat)4294967295.0f, result);
             }
         }
@@ -1518,32 +1518,32 @@ namespace System.Runtime.InteropServices.Tests
         {
             NFloat result;
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<NFloat>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal(PositiveOne, result);
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal((NFloat)9223372036854775807.0, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<ulong>(0x8000000000000000, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x8000000000000000, out result));
                 Assert.Equal((NFloat)9223372036854775808.0, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
                 Assert.Equal((NFloat)18446744073709551615.0, result);
             }
             else
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal((NFloat)9223372036854775807.0f, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<ulong>(0x8000000000000000, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x8000000000000000, out result));
                 Assert.Equal((NFloat)9223372036854775808.0f, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
                 Assert.Equal((NFloat)18446744073709551615.0f, result);
             }
         }
@@ -1555,38 +1555,38 @@ namespace System.Runtime.InteropServices.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal(PositiveZero, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal(PositiveOne, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((NFloat)9223372036854775807.0, result);
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 // Assert.Equal((NFloat)9223372036854775808.0, result);
                 //
-                // Assert.True(NumberHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 // Assert.Equal((NFloat)18446744073709551615.0, result);
             }
             else
             {
-                Assert.True(NumberHelper<NFloat>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal(PositiveZero, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal(PositiveOne, result);
 
-                Assert.True(NumberHelper<NFloat>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((NFloat)2147483647.0f, result);
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 // Assert.Equal((NFloat)2147483648.0f, result);
                 //
-                // Assert.True(NumberHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                // Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 // Assert.Equal((NFloat)4294967295.0f, result);
             }
         }

--- a/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
+++ b/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
@@ -29,8 +29,8 @@ namespace System.Numerics
         public static System.Numerics.BigInteger MinusOne { get { throw null; } }
         public static System.Numerics.BigInteger One { get { throw null; } }
         public int Sign { get { throw null; } }
-        static System.Numerics.BigInteger System.Numerics.IAdditiveIdentity<System.Numerics.BigInteger, System.Numerics.BigInteger>.AdditiveIdentity { get { throw null; } }
-        static System.Numerics.BigInteger System.Numerics.IMultiplicativeIdentity<System.Numerics.BigInteger, System.Numerics.BigInteger>.MultiplicativeIdentity { get { throw null; } }
+        static System.Numerics.BigInteger System.Numerics.IAdditiveIdentity<System.Numerics.BigInteger,System.Numerics.BigInteger>.AdditiveIdentity { get { throw null; } }
+        static System.Numerics.BigInteger System.Numerics.IMultiplicativeIdentity<System.Numerics.BigInteger,System.Numerics.BigInteger>.MultiplicativeIdentity { get { throw null; } }
         static System.Numerics.BigInteger System.Numerics.ISignedNumber<System.Numerics.BigInteger>.NegativeOne { get { throw null; } }
         public static System.Numerics.BigInteger Zero { get { throw null; } }
         public static System.Numerics.BigInteger Abs(System.Numerics.BigInteger value) { throw null; }
@@ -43,9 +43,9 @@ namespace System.Numerics
         [System.CLSCompliantAttribute(false)]
         public int CompareTo(ulong other) { throw null; }
         public static System.Numerics.BigInteger CopySign(System.Numerics.BigInteger value, System.Numerics.BigInteger sign) { throw null; }
-        public static System.Numerics.BigInteger CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static System.Numerics.BigInteger CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static System.Numerics.BigInteger CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static System.Numerics.BigInteger CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.Numerics.BigInteger CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.Numerics.BigInteger CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static System.Numerics.BigInteger Divide(System.Numerics.BigInteger dividend, System.Numerics.BigInteger divisor) { throw null; }
         public static (System.Numerics.BigInteger Quotient, System.Numerics.BigInteger Remainder) DivRem(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         public static System.Numerics.BigInteger DivRem(System.Numerics.BigInteger dividend, System.Numerics.BigInteger divisor, out System.Numerics.BigInteger remainder) { throw null; }
@@ -193,6 +193,17 @@ namespace System.Numerics
         static System.Numerics.BigInteger System.Numerics.IDivisionOperators<System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger>.operator checked /(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         static System.Numerics.BigInteger System.Numerics.IIncrementOperators<System.Numerics.BigInteger>.operator checked ++(System.Numerics.BigInteger value) { throw null; }
         static System.Numerics.BigInteger System.Numerics.IMultiplyOperators<System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger>.operator checked *(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsFinite(System.Numerics.BigInteger value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsInfinity(System.Numerics.BigInteger value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsNaN(System.Numerics.BigInteger value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsNegativeInfinity(System.Numerics.BigInteger value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsNormal(System.Numerics.BigInteger value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsPositiveInfinity(System.Numerics.BigInteger value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsSubnormal(System.Numerics.BigInteger value) { throw null; }
+        static System.Numerics.BigInteger System.Numerics.INumberBase<System.Numerics.BigInteger>.MaxMagnitudeNumber(System.Numerics.BigInteger x, System.Numerics.BigInteger y) { throw null; }
+        static System.Numerics.BigInteger System.Numerics.INumberBase<System.Numerics.BigInteger>.MinMagnitudeNumber(System.Numerics.BigInteger x, System.Numerics.BigInteger y) { throw null; }
+        static System.Numerics.BigInteger System.Numerics.INumber<System.Numerics.BigInteger>.MaxNumber(System.Numerics.BigInteger x, System.Numerics.BigInteger y) { throw null; }
+        static System.Numerics.BigInteger System.Numerics.INumber<System.Numerics.BigInteger>.MinNumber(System.Numerics.BigInteger x, System.Numerics.BigInteger y) { throw null; }
         static int System.Numerics.INumber<System.Numerics.BigInteger>.Sign(System.Numerics.BigInteger value) { throw null; }
         static System.Numerics.BigInteger System.Numerics.ISubtractionOperators<System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger>.operator checked -(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         static System.Numerics.BigInteger System.Numerics.IUnaryNegationOperators<System.Numerics.BigInteger, System.Numerics.BigInteger>.operator checked -(System.Numerics.BigInteger value) { throw null; }
@@ -203,7 +214,7 @@ namespace System.Numerics
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static System.Numerics.BigInteger TrailingZeroCount(System.Numerics.BigInteger value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out System.Numerics.BigInteger result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Numerics.BigInteger result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> value, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Numerics.BigInteger result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Numerics.BigInteger result) { throw null; }
@@ -213,7 +224,7 @@ namespace System.Numerics
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? value, out System.Numerics.BigInteger result) { throw null; }
         public bool TryWriteBytes(System.Span<byte> destination, out int bytesWritten, bool isUnsigned = false, bool isBigEndian = false) { throw null; }
     }
-    public readonly partial struct Complex : System.IEquatable<System.Numerics.Complex>, System.IFormattable, System.ISpanFormattable, System.Numerics.IAdditionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IAdditiveIdentity<System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IDecrementOperators<System.Numerics.Complex>, System.Numerics.IDivisionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IEqualityOperators<System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IIncrementOperators<System.Numerics.Complex>, System.Numerics.IMultiplicativeIdentity<System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IMultiplyOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.INumberBase<System.Numerics.Complex>, System.Numerics.ISignedNumber<System.Numerics.Complex>, System.Numerics.ISubtractionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IUnaryNegationOperators<System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IUnaryPlusOperators<System.Numerics.Complex, System.Numerics.Complex>
+    public readonly partial struct Complex : System.IEquatable<System.Numerics.Complex>, System.IFormattable, System.IParsable<System.Numerics.Complex>, System.ISpanFormattable, System.ISpanParsable<System.Numerics.Complex>, System.Numerics.IAdditionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IAdditiveIdentity<System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IDecrementOperators<System.Numerics.Complex>, System.Numerics.IDivisionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IEqualityOperators<System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IIncrementOperators<System.Numerics.Complex>, System.Numerics.IMultiplicativeIdentity<System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IMultiplyOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.INumberBase<System.Numerics.Complex>, System.Numerics.ISignedNumber<System.Numerics.Complex>, System.Numerics.ISubtractionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IUnaryNegationOperators<System.Numerics.Complex, System.Numerics.Complex>, System.Numerics.IUnaryPlusOperators<System.Numerics.Complex, System.Numerics.Complex>
     {
         private readonly int _dummyPrimitive;
         public static readonly System.Numerics.Complex ImaginaryOne;
@@ -226,8 +237,8 @@ namespace System.Numerics
         public double Magnitude { get { throw null; } }
         public double Phase { get { throw null; } }
         public double Real { get { throw null; } }
-        static System.Numerics.Complex System.Numerics.IAdditiveIdentity<System.Numerics.Complex, System.Numerics.Complex>.AdditiveIdentity { get { throw null; } }
-        static System.Numerics.Complex System.Numerics.IMultiplicativeIdentity<System.Numerics.Complex, System.Numerics.Complex>.MultiplicativeIdentity { get { throw null; } }
+        static System.Numerics.Complex System.Numerics.IAdditiveIdentity<System.Numerics.Complex,System.Numerics.Complex>.AdditiveIdentity { get { throw null; } }
+        static System.Numerics.Complex System.Numerics.IMultiplicativeIdentity<System.Numerics.Complex,System.Numerics.Complex>.MultiplicativeIdentity { get { throw null; } }
         static System.Numerics.Complex System.Numerics.INumberBase<System.Numerics.Complex>.One { get { throw null; } }
         static System.Numerics.Complex System.Numerics.INumberBase<System.Numerics.Complex>.Zero { get { throw null; } }
         static System.Numerics.Complex System.Numerics.ISignedNumber<System.Numerics.Complex>.NegativeOne { get { throw null; } }
@@ -241,6 +252,9 @@ namespace System.Numerics
         public static System.Numerics.Complex Conjugate(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex Cos(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex Cosh(System.Numerics.Complex value) { throw null; }
+        public static System.Numerics.Complex CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.Numerics.Complex CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.Numerics.Complex CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static System.Numerics.Complex Divide(double dividend, System.Numerics.Complex divisor) { throw null; }
         public static System.Numerics.Complex Divide(System.Numerics.Complex dividend, double divisor) { throw null; }
         public static System.Numerics.Complex Divide(System.Numerics.Complex dividend, System.Numerics.Complex divisor) { throw null; }
@@ -255,6 +269,8 @@ namespace System.Numerics
         public static System.Numerics.Complex Log(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex Log(System.Numerics.Complex value, double baseValue) { throw null; }
         public static System.Numerics.Complex Log10(System.Numerics.Complex value) { throw null; }
+        public static System.Numerics.Complex MaxMagnitude(System.Numerics.Complex x, System.Numerics.Complex y) { throw null; }
+        public static System.Numerics.Complex MinMagnitude(System.Numerics.Complex x, System.Numerics.Complex y) { throw null; }
         public static System.Numerics.Complex Multiply(double left, System.Numerics.Complex right) { throw null; }
         public static System.Numerics.Complex Multiply(System.Numerics.Complex left, double right) { throw null; }
         public static System.Numerics.Complex Multiply(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
@@ -293,29 +309,45 @@ namespace System.Numerics
         public static System.Numerics.Complex operator -(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         public static System.Numerics.Complex operator -(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex operator +(System.Numerics.Complex value) { throw null; }
+        public static System.Numerics.Complex Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
+        public static System.Numerics.Complex Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
+        public static System.Numerics.Complex Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
+        public static System.Numerics.Complex Parse(string s, System.IFormatProvider? provider) { throw null; }
         public static System.Numerics.Complex Pow(System.Numerics.Complex value, double power) { throw null; }
         public static System.Numerics.Complex Pow(System.Numerics.Complex value, System.Numerics.Complex power) { throw null; }
         public static System.Numerics.Complex Reciprocal(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex Sin(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex Sinh(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex Sqrt(System.Numerics.Complex value) { throw null; }
+        public static System.Numerics.Complex Subtract(double left, System.Numerics.Complex right) { throw null; }
+        public static System.Numerics.Complex Subtract(System.Numerics.Complex left, double right) { throw null; }
+        public static System.Numerics.Complex Subtract(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         static System.Numerics.Complex System.Numerics.IAdditionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>.operator checked +(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         static System.Numerics.Complex System.Numerics.IDecrementOperators<System.Numerics.Complex>.operator checked --(System.Numerics.Complex value) { throw null; }
         static System.Numerics.Complex System.Numerics.IDivisionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>.operator checked /(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         static System.Numerics.Complex System.Numerics.IIncrementOperators<System.Numerics.Complex>.operator checked ++(System.Numerics.Complex value) { throw null; }
         static System.Numerics.Complex System.Numerics.IMultiplyOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>.operator checked *(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
+        static System.Numerics.Complex System.Numerics.INumberBase<System.Numerics.Complex>.Abs(System.Numerics.Complex value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsNegative(System.Numerics.Complex value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsNegativeInfinity(System.Numerics.Complex value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsNormal(System.Numerics.Complex value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsPositiveInfinity(System.Numerics.Complex value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsSubnormal(System.Numerics.Complex value) { throw null; }
+        static System.Numerics.Complex System.Numerics.INumberBase<System.Numerics.Complex>.MaxMagnitudeNumber(System.Numerics.Complex x, System.Numerics.Complex y) { throw null; }
+        static System.Numerics.Complex System.Numerics.INumberBase<System.Numerics.Complex>.MinMagnitudeNumber(System.Numerics.Complex x, System.Numerics.Complex y) { throw null; }
         static System.Numerics.Complex System.Numerics.ISubtractionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>.operator checked -(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         static System.Numerics.Complex System.Numerics.IUnaryNegationOperators<System.Numerics.Complex, System.Numerics.Complex>.operator checked -(System.Numerics.Complex value) { throw null; }
-        public static System.Numerics.Complex Subtract(double left, System.Numerics.Complex right) { throw null; }
-        public static System.Numerics.Complex Subtract(System.Numerics.Complex left, double right) { throw null; }
-        public static System.Numerics.Complex Subtract(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
         public static System.Numerics.Complex Tan(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex Tanh(System.Numerics.Complex value) { throw null; }
-
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Numerics.Complex result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Numerics.Complex result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Numerics.Complex result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Numerics.Complex result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Numerics.Complex result) { throw null; }
     }
 }

--- a/src/libraries/System.Runtime.Numerics/src/Resources/Strings.resx
+++ b/src/libraries/System.Runtime.Numerics/src/Resources/Strings.resx
@@ -57,6 +57,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Arg_HexStyleNotSupported" xml:space="preserve">
+    <value>The number style AllowHexSpecifier is not supported on floating point data types.</value>
+  </data>
   <data name="Argument_BadFormatSpecifier" xml:space="preserve">
     <value>Format specifier was invalid.</value>
   </data>

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -3862,10 +3862,33 @@ namespace System.Numerics
             return (currentSign == targetSign) ? value : -value;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
+        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
+        static BigInteger INumber<BigInteger>.MaxNumber(BigInteger x, BigInteger y) => Max(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
+        static BigInteger INumber<BigInteger>.MinNumber(BigInteger x, BigInteger y) => Min(x, y);
+
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        static int INumber<BigInteger>.Sign(BigInteger value)
+        {
+            value.AssertValid();
+
+            if (value._bits is null)
+            {
+                return int.Sign(value._sign);
+            }
+
+            return value._sign;
+        }
+
+        //
+        // INumberBase
+        //
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static BigInteger CreateChecked<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -3934,10 +3957,10 @@ namespace System.Numerics
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static BigInteger CreateSaturating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -4006,10 +4029,10 @@ namespace System.Numerics
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static BigInteger CreateTruncating<TOther>(TOther value)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -4078,48 +4101,88 @@ namespace System.Numerics
             }
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
+        static bool INumberBase<BigInteger>.IsFinite(BigInteger value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
+        static bool INumberBase<BigInteger>.IsInfinity(BigInteger value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
+        static bool INumberBase<BigInteger>.IsNaN(BigInteger value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
         public static bool IsNegative(BigInteger value)
         {
             value.AssertValid();
             return value._sign < 0;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<BigInteger>.IsNegativeInfinity(BigInteger value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<BigInteger>.IsNormal(BigInteger value) => (value != 0);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<BigInteger>.IsPositiveInfinity(BigInteger value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<BigInteger>.IsSubnormal(BigInteger value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static BigInteger MaxMagnitude(BigInteger x, BigInteger y)
         {
             x.AssertValid();
             y.AssertValid();
 
-            return (Abs(x) >= Abs(y)) ? x : y;
+            BigInteger ax = Abs(x);
+            BigInteger ay = Abs(y);
+
+            if (ax > ay)
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static BigInteger INumberBase<BigInteger>.MaxMagnitudeNumber(BigInteger x, BigInteger y) => MaxMagnitude(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
         public static BigInteger MinMagnitude(BigInteger x, BigInteger y)
         {
             x.AssertValid();
             y.AssertValid();
 
-            return (Abs(x) <= Abs(y)) ? x : y;
-        }
+            BigInteger ax = Abs(x);
+            BigInteger ay = Abs(y);
 
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        static int INumber<BigInteger>.Sign(BigInteger value)
-        {
-            value.AssertValid();
-
-            if (value._bits is null)
+            if (ax < ay)
             {
-                return int.Sign(value._sign);
+                return x;
             }
 
-            return value._sign;
+            if (ax == ay)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
         }
 
-        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static BigInteger INumberBase<BigInteger>.MinMagnitudeNumber(BigInteger x, BigInteger y) => MinMagnitude(x, y);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCreate<TOther>(TOther value, out BigInteger result)
-            where TOther : INumber<TOther>
+            where TOther : INumberBase<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -20,6 +20,14 @@ namespace System.Numerics
           INumberBase<Complex>,
           ISignedNumber<Complex>
     {
+        private const NumberStyles DefaultNumberStyle = NumberStyles.Float | NumberStyles.AllowThousands;
+
+        private const NumberStyles InvalidNumberStyles = ~(NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite
+                                                         | NumberStyles.AllowLeadingSign | NumberStyles.AllowTrailingSign
+                                                         | NumberStyles.AllowParentheses | NumberStyles.AllowDecimalPoint
+                                                         | NumberStyles.AllowThousands | NumberStyles.AllowExponent
+                                                         | NumberStyles.AllowCurrencySymbol | NumberStyles.AllowHexSpecifier);
+
         public static readonly Complex Zero = new Complex(0.0, 0.0);
         public static readonly Complex One = new Complex(1.0, 0.0);
         public static readonly Complex ImaginaryOne = new Complex(0.0, 1.0);
@@ -392,7 +400,7 @@ namespace System.Numerics
             return finalHash;
         }
 
-        public override string ToString() => $"({m_real}, {m_imaginary})";
+        public override string ToString() => $"<{m_real}; {m_imaginary}>";
 
         public string ToString([StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format) => ToString(format, null);
 
@@ -400,7 +408,7 @@ namespace System.Numerics
 
         public string ToString([StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format, IFormatProvider? provider)
         {
-            return string.Format(provider, "({0}, {1})", m_real.ToString(format, provider), m_imaginary.ToString(format, provider));
+            return string.Format(provider, "<{0}; {1}>", m_real.ToString(format, provider), m_imaginary.ToString(format, provider));
         }
 
         public static Complex Sin(Complex value)
@@ -920,6 +928,813 @@ namespace System.Numerics
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static Complex INumberBase<Complex>.Zero => new Complex(0.0, 0.0);
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Abs(TSelf)" />
+        static Complex INumberBase<Complex>.Abs(Complex value) => Abs(value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Complex CreateChecked<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            if (typeof(TOther) == typeof(byte))
+            {
+                return (byte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(char))
+            {
+                return (char)(object)value;
+            }
+            else if (typeof(TOther) == typeof(decimal))
+            {
+                return (Complex)(decimal)(object)value;
+            }
+            else if (typeof(TOther) == typeof(double))
+            {
+                return (double)(object)value;
+            }
+            else if (typeof(TOther) == typeof(short))
+            {
+                return (short)(object)value;
+            }
+            else if (typeof(TOther) == typeof(int))
+            {
+                return (int)(object)value;
+            }
+            else if (typeof(TOther) == typeof(long))
+            {
+                return (long)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nint))
+            {
+                return (nint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(sbyte))
+            {
+                return (sbyte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(float))
+            {
+                return (float)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ushort))
+            {
+                return (ushort)(object)value;
+            }
+            else if (typeof(TOther) == typeof(uint))
+            {
+                return (uint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ulong))
+            {
+                return (ulong)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nuint))
+            {
+                return (nuint)(object)value;
+            }
+            else
+            {
+                ThrowHelper.ThrowNotSupportedException();
+                return default;
+            }
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateSaturating{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Complex CreateSaturating<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            if (typeof(TOther) == typeof(byte))
+            {
+                return (byte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(char))
+            {
+                return (char)(object)value;
+            }
+            else if (typeof(TOther) == typeof(decimal))
+            {
+                return (Complex)(decimal)(object)value;
+            }
+            else if (typeof(TOther) == typeof(double))
+            {
+                return (double)(object)value;
+            }
+            else if (typeof(TOther) == typeof(short))
+            {
+                return (short)(object)value;
+            }
+            else if (typeof(TOther) == typeof(int))
+            {
+                return (int)(object)value;
+            }
+            else if (typeof(TOther) == typeof(long))
+            {
+                return (long)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nint))
+            {
+                return (nint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(sbyte))
+            {
+                return (sbyte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(float))
+            {
+                return (float)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ushort))
+            {
+                return (ushort)(object)value;
+            }
+            else if (typeof(TOther) == typeof(uint))
+            {
+                return (uint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ulong))
+            {
+                return (ulong)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nuint))
+            {
+                return (nuint)(object)value;
+            }
+            else
+            {
+                ThrowHelper.ThrowNotSupportedException();
+                return default;
+            }
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.CreateTruncating{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Complex CreateTruncating<TOther>(TOther value)
+            where TOther : INumberBase<TOther>
+        {
+            if (typeof(TOther) == typeof(byte))
+            {
+                return (byte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(char))
+            {
+                return (char)(object)value;
+            }
+            else if (typeof(TOther) == typeof(decimal))
+            {
+                return (Complex)(decimal)(object)value;
+            }
+            else if (typeof(TOther) == typeof(double))
+            {
+                return (double)(object)value;
+            }
+            else if (typeof(TOther) == typeof(short))
+            {
+                return (short)(object)value;
+            }
+            else if (typeof(TOther) == typeof(int))
+            {
+                return (int)(object)value;
+            }
+            else if (typeof(TOther) == typeof(long))
+            {
+                return (long)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nint))
+            {
+                return (nint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(sbyte))
+            {
+                return (sbyte)(object)value;
+            }
+            else if (typeof(TOther) == typeof(float))
+            {
+                return (float)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ushort))
+            {
+                return (ushort)(object)value;
+            }
+            else if (typeof(TOther) == typeof(uint))
+            {
+                return (uint)(object)value;
+            }
+            else if (typeof(TOther) == typeof(ulong))
+            {
+                return (ulong)(object)value;
+            }
+            else if (typeof(TOther) == typeof(nuint))
+            {
+                return (nuint)(object)value;
+            }
+            else
+            {
+                ThrowHelper.ThrowNotSupportedException();
+                return default;
+            }
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
+        static bool INumberBase<Complex>.IsNegative(Complex value)
+        {
+            // since complex numbers do not have a well-defined concept of
+            // negative we report false if this value has an imaginary part
+
+            return (value.m_imaginary == 0.0) && double.IsNegative(value.m_real);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
+        static bool INumberBase<Complex>.IsNegativeInfinity(Complex value)
+        {
+            // since complex numbers do not have a well-defined concept of
+            // negative we report false if this value has an imaginary part
+
+            return (value.m_imaginary == 0.0) && double.IsNegativeInfinity(value.m_real);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
+        static bool INumberBase<Complex>.IsNormal(Complex value)
+        {
+            // much as IsFinite requires both part to be finite, we require both
+            // part to be "normal" (finite, non-zero, and non-subnormal) to be true
+
+            return double.IsNormal(value.m_real) && double.IsNormal(value.m_imaginary);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
+        static bool INumberBase<Complex>.IsPositiveInfinity(Complex value)
+        {
+            // since complex numbers do not have a well-defined concept of
+            // positive we report false if this value has an imaginary part
+
+            return (value.m_imaginary == 0.0) && double.IsPositiveInfinity(value.m_real);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
+        static bool INumberBase<Complex>.IsSubnormal(Complex value)
+        {
+            // much as IsInfinite allows either part to be infinite, we allow either
+            // part to be "subnormal" (finite, non-zero, and non-normal) to be true
+
+            return double.IsSubnormal(value.m_real) || double.IsSubnormal(value.m_imaginary);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        public static Complex MaxMagnitude(Complex x, Complex y)
+        {
+            // complex numbers are not normally comparable, however every complex
+            // number has a real magnitude (absolute value) and so we can provide
+            // an implementation for MaxMagnitude
+
+            // This matches the IEEE 754:2019 `maximumMagnitude` function
+            //
+            // It propagates NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            double ax = Abs(x);
+            double ay = Abs(y);
+
+            if ((ax > ay) || double.IsNaN(ax))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                // We have two equal magnitudes which means we have two of the following
+                //   `+a + ib`
+                //   `-a + ib`
+                //   `+a - ib`
+                //   `-a - ib`
+                //
+                // We want to treat `+a + ib` as greater than everything and `-a - ib` as
+                // lesser. For `-a + ib` and `+a - ib` its "ambiguous" which should be preferred
+                // so we will just preference `+a - ib` since that's the most correct choice
+                // in the face of something like `+a - i0.0` vs `-a + i0.0`. This is the "most
+                // correct" choice because both represent real numbers and `+a` is preferred
+                // over `-a`.
+
+                if (double.IsNegative(y.m_real))
+                {
+                    if (double.IsNegative(y.m_imaginary))
+                    {
+                        // when `y` is `-a - ib` we always prefer `x` (its either the same as
+                        // `x` or some part of `x` is positive).
+
+                        return x;
+                    }
+                    else
+                    {
+                        if (double.IsNegative(x.m_real))
+                        {
+                            // when `y` is `-a + ib` and `x` is `-a + ib` or `-a - ib` then
+                            // we either have same value or both parts of `x` are negative
+                            // and we want to prefer `y`.
+
+                            return y;
+                        }
+                        else
+                        {
+                            // when `y` is `-a + ib` and `x` is `+a + ib` or `+a - ib` then
+                            // we want to prefer `x` because either both parts are positive
+                            // or we want to prefer `+a - ib` due to how it handles when `x`
+                            // represents a real number.
+
+                            return x;
+                        }
+                    }
+                }
+                else if (double.IsNegative(y.m_imaginary))
+                {
+                    if (double.IsNegative(x.m_real))
+                    {
+                        // when `y` is `+a - ib` and `x` is `-a + ib` or `-a - ib` then
+                        // we either both parts of `x` are negative or we want to prefer
+                        // `+a - ib` due to how it handles when `y` represents a real number.
+
+                        return y;
+                    }
+                    else
+                    {
+                        // when `y` is `+a - ib` and `x` is `+a + ib` or `+a - ib` then
+                        // we want to prefer `x` because either both parts are positive
+                        // or they represent the same value.
+
+                        return x;
+                    }
+                }
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        static Complex INumberBase<Complex>.MaxMagnitudeNumber(Complex x, Complex y)
+        {
+            // complex numbers are not normally comparable, however every complex
+            // number has a real magnitude (absolute value) and so we can provide
+            // an implementation for MaxMagnitudeNumber
+
+            // This matches the IEEE 754:2019 `maximumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            double ax = Abs(x);
+            double ay = Abs(y);
+
+            if ((ax > ay) || double.IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                // We have two equal magnitudes which means we have two of the following
+                //   `+a + ib`
+                //   `-a + ib`
+                //   `+a - ib`
+                //   `-a - ib`
+                //
+                // We want to treat `+a + ib` as greater than everything and `-a - ib` as
+                // lesser. For `-a + ib` and `+a - ib` its "ambiguous" which should be preferred
+                // so we will just preference `+a - ib` since that's the most correct choice
+                // in the face of something like `+a - i0.0` vs `-a + i0.0`. This is the "most
+                // correct" choice because both represent real numbers and `+a` is preferred
+                // over `-a`.
+
+                if (double.IsNegative(y.m_real))
+                {
+                    if (double.IsNegative(y.m_imaginary))
+                    {
+                        // when `y` is `-a - ib` we always prefer `x` (its either the same as
+                        // `x` or some part of `x` is positive).
+
+                        return x;
+                    }
+                    else
+                    {
+                        if (double.IsNegative(x.m_real))
+                        {
+                            // when `y` is `-a + ib` and `x` is `-a + ib` or `-a - ib` then
+                            // we either have same value or both parts of `x` are negative
+                            // and we want to prefer `y`.
+
+                            return y;
+                        }
+                        else
+                        {
+                            // when `y` is `-a + ib` and `x` is `+a + ib` or `+a - ib` then
+                            // we want to prefer `x` because either both parts are positive
+                            // or we want to prefer `+a - ib` due to how it handles when `x`
+                            // represents a real number.
+
+                            return x;
+                        }
+                    }
+                }
+                else if (double.IsNegative(y.m_imaginary))
+                {
+                    if (double.IsNegative(x.m_real))
+                    {
+                        // when `y` is `+a - ib` and `x` is `-a + ib` or `-a - ib` then
+                        // we either both parts of `x` are negative or we want to prefer
+                        // `+a - ib` due to how it handles when `y` represents a real number.
+
+                        return y;
+                    }
+                    else
+                    {
+                        // when `y` is `+a - ib` and `x` is `+a + ib` or `+a - ib` then
+                        // we want to prefer `x` because either both parts are positive
+                        // or they represent the same value.
+
+                        return x;
+                    }
+                }
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        public static Complex MinMagnitude(Complex x, Complex y)
+        {
+            // complex numbers are not normally comparable, however every complex
+            // number has a real magnitude (absolute value) and so we can provide
+            // an implementation for MaxMagnitude
+
+            // This matches the IEEE 754:2019 `minimumMagnitude` function
+            //
+            // It propagates NaN inputs back to the caller and
+            // otherwise returns the input with a smaller magnitude.
+            // It treats -0 as smaller than +0 as per the specification.
+
+            double ax = Abs(x);
+            double ay = Abs(y);
+
+            if ((ax < ay) || double.IsNaN(ax))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                // We have two equal magnitudes which means we have two of the following
+                //   `+a + ib`
+                //   `-a + ib`
+                //   `+a - ib`
+                //   `-a - ib`
+                //
+                // We want to treat `+a + ib` as greater than everything and `-a - ib` as
+                // lesser. For `-a + ib` and `+a - ib` its "ambiguous" which should be preferred
+                // so we will just preference `-a + ib` since that's the most correct choice
+                // in the face of something like `+a - i0.0` vs `-a + i0.0`. This is the "most
+                // correct" choice because both represent real numbers and `-a` is preferred
+                // over `+a`.
+
+                if (double.IsNegative(y.m_real))
+                {
+                    if (double.IsNegative(y.m_imaginary))
+                    {
+                        // when `y` is `-a - ib` we always prefer `y` as both parts are negative
+                        return y;
+                    }
+                    else
+                    {
+                        if (double.IsNegative(x.m_real))
+                        {
+                            // when `y` is `-a + ib` and `x` is `-a + ib` or `-a - ib` then
+                            // we either have same value or both parts of `x` are negative
+                            // and we want to prefer it.
+
+                            return x;
+                        }
+                        else
+                        {
+                            // when `y` is `-a + ib` and `x` is `+a + ib` or `+a - ib` then
+                            // we want to prefer `y` because either both parts of 'x' are positive
+                            // or we want to prefer `-a - ib` due to how it handles when `y`
+                            // represents a real number.
+
+                            return y;
+                        }
+                    }
+                }
+                else if (double.IsNegative(y.m_imaginary))
+                {
+                    if (double.IsNegative(x.m_real))
+                    {
+                        // when `y` is `+a - ib` and `x` is `-a + ib` or `-a - ib` then
+                        // either both parts of `x` are negative or we want to prefer
+                        // `-a - ib` due to how it handles when `x` represents a real number.
+
+                        return x;
+                    }
+                    else
+                    {
+                        // when `y` is `+a - ib` and `x` is `+a + ib` or `+a - ib` then
+                        // we want to prefer `y` because either both parts of x are positive
+                        // or they represent the same value.
+
+                        return y;
+                    }
+                }
+            }
+
+            return x;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        static Complex INumberBase<Complex>.MinMagnitudeNumber(Complex x, Complex y)
+        {
+            // complex numbers are not normally comparable, however every complex
+            // number has a real magnitude (absolute value) and so we can provide
+            // an implementation for MinMagnitudeNumber
+
+            // This matches the IEEE 754:2019 `minimumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a smaller magnitude.
+            // It treats -0 as smaller than +0 as per the specification.
+
+            double ax = Abs(x);
+            double ay = Abs(y);
+
+            if ((ax < ay) || double.IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                // We have two equal magnitudes which means we have two of the following
+                //   `+a + ib`
+                //   `-a + ib`
+                //   `+a - ib`
+                //   `-a - ib`
+                //
+                // We want to treat `+a + ib` as greater than everything and `-a - ib` as
+                // lesser. For `-a + ib` and `+a - ib` its "ambiguous" which should be preferred
+                // so we will just preference `-a + ib` since that's the most correct choice
+                // in the face of something like `+a - i0.0` vs `-a + i0.0`. This is the "most
+                // correct" choice because both represent real numbers and `-a` is preferred
+                // over `+a`.
+
+                if (double.IsNegative(y.m_real))
+                {
+                    if (double.IsNegative(y.m_imaginary))
+                    {
+                        // when `y` is `-a - ib` we always prefer `y` as both parts are negative
+                        return y;
+                    }
+                    else
+                    {
+                        if (double.IsNegative(x.m_real))
+                        {
+                            // when `y` is `-a + ib` and `x` is `-a + ib` or `-a - ib` then
+                            // we either have same value or both parts of `x` are negative
+                            // and we want to prefer it.
+
+                            return x;
+                        }
+                        else
+                        {
+                            // when `y` is `-a + ib` and `x` is `+a + ib` or `+a - ib` then
+                            // we want to prefer `y` because either both parts of 'x' are positive
+                            // or we want to prefer `-a - ib` due to how it handles when `y`
+                            // represents a real number.
+
+                            return y;
+                        }
+                    }
+                }
+                else if (double.IsNegative(y.m_imaginary))
+                {
+                    if (double.IsNegative(x.m_real))
+                    {
+                        // when `y` is `+a - ib` and `x` is `-a + ib` or `-a - ib` then
+                        // either both parts of `x` are negative or we want to prefer
+                        // `-a - ib` due to how it handles when `x` represents a real number.
+
+                        return x;
+                    }
+                    else
+                    {
+                        // when `y` is `+a - ib` and `x` is `+a + ib` or `+a - ib` then
+                        // we want to prefer `y` because either both parts of x are positive
+                        // or they represent the same value.
+
+                        return y;
+                    }
+                }
+            }
+
+            return x;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Parse(ReadOnlySpan{char}, NumberStyles, IFormatProvider?)" />
+        public static Complex Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
+        {
+            if (!TryParse(s, style, provider, out Complex result))
+            {
+                ThrowHelper.ThrowOverflowException();
+            }
+            return result;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.Parse(string, NumberStyles, IFormatProvider?)" />
+        public static Complex Parse(string s, NumberStyles style, IFormatProvider? provider)
+        {
+            ArgumentNullException.ThrowIfNull(s);
+            return Parse(s.AsSpan(), style, provider);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryCreate<TOther>(TOther value, out Complex result)
+            where TOther : INumberBase<TOther>
+        {
+            if (typeof(TOther) == typeof(byte))
+            {
+                result = (byte)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(char))
+            {
+                result = (char)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(decimal))
+            {
+                result = (Complex)(decimal)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(double))
+            {
+                result = (double)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(short))
+            {
+                result = (short)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(int))
+            {
+                result = (int)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(long))
+            {
+                result = (long)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(nint))
+            {
+                result = (nint)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(sbyte))
+            {
+                result = (sbyte)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(float))
+            {
+                result = (float)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(ushort))
+            {
+                result = (ushort)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(uint))
+            {
+                result = (uint)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(ulong))
+            {
+                result = (ulong)(object)value;
+                return true;
+            }
+            else if (typeof(TOther) == typeof(nuint))
+            {
+                result = (nuint)(object)value;
+                return true;
+            }
+            else
+            {
+                ThrowHelper.ThrowNotSupportedException();
+                result = default;
+                return false;
+            }
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryParse(ReadOnlySpan{char}, NumberStyles, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out Complex result)
+        {
+            ValidateParseStyleFloatingPoint(style);
+
+            int openBracket = s.IndexOf('<');
+            int semicolon = s.IndexOf(';');
+            int closeBracket = s.IndexOf('>');
+
+            if ((s.Length < 5) || (openBracket == -1) || (semicolon == -1) || (closeBracket == -1) || (openBracket > semicolon) || (openBracket > closeBracket) || (semicolon > closeBracket))
+            {
+                // We need at least 5 characters for `<0;0>`
+                // We also expect a to find an open bracket, a semicolon, and a closing bracket in that order
+
+                result = default;
+                return false;
+            }
+
+            if ((openBracket != 0) && (((style & NumberStyles.AllowLeadingWhite) == 0) || !s.Slice(0, openBracket).IsWhiteSpace()))
+            {
+                // The opening bracket wasn't the first and we either didn't allow leading whitespace
+                // or one of the leading characters wasn't whitespace at all.
+
+                result = default;
+                return false;
+            }
+
+            if (!double.TryParse(s.Slice(openBracket + 1, semicolon), style, provider, out double real))
+            {
+                result = default;
+                return false;
+            }
+
+            if (char.IsWhiteSpace(s[semicolon + 1]))
+            {
+                // We allow a single whitespace after the semicolon regardless of style, this is so that
+                // the output of `ToString` can be correctly parsed by default and values will roundtrip.
+                semicolon += 1;
+            }
+
+            if (!double.TryParse(s.Slice(semicolon + 1, closeBracket - semicolon), style, provider, out double imaginary))
+            {
+                result = default;
+                return false;
+            }
+
+            if ((closeBracket != (s.Length - 1)) && (((style & NumberStyles.AllowTrailingWhite) == 0) || !s.Slice(closeBracket).IsWhiteSpace()))
+            {
+                // The closing bracket wasn't the last and we either didn't allow trailing whitespace
+                // or one of the trailing characters wasn't whitespace at all.
+
+                result = default;
+                return false;
+            }
+
+            result = new Complex(real, imaginary);
+            return true;
+
+            static void ValidateParseStyleFloatingPoint(NumberStyles style)
+            {
+                // Check for undefined flags or hex number
+                if ((style & (InvalidNumberStyles | NumberStyles.AllowHexSpecifier)) != 0)
+                {
+                    ThrowInvalid(style);
+
+                    static void ThrowInvalid(NumberStyles value)
+                    {
+                        if ((value & InvalidNumberStyles) != 0)
+                        {
+                            throw new ArgumentException(SR.Argument_InvalidNumberStyles, nameof(style));
+                        }
+
+                        throw new ArgumentException(SR.Arg_HexStyleNotSupported);
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.TryParse(string, NumberStyles, IFormatProvider?, out TSelf)" />
+        public static bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out Complex result)
+        {
+            if (s is null)
+            {
+                result = default;
+                return false;
+            }
+            return TryParse(s.AsSpan(), style, provider, out result);
+        }
+
+        //
+        // IParsable
+        //
+
+        /// <inheritdoc cref="IParsable{TSelf}.Parse(string, IFormatProvider?)" />
+        public static Complex Parse(string s, IFormatProvider? provider) => Parse(s, DefaultNumberStyle, provider);
+
+        /// <inheritdoc cref="IParsable{TSelf}.TryParse(string?, IFormatProvider?, out TSelf)" />
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out Complex result) => TryParse(s, DefaultNumberStyle, provider, out result);
+
         //
         // ISignedNumber
         //
@@ -936,43 +1751,53 @@ namespace System.Numerics
         {
             int charsWrittenSoFar = 0;
 
-            // We have at least 6 more characters for: (0, 0)
+            // We have at least 6 more characters for: <0; 0>
             if (destination.Length < 6)
             {
                 charsWritten = charsWrittenSoFar;
                 return false;
             }
 
-            destination[charsWrittenSoFar++] = '(';
+            destination[charsWrittenSoFar++] = '<';
 
             bool tryFormatSucceeded = m_real.TryFormat(destination.Slice(charsWrittenSoFar), out int tryFormatCharsWritten, format, provider);
             charsWrittenSoFar += tryFormatCharsWritten;
 
-            // We have at least 4 more characters for: , 0)
+            // We have at least 4 more characters for: ; 0>
             if (!tryFormatSucceeded || (destination.Length < (charsWrittenSoFar + 4)))
             {
                 charsWritten = charsWrittenSoFar;
                 return false;
             }
 
-            destination[charsWrittenSoFar++] = ',';
+            destination[charsWrittenSoFar++] = ';';
             destination[charsWrittenSoFar++] = ' ';
 
             tryFormatSucceeded = m_imaginary.TryFormat(destination.Slice(charsWrittenSoFar), out tryFormatCharsWritten, format, provider);
             charsWrittenSoFar += tryFormatCharsWritten;
 
-            // We have at least 1 more character for: )
+            // We have at least 1 more character for: >
             if (!tryFormatSucceeded || (destination.Length < (charsWrittenSoFar + 1)))
             {
                 charsWritten = charsWrittenSoFar;
                 return false;
             }
 
-            destination[charsWrittenSoFar++] = ')';
+            destination[charsWrittenSoFar++] = '>';
 
             charsWritten = charsWrittenSoFar;
             return true;
         }
+
+        //
+        // ISpanParsable
+        //
+
+        /// <inheritdoc cref="ISpanParsable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static Complex Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, DefaultNumberStyle, provider);
+
+        /// <inheritdoc cref="ISpanParsable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Complex result) => TryParse(s, DefaultNumberStyle, provider, out result);
 
         //
         // ISubtractionOperators

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -1159,7 +1159,8 @@ namespace System.Numerics
             // much as IsFinite requires both part to be finite, we require both
             // part to be "normal" (finite, non-zero, and non-subnormal) to be true
 
-            return double.IsNormal(value.m_real) && double.IsNormal(value.m_imaginary);
+            return double.IsNormal(value.m_real)
+                && ((value.m_imaginary == 0.0) || double.IsNormal(value.m_imaginary));
         }
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
@@ -1443,9 +1444,13 @@ namespace System.Numerics
                         return y;
                     }
                 }
+                else
+                {
+                    return x;
+                }
             }
 
-            return x;
+            return y;
         }
 
         /// <inheritdoc cref="INumberBase{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
@@ -1531,9 +1536,13 @@ namespace System.Numerics
                         return y;
                     }
                 }
+                else
+                {
+                    return x;
+                }
             }
 
-            return x;
+            return y;
         }
 
         /// <inheritdoc cref="INumberBase{TSelf}.Parse(ReadOnlySpan{char}, NumberStyles, IFormatProvider?)" />

--- a/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
@@ -145,35 +145,9 @@ namespace System.Numerics.Tests
 
         internal static readonly BigInteger Zero = new BigInteger(0);
 
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal(Zero, AdditiveIdentityHelper<BigInteger, BigInteger>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal(One, MultiplicativeIdentityHelper<BigInteger, BigInteger>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            Assert.Equal(NegativeOne, SignedNumberHelper<BigInteger>.NegativeOne);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal(One, NumberBaseHelper<BigInteger>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -201,6 +175,34 @@ namespace System.Numerics.Tests
 
             Assert.Equal(Int64MaxValuePlusTwo, AdditionOperatorsHelper<BigInteger, BigInteger, BigInteger>.op_CheckedAddition(Int64MaxValuePlusOne, 1));
             Assert.Equal(TwoPow64, AdditionOperatorsHelper<BigInteger, BigInteger, BigInteger>.op_CheckedAddition(UInt64MaxValue, 1));
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal(Zero, AdditiveIdentityHelper<BigInteger, BigInteger>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            Assert.Equal((Zero, Zero), BinaryIntegerHelper<BigInteger>.DivRem(Zero, 2));
+            Assert.Equal((Zero, One), BinaryIntegerHelper<BigInteger>.DivRem(One, 2));
+            Assert.Equal(((BigInteger)0x3FFFFFFFFFFFFFFF, One), BinaryIntegerHelper<BigInteger>.DivRem(Int64MaxValue, 2));
+
+            Assert.Equal((unchecked((BigInteger)(long)0xC000000000000000), Zero), BinaryIntegerHelper<BigInteger>.DivRem(Int64MinValue, 2));
+            Assert.Equal((Zero, NegativeOne), BinaryIntegerHelper<BigInteger>.DivRem(NegativeOne, 2));
+
+            Assert.Equal((unchecked((BigInteger)0x4000000000000000), Zero), BinaryIntegerHelper<BigInteger>.DivRem(Int64MaxValuePlusOne, 2));
+            Assert.Equal((Int64MaxValue, One), BinaryIntegerHelper<BigInteger>.DivRem(UInt64MaxValue, 2));
         }
 
         [Fact]
@@ -366,6 +368,28 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            Assert.Equal(4, BinaryIntegerHelper<BigInteger>.GetByteCount(Zero));
+            Assert.Equal(4, BinaryIntegerHelper<BigInteger>.GetByteCount(One));
+            Assert.Equal(8, BinaryIntegerHelper<BigInteger>.GetByteCount(Int64MaxValue));
+
+            Assert.Equal(8, BinaryIntegerHelper<BigInteger>.GetByteCount(Int64MinValue));
+            Assert.Equal(4, BinaryIntegerHelper<BigInteger>.GetByteCount(NegativeOne));
+
+            Assert.Equal(8, BinaryIntegerHelper<BigInteger>.GetByteCount(Int64MaxValuePlusOne));
+            Assert.Equal(8, BinaryIntegerHelper<BigInteger>.GetByteCount(UInt64MaxValue));
+
+            Assert.Equal(16, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MaxValue));
+            Assert.Equal(16, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MinValue));
+            Assert.Equal(20, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MinValueMinusOne));
+            Assert.Equal(16, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MinValuePlusOne));
+            Assert.Equal(20, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MinValueTimesTwo));
+            Assert.Equal(16, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MaxValuePlusOne));
+            Assert.Equal(16, BinaryIntegerHelper<BigInteger>.GetByteCount(UInt128MaxValue));
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             Assert.Equal(0x00, BinaryIntegerHelper<BigInteger>.GetShortestBitLength(Zero));
@@ -386,6 +410,144 @@ namespace System.Numerics.Tests
             Assert.Equal(0x80, BinaryIntegerHelper<BigInteger>.GetShortestBitLength(Int128MaxValuePlusOne));
             Assert.Equal(0x80, BinaryIntegerHelper<BigInteger>.GetShortestBitLength(UInt128MaxValue));
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[20];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Zero, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 4).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(One, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.Slice(0, 4).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int64MaxValue, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 8).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int64MinValue, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 8).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(NegativeOne, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 4).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int64MaxValuePlusOne, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 8).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(UInt64MaxValue, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 8).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MaxValue, destination, out bytesWritten));
+            Assert.Equal(16, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 16).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MinValue, destination, out bytesWritten));
+            Assert.Equal(16, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 16).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MinValueMinusOne, destination, out bytesWritten));
+            Assert.Equal(20, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 20).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MinValuePlusOne, destination, out bytesWritten));
+            Assert.Equal(16, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.Slice(0, 16).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MinValueTimesTwo, destination, out bytesWritten));
+            Assert.Equal(20, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 20).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MaxValuePlusOne, destination, out bytesWritten));
+            Assert.Equal(16, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 16).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(UInt128MaxValue, destination, out bytesWritten));
+            Assert.Equal(16, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 16).ToArray());
+
+            Assert.False(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[20];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Zero, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 4).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(One, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.Slice(0, 4).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int64MaxValue, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.Slice(0, 8).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int64MinValue, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.Slice(0, 8).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(NegativeOne, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 4).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int64MaxValuePlusOne, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.Slice(0, 8).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(UInt64MaxValue, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 8).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MaxValue, destination, out bytesWritten));
+            Assert.Equal(16, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.Slice(0, 16).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MinValue, destination, out bytesWritten));
+            Assert.Equal(16, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.Slice(0, 16).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MinValueMinusOne, destination, out bytesWritten));
+            Assert.Equal(20, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 20).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MinValuePlusOne, destination, out bytesWritten));
+            Assert.Equal(16, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.Slice(0, 16).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MinValueTimesTwo, destination, out bytesWritten));
+            Assert.Equal(20, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 20).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MaxValuePlusOne, destination, out bytesWritten));
+            Assert.Equal(16, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.Slice(0, 16).ToArray());
+
+            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(UInt128MaxValue, destination, out bytesWritten));
+            Assert.Equal(16, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 16).ToArray());
+
+            Assert.False(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -414,6 +576,10 @@ namespace System.Numerics.Tests
             Assert.Equal((BigInteger)63, BinaryNumberHelper<BigInteger>.Log2(Int64MaxValuePlusOne));
             Assert.Equal((BigInteger)63, BinaryNumberHelper<BigInteger>.Log2(UInt64MaxValue));
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -472,33 +638,9 @@ namespace System.Numerics.Tests
             Assert.Equal(NegativeTwoPow64, BitwiseOperatorsHelper<BigInteger, BigInteger, BigInteger>.op_OnesComplement(UInt64MaxValue));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(Zero, 1));
-            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(One, 1));
-            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(Int64MaxValue, 1));
-
-            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(Int64MinValue, 1));
-            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(NegativeOne, 1));
-
-            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(Int64MaxValuePlusOne, 1));
-            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(UInt64MaxValue, 1));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(Zero, 1));
-            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(One, 1));
-            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(Int64MaxValue, 1));
-
-            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(Int64MinValue, 1));
-            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(NegativeOne, 1));
-
-            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(Int64MaxValuePlusOne, 1));
-            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(UInt64MaxValue, 1));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -527,6 +669,38 @@ namespace System.Numerics.Tests
             Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_GreaterThanOrEqual(Int64MaxValuePlusOne, 1));
             Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_GreaterThanOrEqual(UInt64MaxValue, 1));
         }
+
+        [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(Zero, 1));
+            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(One, 1));
+            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(Int64MaxValue, 1));
+
+            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(Int64MinValue, 1));
+            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(NegativeOne, 1));
+
+            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(Int64MaxValuePlusOne, 1));
+            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThan(UInt64MaxValue, 1));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(Zero, 1));
+            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(One, 1));
+            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(Int64MaxValue, 1));
+
+            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(Int64MinValue, 1));
+            Assert.True(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(NegativeOne, 1));
+
+            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(Int64MaxValuePlusOne, 1));
+            Assert.False(ComparisonOperatorsHelper<BigInteger, BigInteger>.op_LessThanOrEqual(UInt64MaxValue, 1));
+        }
+
+        //
+        // IDecrementOperators
+        //
 
         [Fact]
         public static void op_DecrementTest()
@@ -560,6 +734,10 @@ namespace System.Numerics.Tests
             Assert.Equal(UInt64MaxValueMinusOne, DecrementOperatorsHelper<BigInteger>.op_CheckedDecrement(UInt64MaxValue));
         }
 
+        //
+        // IDivisionOperators
+        //
+
         [Fact]
         public static void op_DivisionTest()
         {
@@ -592,6 +770,10 @@ namespace System.Numerics.Tests
             Assert.Throws<DivideByZeroException>(() => DivisionOperatorsHelper<BigInteger, BigInteger, BigInteger>.op_CheckedDivision(One, 0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -619,6 +801,10 @@ namespace System.Numerics.Tests
             Assert.True(EqualityOperatorsHelper<BigInteger, BigInteger>.op_Inequality(Int64MaxValuePlusOne, 1));
             Assert.True(EqualityOperatorsHelper<BigInteger, BigInteger>.op_Inequality(UInt64MaxValue, 1));
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -648,6 +834,10 @@ namespace System.Numerics.Tests
             Assert.Equal(TwoPow64, IncrementOperatorsHelper<BigInteger>.op_CheckedIncrement(UInt64MaxValue));
         }
 
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -663,6 +853,20 @@ namespace System.Numerics.Tests
 
             Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<BigInteger, BigInteger, BigInteger>.op_Modulus(One, 0));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal(One, MultiplicativeIdentityHelper<BigInteger, BigInteger>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -692,19 +896,9 @@ namespace System.Numerics.Tests
             Assert.Equal(UInt64MaxValueTimesTwo, MultiplyOperatorsHelper<BigInteger, BigInteger, BigInteger>.op_CheckedMultiply(UInt64MaxValue, 2));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.Abs(Zero));
-            Assert.Equal(One, NumberBaseHelper<BigInteger>.Abs(One));
-            Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.Abs(Int64MaxValue));
-
-            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.Abs(Int64MinValue));
-            Assert.Equal(One, NumberBaseHelper<BigInteger>.Abs(NegativeOne));
-
-            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.Abs(Int64MaxValuePlusOne));
-            Assert.Equal(UInt64MaxValue, NumberBaseHelper<BigInteger>.Abs(UInt64MaxValue));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -718,6 +912,78 @@ namespace System.Numerics.Tests
 
             Assert.Equal((BigInteger)0x3F, NumberHelper<BigInteger>.Clamp(Int64MaxValuePlusOne, unchecked((BigInteger)(int)0xFFFFFFC0), 0x003F));
             Assert.Equal((BigInteger)0x3F, NumberHelper<BigInteger>.Clamp(UInt64MaxValue, unchecked((BigInteger)(int)0xFFFFFFC0), 0x003F));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal(One, NumberHelper<BigInteger>.Max(Zero, 1));
+            Assert.Equal(One, NumberHelper<BigInteger>.Max(One, 1));
+            Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.Max(Int64MaxValue, 1));
+
+            Assert.Equal(One, NumberHelper<BigInteger>.Max(Int64MinValue, 1));
+            Assert.Equal(One, NumberHelper<BigInteger>.Max(NegativeOne, 1));
+
+            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<BigInteger>.Max(Int64MaxValuePlusOne, 1));
+            Assert.Equal(UInt64MaxValue, NumberHelper<BigInteger>.Max(UInt64MaxValue, 1));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal(Zero, NumberHelper<BigInteger>.Min(Zero, 1));
+            Assert.Equal(One, NumberHelper<BigInteger>.Min(One, 1));
+            Assert.Equal(One, NumberHelper<BigInteger>.Min(Int64MaxValue, 1));
+
+            Assert.Equal(Int64MinValue, NumberHelper<BigInteger>.Min(Int64MinValue, 1));
+            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.Min(NegativeOne, 1));
+
+            Assert.Equal(One, NumberHelper<BigInteger>.Min(Int64MaxValuePlusOne, 1));
+            Assert.Equal(One, NumberHelper<BigInteger>.Min(UInt64MaxValue, 1));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(0, NumberHelper<BigInteger>.Sign(Zero));
+            Assert.Equal(1, NumberHelper<BigInteger>.Sign(One));
+            Assert.Equal(1, NumberHelper<BigInteger>.Sign(Int64MaxValue));
+
+            Assert.Equal(-1, NumberHelper<BigInteger>.Sign(Int64MinValue));
+            Assert.Equal(-1, NumberHelper<BigInteger>.Sign(NegativeOne));
+
+            Assert.Equal(1, NumberHelper<BigInteger>.Sign(Int64MaxValuePlusOne));
+            Assert.Equal(1, NumberHelper<BigInteger>.Sign(UInt64MaxValue));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.Abs(Zero));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.Abs(One));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.Abs(Int64MaxValue));
+
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.Abs(Int64MinValue));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.Abs(NegativeOne));
+
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.Abs(Int64MaxValuePlusOne));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<BigInteger>.Abs(UInt64MaxValue));
         }
 
         [Fact]
@@ -1117,62 +1383,6 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            Assert.Equal((Zero, Zero), BinaryIntegerHelper<BigInteger>.DivRem(Zero, 2));
-            Assert.Equal((Zero, One), BinaryIntegerHelper<BigInteger>.DivRem(One, 2));
-            Assert.Equal(((BigInteger)0x3FFFFFFFFFFFFFFF, One), BinaryIntegerHelper<BigInteger>.DivRem(Int64MaxValue, 2));
-
-            Assert.Equal((unchecked((BigInteger)(long)0xC000000000000000), Zero), BinaryIntegerHelper<BigInteger>.DivRem(Int64MinValue, 2));
-            Assert.Equal((Zero, NegativeOne), BinaryIntegerHelper<BigInteger>.DivRem(NegativeOne, 2));
-
-            Assert.Equal((unchecked((BigInteger)0x4000000000000000), Zero), BinaryIntegerHelper<BigInteger>.DivRem(Int64MaxValuePlusOne, 2));
-            Assert.Equal((Int64MaxValue, One), BinaryIntegerHelper<BigInteger>.DivRem(UInt64MaxValue, 2));
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            Assert.Equal(One, NumberHelper<BigInteger>.Max(Zero, 1));
-            Assert.Equal(One, NumberHelper<BigInteger>.Max(One, 1));
-            Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.Max(Int64MaxValue, 1));
-
-            Assert.Equal(One, NumberHelper<BigInteger>.Max(Int64MinValue, 1));
-            Assert.Equal(One, NumberHelper<BigInteger>.Max(NegativeOne, 1));
-
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<BigInteger>.Max(Int64MaxValuePlusOne, 1));
-            Assert.Equal(UInt64MaxValue, NumberHelper<BigInteger>.Max(UInt64MaxValue, 1));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.Min(Zero, 1));
-            Assert.Equal(One, NumberHelper<BigInteger>.Min(One, 1));
-            Assert.Equal(One, NumberHelper<BigInteger>.Min(Int64MaxValue, 1));
-
-            Assert.Equal(Int64MinValue, NumberHelper<BigInteger>.Min(Int64MinValue, 1));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.Min(NegativeOne, 1));
-
-            Assert.Equal(One, NumberHelper<BigInteger>.Min(Int64MaxValuePlusOne, 1));
-            Assert.Equal(One, NumberHelper<BigInteger>.Min(UInt64MaxValue, 1));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(0, NumberHelper<BigInteger>.Sign(Zero));
-            Assert.Equal(1, NumberHelper<BigInteger>.Sign(One));
-            Assert.Equal(1, NumberHelper<BigInteger>.Sign(Int64MaxValue));
-
-            Assert.Equal(-1, NumberHelper<BigInteger>.Sign(Int64MinValue));
-            Assert.Equal(-1, NumberHelper<BigInteger>.Sign(NegativeOne));
-
-            Assert.Equal(1, NumberHelper<BigInteger>.Sign(Int64MaxValuePlusOne));
-            Assert.Equal(1, NumberHelper<BigInteger>.Sign(UInt64MaxValue));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             BigInteger result;
@@ -1443,161 +1653,9 @@ namespace System.Numerics.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            Assert.Equal(4, BinaryIntegerHelper<BigInteger>.GetByteCount(Zero));
-            Assert.Equal(4, BinaryIntegerHelper<BigInteger>.GetByteCount(One));
-            Assert.Equal(8, BinaryIntegerHelper<BigInteger>.GetByteCount(Int64MaxValue));
-
-            Assert.Equal(8, BinaryIntegerHelper<BigInteger>.GetByteCount(Int64MinValue));
-            Assert.Equal(4, BinaryIntegerHelper<BigInteger>.GetByteCount(NegativeOne));
-
-            Assert.Equal(8, BinaryIntegerHelper<BigInteger>.GetByteCount(Int64MaxValuePlusOne));
-            Assert.Equal(8, BinaryIntegerHelper<BigInteger>.GetByteCount(UInt64MaxValue));
-
-            Assert.Equal(16, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MaxValue));
-            Assert.Equal(16, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MinValue));
-            Assert.Equal(20, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MinValueMinusOne));
-            Assert.Equal(16, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MinValuePlusOne));
-            Assert.Equal(20, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MinValueTimesTwo));
-            Assert.Equal(16, BinaryIntegerHelper<BigInteger>.GetByteCount(Int128MaxValuePlusOne));
-            Assert.Equal(16, BinaryIntegerHelper<BigInteger>.GetByteCount(UInt128MaxValue));
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[20];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Zero, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 4).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(One, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.Slice(0, 4).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int64MaxValue, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 8).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int64MinValue, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 8).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(NegativeOne, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 4).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int64MaxValuePlusOne, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 8).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(UInt64MaxValue, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 8).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MaxValue, destination, out bytesWritten));
-            Assert.Equal(16, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 16).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MinValue, destination, out bytesWritten));
-            Assert.Equal(16, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 16).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MinValueMinusOne, destination, out bytesWritten));
-            Assert.Equal(20, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 20).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MinValuePlusOne, destination, out bytesWritten));
-            Assert.Equal(16, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.Slice(0, 16).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MinValueTimesTwo, destination, out bytesWritten));
-            Assert.Equal(20, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 20).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(Int128MaxValuePlusOne, destination, out bytesWritten));
-            Assert.Equal(16, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 16).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(UInt128MaxValue, destination, out bytesWritten));
-            Assert.Equal(16, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 16).ToArray());
-
-            Assert.False(BinaryIntegerHelper<BigInteger>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[20];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Zero, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.Slice(0, 4).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(One, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.Slice(0, 4).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int64MaxValue, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.Slice(0, 8).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int64MinValue, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.Slice(0, 8).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(NegativeOne, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 4).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int64MaxValuePlusOne, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.Slice(0, 8).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(UInt64MaxValue, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 8).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MaxValue, destination, out bytesWritten));
-            Assert.Equal(16, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.Slice(0, 16).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MinValue, destination, out bytesWritten));
-            Assert.Equal(16, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.Slice(0, 16).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MinValueMinusOne, destination, out bytesWritten));
-            Assert.Equal(20, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 20).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MinValuePlusOne, destination, out bytesWritten));
-            Assert.Equal(16, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.Slice(0, 16).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MinValueTimesTwo, destination, out bytesWritten));
-            Assert.Equal(20, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 20).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(Int128MaxValuePlusOne, destination, out bytesWritten));
-            Assert.Equal(16, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.Slice(0, 16).ToArray());
-
-            Assert.True(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(UInt128MaxValue, destination, out bytesWritten));
-            Assert.Equal(16, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.Slice(0, 16).ToArray());
-
-            Assert.False(BinaryIntegerHelper<BigInteger>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1641,6 +1699,20 @@ namespace System.Numerics.Tests
             Assert.Equal(Int64MaxValue, ShiftOperatorsHelper<BigInteger, BigInteger>.op_UnsignedRightShift(UInt64MaxValue, 1));
         }
 
+        //
+        // ISignedNumber
+        //
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(NegativeOne, SignedNumberHelper<BigInteger>.NegativeOne);
+        }
+
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1669,6 +1741,10 @@ namespace System.Numerics.Tests
             Assert.Equal(UInt64MaxValueMinusOne, SubtractionOperatorsHelper<BigInteger, BigInteger, BigInteger>.op_CheckedSubtraction(UInt64MaxValue, 1));
         }
 
+        //
+        // IUnaryNegationOperators
+        //
+
         [Fact]
         public static void op_UnaryNegationTest()
         {
@@ -1696,6 +1772,10 @@ namespace System.Numerics.Tests
             Assert.Equal(Int64MinValue, UnaryNegationOperatorsHelper<BigInteger, BigInteger>.op_CheckedUnaryNegation(Int64MaxValuePlusOne));
             Assert.Equal(NegativeTwoPow64PlusOne, UnaryNegationOperatorsHelper<BigInteger, BigInteger>.op_CheckedUnaryNegation(UInt64MaxValue));
         }
+
+        //
+        // IUnaryPlusOperators
+        //
 
         [Fact]
         public static void op_UnaryPlusTest()

--- a/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
@@ -695,15 +695,15 @@ namespace System.Numerics.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.Abs(Zero));
-            Assert.Equal(One, NumberHelper<BigInteger>.Abs(One));
-            Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.Abs(Int64MaxValue));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.Abs(Zero));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.Abs(One));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.Abs(Int64MaxValue));
 
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<BigInteger>.Abs(Int64MinValue));
-            Assert.Equal(One, NumberHelper<BigInteger>.Abs(NegativeOne));
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.Abs(Int64MinValue));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.Abs(NegativeOne));
 
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<BigInteger>.Abs(Int64MaxValuePlusOne));
-            Assert.Equal(UInt64MaxValue, NumberHelper<BigInteger>.Abs(UInt64MaxValue));
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.Abs(Int64MaxValuePlusOne));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<BigInteger>.Abs(UInt64MaxValue));
         }
 
         [Fact]
@@ -723,51 +723,51 @@ namespace System.Numerics.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<byte>(0x00));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<byte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<BigInteger>.CreateChecked<byte>(0x7F));
-            Assert.Equal(SByteMaxValuePlusOne, NumberHelper<BigInteger>.CreateChecked<byte>(0x80));
-            Assert.Equal(ByteMaxValue, NumberHelper<BigInteger>.CreateChecked<byte>(0xFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<byte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<byte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<BigInteger>.CreateChecked<byte>(0x7F));
+            Assert.Equal(SByteMaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateChecked<byte>(0x80));
+            Assert.Equal(ByteMaxValue, NumberBaseHelper<BigInteger>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<char>((char)0x0000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<char>((char)0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<BigInteger>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<BigInteger>.CreateChecked<char>((char)0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<BigInteger>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<char>((char)0x0000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<char>((char)0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateChecked<char>((char)0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<short>(0x0000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<short>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<BigInteger>.CreateChecked<short>(0x7FFF));
-            Assert.Equal(Int16MinValue, NumberHelper<BigInteger>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<short>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<short>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<short>(0x7FFF));
+            Assert.Equal(Int16MinValue, NumberBaseHelper<BigInteger>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<int>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<int>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Equal(Int32MinValue, NumberHelper<BigInteger>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<int>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<int>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Equal(Int32MinValue, NumberBaseHelper<BigInteger>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<long>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<long>(0x00000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MinValue, NumberHelper<BigInteger>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<long>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<long>(0x00000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MinValue, NumberBaseHelper<BigInteger>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
@@ -775,60 +775,60 @@ namespace System.Numerics.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0x00000000)));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0x00000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MinValue, NumberHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0x00000000)));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0x00000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MinValue, NumberBaseHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(Int32MinValue, NumberHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(Int32MinValue, NumberBaseHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<sbyte>(0x00));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<sbyte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<BigInteger>.CreateChecked<sbyte>(0x7F));
-            Assert.Equal(SByteMinValue, NumberHelper<BigInteger>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<sbyte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<sbyte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<BigInteger>.CreateChecked<sbyte>(0x7F));
+            Assert.Equal(SByteMinValue, NumberBaseHelper<BigInteger>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<ushort>(0x0000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<ushort>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<BigInteger>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<BigInteger>.CreateChecked<ushort>(0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<BigInteger>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<ushort>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<ushort>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateChecked<ushort>(0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<uint>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<uint>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Equal(Int32MaxValuePlusOne, NumberHelper<BigInteger>.CreateChecked<uint>(0x80000000));
-            Assert.Equal(UInt32MaxValue, NumberHelper<BigInteger>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<uint>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<uint>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateChecked<uint>(0x80000000));
+            Assert.Equal(UInt32MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<ulong>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<ulong>(0x00000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<BigInteger>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Equal(UInt64MaxValue, NumberHelper<BigInteger>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<ulong>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<ulong>(0x00000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -836,70 +836,70 @@ namespace System.Numerics.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<nuint>(unchecked((nuint)0x00000000)));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<nuint>(unchecked((nuint)0x00000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MaxValuePlusOne, NumberHelper<BigInteger>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(UInt64MaxValue, NumberHelper<BigInteger>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<nuint>(unchecked((nuint)0x00000000)));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<nuint>(unchecked((nuint)0x00000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(UInt64MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(Int32MaxValuePlusOne, NumberHelper<BigInteger>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Equal(UInt32MaxValue, NumberHelper<BigInteger>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Equal(UInt32MaxValue, NumberBaseHelper<BigInteger>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<byte>(0x00));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<byte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<BigInteger>.CreateSaturating<byte>(0x7F));
-            Assert.Equal(SByteMaxValuePlusOne, NumberHelper<BigInteger>.CreateSaturating<byte>(0x80));
-            Assert.Equal(ByteMaxValue, NumberHelper<BigInteger>.CreateSaturating<byte>(0xFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<byte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<byte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<byte>(0x7F));
+            Assert.Equal(SByteMaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateSaturating<byte>(0x80));
+            Assert.Equal(ByteMaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<BigInteger>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<BigInteger>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<BigInteger>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<short>(0x0000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<short>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<BigInteger>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal(Int16MinValue, NumberHelper<BigInteger>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<short>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<short>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal(Int16MinValue, NumberBaseHelper<BigInteger>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<int>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<int>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal(Int32MinValue, NumberHelper<BigInteger>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<int>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<int>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal(Int32MinValue, NumberBaseHelper<BigInteger>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<long>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<long>(0x00000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MinValue, NumberHelper<BigInteger>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<long>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<long>(0x00000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MinValue, NumberBaseHelper<BigInteger>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -907,60 +907,60 @@ namespace System.Numerics.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0x00000000)));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0x00000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MinValue, NumberHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0x00000000)));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0x00000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MinValue, NumberBaseHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(Int32MinValue, NumberHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(Int32MinValue, NumberBaseHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<BigInteger>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal(SByteMinValue, NumberHelper<BigInteger>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal(SByteMinValue, NumberBaseHelper<BigInteger>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<BigInteger>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<BigInteger>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<BigInteger>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal(Int32MaxValuePlusOne, NumberHelper<BigInteger>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal(UInt32MaxValue, NumberHelper<BigInteger>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal(UInt32MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<ulong>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<ulong>(0x00000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<BigInteger>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal(UInt64MaxValue, NumberHelper<BigInteger>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<ulong>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<ulong>(0x00000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -968,70 +968,70 @@ namespace System.Numerics.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<nuint>(unchecked((nuint)0x00000000)));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<nuint>(unchecked((nuint)0x00000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MaxValuePlusOne, NumberHelper<BigInteger>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(UInt64MaxValue, NumberHelper<BigInteger>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<nuint>(unchecked((nuint)0x00000000)));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<nuint>(unchecked((nuint)0x00000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(UInt64MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(Int32MaxValuePlusOne, NumberHelper<BigInteger>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal(UInt32MaxValue, NumberHelper<BigInteger>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal(UInt32MaxValue, NumberBaseHelper<BigInteger>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<byte>(0x00));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<byte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<BigInteger>.CreateTruncating<byte>(0x7F));
-            Assert.Equal(SByteMaxValuePlusOne, NumberHelper<BigInteger>.CreateTruncating<byte>(0x80));
-            Assert.Equal(ByteMaxValue, NumberHelper<BigInteger>.CreateTruncating<byte>(0xFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<byte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<byte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<byte>(0x7F));
+            Assert.Equal(SByteMaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateTruncating<byte>(0x80));
+            Assert.Equal(ByteMaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<BigInteger>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<BigInteger>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<BigInteger>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<short>(0x0000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<short>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<BigInteger>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal(Int16MinValue, NumberHelper<BigInteger>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<short>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<short>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal(Int16MinValue, NumberBaseHelper<BigInteger>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<int>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<int>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal(Int32MinValue, NumberHelper<BigInteger>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<int>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<int>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal(Int32MinValue, NumberBaseHelper<BigInteger>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<long>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<long>(0x00000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MinValue, NumberHelper<BigInteger>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<long>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<long>(0x00000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MinValue, NumberBaseHelper<BigInteger>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -1039,60 +1039,60 @@ namespace System.Numerics.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0x00000000)));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0x00000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MinValue, NumberHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0x00000000)));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0x00000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MinValue, NumberBaseHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(Int32MinValue, NumberHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(Int32MinValue, NumberBaseHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<BigInteger>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal(SByteMinValue, NumberHelper<BigInteger>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal(SByteMinValue, NumberBaseHelper<BigInteger>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<BigInteger>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<BigInteger>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<BigInteger>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal(Int32MaxValuePlusOne, NumberHelper<BigInteger>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal(UInt32MaxValue, NumberHelper<BigInteger>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal(UInt32MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<ulong>(0x00000000));
-            Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<ulong>(0x00000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<BigInteger>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal(UInt64MaxValue, NumberHelper<BigInteger>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<ulong>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<ulong>(0x00000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -1100,19 +1100,19 @@ namespace System.Numerics.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<nuint>(unchecked((nuint)0x00000000)));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<nuint>(unchecked((nuint)0x00000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MaxValuePlusOne, NumberHelper<BigInteger>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(UInt64MaxValue, NumberHelper<BigInteger>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>(unchecked((nuint)0x00000000)));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>(unchecked((nuint)0x00000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(UInt64MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<BigInteger>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal(One, NumberHelper<BigInteger>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<BigInteger>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(Int32MaxValuePlusOne, NumberHelper<BigInteger>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal(UInt32MaxValue, NumberHelper<BigInteger>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(Zero, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal(UInt32MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -1177,19 +1177,19 @@ namespace System.Numerics.Tests
         {
             BigInteger result;
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<byte>(0x00, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<byte>(0x01, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<byte>(0x7F, out result));
             Assert.Equal(SByteMaxValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<byte>(0x80, out result));
             Assert.Equal(SByteMaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<byte>(0xFF, out result));
             Assert.Equal(ByteMaxValue, result);
         }
 
@@ -1198,19 +1198,19 @@ namespace System.Numerics.Tests
         {
             BigInteger result;
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal(Int16MaxValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal(Int16MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal(UInt16MaxValue, result);
         }
 
@@ -1219,19 +1219,19 @@ namespace System.Numerics.Tests
         {
             BigInteger result;
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<short>(0x0000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<short>(0x0001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal(Int16MaxValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal(Int16MinValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1240,19 +1240,19 @@ namespace System.Numerics.Tests
         {
             BigInteger result;
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<int>(0x00000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<int>(0x00000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal(Int32MaxValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal(Int32MinValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1261,19 +1261,19 @@ namespace System.Numerics.Tests
         {
             BigInteger result;
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<long>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<long>(0x00000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<long>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<long>(0x00000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(Int64MaxValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
             Assert.Equal(Int64MinValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1284,36 +1284,36 @@ namespace System.Numerics.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0x00000000), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0x00000000), out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0x00000001), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0x00000001), out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(Int64MaxValue, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal(Int64MinValue, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(NegativeOne, result);
             }
             else
             {
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal(Int32MaxValue, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal(Int32MinValue, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(NegativeOne, result);
             }
         }
@@ -1323,19 +1323,19 @@ namespace System.Numerics.Tests
         {
             BigInteger result;
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal(SByteMaxValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal(SByteMinValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1344,19 +1344,19 @@ namespace System.Numerics.Tests
         {
             BigInteger result;
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal(Int16MaxValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal(Int16MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal(UInt16MaxValue, result);
         }
 
@@ -1365,19 +1365,19 @@ namespace System.Numerics.Tests
         {
             BigInteger result;
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal(Int32MaxValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<uint>(0x80000000, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal(Int32MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal(UInt32MaxValue, result);
         }
 
@@ -1386,19 +1386,19 @@ namespace System.Numerics.Tests
         {
             BigInteger result;
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<ulong>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<ulong>(0x00000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<ulong>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<ulong>(0x00000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(Int64MaxValue, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal(Int64MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<BigInteger>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<BigInteger>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal(UInt64MaxValue, result);
         }
 
@@ -1409,36 +1409,36 @@ namespace System.Numerics.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0x00000000), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0x00000000), out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0x00000001), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0x00000001), out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(Int64MaxValue, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal(Int64MaxValuePlusOne, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(UInt64MaxValue, result);
             }
             else
             {
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal(Int32MaxValue, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal(Int32MaxValuePlusOne, result);
 
-                Assert.True(NumberHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<BigInteger>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal(UInt32MaxValue, result);
             }
         }

--- a/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
@@ -929,6 +929,20 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal(One, NumberHelper<BigInteger>.MaxNumber(Zero, 1));
+            Assert.Equal(One, NumberHelper<BigInteger>.MaxNumber(One, 1));
+            Assert.Equal(Int64MaxValue, NumberHelper<BigInteger>.MaxNumber(Int64MaxValue, 1));
+
+            Assert.Equal(One, NumberHelper<BigInteger>.MaxNumber(Int64MinValue, 1));
+            Assert.Equal(One, NumberHelper<BigInteger>.MaxNumber(NegativeOne, 1));
+
+            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<BigInteger>.MaxNumber(Int64MaxValuePlusOne, 1));
+            Assert.Equal(UInt64MaxValue, NumberHelper<BigInteger>.MaxNumber(UInt64MaxValue, 1));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal(Zero, NumberHelper<BigInteger>.Min(Zero, 1));
@@ -940,6 +954,20 @@ namespace System.Numerics.Tests
 
             Assert.Equal(One, NumberHelper<BigInteger>.Min(Int64MaxValuePlusOne, 1));
             Assert.Equal(One, NumberHelper<BigInteger>.Min(UInt64MaxValue, 1));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal(Zero, NumberHelper<BigInteger>.MinNumber(Zero, 1));
+            Assert.Equal(One, NumberHelper<BigInteger>.MinNumber(One, 1));
+            Assert.Equal(One, NumberHelper<BigInteger>.MinNumber(Int64MaxValue, 1));
+
+            Assert.Equal(Int64MinValue, NumberHelper<BigInteger>.MinNumber(Int64MinValue, 1));
+            Assert.Equal(NegativeOne, NumberHelper<BigInteger>.MinNumber(NegativeOne, 1));
+
+            Assert.Equal(One, NumberHelper<BigInteger>.MinNumber(Int64MaxValuePlusOne, 1));
+            Assert.Equal(One, NumberHelper<BigInteger>.MinNumber(UInt64MaxValue, 1));
         }
 
         [Fact]
@@ -1380,6 +1408,174 @@ namespace System.Numerics.Tests
                 Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal(UInt32MaxValue, NumberBaseHelper<BigInteger>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<BigInteger>.IsFinite(Zero));
+            Assert.True(NumberBaseHelper<BigInteger>.IsFinite(One));
+            Assert.True(NumberBaseHelper<BigInteger>.IsFinite(Int64MaxValue));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsFinite(Int64MinValue));
+            Assert.True(NumberBaseHelper<BigInteger>.IsFinite(NegativeOne));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsFinite(Int64MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<BigInteger>.IsFinite(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<BigInteger>.IsInfinity(Zero));
+            Assert.False(NumberBaseHelper<BigInteger>.IsInfinity(One));
+            Assert.False(NumberBaseHelper<BigInteger>.IsInfinity(Int64MaxValue));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsInfinity(Int64MinValue));
+            Assert.False(NumberBaseHelper<BigInteger>.IsInfinity(NegativeOne));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsInfinity(Int64MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<BigInteger>.IsInfinity(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<BigInteger>.IsNaN(Zero));
+            Assert.False(NumberBaseHelper<BigInteger>.IsNaN(One));
+            Assert.False(NumberBaseHelper<BigInteger>.IsNaN(Int64MaxValue));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsNaN(Int64MinValue));
+            Assert.False(NumberBaseHelper<BigInteger>.IsNaN(NegativeOne));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsNaN(Int64MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<BigInteger>.IsNaN(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegative(Zero));
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegative(One));
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegative(Int64MaxValue));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsNegative(Int64MinValue));
+            Assert.True(NumberBaseHelper<BigInteger>.IsNegative(NegativeOne));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegative(Int64MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegative(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegativeInfinity(Zero));
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegativeInfinity(One));
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegativeInfinity(Int64MaxValue));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegativeInfinity(Int64MinValue));
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegativeInfinity(NegativeOne));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegativeInfinity(Int64MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<BigInteger>.IsNegativeInfinity(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<BigInteger>.IsNormal(Zero));
+            Assert.True(NumberBaseHelper<BigInteger>.IsNormal(One));
+            Assert.True(NumberBaseHelper<BigInteger>.IsNormal(Int64MaxValue));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsNormal(Int64MinValue));
+            Assert.True(NumberBaseHelper<BigInteger>.IsNormal(NegativeOne));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsNormal(Int64MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<BigInteger>.IsNormal(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<BigInteger>.IsPositiveInfinity(Zero));
+            Assert.False(NumberBaseHelper<BigInteger>.IsPositiveInfinity(One));
+            Assert.False(NumberBaseHelper<BigInteger>.IsPositiveInfinity(Int64MaxValue));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsPositiveInfinity(Int64MinValue));
+            Assert.False(NumberBaseHelper<BigInteger>.IsPositiveInfinity(NegativeOne));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsPositiveInfinity(Int64MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<BigInteger>.IsPositiveInfinity(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<BigInteger>.IsSubnormal(Zero));
+            Assert.False(NumberBaseHelper<BigInteger>.IsSubnormal(One));
+            Assert.False(NumberBaseHelper<BigInteger>.IsSubnormal(Int64MaxValue));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsSubnormal(Int64MinValue));
+            Assert.False(NumberBaseHelper<BigInteger>.IsSubnormal(NegativeOne));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsSubnormal(Int64MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<BigInteger>.IsSubnormal(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MaxMagnitude(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MaxMagnitude(One, 1));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.MaxMagnitude(Int64MaxValue, 1));
+
+            Assert.Equal(Int64MinValue, NumberBaseHelper<BigInteger>.MaxMagnitude(Int64MinValue, 1));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MaxMagnitude(NegativeOne, 1));
+
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.MaxMagnitude(Int64MaxValuePlusOne, 1));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<BigInteger>.MaxMagnitude(UInt64MaxValue, 1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MaxMagnitudeNumber(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MaxMagnitudeNumber(One, 1));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<BigInteger>.MaxMagnitudeNumber(Int64MaxValue, 1));
+
+            Assert.Equal(Int64MinValue, NumberBaseHelper<BigInteger>.MaxMagnitudeNumber(Int64MinValue, 1));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MaxMagnitudeNumber(NegativeOne, 1));
+
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<BigInteger>.MaxMagnitudeNumber(Int64MaxValuePlusOne, 1));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<BigInteger>.MaxMagnitudeNumber(UInt64MaxValue, 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.MinMagnitude(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MinMagnitude(One, 1));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MinMagnitude(Int64MaxValue, 1));
+
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MinMagnitude(Int64MinValue, 1));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.MinMagnitude(NegativeOne, 1));
+
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MinMagnitude(Int64MaxValuePlusOne, 1));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MinMagnitude(UInt64MaxValue, 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal(Zero, NumberBaseHelper<BigInteger>.MinMagnitudeNumber(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MinMagnitudeNumber(One, 1));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MinMagnitudeNumber(Int64MaxValue, 1));
+
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MinMagnitudeNumber(Int64MinValue, 1));
+            Assert.Equal(NegativeOne, NumberBaseHelper<BigInteger>.MinMagnitudeNumber(NegativeOne, 1));
+
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MinMagnitudeNumber(Int64MaxValuePlusOne, 1));
+            Assert.Equal(One, NumberBaseHelper<BigInteger>.MinMagnitudeNumber(UInt64MaxValue, 1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime.Numerics/tests/ComplexTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/ComplexTests.GenericMath.cs
@@ -35,35 +35,9 @@ namespace System.Numerics.Tests
             AssertBitwiseEqual(expected.Imaginary, actual.Imaginary);
         }
 
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            AssertBitwiseEqual(0.0, AdditiveIdentityHelper<Complex, Complex>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            AssertBitwiseEqual(1.0, MultiplicativeIdentityHelper<Complex, Complex>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            Assert.Equal(-1.0, SignedNumberHelper<Complex>.NegativeOne);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -93,6 +67,20 @@ namespace System.Numerics.Tests
             AssertBitwiseEqual(2.0, AdditionOperatorsHelper<Complex, Complex, Complex>.op_CheckedAddition(1.0, 1.0));
         }
 
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            AssertBitwiseEqual(0.0, AdditiveIdentityHelper<Complex, Complex>.AdditiveIdentity);
+        }
+
+        //
+        // IDecrementOperators
+        //
+
         [Fact]
         public static void op_DecrementTest()
         {
@@ -120,6 +108,10 @@ namespace System.Numerics.Tests
             AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<Complex>.op_CheckedDecrement(MinNormal));
             AssertBitwiseEqual(0.0, DecrementOperatorsHelper<Complex>.op_CheckedDecrement(1.0));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -149,6 +141,10 @@ namespace System.Numerics.Tests
             AssertBitwiseEqual(0.5, DivisionOperatorsHelper<Complex, Complex, Complex>.op_CheckedDivision(1.0, 2.0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -176,6 +172,10 @@ namespace System.Numerics.Tests
             Assert.True(EqualityOperatorsHelper<Complex, Complex>.op_Inequality(MinNormal, 1.0));
             Assert.False(EqualityOperatorsHelper<Complex, Complex>.op_Inequality(1.0, 1.0));
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -205,6 +205,20 @@ namespace System.Numerics.Tests
             AssertBitwiseEqual(2.0, IncrementOperatorsHelper<Complex>.op_CheckedIncrement(1.0));
         }
 
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            AssertBitwiseEqual(1.0, MultiplicativeIdentityHelper<Complex, Complex>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
+
         [Fact]
         public static void op_MultiplyTest()
         {
@@ -232,6 +246,36 @@ namespace System.Numerics.Tests
             AssertBitwiseEqual(4.4501477170144028E-308, MultiplyOperatorsHelper<Complex, Complex, Complex>.op_CheckedMultiply(MinNormal, 2.0));
             AssertBitwiseEqual(2.0, MultiplyOperatorsHelper<Complex, Complex, Complex>.op_CheckedMultiply(1.0, 2.0));
         }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.Zero);
+        }
+
+        //
+        // ISignedNumber
+        //
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(-1.0, SignedNumberHelper<Complex>.NegativeOne);
+        }
+
+        //
+        // ISubtractionOperators
+        //
 
         [Fact]
         public static void op_SubtractionTest()
@@ -261,6 +305,10 @@ namespace System.Numerics.Tests
             AssertBitwiseEqual(0.0, SubtractionOperatorsHelper<Complex, Complex, Complex>.op_CheckedSubtraction(1.0, 1.0));
         }
 
+        //
+        // IUnaryNegationOperators
+        //
+
         [Fact]
         public static void op_UnaryNegationTest()
         {
@@ -288,6 +336,10 @@ namespace System.Numerics.Tests
             AssertBitwiseEqual(-MinNormal, UnaryNegationOperatorsHelper<Complex, Complex>.op_CheckedUnaryNegation(MinNormal));
             AssertBitwiseEqual(new Complex(-1.0, -0.0), UnaryNegationOperatorsHelper<Complex, Complex>.op_CheckedUnaryNegation(1.0));
         }
+
+        //
+        // IUnaryPlusOperators
+        //
 
         [Fact]
         public static void op_UnaryPlusTest()

--- a/src/libraries/System.Runtime.Numerics/tests/ComplexTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/ComplexTests.GenericMath.cs
@@ -263,6 +263,1347 @@ namespace System.Numerics.Tests
             AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.Zero);
         }
 
+        [Fact]
+        public static void AbsTest()
+        {
+            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<Complex>.Abs(double.NegativeInfinity));
+            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<Complex>.Abs(double.MinValue));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.Abs(-1.0));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Complex>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Complex>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<Complex>.Abs(-double.Epsilon));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.Abs(-0.0));
+            AssertBitwiseEqual(double.NaN, NumberBaseHelper<Complex>.Abs(double.NaN));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.Abs(0.0));
+            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<Complex>.Abs(double.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Complex>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Complex>.Abs(MinNormal));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.Abs(1.0));
+            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<Complex>.Abs(double.MaxValue));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<Complex>.Abs(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<byte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<byte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<Complex>.CreateChecked<byte>(0x7F));
+            AssertBitwiseEqual(128.0, NumberBaseHelper<Complex>.CreateChecked<byte>(0x80));
+            AssertBitwiseEqual(255.0, NumberBaseHelper<Complex>.CreateChecked<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromCharTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<char>((char)0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<Complex>.CreateChecked<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<Complex>.CreateChecked<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<Complex>.CreateChecked<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<short>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<short>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<Complex>.CreateChecked<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0, NumberBaseHelper<Complex>.CreateChecked<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateChecked<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<int>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateChecked<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<Complex>.CreateChecked<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<Complex>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<Complex>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<Complex>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateCheckedFromSByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<sbyte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<sbyte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<Complex>.CreateChecked<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0, NumberBaseHelper<Complex>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<ushort>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<Complex>.CreateChecked<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<Complex>.CreateChecked<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<Complex>.CreateChecked<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<uint>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateChecked<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0, NumberBaseHelper<Complex>.CreateChecked<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0, NumberBaseHelper<Complex>.CreateChecked<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<Complex>.CreateChecked<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0, NumberBaseHelper<Complex>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<Complex>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0,NumberBaseHelper<Complex>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateChecked<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateChecked<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(2147483648.0, NumberBaseHelper<Complex>.CreateChecked<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0, NumberBaseHelper<Complex>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<byte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<byte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<Complex>.CreateSaturating<byte>(0x7F));
+            AssertBitwiseEqual(128.0, NumberBaseHelper<Complex>.CreateSaturating<byte>(0x80));
+            AssertBitwiseEqual(255.0, NumberBaseHelper<Complex>.CreateSaturating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromCharTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<char>((char)0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<Complex>.CreateSaturating<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<Complex>.CreateSaturating<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<Complex>.CreateSaturating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<short>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<short>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<Complex>.CreateSaturating<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0, NumberBaseHelper<Complex>.CreateSaturating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<int>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateSaturating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<Complex>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<Complex>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<Complex>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<Complex>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromSByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<sbyte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<sbyte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<Complex>.CreateSaturating<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0, NumberBaseHelper<Complex>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<ushort>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<Complex>.CreateSaturating<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<Complex>.CreateSaturating<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<Complex>.CreateSaturating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<uint>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateSaturating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0, NumberBaseHelper<Complex>.CreateSaturating<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0, NumberBaseHelper<Complex>.CreateSaturating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<Complex>.CreateSaturating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0, NumberBaseHelper<Complex>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<Complex>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0, NumberBaseHelper<Complex>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateSaturating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateSaturating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(2147483648.0, NumberBaseHelper<Complex>.CreateSaturating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0, NumberBaseHelper<Complex>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<byte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<byte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<Complex>.CreateTruncating<byte>(0x7F));
+            AssertBitwiseEqual(128.0, NumberBaseHelper<Complex>.CreateTruncating<byte>(0x80));
+            AssertBitwiseEqual(255.0, NumberBaseHelper<Complex>.CreateTruncating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromCharTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<char>((char)0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<Complex>.CreateTruncating<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<Complex>.CreateTruncating<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<Complex>.CreateTruncating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<short>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<short>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<Complex>.CreateTruncating<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0, NumberBaseHelper<Complex>.CreateTruncating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<int>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateTruncating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<Complex>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<Complex>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<Complex>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<Complex>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromSByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<sbyte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<sbyte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<Complex>.CreateTruncating<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0, NumberBaseHelper<Complex>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<ushort>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<Complex>.CreateTruncating<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<Complex>.CreateTruncating<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<Complex>.CreateTruncating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<uint>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateTruncating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0, NumberBaseHelper<Complex>.CreateTruncating<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0, NumberBaseHelper<Complex>.CreateTruncating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<Complex>.CreateTruncating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0, NumberBaseHelper<Complex>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<Complex>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<Complex>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0, NumberBaseHelper<Complex>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.CreateTruncating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.CreateTruncating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<Complex>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(2147483648.0, NumberBaseHelper<Complex>.CreateTruncating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0, NumberBaseHelper<Complex>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(double.MinValue));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(-1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(-MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(-double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(double.NaN));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(0.0));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(MaxSubnormal));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(-1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(-1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(-1.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(-0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(-0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(-0.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(0.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(0.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(1.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(1.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsFinite(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsFinite(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(double.MinValue));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(-double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(double.NaN));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(double.MaxValue));
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(double.PositiveInfinity));
+
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(-1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(-1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(-1.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(-0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(-0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(-0.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(double.NaN, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(0.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(1.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsInfinity(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(double.MinValue));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(-double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(-0.0));
+            Assert.True(NumberBaseHelper<Complex>.IsNaN(double.NaN));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-1.0, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNaN(new Complex(-1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-0.0, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNaN(new Complex(-0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsNaN(new Complex(double.NaN, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNaN(new Complex(double.NaN, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNaN(new Complex(double.NaN, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsNaN(new Complex(double.NaN, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNaN(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(0.0, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNaN(new Complex(0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(1.0, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNaN(new Complex(1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNaN(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(double.MinValue));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(-1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(-MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(-double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(-0.0));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(double.NaN));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(-1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(-1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(-0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(-0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(double.NaN, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(double.NaN, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsNegative(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegative(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.True(NumberBaseHelper<Complex>.IsNegativeInfinity(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(double.MinValue));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(-double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(double.NaN));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNegativeInfinity(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(double.MinValue));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(-1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(-double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(double.NaN));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(MaxSubnormal));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(new Complex(-1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(-1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(new Complex(-1.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(-0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(-0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(1.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(new Complex(1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(new Complex(1.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsNormal(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsNormal(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(double.MinValue));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(-double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(double.NaN));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(double.MaxValue));
+            Assert.True(NumberBaseHelper<Complex>.IsPositiveInfinity(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(double.MinValue));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(-MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsSubnormal(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<Complex>.IsSubnormal(-double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(double.NaN));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(0.0));
+            Assert.True(NumberBaseHelper<Complex>.IsSubnormal(double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsSubnormal(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, NumberBaseHelper<Complex>.MaxMagnitude(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(double.MinValue, NumberBaseHelper<Complex>.MaxMagnitude(double.MinValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitude(-1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitude(-MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitude(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitude(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitude(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, NumberBaseHelper<Complex>.MaxMagnitude(double.NaN, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitude(0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitude(double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitude(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitude(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitude(1.0, 1.0));
+            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<Complex>.MaxMagnitude(double.MaxValue, 1.0));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<Complex>.MaxMagnitude(double.PositiveInfinity, 1.0));
+
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(-1.0, -1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(-1.0, -1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(-1.0, -1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(-1.0, -1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(-1.0, +1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(-1.0, +1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(-1.0, +1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(-1.0, +1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(+1.0, -1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(+1.0, -1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(+1.0, -1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(+1.0, -1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(+1.0, +1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(+1.0, +1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(+1.0, +1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitude(new Complex(+1.0, +1.0), new Complex(+1.0, +1.0)));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, NumberBaseHelper<Complex>.MaxMagnitudeNumber(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(double.MinValue, NumberBaseHelper<Complex>.MaxMagnitudeNumber(double.MinValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitudeNumber(-1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitudeNumber(-MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitudeNumber(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitudeNumber(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitudeNumber(-0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitudeNumber(double.NaN, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitudeNumber(0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitudeNumber(double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitudeNumber(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitudeNumber(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MaxMagnitudeNumber(1.0, 1.0));
+            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<Complex>.MaxMagnitudeNumber(double.MaxValue, 1.0));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<Complex>.MaxMagnitudeNumber(double.PositiveInfinity, 1.0));
+
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(-1.0, -1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(-1.0, -1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(-1.0, -1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(-1.0, -1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(-1.0, +1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(-1.0, +1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(-1.0, +1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(-1.0, +1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(+1.0, -1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(+1.0, -1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(+1.0, -1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(+1.0, -1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(+1.0, +1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(+1.0, +1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(+1.0, +1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MaxMagnitudeNumber(new Complex(+1.0, +1.0), new Complex(+1.0, +1.0)));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MinMagnitude(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MinMagnitude(double.MinValue, 1.0));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.MinMagnitude(-1.0, 1.0));
+            AssertBitwiseEqual(-MinNormal, NumberBaseHelper<Complex>.MinMagnitude(-MinNormal, 1.0));
+            AssertBitwiseEqual(-MaxSubnormal, NumberBaseHelper<Complex>.MinMagnitude(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(-double.Epsilon, NumberBaseHelper<Complex>.MinMagnitude(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(-0.0, NumberBaseHelper<Complex>.MinMagnitude(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, NumberBaseHelper<Complex>.MinMagnitude(double.NaN, 1.0));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.MinMagnitude(0.0, 1.0));
+            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<Complex>.MinMagnitude(double.Epsilon, 1.0));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Complex>.MinMagnitude(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Complex>.MinMagnitude(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MinMagnitude(1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MinMagnitude(double.MaxValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MinMagnitude(double.PositiveInfinity, 1.0));
+
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(-1.0, -1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(-1.0, -1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(-1.0, -1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(-1.0, -1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(-1.0, +1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(-1.0, +1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(-1.0, +1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(-1.0, +1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(+1.0, -1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(+1.0, -1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(+1.0, -1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(+1.0, -1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(+1.0, +1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(+1.0, +1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(+1.0, +1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitude(new Complex(+1.0, +1.0), new Complex(+1.0, +1.0)));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MinMagnitudeNumber(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MinMagnitudeNumber(double.MinValue, 1.0));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<Complex>.MinMagnitudeNumber(-1.0, 1.0));
+            AssertBitwiseEqual(-MinNormal, NumberBaseHelper<Complex>.MinMagnitudeNumber(-MinNormal, 1.0));
+            AssertBitwiseEqual(-MaxSubnormal, NumberBaseHelper<Complex>.MinMagnitudeNumber(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(-double.Epsilon, NumberBaseHelper<Complex>.MinMagnitudeNumber(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(-0.0, NumberBaseHelper<Complex>.MinMagnitudeNumber(-0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MinMagnitudeNumber(double.NaN, 1.0));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.MinMagnitudeNumber(0.0, 1.0));
+            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<Complex>.MinMagnitudeNumber(double.Epsilon, 1.0));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Complex>.MinMagnitudeNumber(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Complex>.MinMagnitudeNumber(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MinMagnitudeNumber(1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MinMagnitudeNumber(double.MaxValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<Complex>.MinMagnitudeNumber(double.PositiveInfinity, 1.0));
+
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(-1.0, -1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(-1.0, -1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(-1.0, -1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(-1.0, -1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(-1.0, +1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(-1.0, +1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(-1.0, +1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(-1.0, +1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(+1.0, -1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(+1.0, -1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(+1.0, -1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(+1.0, -1.0), new Complex(+1.0, +1.0)));
+
+            AssertBitwiseEqual(new Complex(-1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(+1.0, +1.0), new Complex(-1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(-1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(+1.0, +1.0), new Complex(-1.0, +1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, -1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(+1.0, +1.0), new Complex(+1.0, -1.0)));
+            AssertBitwiseEqual(new Complex(+1.0, +1.0), NumberBaseHelper<Complex>.MinMagnitudeNumber(new Complex(+1.0, +1.0), new Complex(+1.0, +1.0)));
+        }
+
+        [Fact]
+        public static void TryCreateFromByteTest()
+        {
+            Complex result;
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<byte>(0x00, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<byte>(0x01, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<byte>(0x7F, out result));
+            Assert.Equal(127.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<byte>(0x80, out result));
+            Assert.Equal(128.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<byte>(0xFF, out result));
+            Assert.Equal(255.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromCharTest()
+        {
+            Complex result;
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<char>((char)0x0000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<char>((char)0x0001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.Equal(32767.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<char>((char)0x8000, out result));
+            Assert.Equal(32768.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.Equal(65535.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt16Test()
+        {
+            Complex result;
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<short>(0x0000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<short>(0x0001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<short>(0x7FFF, out result));
+            Assert.Equal(32767.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.Equal(-32768.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.Equal(-1.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt32Test()
+        {
+            Complex result;
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<int>(0x00000000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<int>(0x00000001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.Equal(2147483647.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.Equal(-2147483648.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.Equal(-1.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt64Test()
+        {
+            Complex result;
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal(9223372036854775807.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+            Assert.Equal(-9223372036854775808.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.Equal(-1.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromIntPtrTest()
+        {
+            Complex result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.Equal(0.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.Equal(1.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal(9223372036854775807.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.Equal(-9223372036854775808.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.Equal(-1.0, result);
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.Equal(0.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.Equal(1.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.Equal(2147483647.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.Equal(-2147483648.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.Equal(-1.0, result);
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromSByteTest()
+        {
+            Complex result;
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<sbyte>(0x00, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<sbyte>(0x01, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<sbyte>(0x7F, out result));
+            Assert.Equal(127.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.Equal(-128.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.Equal(-1.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt16Test()
+        {
+            Complex result;
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<ushort>(0x0000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<ushort>(0x0001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.Equal(32767.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<ushort>(0x8000, out result));
+            Assert.Equal(32768.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.Equal(65535.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt32Test()
+        {
+            Complex result;
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<uint>(0x00000000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<uint>(0x00000001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.Equal(2147483647.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<uint>(0x80000000, out result));
+            Assert.Equal(2147483648.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.Equal(4294967295.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt64Test()
+        {
+            Complex result;
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal(9223372036854775807.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.Equal(9223372036854775808.0, result);
+
+            Assert.True(NumberBaseHelper<Complex>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.Equal(18446744073709551615.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUIntPtrTest()
+        {
+            Complex result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.Equal(0.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.Equal(1.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal(9223372036854775807.0, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberBaseHelper<Complex>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                // Assert.Equal(9223372036854775808.0, result);
+                //
+                // Assert.True(NumberBaseHelper<Complex>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                // Assert.Equal(18446744073709551615.0, result);
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.Equal(0.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.Equal(1.0, result);
+
+                Assert.True(NumberBaseHelper<Complex>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.Equal(2147483647.0, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberBaseHelper<Complex>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                // Assert.Equal(2147483648.0, result);
+                //
+                // Assert.True(NumberBaseHelper<Complex>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                // Assert.Equal(4294967295.0, result);
+            }
+        }
+
         //
         // ISignedNumber
         //

--- a/src/libraries/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -1732,22 +1732,22 @@ namespace System.Numerics.Tests
         {
             var complex = new Complex(real, imaginary);
 
-            string expected = "(" + real.ToString() + ", " + imaginary.ToString() + ")";
+            string expected = "<" + real.ToString() + "; " + imaginary.ToString() + ">";
             string actual = complex.ToString();
             Assert.Equal(expected, actual);
 
             NumberFormatInfo numberFormatInfo = CultureInfo.CurrentCulture.NumberFormat;
-            expected = "(" + real.ToString(numberFormatInfo) + ", " + imaginary.ToString(numberFormatInfo) + ")";
+            expected = "<" + real.ToString(numberFormatInfo) + "; " + imaginary.ToString(numberFormatInfo) + ">";
             actual = complex.ToString(numberFormatInfo);
             Assert.Equal(expected, complex.ToString(numberFormatInfo));
 
             foreach (string format in s_supportedStandardNumericFormats)
             {
-                expected = "(" + real.ToString(format) + ", " + imaginary.ToString(format) + ")";
+                expected = "<" + real.ToString(format) + "; " + imaginary.ToString(format) + ">";
                 actual = complex.ToString(format);
                 Assert.Equal(expected, actual);
 
-                expected = "(" + real.ToString(format, numberFormatInfo) + ", " + imaginary.ToString(format, numberFormatInfo) + ")";
+                expected = "<" + real.ToString(format, numberFormatInfo) + "; " + imaginary.ToString(format, numberFormatInfo) + ">";
                 actual = complex.ToString(format, numberFormatInfo);
                 Assert.Equal(expected, actual);
             }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -727,9 +727,9 @@ namespace System
         public static byte Clamp(byte value, byte min, byte max) { throw null; }
         public int CompareTo(byte value) { throw null; }
         public int CompareTo(object? value) { throw null; }
-        public static byte CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static byte CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static byte CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static byte CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static byte CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static byte CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (byte Quotient, byte Remainder) DivRem(byte left, byte right) { throw null; }
         public bool Equals(byte obj) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
@@ -790,11 +790,22 @@ namespace System
         static byte System.Numerics.IModulusOperators<byte, byte, byte>.operator %(byte left, byte right) { throw null; }
         static byte System.Numerics.IMultiplyOperators<byte, byte, byte>.operator checked *(byte left, byte right) { throw null; }
         static byte System.Numerics.IMultiplyOperators<byte, byte, byte>.operator *(byte left, byte right) { throw null; }
-        static byte System.Numerics.INumber<byte>.Abs(byte value) { throw null; }
+        static byte System.Numerics.INumberBase<byte>.Abs(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsFinite(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsInfinity(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsNaN(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsNegative(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsNegativeInfinity(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsNormal(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsPositiveInfinity(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsSubnormal(byte value) { throw null; }
+        static byte System.Numerics.INumberBase<byte>.MaxMagnitude(byte x, byte y) { throw null; }
+        static byte System.Numerics.INumberBase<byte>.MaxMagnitudeNumber(byte x, byte y) { throw null; }
+        static byte System.Numerics.INumberBase<byte>.MinMagnitude(byte x, byte y) { throw null; }
+        static byte System.Numerics.INumberBase<byte>.MinMagnitudeNumber(byte x, byte y) { throw null; }
         static byte System.Numerics.INumber<byte>.CopySign(byte value, byte sign) { throw null; }
-        static bool System.Numerics.INumber<byte>.IsNegative(byte value) { throw null; }
-        static byte System.Numerics.INumber<byte>.MaxMagnitude(byte x, byte y) { throw null; }
-        static byte System.Numerics.INumber<byte>.MinMagnitude(byte x, byte y) { throw null; }
+        static byte System.Numerics.INumber<byte>.MaxNumber(byte x, byte y) { throw null; }
+        static byte System.Numerics.INumber<byte>.MinNumber(byte x, byte y) { throw null; }
         static byte System.Numerics.IShiftOperators<byte, byte>.operator <<(byte value, int shiftAmount) { throw null; }
         static byte System.Numerics.IShiftOperators<byte, byte>.operator >>(byte value, int shiftAmount) { throw null; }
         static byte System.Numerics.IShiftOperators<byte, byte>.operator >>>(byte value, int shiftAmount) { throw null; }
@@ -808,7 +819,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static byte TrailingZeroCount(byte value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out byte result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out byte result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out byte result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out byte result) { throw null; }
@@ -943,23 +954,34 @@ namespace System
         static char System.Numerics.IModulusOperators<char, char, char>.operator %(char left, char right) { throw null; }
         static char System.Numerics.IMultiplyOperators<char, char, char>.operator checked *(char left, char right) { throw null; }
         static char System.Numerics.IMultiplyOperators<char, char, char>.operator *(char left, char right) { throw null; }
-        static char System.Numerics.INumber<char>.Abs(char value) { throw null; }
+        static char System.Numerics.INumberBase<char>.Abs(char value) { throw null; }
+        static char System.Numerics.INumberBase<char>.CreateChecked<TOther>(TOther value) { throw null; }
+        static char System.Numerics.INumberBase<char>.CreateSaturating<TOther>(TOther value) { throw null; }
+        static char System.Numerics.INumberBase<char>.CreateTruncating<TOther>(TOther value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsFinite(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsInfinity(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsNaN(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsNegative(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsNegativeInfinity(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsNormal(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsPositiveInfinity(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsSubnormal(char value) { throw null; }
+        static char System.Numerics.INumberBase<char>.MaxMagnitude(char x, char y) { throw null; }
+        static char System.Numerics.INumberBase<char>.MaxMagnitudeNumber(char x, char y) { throw null; }
+        static char System.Numerics.INumberBase<char>.MinMagnitude(char x, char y) { throw null; }
+        static char System.Numerics.INumberBase<char>.MinMagnitudeNumber(char x, char y) { throw null; }
+        static char System.Numerics.INumberBase<char>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
+        static char System.Numerics.INumberBase<char>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
+        static bool System.Numerics.INumberBase<char>.TryCreate<TOther>(TOther value, out char result) { throw null; }
+        static bool System.Numerics.INumberBase<char>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out char result) { throw null; }
+        static bool System.Numerics.INumberBase<char>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out char result) { throw null; }
         static char System.Numerics.INumber<char>.Clamp(char value, char min, char max) { throw null; }
         static char System.Numerics.INumber<char>.CopySign(char value, char sign) { throw null; }
-        static char System.Numerics.INumber<char>.CreateChecked<TOther>(TOther value) { throw null; }
-        static char System.Numerics.INumber<char>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static char System.Numerics.INumber<char>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static bool System.Numerics.INumber<char>.IsNegative(char value) { throw null; }
         static char System.Numerics.INumber<char>.Max(char x, char y) { throw null; }
-        static char System.Numerics.INumber<char>.MaxMagnitude(char x, char y) { throw null; }
+        static char System.Numerics.INumber<char>.MaxNumber(char x, char y) { throw null; }
         static char System.Numerics.INumber<char>.Min(char x, char y) { throw null; }
-        static char System.Numerics.INumber<char>.MinMagnitude(char x, char y) { throw null; }
-        static char System.Numerics.INumber<char>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static char System.Numerics.INumber<char>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
+        static char System.Numerics.INumber<char>.MinNumber(char x, char y) { throw null; }
         static int System.Numerics.INumber<char>.Sign(char value) { throw null; }
-        static bool System.Numerics.INumber<char>.TryCreate<TOther>(TOther value, out char result) { throw null; }
-        static bool System.Numerics.INumber<char>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out char result) { throw null; }
-        static bool System.Numerics.INumber<char>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out char result) { throw null; }
         static char System.Numerics.IShiftOperators<char, char>.operator <<(char value, int shiftAmount) { throw null; }
         static char System.Numerics.IShiftOperators<char, char>.operator >>(char value, int shiftAmount) { throw null; }
         static char System.Numerics.IShiftOperators<char, char>.operator >>>(char value, int shiftAmount) { throw null; }
@@ -1845,9 +1867,9 @@ namespace System
         public int CompareTo(decimal value) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public static decimal CopySign(decimal value, decimal sign) { throw null; }
-        public static decimal CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static decimal CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static decimal CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static decimal CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static decimal CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static decimal CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static decimal Divide(decimal d1, decimal d2) { throw null; }
         public bool Equals(decimal value) { throw null; }
         public static bool Equals(decimal d1, decimal d2) { throw null; }
@@ -1944,13 +1966,24 @@ namespace System
         static decimal System.Numerics.IDivisionOperators<decimal, decimal, decimal>.operator checked /(decimal left, decimal right) { throw null; }
         int System.Numerics.IFloatingPoint<decimal>.GetExponentByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<decimal>.GetExponentShortestBitLength() { throw null; }
-        int System.Numerics.IFloatingPoint<decimal>.GetSignificandByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<decimal>.GetSignificandBitLength() { throw null; }
-        bool System.Numerics.IFloatingPoint<decimal>.TryWriteExponentBigEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<decimal>.TryWriteExponentLittleEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<decimal>.TryWriteSignificandBigEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<decimal>.TryWriteSignificandLittleEndian(Span<byte> destination, out int bytesWritten) { throw null; }
+        int System.Numerics.IFloatingPoint<decimal>.GetSignificandByteCount() { throw null; }
+        bool System.Numerics.IFloatingPoint<decimal>.TryWriteExponentBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<decimal>.TryWriteExponentLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<decimal>.TryWriteSignificandBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<decimal>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         static decimal System.Numerics.IIncrementOperators<decimal>.operator checked ++(decimal value) { throw null; }
+        static bool System.Numerics.INumberBase<decimal>.IsFinite(decimal value) { throw null; }
+        static bool System.Numerics.INumberBase<decimal>.IsInfinity(decimal value) { throw null; }
+        static bool System.Numerics.INumberBase<decimal>.IsNaN(decimal value) { throw null; }
+        static bool System.Numerics.INumberBase<decimal>.IsNegativeInfinity(decimal value) { throw null; }
+        static bool System.Numerics.INumberBase<decimal>.IsNormal(decimal value) { throw null; }
+        static bool System.Numerics.INumberBase<decimal>.IsPositiveInfinity(decimal value) { throw null; }
+        static bool System.Numerics.INumberBase<decimal>.IsSubnormal(decimal value) { throw null; }
+        static decimal System.Numerics.INumberBase<decimal>.MaxMagnitudeNumber(decimal x, decimal y) { throw null; }
+        static decimal System.Numerics.INumberBase<decimal>.MinMagnitudeNumber(decimal x, decimal y) { throw null; }
+        static decimal System.Numerics.INumber<decimal>.MaxNumber(decimal x, decimal y) { throw null; }
+        static decimal System.Numerics.INumber<decimal>.MinNumber(decimal x, decimal y) { throw null; }
         static decimal System.Numerics.ISubtractionOperators<decimal, decimal, decimal>.operator checked -(decimal left, decimal right) { throw null; }
         static decimal System.Numerics.IUnaryNegationOperators<decimal, decimal>.operator checked -(decimal value) { throw null; }
         void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object? sender) { }
@@ -1975,7 +2008,7 @@ namespace System
         [System.CLSCompliantAttribute(false)]
         public static ulong ToUInt64(decimal d) { throw null; }
         public static decimal Truncate(decimal d) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out decimal result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out decimal result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryGetBits(decimal d, System.Span<int> destination, out int valuesWritten) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out decimal result) { throw null; }
@@ -2077,9 +2110,9 @@ namespace System
         public static double CopySign(double x, double y) { throw null; }
         public static double Cos(double x) { throw null; }
         public static double Cosh(double x) { throw null; }
-        public static double CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static double CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static double CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static double CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static double CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static double CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool Equals(double obj) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public static double Exp(double x) { throw null; }
@@ -2170,12 +2203,12 @@ namespace System
         static double System.Numerics.IDivisionOperators<double, double, double>.operator /(double left, double right) { throw null; }
         int System.Numerics.IFloatingPoint<double>.GetExponentByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<double>.GetExponentShortestBitLength() { throw null; }
-        int System.Numerics.IFloatingPoint<double>.GetSignificandByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<double>.GetSignificandBitLength() { throw null; }
-        bool System.Numerics.IFloatingPoint<double>.TryWriteExponentBigEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<double>.TryWriteExponentLittleEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<double>.TryWriteSignificandBigEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<double>.TryWriteSignificandLittleEndian(Span<byte> destination, out int bytesWritten) { throw null; }
+        int System.Numerics.IFloatingPoint<double>.GetSignificandByteCount() { throw null; }
+        bool System.Numerics.IFloatingPoint<double>.TryWriteExponentBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<double>.TryWriteExponentLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<double>.TryWriteSignificandBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<double>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         static double System.Numerics.IIncrementOperators<double>.operator checked ++(double value) { throw null; }
         static double System.Numerics.IIncrementOperators<double>.operator ++(double value) { throw null; }
         static double System.Numerics.IModulusOperators<double, double, double>.operator %(double left, double right) { throw null; }
@@ -2193,7 +2226,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static double Truncate(double x) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out double result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out double result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out double result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out double result) { throw null; }
@@ -2679,9 +2712,9 @@ namespace System
         public static System.Half CopySign(System.Half x, System.Half y) { throw null; }
         public static System.Half Cos(System.Half x) { throw null; }
         public static System.Half Cosh(System.Half x) { throw null; }
-        public static System.Half CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static System.Half CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static System.Half CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static System.Half CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.Half CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.Half CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool Equals(System.Half other) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public static System.Half Exp(System.Half x) { throw null; }
@@ -2766,12 +2799,12 @@ namespace System
         static System.Half System.Numerics.IDivisionOperators<System.Half, System.Half, System.Half>.operator checked /(System.Half left, System.Half right) { throw null; }
         int System.Numerics.IFloatingPoint<System.Half>.GetExponentByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<System.Half>.GetExponentShortestBitLength() { throw null; }
-        int System.Numerics.IFloatingPoint<System.Half>.GetSignificandByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<System.Half>.GetSignificandBitLength() { throw null; }
-        bool System.Numerics.IFloatingPoint<System.Half>.TryWriteExponentBigEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<System.Half>.TryWriteExponentLittleEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<System.Half>.TryWriteSignificandBigEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<System.Half>.TryWriteSignificandLittleEndian(Span<byte> destination, out int bytesWritten) { throw null; }
+        int System.Numerics.IFloatingPoint<System.Half>.GetSignificandByteCount() { throw null; }
+        bool System.Numerics.IFloatingPoint<System.Half>.TryWriteExponentBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<System.Half>.TryWriteExponentLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<System.Half>.TryWriteSignificandBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<System.Half>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         static System.Half System.Numerics.IIncrementOperators<System.Half>.operator checked ++(System.Half value) { throw null; }
         static System.Half System.Numerics.IMultiplyOperators<System.Half, System.Half, System.Half>.operator checked *(System.Half left, System.Half right) { throw null; }
         static System.Half System.Numerics.ISubtractionOperators<System.Half, System.Half, System.Half>.operator checked -(System.Half left, System.Half right) { throw null; }
@@ -2783,7 +2816,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static System.Half Truncate(System.Half x) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out System.Half result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Half result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Half result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.Half result) { throw null; }
@@ -2934,9 +2967,9 @@ namespace System
         public int CompareTo(System.Int128 value) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public static System.Int128 CopySign(System.Int128 value, System.Int128 sign) { throw null; }
-        public static System.Int128 CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static System.Int128 CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static System.Int128 CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static System.Int128 CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.Int128 CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.Int128 CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (System.Int128 Quotient, System.Int128 Remainder) DivRem(System.Int128 left, System.Int128 right) { throw null; }
         public bool Equals(System.Int128 other) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
@@ -2957,7 +2990,6 @@ namespace System
         public static System.Int128 operator checked /(System.Int128 left, System.Int128 right) { throw null; }
         public static explicit operator checked System.Int128 (double value) { throw null; }
         public static explicit operator checked System.Int128 (System.Half value) { throw null; }
-        public static explicit operator checked System.Int128 (float value) { throw null; }
         public static explicit operator checked byte (System.Int128 value) { throw null; }
         public static explicit operator checked char (System.Int128 value) { throw null; }
         public static explicit operator checked short (System.Int128 value) { throw null; }
@@ -2976,6 +3008,7 @@ namespace System
         public static explicit operator checked System.UInt128 (System.Int128 value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static explicit operator checked nuint (System.Int128 value) { throw null; }
+        public static explicit operator checked System.Int128 (float value) { throw null; }
         public static System.Int128 operator checked ++(System.Int128 value) { throw null; }
         public static System.Int128 operator checked *(System.Int128 left, System.Int128 right) { throw null; }
         public static System.Int128 operator checked -(System.Int128 left, System.Int128 right) { throw null; }
@@ -3055,12 +3088,23 @@ namespace System
         int System.Numerics.IBinaryInteger<System.Int128>.GetShortestBitLength() { throw null; }
         bool System.Numerics.IBinaryInteger<System.Int128>.TryWriteBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IBinaryInteger<System.Int128>.TryWriteLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsFinite(System.Int128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsInfinity(System.Int128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsNaN(System.Int128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsNegativeInfinity(System.Int128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsNormal(System.Int128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsPositiveInfinity(System.Int128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsSubnormal(System.Int128 value) { throw null; }
+        static System.Int128 System.Numerics.INumberBase<System.Int128>.MaxMagnitudeNumber(System.Int128 x, System.Int128 y) { throw null; }
+        static System.Int128 System.Numerics.INumberBase<System.Int128>.MinMagnitudeNumber(System.Int128 x, System.Int128 y) { throw null; }
+        static System.Int128 System.Numerics.INumber<System.Int128>.MaxNumber(System.Int128 x, System.Int128 y) { throw null; }
+        static System.Int128 System.Numerics.INumber<System.Int128>.MinNumber(System.Int128 x, System.Int128 y) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static System.Int128 TrailingZeroCount(System.Int128 value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out System.Int128 result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Int128 result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int128 result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Int128 result) { throw null; }
@@ -3086,9 +3130,9 @@ namespace System
         public int CompareTo(short value) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public static short CopySign(short value, short sign) { throw null; }
-        public static short CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static short CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static short CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static short CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static short CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static short CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (short Quotient, short Remainder) DivRem(short left, short right) { throw null; }
         public bool Equals(short obj) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
@@ -3152,6 +3196,17 @@ namespace System
         static short System.Numerics.IModulusOperators<short, short, short>.operator %(short left, short right) { throw null; }
         static short System.Numerics.IMultiplyOperators<short, short, short>.operator checked *(short left, short right) { throw null; }
         static short System.Numerics.IMultiplyOperators<short, short, short>.operator *(short left, short right) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsFinite(short value) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsInfinity(short value) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsNaN(short value) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsNegativeInfinity(short value) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsNormal(short value) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsPositiveInfinity(short value) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsSubnormal(short value) { throw null; }
+        static short System.Numerics.INumberBase<short>.MaxMagnitudeNumber(short x, short y) { throw null; }
+        static short System.Numerics.INumberBase<short>.MinMagnitudeNumber(short x, short y) { throw null; }
+        static short System.Numerics.INumber<short>.MaxNumber(short x, short y) { throw null; }
+        static short System.Numerics.INumber<short>.MinNumber(short x, short y) { throw null; }
         static short System.Numerics.IShiftOperators<short, short>.operator <<(short value, int shiftAmount) { throw null; }
         static short System.Numerics.IShiftOperators<short, short>.operator >>(short value, int shiftAmount) { throw null; }
         static short System.Numerics.IShiftOperators<short, short>.operator >>>(short value, int shiftAmount) { throw null; }
@@ -3165,7 +3220,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static short TrailingZeroCount(short value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out short result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out short result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out short result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out short result) { throw null; }
@@ -3191,9 +3246,9 @@ namespace System
         public int CompareTo(int value) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public static int CopySign(int value, int sign) { throw null; }
-        public static int CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static int CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static int CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static int CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static int CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static int CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (int Quotient, int Remainder) DivRem(int left, int right) { throw null; }
         public bool Equals(int obj) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
@@ -3257,6 +3312,17 @@ namespace System
         static int System.Numerics.IModulusOperators<int, int, int>.operator %(int left, int right) { throw null; }
         static int System.Numerics.IMultiplyOperators<int, int, int>.operator checked *(int left, int right) { throw null; }
         static int System.Numerics.IMultiplyOperators<int, int, int>.operator *(int left, int right) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsFinite(int value) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsInfinity(int value) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsNaN(int value) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsNegativeInfinity(int value) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsNormal(int value) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsPositiveInfinity(int value) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsSubnormal(int value) { throw null; }
+        static int System.Numerics.INumberBase<int>.MaxMagnitudeNumber(int x, int y) { throw null; }
+        static int System.Numerics.INumberBase<int>.MinMagnitudeNumber(int x, int y) { throw null; }
+        static int System.Numerics.INumber<int>.MaxNumber(int x, int y) { throw null; }
+        static int System.Numerics.INumber<int>.MinNumber(int x, int y) { throw null; }
         static int System.Numerics.IShiftOperators<int, int>.operator <<(int value, int shiftAmount) { throw null; }
         static int System.Numerics.IShiftOperators<int, int>.operator >>(int value, int shiftAmount) { throw null; }
         static int System.Numerics.IShiftOperators<int, int>.operator >>>(int value, int shiftAmount) { throw null; }
@@ -3270,8 +3336,8 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static int TrailingZeroCount(int value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out int result) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public bool TryFormat(System.Span<char> destination, out System.Int32 charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out int result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out int result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out int result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out int result) { throw null; }
@@ -3296,9 +3362,9 @@ namespace System
         public int CompareTo(long value) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public static long CopySign(long value, long sign) { throw null; }
-        public static long CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static long CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static long CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static long CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static long CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static long CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (long Quotient, long Remainder) DivRem(long left, long right) { throw null; }
         public bool Equals(long obj) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
@@ -3362,6 +3428,17 @@ namespace System
         static long System.Numerics.IModulusOperators<long, long, long>.operator %(long left, long right) { throw null; }
         static long System.Numerics.IMultiplyOperators<long, long, long>.operator checked *(long left, long right) { throw null; }
         static long System.Numerics.IMultiplyOperators<long, long, long>.operator *(long left, long right) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsFinite(long value) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsInfinity(long value) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsNaN(long value) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsNegativeInfinity(long value) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsNormal(long value) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsPositiveInfinity(long value) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsSubnormal(long value) { throw null; }
+        static long System.Numerics.INumberBase<long>.MaxMagnitudeNumber(long x, long y) { throw null; }
+        static long System.Numerics.INumberBase<long>.MinMagnitudeNumber(long x, long y) { throw null; }
+        static long System.Numerics.INumber<long>.MaxNumber(long x, long y) { throw null; }
+        static long System.Numerics.INumber<long>.MinNumber(long x, long y) { throw null; }
         static long System.Numerics.IShiftOperators<long, long>.operator <<(long value, int shiftAmount) { throw null; }
         static long System.Numerics.IShiftOperators<long, long>.operator >>(long value, int shiftAmount) { throw null; }
         static long System.Numerics.IShiftOperators<long, long>.operator >>>(long value, int shiftAmount) { throw null; }
@@ -3375,7 +3452,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static long TrailingZeroCount(long value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out long result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out long result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out long result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out long result) { throw null; }
@@ -3408,9 +3485,9 @@ namespace System
         public int CompareTo(System.IntPtr value) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public static nint CopySign(nint value, nint sign) { throw null; }
-        public static nint CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static nint CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static nint CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static nint CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static nint CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static nint CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (nint Quotient, nint Remainder) DivRem(nint left, nint right) { throw null; }
         public bool Equals(System.IntPtr other) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
@@ -3469,6 +3546,17 @@ namespace System
         static nint System.Numerics.IModulusOperators<nint, nint, nint>.operator %(nint left, nint right) { throw null; }
         static nint System.Numerics.IMultiplyOperators<nint, nint, nint>.operator checked *(nint left, nint right) { throw null; }
         static nint System.Numerics.IMultiplyOperators<nint, nint, nint>.operator *(nint left, nint right) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsFinite(nint value) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsInfinity(nint value) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsNaN(nint value) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsNegativeInfinity(nint value) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsNormal(nint value) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsPositiveInfinity(nint value) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsSubnormal(nint value) { throw null; }
+        static nint System.Numerics.INumberBase<nint>.MaxMagnitudeNumber(nint x, nint y) { throw null; }
+        static nint System.Numerics.INumberBase<nint>.MinMagnitudeNumber(nint x, nint y) { throw null; }
+        static nint System.Numerics.INumber<nint>.MaxNumber(nint x, nint y) { throw null; }
+        static nint System.Numerics.INumber<nint>.MinNumber(nint x, nint y) { throw null; }
         static nint System.Numerics.IShiftOperators<nint, nint>.operator <<(nint value, int shiftAmount) { throw null; }
         static nint System.Numerics.IShiftOperators<nint, nint>.operator >>(nint value, int shiftAmount) { throw null; }
         static nint System.Numerics.IShiftOperators<nint, nint>.operator >>>(nint value, int shiftAmount) { throw null; }
@@ -3487,7 +3575,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static nint TrailingZeroCount(nint value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out nint result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out nint result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.IntPtr result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.IntPtr result) { throw null; }
@@ -4318,9 +4406,9 @@ namespace System
         public int CompareTo(object? obj) { throw null; }
         public int CompareTo(sbyte value) { throw null; }
         public static sbyte CopySign(sbyte value, sbyte sign) { throw null; }
-        public static sbyte CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static sbyte CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static sbyte CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static sbyte CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static sbyte CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static sbyte CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (sbyte Quotient, sbyte Remainder) DivRem(sbyte left, sbyte right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(sbyte obj) { throw null; }
@@ -4384,6 +4472,17 @@ namespace System
         static sbyte System.Numerics.IModulusOperators<sbyte, sbyte, sbyte>.operator %(sbyte left, sbyte right) { throw null; }
         static sbyte System.Numerics.IMultiplyOperators<sbyte, sbyte, sbyte>.operator checked *(sbyte left, sbyte right) { throw null; }
         static sbyte System.Numerics.IMultiplyOperators<sbyte, sbyte, sbyte>.operator *(sbyte left, sbyte right) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsFinite(sbyte value) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsInfinity(sbyte value) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsNaN(sbyte value) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsNegativeInfinity(sbyte value) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsNormal(sbyte value) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsPositiveInfinity(sbyte value) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsSubnormal(sbyte value) { throw null; }
+        static sbyte System.Numerics.INumberBase<sbyte>.MaxMagnitudeNumber(sbyte x, sbyte y) { throw null; }
+        static sbyte System.Numerics.INumberBase<sbyte>.MinMagnitudeNumber(sbyte x, sbyte y) { throw null; }
+        static sbyte System.Numerics.INumber<sbyte>.MaxNumber(sbyte x, sbyte y) { throw null; }
+        static sbyte System.Numerics.INumber<sbyte>.MinNumber(sbyte x, sbyte y) { throw null; }
         static sbyte System.Numerics.IShiftOperators<sbyte, sbyte>.operator <<(sbyte value, int shiftAmount) { throw null; }
         static sbyte System.Numerics.IShiftOperators<sbyte, sbyte>.operator >>(sbyte value, int shiftAmount) { throw null; }
         static sbyte System.Numerics.IShiftOperators<sbyte, sbyte>.operator >>>(sbyte value, int shiftAmount) { throw null; }
@@ -4397,7 +4496,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static sbyte TrailingZeroCount(sbyte value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out sbyte result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out sbyte result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out sbyte result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out sbyte result) { throw null; }
@@ -4457,9 +4556,9 @@ namespace System
         public static float CopySign(float x, float y) { throw null; }
         public static float Cos(float x) { throw null; }
         public static float Cosh(float x) { throw null; }
-        public static float CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static float CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static float CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static float CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static float CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static float CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(float obj) { throw null; }
         public static float Exp(float x) { throw null; }
@@ -4550,12 +4649,12 @@ namespace System
         static float System.Numerics.IDivisionOperators<float, float, float>.operator /(float left, float right) { throw null; }
         int System.Numerics.IFloatingPoint<float>.GetExponentByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<float>.GetExponentShortestBitLength() { throw null; }
-        int System.Numerics.IFloatingPoint<float>.GetSignificandByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<float>.GetSignificandBitLength() { throw null; }
-        bool System.Numerics.IFloatingPoint<float>.TryWriteExponentBigEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<float>.TryWriteExponentLittleEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<float>.TryWriteSignificandBigEndian(Span<byte> destination, out int bytesWritten) { throw null; }
-        bool System.Numerics.IFloatingPoint<float>.TryWriteSignificandLittleEndian(Span<byte> destination, out int bytesWritten) { throw null; }
+        int System.Numerics.IFloatingPoint<float>.GetSignificandByteCount() { throw null; }
+        bool System.Numerics.IFloatingPoint<float>.TryWriteExponentBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<float>.TryWriteExponentLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<float>.TryWriteSignificandBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        bool System.Numerics.IFloatingPoint<float>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         static float System.Numerics.IIncrementOperators<float>.operator checked ++(float value) { throw null; }
         static float System.Numerics.IIncrementOperators<float>.operator ++(float value) { throw null; }
         static float System.Numerics.IModulusOperators<float, float, float>.operator %(float left, float right) { throw null; }
@@ -4573,7 +4672,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static float Truncate(float x) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out float result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out float result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out float result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out float result) { throw null; }
@@ -5764,9 +5863,9 @@ namespace System
         public static System.UInt128 Clamp(System.UInt128 value, System.UInt128 min, System.UInt128 max) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public int CompareTo(System.UInt128 value) { throw null; }
-        public static System.UInt128 CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static System.UInt128 CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static System.UInt128 CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static System.UInt128 CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.UInt128 CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static System.UInt128 CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (System.UInt128 Quotient, System.UInt128 Remainder) DivRem(System.UInt128 left, System.UInt128 right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(System.UInt128 other) { throw null; }
@@ -5888,17 +5987,28 @@ namespace System
         int System.Numerics.IBinaryInteger<System.UInt128>.GetShortestBitLength() { throw null; }
         bool System.Numerics.IBinaryInteger<System.UInt128>.TryWriteBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IBinaryInteger<System.UInt128>.TryWriteLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
-        static System.UInt128 System.Numerics.INumber<System.UInt128>.Abs(System.UInt128 value) { throw null; }
+        static System.UInt128 System.Numerics.INumberBase<System.UInt128>.Abs(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsFinite(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsInfinity(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsNaN(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsNegative(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsNegativeInfinity(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsNormal(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsPositiveInfinity(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsSubnormal(System.UInt128 value) { throw null; }
+        static System.UInt128 System.Numerics.INumberBase<System.UInt128>.MaxMagnitude(System.UInt128 x, System.UInt128 y) { throw null; }
+        static System.UInt128 System.Numerics.INumberBase<System.UInt128>.MaxMagnitudeNumber(System.UInt128 x, System.UInt128 y) { throw null; }
+        static System.UInt128 System.Numerics.INumberBase<System.UInt128>.MinMagnitude(System.UInt128 x, System.UInt128 y) { throw null; }
+        static System.UInt128 System.Numerics.INumberBase<System.UInt128>.MinMagnitudeNumber(System.UInt128 x, System.UInt128 y) { throw null; }
         static System.UInt128 System.Numerics.INumber<System.UInt128>.CopySign(System.UInt128 value, System.UInt128 sign) { throw null; }
-        static bool System.Numerics.INumber<System.UInt128>.IsNegative(System.UInt128 value) { throw null; }
-        static System.UInt128 System.Numerics.INumber<System.UInt128>.MaxMagnitude(System.UInt128 x, System.UInt128 y) { throw null; }
-        static System.UInt128 System.Numerics.INumber<System.UInt128>.MinMagnitude(System.UInt128 x, System.UInt128 y) { throw null; }
+        static System.UInt128 System.Numerics.INumber<System.UInt128>.MaxNumber(System.UInt128 x, System.UInt128 y) { throw null; }
+        static System.UInt128 System.Numerics.INumber<System.UInt128>.MinNumber(System.UInt128 x, System.UInt128 y) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static System.UInt128 TrailingZeroCount(System.UInt128 value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out System.UInt128 result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.UInt128 result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt128 result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.UInt128 result) { throw null; }
@@ -5922,9 +6032,9 @@ namespace System
         public static ushort Clamp(ushort value, ushort min, ushort max) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public int CompareTo(ushort value) { throw null; }
-        public static ushort CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static ushort CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static ushort CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static ushort CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static ushort CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static ushort CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (ushort Quotient, ushort Remainder) DivRem(ushort left, ushort right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(ushort obj) { throw null; }
@@ -5985,11 +6095,22 @@ namespace System
         static ushort System.Numerics.IModulusOperators<ushort, ushort, ushort>.operator %(ushort left, ushort right) { throw null; }
         static ushort System.Numerics.IMultiplyOperators<ushort, ushort, ushort>.operator checked *(ushort left, ushort right) { throw null; }
         static ushort System.Numerics.IMultiplyOperators<ushort, ushort, ushort>.operator *(ushort left, ushort right) { throw null; }
-        static ushort System.Numerics.INumber<ushort>.Abs(ushort value) { throw null; }
+        static ushort System.Numerics.INumberBase<ushort>.Abs(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsFinite(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsInfinity(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsNaN(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsNegative(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsNegativeInfinity(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsNormal(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsPositiveInfinity(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsSubnormal(ushort value) { throw null; }
+        static ushort System.Numerics.INumberBase<ushort>.MaxMagnitude(ushort x, ushort y) { throw null; }
+        static ushort System.Numerics.INumberBase<ushort>.MaxMagnitudeNumber(ushort x, ushort y) { throw null; }
+        static ushort System.Numerics.INumberBase<ushort>.MinMagnitude(ushort x, ushort y) { throw null; }
+        static ushort System.Numerics.INumberBase<ushort>.MinMagnitudeNumber(ushort x, ushort y) { throw null; }
         static ushort System.Numerics.INumber<ushort>.CopySign(ushort value, ushort sign) { throw null; }
-        static bool System.Numerics.INumber<ushort>.IsNegative(ushort value) { throw null; }
-        static ushort System.Numerics.INumber<ushort>.MaxMagnitude(ushort x, ushort y) { throw null; }
-        static ushort System.Numerics.INumber<ushort>.MinMagnitude(ushort x, ushort y) { throw null; }
+        static ushort System.Numerics.INumber<ushort>.MaxNumber(ushort x, ushort y) { throw null; }
+        static ushort System.Numerics.INumber<ushort>.MinNumber(ushort x, ushort y) { throw null; }
         static ushort System.Numerics.IShiftOperators<ushort, ushort>.operator <<(ushort value, int shiftAmount) { throw null; }
         static ushort System.Numerics.IShiftOperators<ushort, ushort>.operator >>(ushort value, int shiftAmount) { throw null; }
         static ushort System.Numerics.IShiftOperators<ushort, ushort>.operator >>>(ushort value, int shiftAmount) { throw null; }
@@ -6003,7 +6124,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static ushort TrailingZeroCount(ushort value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out ushort result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out ushort result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out ushort result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out ushort result) { throw null; }
@@ -6027,9 +6148,9 @@ namespace System
         public static uint Clamp(uint value, uint min, uint max) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public int CompareTo(uint value) { throw null; }
-        public static uint CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static uint CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static uint CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static uint CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static uint CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static uint CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (uint Quotient, uint Remainder) DivRem(uint left, uint right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(uint obj) { throw null; }
@@ -6090,11 +6211,22 @@ namespace System
         static uint System.Numerics.IModulusOperators<uint, uint, uint>.operator %(uint left, uint right) { throw null; }
         static uint System.Numerics.IMultiplyOperators<uint, uint, uint>.operator checked *(uint left, uint right) { throw null; }
         static uint System.Numerics.IMultiplyOperators<uint, uint, uint>.operator *(uint left, uint right) { throw null; }
-        static uint System.Numerics.INumber<uint>.Abs(uint value) { throw null; }
+        static uint System.Numerics.INumberBase<uint>.Abs(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsFinite(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsInfinity(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsNaN(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsNegative(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsNegativeInfinity(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsNormal(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsPositiveInfinity(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsSubnormal(uint value) { throw null; }
+        static uint System.Numerics.INumberBase<uint>.MaxMagnitude(uint x, uint y) { throw null; }
+        static uint System.Numerics.INumberBase<uint>.MaxMagnitudeNumber(uint x, uint y) { throw null; }
+        static uint System.Numerics.INumberBase<uint>.MinMagnitude(uint x, uint y) { throw null; }
+        static uint System.Numerics.INumberBase<uint>.MinMagnitudeNumber(uint x, uint y) { throw null; }
         static uint System.Numerics.INumber<uint>.CopySign(uint value, uint sign) { throw null; }
-        static bool System.Numerics.INumber<uint>.IsNegative(uint value) { throw null; }
-        static uint System.Numerics.INumber<uint>.MaxMagnitude(uint x, uint y) { throw null; }
-        static uint System.Numerics.INumber<uint>.MinMagnitude(uint x, uint y) { throw null; }
+        static uint System.Numerics.INumber<uint>.MaxNumber(uint x, uint y) { throw null; }
+        static uint System.Numerics.INumber<uint>.MinNumber(uint x, uint y) { throw null; }
         static uint System.Numerics.IShiftOperators<uint, uint>.operator <<(uint value, int shiftAmount) { throw null; }
         static uint System.Numerics.IShiftOperators<uint, uint>.operator >>(uint value, int shiftAmount) { throw null; }
         static uint System.Numerics.IShiftOperators<uint, uint>.operator >>>(uint value, int shiftAmount) { throw null; }
@@ -6108,7 +6240,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static uint TrailingZeroCount(uint value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out uint result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out uint result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out uint result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out uint result) { throw null; }
@@ -6132,9 +6264,9 @@ namespace System
         public static ulong Clamp(ulong value, ulong min, ulong max) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public int CompareTo(ulong value) { throw null; }
-        public static ulong CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static ulong CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static ulong CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static ulong CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static ulong CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static ulong CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (ulong Quotient, ulong Remainder) DivRem(ulong left, ulong right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(ulong obj) { throw null; }
@@ -6195,11 +6327,22 @@ namespace System
         static ulong System.Numerics.IModulusOperators<ulong, ulong, ulong>.operator %(ulong left, ulong right) { throw null; }
         static ulong System.Numerics.IMultiplyOperators<ulong, ulong, ulong>.operator checked *(ulong left, ulong right) { throw null; }
         static ulong System.Numerics.IMultiplyOperators<ulong, ulong, ulong>.operator *(ulong left, ulong right) { throw null; }
-        static ulong System.Numerics.INumber<ulong>.Abs(ulong value) { throw null; }
+        static ulong System.Numerics.INumberBase<ulong>.Abs(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsFinite(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsInfinity(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsNaN(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsNegative(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsNegativeInfinity(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsNormal(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsPositiveInfinity(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsSubnormal(ulong value) { throw null; }
+        static ulong System.Numerics.INumberBase<ulong>.MaxMagnitude(ulong x, ulong y) { throw null; }
+        static ulong System.Numerics.INumberBase<ulong>.MaxMagnitudeNumber(ulong x, ulong y) { throw null; }
+        static ulong System.Numerics.INumberBase<ulong>.MinMagnitude(ulong x, ulong y) { throw null; }
+        static ulong System.Numerics.INumberBase<ulong>.MinMagnitudeNumber(ulong x, ulong y) { throw null; }
         static ulong System.Numerics.INumber<ulong>.CopySign(ulong value, ulong sign) { throw null; }
-        static bool System.Numerics.INumber<ulong>.IsNegative(ulong value) { throw null; }
-        static ulong System.Numerics.INumber<ulong>.MaxMagnitude(ulong x, ulong y) { throw null; }
-        static ulong System.Numerics.INumber<ulong>.MinMagnitude(ulong x, ulong y) { throw null; }
+        static ulong System.Numerics.INumber<ulong>.MaxNumber(ulong x, ulong y) { throw null; }
+        static ulong System.Numerics.INumber<ulong>.MinNumber(ulong x, ulong y) { throw null; }
         static ulong System.Numerics.IShiftOperators<ulong, ulong>.operator <<(ulong value, int shiftAmount) { throw null; }
         static ulong System.Numerics.IShiftOperators<ulong, ulong>.operator >>(ulong value, int shiftAmount) { throw null; }
         static ulong System.Numerics.IShiftOperators<ulong, ulong>.operator >>>(ulong value, int shiftAmount) { throw null; }
@@ -6213,7 +6356,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public static ulong TrailingZeroCount(ulong value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out ulong result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out ulong result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out ulong result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out ulong result) { throw null; }
@@ -6243,9 +6386,9 @@ namespace System
         public static nuint Clamp(nuint value, nuint min, nuint max) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public int CompareTo(System.UIntPtr value) { throw null; }
-        public static nuint CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static nuint CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
-        public static nuint CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static nuint CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static nuint CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
+        public static nuint CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public static (nuint Quotient, nuint Remainder) DivRem(nuint left, nuint right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(System.UIntPtr other) { throw null; }
@@ -6254,9 +6397,7 @@ namespace System
         public static nuint LeadingZeroCount(nuint value) { throw null; }
         public static nuint Log2(nuint value) { throw null; }
         public static nuint Max(nuint x, nuint y) { throw null; }
-        public static nuint MaxMagnitude(nuint x, nuint y) { throw null; }
         public static nuint Min(nuint x, nuint y) { throw null; }
-        public static nuint MinMagnitude(nuint x, nuint y) { throw null; }
         public static System.UIntPtr operator +(System.UIntPtr pointer, int offset) { throw null; }
         public static bool operator ==(System.UIntPtr value1, System.UIntPtr value2) { throw null; }
         public static explicit operator System.UIntPtr (uint value) { throw null; }
@@ -6301,9 +6442,22 @@ namespace System
         static nuint System.Numerics.IModulusOperators<nuint, nuint, nuint>.operator %(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.IMultiplyOperators<nuint, nuint, nuint>.operator checked *(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.IMultiplyOperators<nuint, nuint, nuint>.operator *(nuint left, nuint right) { throw null; }
-        static nuint System.Numerics.INumber<nuint>.Abs(nuint value) { throw null; }
+        static nuint System.Numerics.INumberBase<nuint>.Abs(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsFinite(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsInfinity(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsNaN(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsNegative(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsNegativeInfinity(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsNormal(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsPositiveInfinity(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsSubnormal(nuint value) { throw null; }
+        static nuint System.Numerics.INumberBase<nuint>.MaxMagnitude(nuint x, nuint y) { throw null; }
+        static nuint System.Numerics.INumberBase<nuint>.MaxMagnitudeNumber(nuint x, nuint y) { throw null; }
+        static nuint System.Numerics.INumberBase<nuint>.MinMagnitude(nuint x, nuint y) { throw null; }
+        static nuint System.Numerics.INumberBase<nuint>.MinMagnitudeNumber(nuint x, nuint y) { throw null; }
         static nuint System.Numerics.INumber<nuint>.CopySign(nuint value, nuint sign) { throw null; }
-        static bool System.Numerics.INumber<nuint>.IsNegative(nuint value) { throw null; }
+        static nuint System.Numerics.INumber<nuint>.MaxNumber(nuint x, nuint y) { throw null; }
+        static nuint System.Numerics.INumber<nuint>.MinNumber(nuint x, nuint y) { throw null; }
         static nuint System.Numerics.IShiftOperators<nuint, nuint>.operator <<(nuint value, int shiftAmount) { throw null; }
         static nuint System.Numerics.IShiftOperators<nuint, nuint>.operator >>(nuint value, int shiftAmount) { throw null; }
         static nuint System.Numerics.IShiftOperators<nuint, nuint>.operator >>>(nuint value, int shiftAmount) { throw null; }
@@ -6321,7 +6475,7 @@ namespace System
         public uint ToUInt32() { throw null; }
         public ulong ToUInt64() { throw null; }
         public static nuint TrailingZeroCount(nuint value) { throw null; }
-        public static bool TryCreate<TOther>(TOther value, out nuint result) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out nuint result) where TOther : System.Numerics.INumberBase<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UIntPtr result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.UIntPtr result) { throw null; }
@@ -9999,17 +10153,6 @@ namespace System.Numerics
         static abstract TSelf FusedMultiplyAdd(TSelf left, TSelf right, TSelf addend);
         static abstract TSelf Ieee754Remainder(TSelf left, TSelf right);
         static abstract int ILogB(TSelf x);
-        static abstract bool IsFinite(TSelf value);
-        static abstract bool IsInfinity(TSelf value);
-        static abstract bool IsNaN(TSelf value);
-        static abstract bool IsNegativeInfinity(TSelf value);
-        static abstract bool IsNormal(TSelf value);
-        static abstract bool IsPositiveInfinity(TSelf value);
-        static abstract bool IsSubnormal(TSelf value);
-        static abstract TSelf MaxMagnitudeNumber(TSelf x, TSelf y);
-        static abstract TSelf MaxNumber(TSelf x, TSelf y);
-        static abstract TSelf MinMagnitudeNumber(TSelf x, TSelf y);
-        static abstract TSelf MinNumber(TSelf x, TSelf y);
         static abstract TSelf ReciprocalEstimate(TSelf x);
         static abstract TSelf ReciprocalSqrtEstimate(TSelf x);
         static abstract TSelf ScaleB(TSelf x, int n);
@@ -10086,30 +10229,41 @@ namespace System.Numerics
         static abstract TResult operator checked *(TSelf left, TOther right);
         static abstract TResult operator *(TSelf left, TOther right);
     }
-    public partial interface INumberBase<TSelf> : System.IEquatable<TSelf>, System.IFormattable, System.ISpanFormattable, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf> where TSelf : System.Numerics.INumberBase<TSelf>
+    public partial interface INumberBase<TSelf> : System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf> where TSelf : System.Numerics.INumberBase<TSelf>
     {
         static abstract TSelf One { get; }
         static abstract TSelf Zero { get; }
+        static abstract TSelf Abs(TSelf value);
+        static abstract TSelf CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
+        static abstract TSelf CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+        static abstract TSelf CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+        static abstract bool IsFinite(TSelf value);
+        static abstract bool IsInfinity(TSelf value);
+        static abstract bool IsNaN(TSelf value);
+        static abstract bool IsNegative(TSelf value);
+        static abstract bool IsNegativeInfinity(TSelf value);
+        static abstract bool IsNormal(TSelf value);
+        static abstract bool IsPositiveInfinity(TSelf value);
+        static abstract bool IsSubnormal(TSelf value);
+        static abstract TSelf MaxMagnitude(TSelf x, TSelf y);
+        static abstract TSelf MaxMagnitudeNumber(TSelf x, TSelf y);
+        static abstract TSelf MinMagnitude(TSelf x, TSelf y);
+        static abstract TSelf MinMagnitudeNumber(TSelf x, TSelf y);
+        static abstract TSelf Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider);
+        static abstract TSelf Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider);
+        static abstract bool TryCreate<TOther>(TOther value, out TSelf result) where TOther : INumberBase<TOther>;
+        static abstract bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out TSelf result);
+        static abstract bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out TSelf result);
     }
     public partial interface INumber<TSelf> : System.IComparable, System.IComparable<TSelf>, System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IComparisonOperators<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IModulusOperators<TSelf, TSelf, TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.INumberBase<TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf> where TSelf : System.Numerics.INumber<TSelf>
     {
-        static abstract TSelf Abs(TSelf value);
         static abstract TSelf Clamp(TSelf value, TSelf min, TSelf max);
         static abstract TSelf CopySign(TSelf value, TSelf sign);
-        static abstract TSelf CreateChecked<TOther>(TOther value) where TOther : INumber<TOther>;
-        static abstract TSelf CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther>;
-        static abstract TSelf CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther>;
-        static abstract bool IsNegative(TSelf value);
         static abstract TSelf Max(TSelf x, TSelf y);
-        static abstract TSelf MaxMagnitude(TSelf x, TSelf y);
+        static abstract TSelf MaxNumber(TSelf x, TSelf y);
         static abstract TSelf Min(TSelf x, TSelf y);
-        static abstract TSelf MinMagnitude(TSelf x, TSelf y);
-        static abstract TSelf Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider);
-        static abstract TSelf Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider);
+        static abstract TSelf MinNumber(TSelf x, TSelf y);
         static abstract int Sign(TSelf value);
-        static abstract bool TryCreate<TOther>(TOther value, out TSelf result) where TOther : INumber<TOther>;
-        static abstract bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out TSelf result);
-        static abstract bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out TSelf result);
     }
     public partial interface IPowerFunctions<TSelf> where TSelf : System.Numerics.IPowerFunctions<TSelf>
     {

--- a/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
@@ -495,6 +495,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal((byte)0x01, NumberHelper<byte>.MaxNumber((byte)0x00, (byte)1));
+            Assert.Equal((byte)0x01, NumberHelper<byte>.MaxNumber((byte)0x01, (byte)1));
+            Assert.Equal((byte)0x7F, NumberHelper<byte>.MaxNumber((byte)0x7F, (byte)1));
+            Assert.Equal((byte)0x80, NumberHelper<byte>.MaxNumber((byte)0x80, (byte)1));
+            Assert.Equal((byte)0xFF, NumberHelper<byte>.MaxNumber((byte)0xFF, (byte)1));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal((byte)0x00, NumberHelper<byte>.Min((byte)0x00, (byte)1));
@@ -502,6 +512,16 @@ namespace System.Tests
             Assert.Equal((byte)0x01, NumberHelper<byte>.Min((byte)0x7F, (byte)1));
             Assert.Equal((byte)0x01, NumberHelper<byte>.Min((byte)0x80, (byte)1));
             Assert.Equal((byte)0x01, NumberHelper<byte>.Min((byte)0xFF, (byte)1));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal((byte)0x00, NumberHelper<byte>.MinNumber((byte)0x00, (byte)1));
+            Assert.Equal((byte)0x01, NumberHelper<byte>.MinNumber((byte)0x01, (byte)1));
+            Assert.Equal((byte)0x01, NumberHelper<byte>.MinNumber((byte)0x7F, (byte)1));
+            Assert.Equal((byte)0x01, NumberHelper<byte>.MinNumber((byte)0x80, (byte)1));
+            Assert.Equal((byte)0x01, NumberHelper<byte>.MinNumber((byte)0xFF, (byte)1));
         }
 
         [Fact]
@@ -934,6 +954,126 @@ namespace System.Tests
                 Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<byte>.IsFinite((byte)0x00));
+            Assert.True(NumberBaseHelper<byte>.IsFinite((byte)0x01));
+            Assert.True(NumberBaseHelper<byte>.IsFinite((byte)0x7F));
+            Assert.True(NumberBaseHelper<byte>.IsFinite((byte)0x80));
+            Assert.True(NumberBaseHelper<byte>.IsFinite((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<byte>.IsInfinity((byte)0x00));
+            Assert.False(NumberBaseHelper<byte>.IsInfinity((byte)0x01));
+            Assert.False(NumberBaseHelper<byte>.IsInfinity((byte)0x7F));
+            Assert.False(NumberBaseHelper<byte>.IsInfinity((byte)0x80));
+            Assert.False(NumberBaseHelper<byte>.IsInfinity((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<byte>.IsNaN((byte)0x00));
+            Assert.False(NumberBaseHelper<byte>.IsNaN((byte)0x01));
+            Assert.False(NumberBaseHelper<byte>.IsNaN((byte)0x7F));
+            Assert.False(NumberBaseHelper<byte>.IsNaN((byte)0x80));
+            Assert.False(NumberBaseHelper<byte>.IsNaN((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<byte>.IsNegative((byte)0x00));
+            Assert.False(NumberBaseHelper<byte>.IsNegative((byte)0x01));
+            Assert.False(NumberBaseHelper<byte>.IsNegative((byte)0x7F));
+            Assert.False(NumberBaseHelper<byte>.IsNegative((byte)0x80));
+            Assert.False(NumberBaseHelper<byte>.IsNegative((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<byte>.IsNegativeInfinity((byte)0x00));
+            Assert.False(NumberBaseHelper<byte>.IsNegativeInfinity((byte)0x01));
+            Assert.False(NumberBaseHelper<byte>.IsNegativeInfinity((byte)0x7F));
+            Assert.False(NumberBaseHelper<byte>.IsNegativeInfinity((byte)0x80));
+            Assert.False(NumberBaseHelper<byte>.IsNegativeInfinity((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<byte>.IsNormal((byte)0x00));
+            Assert.True(NumberBaseHelper<byte>.IsNormal((byte)0x01));
+            Assert.True(NumberBaseHelper<byte>.IsNormal((byte)0x7F));
+            Assert.True(NumberBaseHelper<byte>.IsNormal((byte)0x80));
+            Assert.True(NumberBaseHelper<byte>.IsNormal((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<byte>.IsPositiveInfinity((byte)0x00));
+            Assert.False(NumberBaseHelper<byte>.IsPositiveInfinity((byte)0x01));
+            Assert.False(NumberBaseHelper<byte>.IsPositiveInfinity((byte)0x7F));
+            Assert.False(NumberBaseHelper<byte>.IsPositiveInfinity((byte)0x80));
+            Assert.False(NumberBaseHelper<byte>.IsPositiveInfinity((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<byte>.IsSubnormal((byte)0x00));
+            Assert.False(NumberBaseHelper<byte>.IsSubnormal((byte)0x01));
+            Assert.False(NumberBaseHelper<byte>.IsSubnormal((byte)0x7F));
+            Assert.False(NumberBaseHelper<byte>.IsSubnormal((byte)0x80));
+            Assert.False(NumberBaseHelper<byte>.IsSubnormal((byte)0xFF));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MaxMagnitude((byte)0x00, (byte)1));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MaxMagnitude((byte)0x01, (byte)1));
+            Assert.Equal((byte)0x7F, NumberBaseHelper<byte>.MaxMagnitude((byte)0x7F, (byte)1));
+            Assert.Equal((byte)0x80, NumberBaseHelper<byte>.MaxMagnitude((byte)0x80, (byte)1));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.MaxMagnitude((byte)0xFF, (byte)1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MaxMagnitudeNumber((byte)0x00, (byte)1));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MaxMagnitudeNumber((byte)0x01, (byte)1));
+            Assert.Equal((byte)0x7F, NumberBaseHelper<byte>.MaxMagnitudeNumber((byte)0x7F, (byte)1));
+            Assert.Equal((byte)0x80, NumberBaseHelper<byte>.MaxMagnitudeNumber((byte)0x80, (byte)1));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.MaxMagnitudeNumber((byte)0xFF, (byte)1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.MinMagnitude((byte)0x00, (byte)1));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MinMagnitude((byte)0x01, (byte)1));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MinMagnitude((byte)0x7F, (byte)1));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MinMagnitude((byte)0x80, (byte)1));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MinMagnitude((byte)0xFF, (byte)1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.MinMagnitudeNumber((byte)0x00, (byte)1));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MinMagnitudeNumber((byte)0x01, (byte)1));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MinMagnitudeNumber((byte)0x7F, (byte)1));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MinMagnitudeNumber((byte)0x80, (byte)1));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.MinMagnitudeNumber((byte)0xFF, (byte)1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
@@ -8,41 +8,9 @@ namespace System.Tests
 {
     public class ByteTests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal((byte)0x00, AdditiveIdentityHelper<byte, byte>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            Assert.Equal((byte)0x00, MinMaxValueHelper<byte>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            Assert.Equal((byte)0xFF, MinMaxValueHelper<byte>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal((byte)0x01, MultiplicativeIdentityHelper<byte, byte>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -63,6 +31,30 @@ namespace System.Tests
             Assert.Equal((byte)0x81, AdditionOperatorsHelper<byte, byte, byte>.op_CheckedAddition((byte)0x80, (byte)1));
 
             Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<byte, byte, byte>.op_CheckedAddition((byte)0xFF, (byte)1));
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal((byte)0x00, AdditiveIdentityHelper<byte, byte>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            Assert.Equal(((byte)0x00, (byte)0x00), BinaryIntegerHelper<byte>.DivRem((byte)0x00, (byte)2));
+            Assert.Equal(((byte)0x00, (byte)0x01), BinaryIntegerHelper<byte>.DivRem((byte)0x01, (byte)2));
+            Assert.Equal(((byte)0x3F, (byte)0x01), BinaryIntegerHelper<byte>.DivRem((byte)0x7F, (byte)2));
+            Assert.Equal(((byte)0x40, (byte)0x00), BinaryIntegerHelper<byte>.DivRem((byte)0x80, (byte)2));
+            Assert.Equal(((byte)0x7F, (byte)0x01), BinaryIntegerHelper<byte>.DivRem((byte)0xFF, (byte)2));
         }
 
         [Fact]
@@ -116,6 +108,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            Assert.Equal(1, BinaryIntegerHelper<byte>.GetByteCount((byte)0x00));
+            Assert.Equal(1, BinaryIntegerHelper<byte>.GetByteCount((byte)0x01));
+            Assert.Equal(1, BinaryIntegerHelper<byte>.GetByteCount((byte)0x7F));
+            Assert.Equal(1, BinaryIntegerHelper<byte>.GetByteCount((byte)0x80));
+            Assert.Equal(1, BinaryIntegerHelper<byte>.GetByteCount((byte)0xFF));
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             Assert.Equal(0x00, BinaryIntegerHelper<byte>.GetShortestBitLength((byte)0x00));
@@ -124,6 +126,72 @@ namespace System.Tests
             Assert.Equal(0x08, BinaryIntegerHelper<byte>.GetShortestBitLength((byte)0x80));
             Assert.Equal(0x08, BinaryIntegerHelper<byte>.GetShortestBitLength((byte)0xFF));
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[1];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<byte>.TryWriteBigEndian((byte)0x00, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<byte>.TryWriteBigEndian((byte)0x01, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x01 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<byte>.TryWriteBigEndian((byte)0x7F, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<byte>.TryWriteBigEndian((byte)0x80, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<byte>.TryWriteBigEndian((byte)0xFF, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<byte>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[1];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<byte>.TryWriteLittleEndian((byte)0x00, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<byte>.TryWriteLittleEndian((byte)0x01, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x01 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<byte>.TryWriteLittleEndian((byte)0x7F, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<byte>.TryWriteLittleEndian((byte)0x80, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<byte>.TryWriteLittleEndian((byte)0xFF, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<byte>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -144,6 +212,10 @@ namespace System.Tests
             Assert.Equal((byte)0x07, BinaryNumberHelper<byte>.Log2((byte)0x80));
             Assert.Equal((byte)0x07, BinaryNumberHelper<byte>.Log2((byte)0xFF));
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -185,25 +257,9 @@ namespace System.Tests
             Assert.Equal((byte)0x00, BitwiseOperatorsHelper<byte, byte, byte>.op_OnesComplement((byte)0xFF));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<byte, byte>.op_LessThan((byte)0x00, (byte)1));
-            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThan((byte)0x01, (byte)1));
-            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThan((byte)0x7F, (byte)1));
-            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThan((byte)0x80, (byte)1));
-            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThan((byte)0xFF, (byte)1));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<byte, byte>.op_LessThanOrEqual((byte)0x00, (byte)1));
-            Assert.True(ComparisonOperatorsHelper<byte, byte>.op_LessThanOrEqual((byte)0x01, (byte)1));
-            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThanOrEqual((byte)0x7F, (byte)1));
-            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThanOrEqual((byte)0x80, (byte)1));
-            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThanOrEqual((byte)0xFF, (byte)1));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -226,6 +282,30 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<byte, byte>.op_LessThan((byte)0x00, (byte)1));
+            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThan((byte)0x01, (byte)1));
+            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThan((byte)0x7F, (byte)1));
+            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThan((byte)0x80, (byte)1));
+            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThan((byte)0xFF, (byte)1));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<byte, byte>.op_LessThanOrEqual((byte)0x00, (byte)1));
+            Assert.True(ComparisonOperatorsHelper<byte, byte>.op_LessThanOrEqual((byte)0x01, (byte)1));
+            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThanOrEqual((byte)0x7F, (byte)1));
+            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThanOrEqual((byte)0x80, (byte)1));
+            Assert.False(ComparisonOperatorsHelper<byte, byte>.op_LessThanOrEqual((byte)0xFF, (byte)1));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             Assert.Equal((byte)0xFF, DecrementOperatorsHelper<byte>.op_Decrement((byte)0x00));
@@ -245,6 +325,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<byte>.op_CheckedDecrement((byte)0x00));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -270,6 +354,10 @@ namespace System.Tests
             Assert.Throws<DivideByZeroException>(() => DivisionOperatorsHelper<byte, byte, byte>.op_CheckedDivision((byte)0x01, (byte)0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -289,6 +377,10 @@ namespace System.Tests
             Assert.True(EqualityOperatorsHelper<byte, byte>.op_Inequality((byte)0x80, (byte)1));
             Assert.True(EqualityOperatorsHelper<byte, byte>.op_Inequality((byte)0xFF, (byte)1));
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -311,6 +403,26 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<byte>.op_CheckedIncrement((byte)0xFF));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            Assert.Equal((byte)0xFF, MinMaxValueHelper<byte>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal((byte)0x00, MinMaxValueHelper<byte>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -322,6 +434,20 @@ namespace System.Tests
 
             Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<byte, byte, byte>.op_Modulus((byte)0x01, (byte)0));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal((byte)0x01, MultiplicativeIdentityHelper<byte, byte>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -344,15 +470,9 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<byte, byte, byte>.op_CheckedMultiply((byte)0xFF, (byte)2));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.Abs((byte)0x00));
-            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.Abs((byte)0x01));
-            Assert.Equal((byte)0x7F, NumberBaseHelper<byte>.Abs((byte)0x7F));
-            Assert.Equal((byte)0x80, NumberBaseHelper<byte>.Abs((byte)0x80));
-            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.Abs((byte)0xFF));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -362,6 +482,62 @@ namespace System.Tests
             Assert.Equal((byte)0x3F, NumberHelper<byte>.Clamp((byte)0x7F, (byte)0x01, (byte)0x3F));
             Assert.Equal((byte)0x3F, NumberHelper<byte>.Clamp((byte)0x80, (byte)0x01, (byte)0x3F));
             Assert.Equal((byte)0x3F, NumberHelper<byte>.Clamp((byte)0xFF, (byte)0x01, (byte)0x3F));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal((byte)0x01, NumberHelper<byte>.Max((byte)0x00, (byte)1));
+            Assert.Equal((byte)0x01, NumberHelper<byte>.Max((byte)0x01, (byte)1));
+            Assert.Equal((byte)0x7F, NumberHelper<byte>.Max((byte)0x7F, (byte)1));
+            Assert.Equal((byte)0x80, NumberHelper<byte>.Max((byte)0x80, (byte)1));
+            Assert.Equal((byte)0xFF, NumberHelper<byte>.Max((byte)0xFF, (byte)1));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal((byte)0x00, NumberHelper<byte>.Min((byte)0x00, (byte)1));
+            Assert.Equal((byte)0x01, NumberHelper<byte>.Min((byte)0x01, (byte)1));
+            Assert.Equal((byte)0x01, NumberHelper<byte>.Min((byte)0x7F, (byte)1));
+            Assert.Equal((byte)0x01, NumberHelper<byte>.Min((byte)0x80, (byte)1));
+            Assert.Equal((byte)0x01, NumberHelper<byte>.Min((byte)0xFF, (byte)1));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(0, NumberHelper<byte>.Sign((byte)0x00));
+            Assert.Equal(1, NumberHelper<byte>.Sign((byte)0x01));
+            Assert.Equal(1, NumberHelper<byte>.Sign((byte)0x7F));
+            Assert.Equal(1, NumberHelper<byte>.Sign((byte)0x80));
+            Assert.Equal(1, NumberHelper<byte>.Sign((byte)0xFF));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.Abs((byte)0x00));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.Abs((byte)0x01));
+            Assert.Equal((byte)0x7F, NumberBaseHelper<byte>.Abs((byte)0x7F));
+            Assert.Equal((byte)0x80, NumberBaseHelper<byte>.Abs((byte)0x80));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.Abs((byte)0xFF));
         }
 
         [Fact]
@@ -761,46 +937,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            Assert.Equal(((byte)0x00, (byte)0x00), BinaryIntegerHelper<byte>.DivRem((byte)0x00, (byte)2));
-            Assert.Equal(((byte)0x00, (byte)0x01), BinaryIntegerHelper<byte>.DivRem((byte)0x01, (byte)2));
-            Assert.Equal(((byte)0x3F, (byte)0x01), BinaryIntegerHelper<byte>.DivRem((byte)0x7F, (byte)2));
-            Assert.Equal(((byte)0x40, (byte)0x00), BinaryIntegerHelper<byte>.DivRem((byte)0x80, (byte)2));
-            Assert.Equal(((byte)0x7F, (byte)0x01), BinaryIntegerHelper<byte>.DivRem((byte)0xFF, (byte)2));
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            Assert.Equal((byte)0x01, NumberHelper<byte>.Max((byte)0x00, (byte)1));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.Max((byte)0x01, (byte)1));
-            Assert.Equal((byte)0x7F, NumberHelper<byte>.Max((byte)0x7F, (byte)1));
-            Assert.Equal((byte)0x80, NumberHelper<byte>.Max((byte)0x80, (byte)1));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.Max((byte)0xFF, (byte)1));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.Min((byte)0x00, (byte)1));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.Min((byte)0x01, (byte)1));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.Min((byte)0x7F, (byte)1));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.Min((byte)0x80, (byte)1));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.Min((byte)0xFF, (byte)1));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(0, NumberHelper<byte>.Sign((byte)0x00));
-            Assert.Equal(1, NumberHelper<byte>.Sign((byte)0x01));
-            Assert.Equal(1, NumberHelper<byte>.Sign((byte)0x7F));
-            Assert.Equal(1, NumberHelper<byte>.Sign((byte)0x80));
-            Assert.Equal(1, NumberHelper<byte>.Sign((byte)0xFF));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             byte result;
@@ -1071,77 +1207,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            Assert.Equal(1, BinaryIntegerHelper<byte>.GetByteCount((byte)0x00));
-            Assert.Equal(1, BinaryIntegerHelper<byte>.GetByteCount((byte)0x01));
-            Assert.Equal(1, BinaryIntegerHelper<byte>.GetByteCount((byte)0x7F));
-            Assert.Equal(1, BinaryIntegerHelper<byte>.GetByteCount((byte)0x80));
-            Assert.Equal(1, BinaryIntegerHelper<byte>.GetByteCount((byte)0xFF));
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[1];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<byte>.TryWriteBigEndian((byte)0x00, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<byte>.TryWriteBigEndian((byte)0x01, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x01 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<byte>.TryWriteBigEndian((byte)0x7F, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<byte>.TryWriteBigEndian((byte)0x80, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<byte>.TryWriteBigEndian((byte)0xFF, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<byte>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[1];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<byte>.TryWriteLittleEndian((byte)0x00, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<byte>.TryWriteLittleEndian((byte)0x01, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x01 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<byte>.TryWriteLittleEndian((byte)0x7F, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<byte>.TryWriteLittleEndian((byte)0x80, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<byte>.TryWriteLittleEndian((byte)0xFF, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<byte>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1173,6 +1241,10 @@ namespace System.Tests
             Assert.Equal((byte)0x7F, ShiftOperatorsHelper<byte, byte>.op_UnsignedRightShift((byte)0xFF, 1));
         }
 
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1193,6 +1265,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<byte, byte, byte>.op_CheckedSubtraction((byte)0x00, (byte)1));
         }
+
+        //
+        // IUnaryNegationOperators
+        //
 
         [Fact]
         public static void op_UnaryNegationTest()
@@ -1215,6 +1291,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => UnaryNegationOperatorsHelper<byte, byte>.op_CheckedUnaryNegation((byte)0xFF));
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1224,6 +1304,10 @@ namespace System.Tests
             Assert.Equal((byte)0x80, UnaryPlusOperatorsHelper<byte, byte>.op_UnaryPlus((byte)0x80));
             Assert.Equal((byte)0xFF, UnaryPlusOperatorsHelper<byte, byte>.op_UnaryPlus((byte)0xFF));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(ByteTests.Parse_Valid_TestData), MemberType = typeof(ByteTests))]

--- a/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
@@ -347,11 +347,11 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.Abs((byte)0x00));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.Abs((byte)0x01));
-            Assert.Equal((byte)0x7F, NumberHelper<byte>.Abs((byte)0x7F));
-            Assert.Equal((byte)0x80, NumberHelper<byte>.Abs((byte)0x80));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.Abs((byte)0xFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.Abs((byte)0x00));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.Abs((byte)0x01));
+            Assert.Equal((byte)0x7F, NumberBaseHelper<byte>.Abs((byte)0x7F));
+            Assert.Equal((byte)0x80, NumberBaseHelper<byte>.Abs((byte)0x80));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.Abs((byte)0xFF));
         }
 
         [Fact]
@@ -367,51 +367,51 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<byte>(0x00));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<byte>(0x01));
-            Assert.Equal((byte)0x7F, NumberHelper<byte>.CreateChecked<byte>(0x7F));
-            Assert.Equal((byte)0x80, NumberHelper<byte>.CreateChecked<byte>(0x80));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateChecked<byte>(0xFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<byte>(0x00));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<byte>(0x01));
+            Assert.Equal((byte)0x7F, NumberBaseHelper<byte>.CreateChecked<byte>(0x7F));
+            Assert.Equal((byte)0x80, NumberBaseHelper<byte>.CreateChecked<byte>(0x80));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<char>((char)0x0000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<char>((char)0x0001));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<char>((char)0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<char>((char)0x8000));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<char>((char)0x0000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<char>((char)0x0001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<char>((char)0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<char>((char)0x8000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<short>(0x0000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<short>(0x0001));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<short>(0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<short>(0x0000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<short>(0x0001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<short>(0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<int>(0x00000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<int>(0x00000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<int>(0x00000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<int>(0x00000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<long>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<long>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -419,60 +419,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<sbyte>(0x00));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<sbyte>(0x01));
-            Assert.Equal((byte)0x7F, NumberHelper<byte>.CreateChecked<sbyte>(0x7F));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<sbyte>(0x00));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<sbyte>(0x01));
+            Assert.Equal((byte)0x7F, NumberBaseHelper<byte>.CreateChecked<sbyte>(0x7F));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<ushort>(0x0000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<ushort>(0x0001));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<ushort>(0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<ushort>(0x8000));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<ushort>(0x0000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<ushort>(0x0001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<ushort>(0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<ushort>(0x8000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<uint>(0x00000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<uint>(0x00000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<uint>(0x80000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<uint>(0x00000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<uint>(0x00000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<uint>(0x80000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -480,70 +480,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Throws<OverflowException>(() => NumberHelper<byte>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<byte>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<byte>(0x00));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<byte>(0x01));
-            Assert.Equal((byte)0x7F, NumberHelper<byte>.CreateSaturating<byte>(0x7F));
-            Assert.Equal((byte)0x80, NumberHelper<byte>.CreateSaturating<byte>(0x80));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<byte>(0xFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<byte>(0x00));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<byte>(0x01));
+            Assert.Equal((byte)0x7F, NumberBaseHelper<byte>.CreateSaturating<byte>(0x7F));
+            Assert.Equal((byte)0x80, NumberBaseHelper<byte>.CreateSaturating<byte>(0x80));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<short>(0x0000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<short>(0x0001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<short>(0x0000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<short>(0x0001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<int>(0x00000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<int>(0x00000001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<int>(0x00000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<int>(0x00000001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -551,60 +551,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal((byte)0x7F, NumberHelper<byte>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal((byte)0x7F, NumberBaseHelper<byte>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -612,70 +612,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<byte>(0x00));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<byte>(0x01));
-            Assert.Equal((byte)0x7F, NumberHelper<byte>.CreateTruncating<byte>(0x7F));
-            Assert.Equal((byte)0x80, NumberHelper<byte>.CreateTruncating<byte>(0x80));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<byte>(0xFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<byte>(0x00));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<byte>(0x01));
+            Assert.Equal((byte)0x7F, NumberBaseHelper<byte>.CreateTruncating<byte>(0x7F));
+            Assert.Equal((byte)0x80, NumberBaseHelper<byte>.CreateTruncating<byte>(0x80));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<short>(0x0000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<short>(0x0001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<short>(0x0000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<short>(0x0001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<int>(0x00000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<int>(0x00000001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<int>(0x00000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<int>(0x00000001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -683,60 +683,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal((byte)0x7F, NumberHelper<byte>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal((byte)0x80, NumberHelper<byte>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal((byte)0x7F, NumberBaseHelper<byte>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal((byte)0x80, NumberBaseHelper<byte>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -744,19 +744,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal((byte)0x01, NumberHelper<byte>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal((byte)0xFF, NumberHelper<byte>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal((byte)0x01, NumberBaseHelper<byte>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -805,19 +805,19 @@ namespace System.Tests
         {
             byte result;
 
-            Assert.True(NumberHelper<byte>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<byte>(0x00, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<byte>(0x01, out result));
             Assert.Equal((byte)0x01, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((byte)0x7F, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<byte>(0x80, out result));
             Assert.Equal((byte)0x80, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((byte)0xFF, result);
         }
 
@@ -826,19 +826,19 @@ namespace System.Tests
         {
             byte result;
 
-            Assert.True(NumberHelper<byte>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal((byte)0x01, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<char>((char)0x8000, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((byte)0x00, result);
         }
 
@@ -847,19 +847,19 @@ namespace System.Tests
         {
             byte result;
 
-            Assert.True(NumberHelper<byte>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<short>(0x0000, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<short>(0x0001, out result));
             Assert.Equal((byte)0x01, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<short>(0x7FFF, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal((byte)0x00, result);
         }
 
@@ -868,19 +868,19 @@ namespace System.Tests
         {
             byte result;
 
-            Assert.True(NumberHelper<byte>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<int>(0x00000000, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<int>(0x00000001, out result));
             Assert.Equal((byte)0x01, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal((byte)0x00, result);
         }
 
@@ -889,19 +889,19 @@ namespace System.Tests
         {
             byte result;
 
-            Assert.True(NumberHelper<byte>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal((byte)0x01, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
             Assert.Equal((byte)0x00, result);
         }
 
@@ -912,36 +912,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<byte>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<byte>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.True(NumberHelper<byte>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<byte>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal((byte)0x01, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((byte)0x00, result);
             }
             else
             {
-                Assert.True(NumberHelper<byte>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<byte>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.True(NumberHelper<byte>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<byte>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal((byte)0x01, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal((byte)0x00, result);
             }
         }
@@ -951,19 +951,19 @@ namespace System.Tests
         {
             byte result;
 
-            Assert.True(NumberHelper<byte>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal((byte)0x01, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((byte)0x7F, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal((byte)0x00, result);
         }
 
@@ -972,19 +972,19 @@ namespace System.Tests
         {
             byte result;
 
-            Assert.True(NumberHelper<byte>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal((byte)0x01, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<ushort>(0x8000, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((byte)0x00, result);
         }
 
@@ -993,19 +993,19 @@ namespace System.Tests
         {
             byte result;
 
-            Assert.True(NumberHelper<byte>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal((byte)0x01, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<uint>(0x80000000, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal((byte)0x00, result);
         }
 
@@ -1014,19 +1014,19 @@ namespace System.Tests
         {
             byte result;
 
-            Assert.True(NumberHelper<byte>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.True(NumberHelper<byte>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<byte>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal((byte)0x01, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal((byte)0x00, result);
 
-            Assert.False(NumberHelper<byte>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<byte>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal((byte)0x00, result);
         }
 
@@ -1037,36 +1037,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<byte>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<byte>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.True(NumberHelper<byte>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<byte>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal((byte)0x01, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((byte)0x00, result);
             }
             else
             {
-                Assert.True(NumberHelper<byte>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<byte>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.True(NumberHelper<byte>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<byte>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal((byte)0x01, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal((byte)0x00, result);
 
-                Assert.False(NumberHelper<byte>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<byte>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal((byte)0x00, result);
             }
         }
@@ -1242,12 +1242,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Equal(expected, NumberHelper<byte>.Parse(value, style, provider));
+                Assert.Equal(expected, NumberBaseHelper<byte>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.True(NumberHelper<byte>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.True(NumberBaseHelper<byte>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(expected, result);
-                Assert.Equal(expected, NumberHelper<byte>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Equal(expected, NumberBaseHelper<byte>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1257,9 +1257,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.True(NumberHelper<byte>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<byte>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
-            Assert.Equal(expected, NumberHelper<byte>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<byte>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1279,12 +1279,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<byte>.Parse(value, style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<byte>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.False(NumberHelper<byte>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.False(NumberBaseHelper<byte>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(default(byte), result);
-                Assert.Throws(exceptionType, () => NumberHelper<byte>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<byte>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1294,9 +1294,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.False(NumberHelper<byte>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<byte>.TryParse(value, style, provider, out result));
             Assert.Equal(default(byte), result);
-            Assert.Throws(exceptionType, () => NumberHelper<byte>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<byte>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1312,9 +1312,9 @@ namespace System.Tests
                 Assert.Equal(expected, result);
             }
 
-            Assert.Equal(expected, NumberHelper<byte>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<byte>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<byte>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<byte>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1336,9 +1336,9 @@ namespace System.Tests
                 Assert.Equal(default(byte), result);
             }
 
-            Assert.Throws(exceptionType, () => NumberHelper<byte>.Parse(value.AsSpan(), style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<byte>.Parse(value.AsSpan(), style, provider));
 
-            Assert.False(NumberHelper<byte>.TryParse(value.AsSpan(), style, provider, out result));
+            Assert.False(NumberBaseHelper<byte>.TryParse(value.AsSpan(), style, provider, out result));
             Assert.Equal(default(byte), result);
         }
     }

--- a/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
@@ -7,41 +7,9 @@ namespace System.Tests
 {
     public class CharTests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal((char)0x0000, AdditiveIdentityHelper<char, char>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            Assert.Equal((char)0x0000, MinMaxValueHelper<char>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            Assert.Equal((char)0xFFFF, MinMaxValueHelper<char>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal((char)0x0001, MultiplicativeIdentityHelper<char, char>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal((char)0x0001, NumberBaseHelper<char>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal((char)0x0000, NumberBaseHelper<char>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -62,6 +30,30 @@ namespace System.Tests
             Assert.Equal((char)0x8001, AdditionOperatorsHelper<char, char, char>.op_CheckedAddition((char)0x8000, (char)1));
 
             Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<char, char, char>.op_CheckedAddition((char)0xFFFF, (char)1));
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal((char)0x0000, AdditiveIdentityHelper<char, char>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            Assert.Equal(((char)0x0000, (char)0x0000), BinaryIntegerHelper<char>.DivRem((char)0x0000, (char)2));
+            Assert.Equal(((char)0x0000, (char)0x0001), BinaryIntegerHelper<char>.DivRem((char)0x0001, (char)2));
+            Assert.Equal(((char)0x3FFF, (char)0x0001), BinaryIntegerHelper<char>.DivRem((char)0x7FFF, (char)2));
+            Assert.Equal(((char)0x4000, (char)0x0000), BinaryIntegerHelper<char>.DivRem((char)0x8000, (char)2));
+            Assert.Equal(((char)0x7FFF, (char)0x0001), BinaryIntegerHelper<char>.DivRem((char)0xFFFF, (char)2));
         }
 
         [Fact]
@@ -115,6 +107,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            Assert.Equal(2, BinaryIntegerHelper<char>.GetByteCount((char)0x0000));
+            Assert.Equal(2, BinaryIntegerHelper<char>.GetByteCount((char)0x0001));
+            Assert.Equal(2, BinaryIntegerHelper<char>.GetByteCount((char)0x7FFF));
+            Assert.Equal(2, BinaryIntegerHelper<char>.GetByteCount((char)0x8000));
+            Assert.Equal(2, BinaryIntegerHelper<char>.GetByteCount((char)0xFFFF));
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             Assert.Equal(0x00, BinaryIntegerHelper<char>.GetShortestBitLength((char)0x0000));
@@ -123,6 +125,72 @@ namespace System.Tests
             Assert.Equal(0x10, BinaryIntegerHelper<char>.GetShortestBitLength((char)0x8000));
             Assert.Equal(0x10, BinaryIntegerHelper<char>.GetShortestBitLength((char)0xFFFF));
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[2];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<char>.TryWriteBigEndian((char)0x0000, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<char>.TryWriteBigEndian((char)0x0001, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x01 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<char>.TryWriteBigEndian((char)0x7FFF, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F, 0xFF }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<char>.TryWriteBigEndian((char)0x8000, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<char>.TryWriteBigEndian((char)0xFFFF, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<char>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[2];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<char>.TryWriteLittleEndian((char)0x0000, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<char>.TryWriteLittleEndian((char)0x0001, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<char>.TryWriteLittleEndian((char)0x7FFF, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0x7F }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<char>.TryWriteLittleEndian((char)0x8000, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x80 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<char>.TryWriteLittleEndian((char)0xFFFF, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<char>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -143,6 +211,10 @@ namespace System.Tests
             Assert.Equal((char)0x000F, BinaryNumberHelper<char>.Log2((char)0x8000));
             Assert.Equal((char)0x000F, BinaryNumberHelper<char>.Log2((char)0xFFFF));
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -184,25 +256,9 @@ namespace System.Tests
             Assert.Equal((char)0x0000, BitwiseOperatorsHelper<char, char, char>.op_OnesComplement((char)0xFFFF));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<char, char>.op_LessThan((char)0x0000, (char)1));
-            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThan((char)0x0001, (char)1));
-            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThan((char)0x7FFF, (char)1));
-            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThan((char)0x8000, (char)1));
-            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThan((char)0xFFFF, (char)1));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<char, char>.op_LessThanOrEqual((char)0x0000, (char)1));
-            Assert.True(ComparisonOperatorsHelper<char, char>.op_LessThanOrEqual((char)0x0001, (char)1));
-            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThanOrEqual((char)0x7FFF, (char)1));
-            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThanOrEqual((char)0x8000, (char)1));
-            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThanOrEqual((char)0xFFFF, (char)1));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -225,6 +281,30 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<char, char>.op_LessThan((char)0x0000, (char)1));
+            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThan((char)0x0001, (char)1));
+            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThan((char)0x7FFF, (char)1));
+            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThan((char)0x8000, (char)1));
+            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThan((char)0xFFFF, (char)1));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<char, char>.op_LessThanOrEqual((char)0x0000, (char)1));
+            Assert.True(ComparisonOperatorsHelper<char, char>.op_LessThanOrEqual((char)0x0001, (char)1));
+            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThanOrEqual((char)0x7FFF, (char)1));
+            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThanOrEqual((char)0x8000, (char)1));
+            Assert.False(ComparisonOperatorsHelper<char, char>.op_LessThanOrEqual((char)0xFFFF, (char)1));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             Assert.Equal((char)0xFFFF, DecrementOperatorsHelper<char>.op_Decrement((char)0x0000));
@@ -244,6 +324,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<char>.op_CheckedDecrement((char)0x0000));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -269,6 +353,10 @@ namespace System.Tests
             Assert.Throws<DivideByZeroException>(() => DivisionOperatorsHelper<char, char, char>.op_CheckedDivision((char)0x0001, (char)0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -288,6 +376,10 @@ namespace System.Tests
             Assert.True(EqualityOperatorsHelper<char, char>.op_Inequality((char)0x8000, (char)1));
             Assert.True(EqualityOperatorsHelper<char, char>.op_Inequality((char)0xFFFF, (char)1));
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -310,6 +402,26 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<char>.op_CheckedIncrement((char)0xFFFF));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            Assert.Equal((char)0xFFFF, MinMaxValueHelper<char>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal((char)0x0000, MinMaxValueHelper<char>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -321,6 +433,20 @@ namespace System.Tests
 
             Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<char, char, char>.op_Modulus((char)0x0001, (char)0));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal((char)0x0001, MultiplicativeIdentityHelper<char, char>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -343,15 +469,9 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<char, char, char>.op_CheckedMultiply((char)0xFFFF, (char)2));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            Assert.Equal((char)0x0000, NumberBaseHelper<char>.Abs((char)0x0000));
-            Assert.Equal((char)0x0001, NumberBaseHelper<char>.Abs((char)0x0001));
-            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.Abs((char)0x7FFF));
-            Assert.Equal((char)0x8000, NumberBaseHelper<char>.Abs((char)0x8000));
-            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.Abs((char)0xFFFF));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -361,6 +481,62 @@ namespace System.Tests
             Assert.Equal((char)0x003F, NumberHelper<char>.Clamp((char)0x7FFF, (char)0x0001, (char)0x003F));
             Assert.Equal((char)0x003F, NumberHelper<char>.Clamp((char)0x8000, (char)0x0001, (char)0x003F));
             Assert.Equal((char)0x003F, NumberHelper<char>.Clamp((char)0xFFFF, (char)0x0001, (char)0x003F));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal((char)0x0001, NumberHelper<char>.Max((char)0x0000, (char)1));
+            Assert.Equal((char)0x0001, NumberHelper<char>.Max((char)0x0001, (char)1));
+            Assert.Equal((char)0x7FFF, NumberHelper<char>.Max((char)0x7FFF, (char)1));
+            Assert.Equal((char)0x8000, NumberHelper<char>.Max((char)0x8000, (char)1));
+            Assert.Equal((char)0xFFFF, NumberHelper<char>.Max((char)0xFFFF, (char)1));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal((char)0x0000, NumberHelper<char>.Min((char)0x0000, (char)1));
+            Assert.Equal((char)0x0001, NumberHelper<char>.Min((char)0x0001, (char)1));
+            Assert.Equal((char)0x0001, NumberHelper<char>.Min((char)0x7FFF, (char)1));
+            Assert.Equal((char)0x0001, NumberHelper<char>.Min((char)0x8000, (char)1));
+            Assert.Equal((char)0x0001, NumberHelper<char>.Min((char)0xFFFF, (char)1));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(0, NumberHelper<char>.Sign((char)0x0000));
+            Assert.Equal(1, NumberHelper<char>.Sign((char)0x0001));
+            Assert.Equal(1, NumberHelper<char>.Sign((char)0x7FFF));
+            Assert.Equal(1, NumberHelper<char>.Sign((char)0x8000));
+            Assert.Equal(1, NumberHelper<char>.Sign((char)0xFFFF));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.Abs((char)0x0000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.Abs((char)0x0001));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.Abs((char)0x7FFF));
+            Assert.Equal((char)0x8000, NumberBaseHelper<char>.Abs((char)0x8000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.Abs((char)0xFFFF));
         }
 
         [Fact]
@@ -760,46 +936,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            Assert.Equal(((char)0x0000, (char)0x0000), BinaryIntegerHelper<char>.DivRem((char)0x0000, (char)2));
-            Assert.Equal(((char)0x0000, (char)0x0001), BinaryIntegerHelper<char>.DivRem((char)0x0001, (char)2));
-            Assert.Equal(((char)0x3FFF, (char)0x0001), BinaryIntegerHelper<char>.DivRem((char)0x7FFF, (char)2));
-            Assert.Equal(((char)0x4000, (char)0x0000), BinaryIntegerHelper<char>.DivRem((char)0x8000, (char)2));
-            Assert.Equal(((char)0x7FFF, (char)0x0001), BinaryIntegerHelper<char>.DivRem((char)0xFFFF, (char)2));
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            Assert.Equal((char)0x0001, NumberHelper<char>.Max((char)0x0000, (char)1));
-            Assert.Equal((char)0x0001, NumberHelper<char>.Max((char)0x0001, (char)1));
-            Assert.Equal((char)0x7FFF, NumberHelper<char>.Max((char)0x7FFF, (char)1));
-            Assert.Equal((char)0x8000, NumberHelper<char>.Max((char)0x8000, (char)1));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.Max((char)0xFFFF, (char)1));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            Assert.Equal((char)0x0000, NumberHelper<char>.Min((char)0x0000, (char)1));
-            Assert.Equal((char)0x0001, NumberHelper<char>.Min((char)0x0001, (char)1));
-            Assert.Equal((char)0x0001, NumberHelper<char>.Min((char)0x7FFF, (char)1));
-            Assert.Equal((char)0x0001, NumberHelper<char>.Min((char)0x8000, (char)1));
-            Assert.Equal((char)0x0001, NumberHelper<char>.Min((char)0xFFFF, (char)1));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(0, NumberHelper<char>.Sign((char)0x0000));
-            Assert.Equal(1, NumberHelper<char>.Sign((char)0x0001));
-            Assert.Equal(1, NumberHelper<char>.Sign((char)0x7FFF));
-            Assert.Equal(1, NumberHelper<char>.Sign((char)0x8000));
-            Assert.Equal(1, NumberHelper<char>.Sign((char)0xFFFF));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             char result;
@@ -1070,77 +1206,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            Assert.Equal(2, BinaryIntegerHelper<char>.GetByteCount((char)0x0000));
-            Assert.Equal(2, BinaryIntegerHelper<char>.GetByteCount((char)0x0001));
-            Assert.Equal(2, BinaryIntegerHelper<char>.GetByteCount((char)0x7FFF));
-            Assert.Equal(2, BinaryIntegerHelper<char>.GetByteCount((char)0x8000));
-            Assert.Equal(2, BinaryIntegerHelper<char>.GetByteCount((char)0xFFFF));
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[2];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<char>.TryWriteBigEndian((char)0x0000, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<char>.TryWriteBigEndian((char)0x0001, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x01 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<char>.TryWriteBigEndian((char)0x7FFF, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F, 0xFF }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<char>.TryWriteBigEndian((char)0x8000, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<char>.TryWriteBigEndian((char)0xFFFF, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<char>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[2];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<char>.TryWriteLittleEndian((char)0x0000, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<char>.TryWriteLittleEndian((char)0x0001, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<char>.TryWriteLittleEndian((char)0x7FFF, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0x7F }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<char>.TryWriteLittleEndian((char)0x8000, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x80 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<char>.TryWriteLittleEndian((char)0xFFFF, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<char>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1172,6 +1240,10 @@ namespace System.Tests
             Assert.Equal((char)0x7FFF, ShiftOperatorsHelper<char, char>.op_UnsignedRightShift((char)0xFFFF, 1));
         }
 
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1193,6 +1265,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<char, char, char>.op_CheckedSubtraction((char)0x0000, (char)1));
         }
 
+        //
+        // IUnaryNegationOperators
+        //
+
         [Fact]
         public static void op_UnaryNegationTest()
         {
@@ -1213,6 +1289,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => UnaryNegationOperatorsHelper<char, char>.op_CheckedUnaryNegation((char)0x8000));
             Assert.Throws<OverflowException>(() => UnaryNegationOperatorsHelper<char, char>.op_CheckedUnaryNegation((char)0xFFFF));
         }
+
+        //
+        // IUnaryPlusOperators
+        //
 
         [Fact]
         public static void op_UnaryPlusTest()

--- a/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
@@ -346,11 +346,11 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.Abs((char)0x0000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.Abs((char)0x0001));
-            Assert.Equal((char)0x7FFF, NumberHelper<char>.Abs((char)0x7FFF));
-            Assert.Equal((char)0x8000, NumberHelper<char>.Abs((char)0x8000));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.Abs((char)0xFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.Abs((char)0x0000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.Abs((char)0x0001));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.Abs((char)0x7FFF));
+            Assert.Equal((char)0x8000, NumberBaseHelper<char>.Abs((char)0x8000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.Abs((char)0xFFFF));
         }
 
         [Fact]
@@ -366,51 +366,51 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<byte>(0x00));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<byte>(0x01));
-            Assert.Equal((char)0x007F, NumberHelper<char>.CreateChecked<byte>(0x7F));
-            Assert.Equal((char)0x0080, NumberHelper<char>.CreateChecked<byte>(0x80));
-            Assert.Equal((char)0x00FF, NumberHelper<char>.CreateChecked<byte>(0xFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<byte>(0x00));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<byte>(0x01));
+            Assert.Equal((char)0x007F, NumberBaseHelper<char>.CreateChecked<byte>(0x7F));
+            Assert.Equal((char)0x0080, NumberBaseHelper<char>.CreateChecked<byte>(0x80));
+            Assert.Equal((char)0x00FF, NumberBaseHelper<char>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<char>((char)0x0000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<char>((char)0x0001));
-            Assert.Equal((char)0x7FFF, NumberHelper<char>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal((char)0x8000, NumberHelper<char>.CreateChecked<char>((char)0x8000));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<char>((char)0x0000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<char>((char)0x0001));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal((char)0x8000, NumberBaseHelper<char>.CreateChecked<char>((char)0x8000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<short>(0x0000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<short>(0x0001));
-            Assert.Equal((char)0x7FFF, NumberHelper<char>.CreateChecked<short>(0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<short>(0x0000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<short>(0x0001));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.CreateChecked<short>(0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<int>(0x00000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<int>(0x00000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<int>(0x00000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<int>(0x00000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<long>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<long>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -418,60 +418,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<sbyte>(0x00));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<sbyte>(0x01));
-            Assert.Equal((char)0x007F, NumberHelper<char>.CreateChecked<sbyte>(0x7F));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<sbyte>(0x00));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<sbyte>(0x01));
+            Assert.Equal((char)0x007F, NumberBaseHelper<char>.CreateChecked<sbyte>(0x7F));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<ushort>(0x0000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<ushort>(0x0001));
-            Assert.Equal((char)0x7FFF, NumberHelper<char>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal((char)0x8000, NumberHelper<char>.CreateChecked<ushort>(0x8000));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<ushort>(0x0000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<ushort>(0x0001));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal((char)0x8000, NumberBaseHelper<char>.CreateChecked<ushort>(0x8000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<uint>(0x00000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<uint>(0x00000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<uint>(0x80000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<uint>(0x00000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<uint>(0x00000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<uint>(0x80000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -479,70 +479,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Throws<OverflowException>(() => NumberHelper<char>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<char>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<byte>(0x00));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<byte>(0x01));
-            Assert.Equal((char)0x007F, NumberHelper<char>.CreateSaturating<byte>(0x7F));
-            Assert.Equal((char)0x0080, NumberHelper<char>.CreateSaturating<byte>(0x80));
-            Assert.Equal((char)0x00FF, NumberHelper<char>.CreateSaturating<byte>(0xFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<byte>(0x00));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<byte>(0x01));
+            Assert.Equal((char)0x007F, NumberBaseHelper<char>.CreateSaturating<byte>(0x7F));
+            Assert.Equal((char)0x0080, NumberBaseHelper<char>.CreateSaturating<byte>(0x80));
+            Assert.Equal((char)0x00FF, NumberBaseHelper<char>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal((char)0x7FFF, NumberHelper<char>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal((char)0x8000, NumberHelper<char>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal((char)0x8000, NumberBaseHelper<char>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<short>(0x0000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<short>(0x0001));
-            Assert.Equal((char)0x7FFF, NumberHelper<char>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<short>(0x0000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<short>(0x0001));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<int>(0x00000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<int>(0x00000001));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<int>(0x00000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<int>(0x00000001));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -550,60 +550,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal((char)0x007F, NumberHelper<char>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal((char)0x007F, NumberBaseHelper<char>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal((char)0x7FFF, NumberHelper<char>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal((char)0x8000, NumberHelper<char>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal((char)0x8000, NumberBaseHelper<char>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -611,70 +611,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<byte>(0x00));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<byte>(0x01));
-            Assert.Equal((char)0x007F, NumberHelper<char>.CreateTruncating<byte>(0x7F));
-            Assert.Equal((char)0x0080, NumberHelper<char>.CreateTruncating<byte>(0x80));
-            Assert.Equal((char)0x00FF, NumberHelper<char>.CreateTruncating<byte>(0xFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<byte>(0x00));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<byte>(0x01));
+            Assert.Equal((char)0x007F, NumberBaseHelper<char>.CreateTruncating<byte>(0x7F));
+            Assert.Equal((char)0x0080, NumberBaseHelper<char>.CreateTruncating<byte>(0x80));
+            Assert.Equal((char)0x00FF, NumberBaseHelper<char>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal((char)0x7FFF, NumberHelper<char>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal((char)0x8000, NumberHelper<char>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal((char)0x8000, NumberBaseHelper<char>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<short>(0x0000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<short>(0x0001));
-            Assert.Equal((char)0x7FFF, NumberHelper<char>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal((char)0x8000, NumberHelper<char>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<short>(0x0000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<short>(0x0001));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal((char)0x8000, NumberBaseHelper<char>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<int>(0x00000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<int>(0x00000001));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<int>(0x00000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<int>(0x00000001));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -682,60 +682,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal((char)0x007F, NumberHelper<char>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal((char)0xFF80, NumberHelper<char>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal((char)0x007F, NumberBaseHelper<char>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal((char)0xFF80, NumberBaseHelper<char>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal((char)0x7FFF, NumberHelper<char>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal((char)0x8000, NumberHelper<char>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal((char)0x8000, NumberBaseHelper<char>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -743,19 +743,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal((char)0x0001, NumberHelper<char>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((char)0x0000, NumberHelper<char>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal((char)0xFFFF, NumberHelper<char>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal((char)0x0001, NumberBaseHelper<char>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -804,19 +804,19 @@ namespace System.Tests
         {
             char result;
 
-            Assert.True(NumberHelper<char>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<byte>(0x00, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<byte>(0x01, out result));
             Assert.Equal((char)0x0001, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((char)0x007F, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<byte>(0x80, out result));
             Assert.Equal((char)0x0080, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((char)0x00FF, result);
         }
 
@@ -825,19 +825,19 @@ namespace System.Tests
         {
             char result;
 
-            Assert.True(NumberHelper<char>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal((char)0x0001, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((char)0x7FFF, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((char)0x8000, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((char)0xFFFF, result);
         }
 
@@ -846,19 +846,19 @@ namespace System.Tests
         {
             char result;
 
-            Assert.True(NumberHelper<char>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<short>(0x0000, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<short>(0x0001, out result));
             Assert.Equal((char)0x0001, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((char)0x7FFF, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal((char)0x0000, result);
         }
 
@@ -867,19 +867,19 @@ namespace System.Tests
         {
             char result;
 
-            Assert.True(NumberHelper<char>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<int>(0x00000000, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<int>(0x00000001, out result));
             Assert.Equal((char)0x0001, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal((char)0x0000, result);
         }
 
@@ -888,19 +888,19 @@ namespace System.Tests
         {
             char result;
 
-            Assert.True(NumberHelper<char>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal((char)0x0001, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
             Assert.Equal((char)0x0000, result);
         }
 
@@ -911,36 +911,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<char>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<char>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.True(NumberHelper<char>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<char>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal((char)0x0001, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((char)0x0000, result);
             }
             else
             {
-                Assert.True(NumberHelper<char>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<char>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.True(NumberHelper<char>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<char>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal((char)0x0001, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal((char)0x0000, result);
             }
         }
@@ -950,19 +950,19 @@ namespace System.Tests
         {
             char result;
 
-            Assert.True(NumberHelper<char>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal((char)0x0001, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((char)0x007F, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal((char)0x0000, result);
         }
 
@@ -971,19 +971,19 @@ namespace System.Tests
         {
             char result;
 
-            Assert.True(NumberHelper<char>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal((char)0x0001, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((char)0x7FFF, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((char)0x8000, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((char)0xFFFF, result);
         }
 
@@ -992,19 +992,19 @@ namespace System.Tests
         {
             char result;
 
-            Assert.True(NumberHelper<char>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal((char)0x0001, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<uint>(0x80000000, out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal((char)0x0000, result);
         }
 
@@ -1013,19 +1013,19 @@ namespace System.Tests
         {
             char result;
 
-            Assert.True(NumberHelper<char>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.True(NumberHelper<char>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<char>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal((char)0x0001, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal((char)0x0000, result);
 
-            Assert.False(NumberHelper<char>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<char>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal((char)0x0000, result);
         }
 
@@ -1036,36 +1036,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<char>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<char>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.True(NumberHelper<char>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<char>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal((char)0x0001, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((char)0x0000, result);
             }
             else
             {
-                Assert.True(NumberHelper<char>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<char>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.True(NumberHelper<char>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<char>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal((char)0x0001, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal((char)0x0000, result);
 
-                Assert.False(NumberHelper<char>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<char>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal((char)0x0000, result);
             }
         }

--- a/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
@@ -494,6 +494,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal((char)0x0001, NumberHelper<char>.MaxNumber((char)0x0000, (char)1));
+            Assert.Equal((char)0x0001, NumberHelper<char>.MaxNumber((char)0x0001, (char)1));
+            Assert.Equal((char)0x7FFF, NumberHelper<char>.MaxNumber((char)0x7FFF, (char)1));
+            Assert.Equal((char)0x8000, NumberHelper<char>.MaxNumber((char)0x8000, (char)1));
+            Assert.Equal((char)0xFFFF, NumberHelper<char>.MaxNumber((char)0xFFFF, (char)1));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal((char)0x0000, NumberHelper<char>.Min((char)0x0000, (char)1));
@@ -501,6 +511,16 @@ namespace System.Tests
             Assert.Equal((char)0x0001, NumberHelper<char>.Min((char)0x7FFF, (char)1));
             Assert.Equal((char)0x0001, NumberHelper<char>.Min((char)0x8000, (char)1));
             Assert.Equal((char)0x0001, NumberHelper<char>.Min((char)0xFFFF, (char)1));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal((char)0x0000, NumberHelper<char>.MinNumber((char)0x0000, (char)1));
+            Assert.Equal((char)0x0001, NumberHelper<char>.MinNumber((char)0x0001, (char)1));
+            Assert.Equal((char)0x0001, NumberHelper<char>.MinNumber((char)0x7FFF, (char)1));
+            Assert.Equal((char)0x0001, NumberHelper<char>.MinNumber((char)0x8000, (char)1));
+            Assert.Equal((char)0x0001, NumberHelper<char>.MinNumber((char)0xFFFF, (char)1));
         }
 
         [Fact]
@@ -933,6 +953,126 @@ namespace System.Tests
                 Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<char>.IsFinite((char)0x0000));
+            Assert.True(NumberBaseHelper<char>.IsFinite((char)0x0001));
+            Assert.True(NumberBaseHelper<char>.IsFinite((char)0x7FFF));
+            Assert.True(NumberBaseHelper<char>.IsFinite((char)0x8000));
+            Assert.True(NumberBaseHelper<char>.IsFinite((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<char>.IsInfinity((char)0x0000));
+            Assert.False(NumberBaseHelper<char>.IsInfinity((char)0x0001));
+            Assert.False(NumberBaseHelper<char>.IsInfinity((char)0x7FFF));
+            Assert.False(NumberBaseHelper<char>.IsInfinity((char)0x8000));
+            Assert.False(NumberBaseHelper<char>.IsInfinity((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<char>.IsNaN((char)0x0000));
+            Assert.False(NumberBaseHelper<char>.IsNaN((char)0x0001));
+            Assert.False(NumberBaseHelper<char>.IsNaN((char)0x7FFF));
+            Assert.False(NumberBaseHelper<char>.IsNaN((char)0x8000));
+            Assert.False(NumberBaseHelper<char>.IsNaN((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<char>.IsNegative((char)0x0000));
+            Assert.False(NumberBaseHelper<char>.IsNegative((char)0x0001));
+            Assert.False(NumberBaseHelper<char>.IsNegative((char)0x7FFF));
+            Assert.False(NumberBaseHelper<char>.IsNegative((char)0x8000));
+            Assert.False(NumberBaseHelper<char>.IsNegative((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<char>.IsNegativeInfinity((char)0x0000));
+            Assert.False(NumberBaseHelper<char>.IsNegativeInfinity((char)0x0001));
+            Assert.False(NumberBaseHelper<char>.IsNegativeInfinity((char)0x7FFF));
+            Assert.False(NumberBaseHelper<char>.IsNegativeInfinity((char)0x8000));
+            Assert.False(NumberBaseHelper<char>.IsNegativeInfinity((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<char>.IsNormal((char)0x0000));
+            Assert.True(NumberBaseHelper<char>.IsNormal((char)0x0001));
+            Assert.True(NumberBaseHelper<char>.IsNormal((char)0x7FFF));
+            Assert.True(NumberBaseHelper<char>.IsNormal((char)0x8000));
+            Assert.True(NumberBaseHelper<char>.IsNormal((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<char>.IsPositiveInfinity((char)0x0000));
+            Assert.False(NumberBaseHelper<char>.IsPositiveInfinity((char)0x0001));
+            Assert.False(NumberBaseHelper<char>.IsPositiveInfinity((char)0x7FFF));
+            Assert.False(NumberBaseHelper<char>.IsPositiveInfinity((char)0x8000));
+            Assert.False(NumberBaseHelper<char>.IsPositiveInfinity((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<char>.IsSubnormal((char)0x0000));
+            Assert.False(NumberBaseHelper<char>.IsSubnormal((char)0x0001));
+            Assert.False(NumberBaseHelper<char>.IsSubnormal((char)0x7FFF));
+            Assert.False(NumberBaseHelper<char>.IsSubnormal((char)0x8000));
+            Assert.False(NumberBaseHelper<char>.IsSubnormal((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void MinMagnitudeMagnitude()
+        {
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MaxMagnitude((char)0x0000, (char)1));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MaxMagnitude((char)0x0001, (char)1));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.MaxMagnitude((char)0x7FFF, (char)1));
+            Assert.Equal((char)0x8000, NumberBaseHelper<char>.MaxMagnitude((char)0x8000, (char)1));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.MaxMagnitude((char)0xFFFF, (char)1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MaxMagnitudeNumber((char)0x0000, (char)1));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MaxMagnitudeNumber((char)0x0001, (char)1));
+            Assert.Equal((char)0x7FFF, NumberBaseHelper<char>.MaxMagnitudeNumber((char)0x7FFF, (char)1));
+            Assert.Equal((char)0x8000, NumberBaseHelper<char>.MaxMagnitudeNumber((char)0x8000, (char)1));
+            Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.MaxMagnitudeNumber((char)0xFFFF, (char)1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.MinMagnitude((char)0x0000, (char)1));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MinMagnitude((char)0x0001, (char)1));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MinMagnitude((char)0x7FFF, (char)1));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MinMagnitude((char)0x8000, (char)1));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MinMagnitude((char)0xFFFF, (char)1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal((char)0x0000, NumberBaseHelper<char>.MinMagnitudeNumber((char)0x0000, (char)1));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MinMagnitudeNumber((char)0x0001, (char)1));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MinMagnitudeNumber((char)0x7FFF, (char)1));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MinMagnitudeNumber((char)0x8000, (char)1));
+            Assert.Equal((char)0x0001, NumberBaseHelper<char>.MinMagnitudeNumber((char)0xFFFF, (char)1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/DecimalTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DecimalTests.GenericMath.cs
@@ -8,47 +8,9 @@ namespace System.Tests
 {
     public class DecimalTests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal(0.0m, AdditiveIdentityHelper<decimal, decimal>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            Assert.Equal(decimal.MinValue, MinMaxValueHelper<decimal>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            Assert.Equal(decimal.MaxValue, MinMaxValueHelper<decimal>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal(1.0m, MultiplicativeIdentityHelper<decimal, decimal>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            Assert.Equal(-1.0m, SignedNumberHelper<decimal>.NegativeOne);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal(1.0m, NumberBaseHelper<decimal>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal(0.0m, NumberBaseHelper<decimal>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -74,27 +36,19 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<decimal, decimal, decimal>.op_CheckedAddition(decimal.MaxValue, 1.0m));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(decimal.MinValue, 1.0m));
-            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(-1.0m, 1.0m));
-            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(-0.0m, 1.0m));
-            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(0.0m, 1.0m));
-            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(1.0m, 1.0m));
-            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(decimal.MaxValue, 1.0m));
-        }
+        //
+        // IAdditiveIdentity
+        //
 
         [Fact]
-        public static void op_LessThanOrEqualTest()
+        public static void AdditiveIdentityTest()
         {
-            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(decimal.MinValue, 1.0m));
-            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(-1.0m, 1.0m));
-            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(-0.0m, 1.0m));
-            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(0.0m, 1.0m));
-            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(1.0m, 1.0m));
-            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(decimal.MaxValue, 1.0m));
+            Assert.Equal(0.0m, AdditiveIdentityHelper<decimal, decimal>.AdditiveIdentity);
         }
+
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -117,6 +71,32 @@ namespace System.Tests
             Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThanOrEqual(1.0m, 1.0m));
             Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThanOrEqual(decimal.MaxValue, 1.0m));
         }
+
+        [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(decimal.MinValue, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(-1.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(-0.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(0.0m, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(1.0m, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(decimal.MinValue, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(-1.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(-0.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(0.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(1.0m, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(decimal.MaxValue, 1.0m));
+        }
+
+        //
+        // IDecrementOperators
+        //
 
         [Fact]
         public static void op_DecrementTest()
@@ -142,6 +122,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<decimal>.op_CheckedDecrement(decimal.MinValue));
         }
 
+        //
+        // IDivisionOperators
+        //
+
         [Fact]
         public static void op_DivisionTest()
         {
@@ -164,6 +148,10 @@ namespace System.Tests
             Assert.Equal(39614081257132168796771975168.0m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_CheckedDivision(decimal.MaxValue, 2.0m));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -185,6 +173,198 @@ namespace System.Tests
             Assert.False(EqualityOperatorsHelper<decimal, decimal>.op_Inequality(1.0m, 1.0m));
             Assert.True(EqualityOperatorsHelper<decimal, decimal>.op_Inequality(decimal.MaxValue, 1.0m));
         }
+
+        //
+        // IFloatingPoint
+        //
+
+        [Fact]
+        public static void GetExponentByteCountTest()
+        {
+            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(decimal.MinValue));
+            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(-1.0m));
+            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(-0.0m));
+            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(0.0m));
+            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(1.0m));
+            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void GetExponentShortestBitLengthTest()
+        {
+            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(decimal.MinValue));
+            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(-1.0m));
+            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(-0.0m));
+            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(0.0m));
+            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(1.0m));
+            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void GetSignificandByteCountTest()
+        {
+            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(decimal.MinValue));
+            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(-1.0m));
+            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(-0.0m));
+            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(0.0m));
+            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(1.0m));
+            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void GetSignificandBitLengthTest()
+        {
+            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(decimal.MinValue));
+            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(-1.0m));
+            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(-0.0m));
+            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(0.0m));
+            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(1.0m));
+            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void TryWriteExponentBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[1];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(decimal.MinValue, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5F }, destination.ToArray()); // +95
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(-1.0m, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(-0.0m, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(0.0m, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(1.0m, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(decimal.MaxValue, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5F }, destination.ToArray()); // +95
+
+            Assert.False(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0x5F }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteExponentLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[1];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(decimal.MinValue, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5F }, destination.ToArray()); // +95
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(-1.0m, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(-0.0m, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(0.0m, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(1.0m, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(decimal.MaxValue, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x5F }, destination.ToArray()); // +95
+
+            Assert.False(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0x5F }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteSignificandBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[12];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(decimal.MinValue, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(-1.0m, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(-0.0m, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(0.0m, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(1.0m, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(decimal.MaxValue, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteSignificandLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[12];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(decimal.MinValue, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(-1.0m, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(-0.0m, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(0.0m, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(1.0m, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(decimal.MaxValue, destination, out bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -210,6 +390,26 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<decimal>.op_CheckedIncrement(decimal.MaxValue));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            Assert.Equal(decimal.MaxValue, MinMaxValueHelper<decimal>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal(decimal.MinValue, MinMaxValueHelper<decimal>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -220,6 +420,20 @@ namespace System.Tests
             Assert.Equal(1.0m, ModulusOperatorsHelper<decimal, decimal, decimal>.op_Modulus(1.0m, 2.0m));
             Assert.Equal(1.0m, ModulusOperatorsHelper<decimal, decimal, decimal>.op_Modulus(decimal.MaxValue, 2.0m));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal(1.0m, MultiplicativeIdentityHelper<decimal, decimal>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -245,16 +459,9 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<decimal, decimal, decimal>.op_CheckedMultiply(decimal.MaxValue, 2.0m));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.Abs(decimal.MinValue));
-            Assert.Equal(1.0m, NumberBaseHelper<decimal>.Abs(-1.0m));
-            Assert.Equal(0.0m, NumberBaseHelper<decimal>.Abs(-0.0m));
-            Assert.Equal(0.0m, NumberBaseHelper<decimal>.Abs(0.0m));
-            Assert.Equal(1.0m, NumberBaseHelper<decimal>.Abs(1.0m));
-            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.Abs(decimal.MaxValue));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -265,6 +472,68 @@ namespace System.Tests
             Assert.Equal(1.0m, NumberHelper<decimal>.Clamp(0.0m, 1.0m, 63.0m));
             Assert.Equal(1.0m, NumberHelper<decimal>.Clamp(1.0m, 1.0m, 63.0m));
             Assert.Equal(63.0m, NumberHelper<decimal>.Clamp(decimal.MaxValue, 1.0m, 63.0m));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal(1.0m, NumberHelper<decimal>.Max(decimal.MinValue, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Max(-1.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Max(-0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Max(0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Max(1.0m, 1.0m));
+            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.Max(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal(decimal.MinValue, NumberHelper<decimal>.Min(decimal.MinValue, 1.0m));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.Min(-1.0m, 1.0m));
+            Assert.Equal(-0.0m, NumberHelper<decimal>.Min(-0.0m, 1.0m));
+            Assert.Equal(0.0m, NumberHelper<decimal>.Min(0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Min(1.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Min(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(-1, NumberHelper<decimal>.Sign(decimal.MinValue));
+            Assert.Equal(-1, NumberHelper<decimal>.Sign(-1.0m));
+
+            Assert.Equal(0, NumberHelper<decimal>.Sign(-0.0m));
+            Assert.Equal(0, NumberHelper<decimal>.Sign(0.0m));
+
+            Assert.Equal(1, NumberHelper<decimal>.Sign(1.0m));
+            Assert.Equal(1, NumberHelper<decimal>.Sign(decimal.MaxValue));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.Abs(decimal.MinValue));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.Abs(-1.0m));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.Abs(-0.0m));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.Abs(0.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.Abs(1.0m));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.Abs(decimal.MaxValue));
         }
 
         [Fact]
@@ -734,41 +1003,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void MaxTest()
-        {
-            Assert.Equal(1.0m, NumberHelper<decimal>.Max(decimal.MinValue, 1.0m));
-            Assert.Equal(1.0m, NumberHelper<decimal>.Max(-1.0m, 1.0m));
-            Assert.Equal(1.0m, NumberHelper<decimal>.Max(-0.0m, 1.0m));
-            Assert.Equal(1.0m, NumberHelper<decimal>.Max(0.0m, 1.0m));
-            Assert.Equal(1.0m, NumberHelper<decimal>.Max(1.0m, 1.0m));
-            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.Max(decimal.MaxValue, 1.0m));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            Assert.Equal(decimal.MinValue, NumberHelper<decimal>.Min(decimal.MinValue, 1.0m));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.Min(-1.0m, 1.0m));
-            Assert.Equal(-0.0m, NumberHelper<decimal>.Min(-0.0m, 1.0m));
-            Assert.Equal(0.0m, NumberHelper<decimal>.Min(0.0m, 1.0m));
-            Assert.Equal(1.0m, NumberHelper<decimal>.Min(1.0m, 1.0m));
-            Assert.Equal(1.0m, NumberHelper<decimal>.Min(decimal.MaxValue, 1.0m));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(-1, NumberHelper<decimal>.Sign(decimal.MinValue));
-            Assert.Equal(-1, NumberHelper<decimal>.Sign(-1.0m));
-
-            Assert.Equal(0, NumberHelper<decimal>.Sign(-0.0m));
-            Assert.Equal(0, NumberHelper<decimal>.Sign(0.0m));
-
-            Assert.Equal(1, NumberHelper<decimal>.Sign(1.0m));
-            Assert.Equal(1, NumberHelper<decimal>.Sign(decimal.MaxValue));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             decimal result;
@@ -1081,189 +1315,19 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetExponentByteCountTest()
-        {
-            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(decimal.MinValue));
-            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(-1.0m));
-            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(-0.0m));
-            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(0.0m));
-            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(1.0m));
-            Assert.Equal(1, FloatingPointHelper<decimal>.GetExponentByteCount(decimal.MaxValue));
-        }
+        //
+        // ISignedNumber
+        //
 
         [Fact]
-        public static void GetExponentShortestBitLengthTest()
+        public static void NegativeOneTest()
         {
-            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(decimal.MinValue));
-            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(-1.0m));
-            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(-0.0m));
-            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(0.0m));
-            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(1.0m));
-            Assert.Equal(7, FloatingPointHelper<decimal>.GetExponentShortestBitLength(decimal.MaxValue));
+            Assert.Equal(-1.0m, SignedNumberHelper<decimal>.NegativeOne);
         }
 
-        [Fact]
-        public static void GetSignificandByteCountTest()
-        {
-            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(decimal.MinValue));
-            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(-1.0m));
-            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(-0.0m));
-            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(0.0m));
-            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(1.0m));
-            Assert.Equal(12, FloatingPointHelper<decimal>.GetSignificandByteCount(decimal.MaxValue));
-        }
-
-        [Fact]
-        public static void GetSignificandBitLengthTest()
-        {
-            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(decimal.MinValue));
-            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(-1.0m));
-            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(-0.0m));
-            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(0.0m));
-            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(1.0m));
-            Assert.Equal(96, FloatingPointHelper<decimal>.GetSignificandBitLength(decimal.MaxValue));
-        }
-
-        [Fact]
-        public static void TryWriteExponentBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[1];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(decimal.MinValue, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5F }, destination.ToArray()); // +95
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(-1.0m, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(-0.0m, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(0.0m, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(1.0m, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(decimal.MaxValue, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5F }, destination.ToArray()); // +95
-
-            Assert.False(FloatingPointHelper<decimal>.TryWriteExponentBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0x5F }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteExponentLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[1];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(decimal.MinValue, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5F }, destination.ToArray()); // +95
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(-1.0m, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(-0.0m, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(0.0m, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(1.0m, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5E }, destination.ToArray()); // +94
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(decimal.MaxValue, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x5F }, destination.ToArray()); // +95
-
-            Assert.False(FloatingPointHelper<decimal>.TryWriteExponentLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0x5F }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteSignificandBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[12];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(decimal.MinValue, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(-1.0m, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(-0.0m, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(0.0m, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(1.0m, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(decimal.MaxValue, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(FloatingPointHelper<decimal>.TryWriteSignificandBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteSignificandLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[12];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(decimal.MinValue, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(-1.0m, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(-0.0m, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(0.0m, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(1.0m, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(decimal.MaxValue, destination, out bytesWritten));
-            Assert.Equal(12, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(FloatingPointHelper<decimal>.TryWriteSignificandLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-        }
+        //
+        // ISubtractionOperators
+        //
 
         [Fact]
         public static void op_SubtractionTest()
@@ -1289,6 +1353,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<decimal, decimal, decimal>.op_CheckedSubtraction(decimal.MinValue, 1.0m));
         }
 
+        //
+        // IUnaryNegationOperators
+        //
+
         [Fact]
         public static void op_UnaryNegationTest()
         {
@@ -1311,6 +1379,10 @@ namespace System.Tests
             Assert.Equal(decimal.MinValue, UnaryNegationOperatorsHelper<decimal, decimal>.op_CheckedUnaryNegation(decimal.MaxValue));
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1321,6 +1393,10 @@ namespace System.Tests
             Assert.Equal(1.0m, UnaryPlusOperatorsHelper<decimal, decimal>.op_UnaryPlus(1.0m));
             Assert.Equal(decimal.MaxValue, UnaryPlusOperatorsHelper<decimal, decimal>.op_UnaryPlus(decimal.MaxValue));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(DecimalTests.Parse_Valid_TestData), MemberType = typeof(DecimalTests))]

--- a/src/libraries/System.Runtime/tests/System/DecimalTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DecimalTests.GenericMath.cs
@@ -486,6 +486,17 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal(1.0m, NumberHelper<decimal>.MaxNumber(decimal.MinValue, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.MaxNumber(-1.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.MaxNumber(-0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.MaxNumber(0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.MaxNumber(1.0m, 1.0m));
+            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.MaxNumber(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal(decimal.MinValue, NumberHelper<decimal>.Min(decimal.MinValue, 1.0m));
@@ -494,6 +505,17 @@ namespace System.Tests
             Assert.Equal(0.0m, NumberHelper<decimal>.Min(0.0m, 1.0m));
             Assert.Equal(1.0m, NumberHelper<decimal>.Min(1.0m, 1.0m));
             Assert.Equal(1.0m, NumberHelper<decimal>.Min(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal(decimal.MinValue, NumberHelper<decimal>.MinNumber(decimal.MinValue, 1.0m));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.MinNumber(-1.0m, 1.0m));
+            Assert.Equal(-0.0m, NumberHelper<decimal>.MinNumber(-0.0m, 1.0m));
+            Assert.Equal(0.0m, NumberHelper<decimal>.MinNumber(0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.MinNumber(1.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.MinNumber(decimal.MaxValue, 1.0m));
         }
 
         [Fact]
@@ -1000,6 +1022,138 @@ namespace System.Tests
                 Assert.Equal(2147483648.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal(4294967295.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<decimal>.IsFinite(decimal.MinValue));
+            Assert.True(NumberBaseHelper<decimal>.IsFinite(-1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsFinite(-0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsFinite(0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsFinite(1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsFinite(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<decimal>.IsInfinity(decimal.MinValue));
+            Assert.False(NumberBaseHelper<decimal>.IsInfinity(-1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsInfinity(-0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsInfinity(0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsInfinity(1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsInfinity(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<decimal>.IsNaN(decimal.MinValue));
+            Assert.False(NumberBaseHelper<decimal>.IsNaN(-1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNaN(-0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNaN(0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNaN(1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNaN(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.True(NumberBaseHelper<decimal>.IsNegative(decimal.MinValue));
+            Assert.True(NumberBaseHelper<decimal>.IsNegative(-1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsNegative(-0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNegative(0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNegative(1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNegative(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<decimal>.IsNegativeInfinity(decimal.MinValue));
+            Assert.False(NumberBaseHelper<decimal>.IsNegativeInfinity(-1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNegativeInfinity(-0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNegativeInfinity(0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNegativeInfinity(1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNegativeInfinity(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.True(NumberBaseHelper<decimal>.IsNormal(decimal.MinValue));
+            Assert.True(NumberBaseHelper<decimal>.IsNormal(-1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNormal(-0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsNormal(0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsNormal(1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsNormal(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<decimal>.IsPositiveInfinity(decimal.MinValue));
+            Assert.False(NumberBaseHelper<decimal>.IsPositiveInfinity(-1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsPositiveInfinity(-0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsPositiveInfinity(0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsPositiveInfinity(1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsPositiveInfinity(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<decimal>.IsSubnormal(decimal.MinValue));
+            Assert.False(NumberBaseHelper<decimal>.IsSubnormal(-1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsSubnormal(-0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsSubnormal(0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsSubnormal(1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsSubnormal(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal(decimal.MinValue, NumberBaseHelper<decimal>.MaxMagnitude(decimal.MinValue, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MaxMagnitude(-1.0m, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MaxMagnitude(-0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MaxMagnitude(0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MaxMagnitude(1.0m, 1.0m));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.MaxMagnitude(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal(decimal.MinValue, NumberBaseHelper<decimal>.MaxMagnitudeNumber(decimal.MinValue, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MaxMagnitudeNumber(-1.0m, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MaxMagnitudeNumber(-0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MaxMagnitudeNumber(0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MaxMagnitudeNumber(1.0m, 1.0m));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.MaxMagnitudeNumber(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MinMagnitude(decimal.MinValue, 1.0m));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.MinMagnitude(-1.0m, 1.0m));
+            Assert.Equal(-0.0m, NumberBaseHelper<decimal>.MinMagnitude(-0.0m, 1.0m));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.MinMagnitude(0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MinMagnitude(1.0m, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MinMagnitude(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MinMagnitudeNumber(decimal.MinValue, 1.0m));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.MinMagnitudeNumber(-1.0m, 1.0m));
+            Assert.Equal(-0.0m, NumberBaseHelper<decimal>.MinMagnitudeNumber(-0.0m, 1.0m));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.MinMagnitudeNumber(0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MinMagnitudeNumber(1.0m, 1.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.MinMagnitudeNumber(decimal.MaxValue, 1.0m));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/DecimalTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DecimalTests.GenericMath.cs
@@ -248,12 +248,12 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.Abs(decimal.MinValue));
-            Assert.Equal(1.0m, NumberHelper<decimal>.Abs(-1.0m));
-            Assert.Equal(0.0m, NumberHelper<decimal>.Abs(-0.0m));
-            Assert.Equal(0.0m, NumberHelper<decimal>.Abs(0.0m));
-            Assert.Equal(1.0m, NumberHelper<decimal>.Abs(1.0m));
-            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.Abs(decimal.MaxValue));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.Abs(decimal.MinValue));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.Abs(-1.0m));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.Abs(-0.0m));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.Abs(0.0m));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.Abs(1.0m));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.Abs(decimal.MaxValue));
         }
 
         [Fact]
@@ -270,62 +270,62 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<byte>(0x00));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<byte>(0x01));
-            Assert.Equal(127.0m, NumberHelper<decimal>.CreateChecked<byte>(0x7F));
-            Assert.Equal(128.0m, NumberHelper<decimal>.CreateChecked<byte>(0x80));
-            Assert.Equal(255.0m, NumberHelper<decimal>.CreateChecked<byte>(0xFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<byte>(0x00));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<byte>(0x01));
+            Assert.Equal(127.0m, NumberBaseHelper<decimal>.CreateChecked<byte>(0x7F));
+            Assert.Equal(128.0m, NumberBaseHelper<decimal>.CreateChecked<byte>(0x80));
+            Assert.Equal(255.0m, NumberBaseHelper<decimal>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<char>((char)0x0000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<char>((char)0x0001));
-            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateChecked<char>((char)0x8000));
-            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<char>((char)0x0000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<char>((char)0x0001));
+            Assert.Equal(32767.0m, NumberBaseHelper<decimal>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal(32768.0m, NumberBaseHelper<decimal>.CreateChecked<char>((char)0x8000));
+            Assert.Equal(65535.0m, NumberBaseHelper<decimal>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<short>(0x0000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<short>(0x0001));
-            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateChecked<short>(0x7FFF));
-            Assert.Equal(-32768.0m, NumberHelper<decimal>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<short>(0x0000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<short>(0x0001));
+            Assert.Equal(32767.0m, NumberBaseHelper<decimal>.CreateChecked<short>(0x7FFF));
+            Assert.Equal(-32768.0m, NumberBaseHelper<decimal>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<int>(0x00000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<int>(0x00000001));
-            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<int>(0x00000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<int>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Equal(-2147483648.0m, NumberBaseHelper<decimal>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<long>(0x0000000000000001));
-            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<long>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(-9223372036854775808.0m, NumberBaseHelper<decimal>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateCheckedFromInt128Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateChecked<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<decimal>.CreateChecked<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            Assert.Throws<OverflowException>(() => NumberHelper<decimal>.CreateChecked<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<decimal>.CreateChecked<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<decimal>.CreateChecked<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
         }
 
         [Fact]
@@ -333,71 +333,71 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(-9223372036854775808.0m, NumberBaseHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(-2147483648.0m, NumberBaseHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<sbyte>(0x00));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<sbyte>(0x01));
-            Assert.Equal(127.0m, NumberHelper<decimal>.CreateChecked<sbyte>(0x7F));
-            Assert.Equal(-128.0m, NumberHelper<decimal>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<sbyte>(0x00));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<sbyte>(0x01));
+            Assert.Equal(127.0m, NumberBaseHelper<decimal>.CreateChecked<sbyte>(0x7F));
+            Assert.Equal(-128.0m, NumberBaseHelper<decimal>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<ushort>(0x0000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<ushort>(0x0001));
-            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateChecked<ushort>(0x8000));
-            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<ushort>(0x0000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<ushort>(0x0001));
+            Assert.Equal(32767.0m, NumberBaseHelper<decimal>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal(32768.0m, NumberBaseHelper<decimal>.CreateChecked<ushort>(0x8000));
+            Assert.Equal(65535.0m, NumberBaseHelper<decimal>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<uint>(0x00000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<uint>(0x00000001));
-            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateChecked<uint>(0x80000000));
-            Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<uint>(0x00000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<uint>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Equal(2147483648.0m, NumberBaseHelper<decimal>.CreateChecked<uint>(0x80000000));
+            Assert.Equal(4294967295.0m, NumberBaseHelper<decimal>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Equal(18446744073709551615.0m, NumberHelper<decimal>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(9223372036854775808.0m, NumberBaseHelper<decimal>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Equal(18446744073709551615.0m, NumberBaseHelper<decimal>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt128Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<decimal>.CreateChecked<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            Assert.Throws<OverflowException>(() => NumberHelper<decimal>.CreateChecked<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            Assert.Throws<OverflowException>(() => NumberHelper<decimal>.CreateChecked<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<decimal>.CreateChecked<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<decimal>.CreateChecked<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<decimal>.CreateChecked<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
         }
 
         [Fact]
@@ -405,82 +405,82 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(18446744073709551615.0m, NumberHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(9223372036854775808.0m, NumberBaseHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(18446744073709551615.0m, NumberBaseHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(2147483648.0m, NumberBaseHelper<decimal>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Equal(4294967295.0m, NumberBaseHelper<decimal>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<byte>(0x00));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<byte>(0x01));
-            Assert.Equal(127.0m, NumberHelper<decimal>.CreateSaturating<byte>(0x7F));
-            Assert.Equal(128.0m, NumberHelper<decimal>.CreateSaturating<byte>(0x80));
-            Assert.Equal(255.0m, NumberHelper<decimal>.CreateSaturating<byte>(0xFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<byte>(0x00));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<byte>(0x01));
+            Assert.Equal(127.0m, NumberBaseHelper<decimal>.CreateSaturating<byte>(0x7F));
+            Assert.Equal(128.0m, NumberBaseHelper<decimal>.CreateSaturating<byte>(0x80));
+            Assert.Equal(255.0m, NumberBaseHelper<decimal>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal(32767.0m, NumberBaseHelper<decimal>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal(32768.0m, NumberBaseHelper<decimal>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal(65535.0m, NumberBaseHelper<decimal>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<short>(0x0000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<short>(0x0001));
-            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal(-32768.0m, NumberHelper<decimal>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<short>(0x0000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<short>(0x0001));
+            Assert.Equal(32767.0m, NumberBaseHelper<decimal>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal(-32768.0m, NumberBaseHelper<decimal>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<int>(0x00000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<int>(0x00000001));
-            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<int>(0x00000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<int>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal(-2147483648.0m, NumberBaseHelper<decimal>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(-9223372036854775808.0m, NumberBaseHelper<decimal>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt128Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
 
-            Assert.Equal(+1.0m, NumberHelper<decimal>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Equal(+1.0m, NumberBaseHelper<decimal>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateSaturating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
 
-            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.CreateSaturating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            Assert.Equal(decimal.MinValue, NumberHelper<decimal>.CreateSaturating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.CreateSaturating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Equal(decimal.MinValue, NumberBaseHelper<decimal>.CreateSaturating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
         }
 
         [Fact]
@@ -488,72 +488,72 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(-9223372036854775808.0m, NumberBaseHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(-2147483648.0m, NumberBaseHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal(127.0m, NumberHelper<decimal>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal(-128.0m, NumberHelper<decimal>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal(127.0m, NumberBaseHelper<decimal>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal(-128.0m, NumberBaseHelper<decimal>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal(32767.0m, NumberBaseHelper<decimal>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal(32768.0m, NumberBaseHelper<decimal>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal(65535.0m, NumberBaseHelper<decimal>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal(2147483648.0m, NumberBaseHelper<decimal>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal(4294967295.0m, NumberBaseHelper<decimal>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal(18446744073709551615.0m, NumberHelper<decimal>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(9223372036854775808.0m, NumberBaseHelper<decimal>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal(18446744073709551615.0m, NumberBaseHelper<decimal>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt128Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
 
-            Assert.Equal(+1.0m, NumberHelper<decimal>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.CreateSaturating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Equal(+1.0m, NumberBaseHelper<decimal>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.CreateSaturating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
 
-            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.CreateSaturating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.CreateSaturating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.CreateSaturating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.CreateSaturating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
         }
 
         [Fact]
@@ -561,82 +561,82 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(18446744073709551615.0m, NumberHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(9223372036854775808.0m, NumberBaseHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(18446744073709551615.0m, NumberBaseHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(2147483648.0m, NumberBaseHelper<decimal>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal(4294967295.0m, NumberBaseHelper<decimal>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<byte>(0x00));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<byte>(0x01));
-            Assert.Equal(127.0m, NumberHelper<decimal>.CreateTruncating<byte>(0x7F));
-            Assert.Equal(128.0m, NumberHelper<decimal>.CreateTruncating<byte>(0x80));
-            Assert.Equal(255.0m, NumberHelper<decimal>.CreateTruncating<byte>(0xFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<byte>(0x00));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<byte>(0x01));
+            Assert.Equal(127.0m, NumberBaseHelper<decimal>.CreateTruncating<byte>(0x7F));
+            Assert.Equal(128.0m, NumberBaseHelper<decimal>.CreateTruncating<byte>(0x80));
+            Assert.Equal(255.0m, NumberBaseHelper<decimal>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal(32767.0m, NumberBaseHelper<decimal>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal(32768.0m, NumberBaseHelper<decimal>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal(65535.0m, NumberBaseHelper<decimal>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<short>(0x0000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<short>(0x0001));
-            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal(-32768.0m, NumberHelper<decimal>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<short>(0x0000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<short>(0x0001));
+            Assert.Equal(32767.0m, NumberBaseHelper<decimal>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal(-32768.0m, NumberBaseHelper<decimal>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<int>(0x00000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<int>(0x00000001));
-            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<int>(0x00000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<int>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal(-2147483648.0m, NumberBaseHelper<decimal>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(-9223372036854775808.0m, NumberBaseHelper<decimal>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt128Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
 
-            Assert.Equal(+1.0m, NumberHelper<decimal>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Equal(+1.0m, NumberBaseHelper<decimal>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateTruncating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
 
-            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.CreateTruncating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.CreateTruncating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
         }
 
         [Fact]
@@ -644,72 +644,72 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(-9223372036854775808.0m, NumberBaseHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(-2147483648.0m, NumberBaseHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal(127.0m, NumberHelper<decimal>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal(-128.0m, NumberHelper<decimal>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal(127.0m, NumberBaseHelper<decimal>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal(-128.0m, NumberBaseHelper<decimal>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(-1.0m, NumberBaseHelper<decimal>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal(32767.0m, NumberBaseHelper<decimal>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal(32768.0m, NumberBaseHelper<decimal>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal(65535.0m, NumberBaseHelper<decimal>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal(2147483648.0m, NumberBaseHelper<decimal>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal(4294967295.0m, NumberBaseHelper<decimal>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal(18446744073709551615.0m, NumberHelper<decimal>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(9223372036854775808.0m, NumberBaseHelper<decimal>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal(18446744073709551615.0m, NumberBaseHelper<decimal>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt128Test()
         {
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
 
-            Assert.Equal(+1.0m, NumberHelper<decimal>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.CreateTruncating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Equal(+1.0m, NumberBaseHelper<decimal>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.CreateTruncating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
 
-            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.CreateTruncating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            Assert.Equal(decimal.MaxValue, NumberBaseHelper<decimal>.CreateTruncating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
         }
 
         [Fact]
@@ -717,19 +717,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(18446744073709551615.0m, NumberHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(9223372036854775808.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(18446744073709551615.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(0.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal(1.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(2147483648.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal(4294967295.0m, NumberBaseHelper<decimal>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -773,19 +773,19 @@ namespace System.Tests
         {
             decimal result;
 
-            Assert.True(NumberHelper<decimal>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<byte>(0x00, out result));
             Assert.Equal(0.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<byte>(0x01, out result));
             Assert.Equal(1.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<byte>(0x7F, out result));
             Assert.Equal(127.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<byte>(0x80, out result));
             Assert.Equal(128.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<byte>(0xFF, out result));
             Assert.Equal(255.0m, result);
         }
 
@@ -794,19 +794,19 @@ namespace System.Tests
         {
             decimal result;
 
-            Assert.True(NumberHelper<decimal>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal(0.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal(1.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal(32767.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal(32768.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal(65535.0m, result);
         }
 
@@ -815,19 +815,19 @@ namespace System.Tests
         {
             decimal result;
 
-            Assert.True(NumberHelper<decimal>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<short>(0x0000, out result));
             Assert.Equal(0.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<short>(0x0001, out result));
             Assert.Equal(1.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal(32767.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal(-32768.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(-1.0m, result);
         }
 
@@ -836,19 +836,19 @@ namespace System.Tests
         {
             decimal result;
 
-            Assert.True(NumberHelper<decimal>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<int>(0x00000000, out result));
             Assert.Equal(0.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<int>(0x00000001, out result));
             Assert.Equal(1.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal(2147483647.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal(-2147483648.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(-1.0m, result);
         }
 
@@ -857,19 +857,19 @@ namespace System.Tests
         {
             decimal result;
 
-            Assert.True(NumberHelper<decimal>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal(0.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal(1.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(9223372036854775807.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
             Assert.Equal(-9223372036854775808.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
             Assert.Equal(-1.0m, result);
         }
 
@@ -878,19 +878,19 @@ namespace System.Tests
         {
             decimal result;
 
-            Assert.True(NumberHelper<decimal>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(0.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
             Assert.Equal(1.0m, result);                         
 
-            Assert.True(NumberHelper<decimal>.TryCreate<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(-1.0m, result);
 
-            Assert.False(NumberHelper<decimal>.TryCreate<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.False(NumberBaseHelper<decimal>.TryCreate<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(0.0m, result);
 
-            Assert.False(NumberHelper<decimal>.TryCreate<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.False(NumberBaseHelper<decimal>.TryCreate<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(0.0m, result);
         }
 
@@ -901,36 +901,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal(0.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal(1.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(9223372036854775807.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal(-9223372036854775808.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(-1.0m, result);
             }
             else
             {
-                Assert.True(NumberHelper<decimal>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal(0.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal(1.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal(2147483647.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal(-2147483648.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(-1.0m, result);
             }
         }
@@ -940,19 +940,19 @@ namespace System.Tests
         {
             decimal result;
 
-            Assert.True(NumberHelper<decimal>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal(0.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal(1.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal(127.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal(-128.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(-1.0m, result);
         }
 
@@ -961,19 +961,19 @@ namespace System.Tests
         {
             decimal result;
 
-            Assert.True(NumberHelper<decimal>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal(0.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal(1.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal(32767.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal(32768.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal(65535.0m, result);
         }
 
@@ -982,19 +982,19 @@ namespace System.Tests
         {
             decimal result;
 
-            Assert.True(NumberHelper<decimal>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal(0.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal(1.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal(2147483647.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<uint>(0x80000000, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal(2147483648.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal(4294967295.0m, result);
         }
 
@@ -1003,19 +1003,19 @@ namespace System.Tests
         {
             decimal result;
 
-            Assert.True(NumberHelper<decimal>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal(0.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal(1.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(9223372036854775807.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal(9223372036854775808.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal(18446744073709551615.0m, result);
         }
 
@@ -1024,19 +1024,19 @@ namespace System.Tests
         {
             decimal result;
 
-            Assert.True(NumberHelper<decimal>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(0.0m, result);
 
-            Assert.True(NumberHelper<decimal>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
+            Assert.True(NumberBaseHelper<decimal>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
             Assert.Equal(1.0m, result);
 
-            Assert.False(NumberHelper<decimal>.TryCreate<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.False(NumberBaseHelper<decimal>.TryCreate<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(0.0m, result);
 
-            Assert.False(NumberHelper<decimal>.TryCreate<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.False(NumberBaseHelper<decimal>.TryCreate<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(0.0m, result);
 
-            Assert.False(NumberHelper<decimal>.TryCreate<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.False(NumberBaseHelper<decimal>.TryCreate<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(0.0m, result);
         }
 
@@ -1047,36 +1047,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal(0.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal(1.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(9223372036854775807.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal(9223372036854775808.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(18446744073709551615.0m, result);
             }
             else
             {
-                Assert.True(NumberHelper<decimal>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal(0.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal(1.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal(2147483647.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal(2147483648.0m, result);
 
-                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal(4294967295.0m, result);
             }
         }
@@ -1333,29 +1333,29 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.True(NumberHelper<decimal>.TryParse(value, null, out result));
+                    Assert.True(ParsableHelper<decimal>.TryParse(value, null, out result));
                     Assert.Equal(expected, result);
 
-                    Assert.Equal(expected, NumberHelper<decimal>.Parse(value, null));
+                    Assert.Equal(expected, ParsableHelper<decimal>.Parse(value, null));
                 }
 
-                Assert.Equal(expected, NumberHelper<decimal>.Parse(value, provider));
+                Assert.Equal(expected, ParsableHelper<decimal>.Parse(value, provider));
             }
 
             // Use Parse(string, NumberStyles, IFormatProvider)
-            Assert.True(NumberHelper<decimal>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
 
-            Assert.Equal(expected, NumberHelper<decimal>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<decimal>.Parse(value, style, provider));
 
             if (isDefaultProvider)
             {
                 // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.True(NumberHelper<decimal>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
+                Assert.True(NumberBaseHelper<decimal>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
                 Assert.Equal(expected, result);
 
-                Assert.Equal(expected, NumberHelper<decimal>.Parse(value, style, null));
-                Assert.Equal(expected, NumberHelper<decimal>.Parse(value, style, NumberFormatInfo.CurrentInfo));
+                Assert.Equal(expected, NumberBaseHelper<decimal>.Parse(value, style, null));
+                Assert.Equal(expected, NumberBaseHelper<decimal>.Parse(value, style, NumberFormatInfo.CurrentInfo));
             }
         }
 
@@ -1370,29 +1370,29 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.False(NumberHelper<decimal>.TryParse(value, null, out result));
+                    Assert.False(ParsableHelper<decimal>.TryParse(value, null, out result));
                     Assert.Equal(default(decimal), result);
 
-                    Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value, null));
+                    Assert.Throws(exceptionType, () => ParsableHelper<decimal>.Parse(value, null));
                 }
 
-                Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value, provider));
+                Assert.Throws(exceptionType, () => ParsableHelper<decimal>.Parse(value, provider));
             }
 
             // Use Parse(string, NumberStyles, IFormatProvider)
-            Assert.False(NumberHelper<decimal>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<decimal>.TryParse(value, style, provider, out result));
             Assert.Equal(default(decimal), result);
 
-            Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<decimal>.Parse(value, style, provider));
 
             if (isDefaultProvider)
             {
                 // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.False(NumberHelper<decimal>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
+                Assert.False(NumberBaseHelper<decimal>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
                 Assert.Equal(default(decimal), result);
 
-                Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value, style, null));
-                Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value, style, NumberFormatInfo.CurrentInfo));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<decimal>.Parse(value, style, null));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<decimal>.Parse(value, style, NumberFormatInfo.CurrentInfo));
             }
         }
 
@@ -1407,18 +1407,18 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.True(NumberHelper<decimal>.TryParse(value.AsSpan(offset, count), null, out result));
+                    Assert.True(SpanParsableHelper<decimal>.TryParse(value.AsSpan(offset, count), null, out result));
                     Assert.Equal(expected, result);
 
-                    Assert.Equal(expected, NumberHelper<decimal>.Parse(value.AsSpan(offset, count), null));
+                    Assert.Equal(expected, SpanParsableHelper<decimal>.Parse(value.AsSpan(offset, count), null));
                 }
 
-                Assert.Equal(expected, NumberHelper<decimal>.Parse(value.AsSpan(offset, count), provider: provider));
+                Assert.Equal(expected, SpanParsableHelper<decimal>.Parse(value.AsSpan(offset, count), provider: provider));
             }
 
-            Assert.Equal(expected, NumberHelper<decimal>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<decimal>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<decimal>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<decimal>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1428,9 +1428,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value.AsSpan(), style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<decimal>.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(NumberHelper<decimal>.TryParse(value.AsSpan(), style, provider, out decimal result));
+                Assert.False(NumberBaseHelper<decimal>.TryParse(value.AsSpan(), style, provider, out decimal result));
                 Assert.Equal(0, result);
             }
         }

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
@@ -30,47 +30,9 @@ namespace System.Tests
             throw new Xunit.Sdk.EqualException(expected, actual);
         }
 
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            AssertBitwiseEqual(0.0, AdditiveIdentityHelper<double, double>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            AssertBitwiseEqual(double.MinValue, MinMaxValueHelper<double>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            AssertBitwiseEqual(double.MaxValue, MinMaxValueHelper<double>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            AssertBitwiseEqual(1.0, MultiplicativeIdentityHelper<double, double>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            Assert.Equal(-1.0, SignedNumberHelper<double>.NegativeOne);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -112,6 +74,20 @@ namespace System.Tests
             AssertBitwiseEqual(double.PositiveInfinity, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(double.PositiveInfinity, 1.0));
         }
 
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            AssertBitwiseEqual(0.0, AdditiveIdentityHelper<double, double>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryNumber
+        //
+
         [Fact]
         public static void IsPow2Test()
         {
@@ -152,45 +128,9 @@ namespace System.Tests
             AssertBitwiseEqual(double.PositiveInfinity, BinaryNumberHelper<double>.Log2(double.PositiveInfinity));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(double.NegativeInfinity, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(double.MinValue, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-1.0, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-MinNormal, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-MaxSubnormal, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-double.Epsilon, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-0.0, 1.0));
-            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(double.NaN, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(0.0, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(double.Epsilon, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(MaxSubnormal, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(MinNormal, 1.0));
-            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(1.0, 1.0));
-            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(double.MaxValue, 1.0));
-            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(double.PositiveInfinity, 1.0));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.NegativeInfinity, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.MinValue, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-1.0, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-MinNormal, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-MaxSubnormal, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-double.Epsilon, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-0.0, 1.0));
-            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.NaN, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(0.0, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.Epsilon, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(MaxSubnormal, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(MinNormal, 1.0));
-            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(1.0, 1.0));
-            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.MaxValue, 1.0));
-            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.PositiveInfinity, 1.0));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -233,6 +173,50 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(double.NegativeInfinity, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(double.MinValue, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-1.0, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-MinNormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-MaxSubnormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-double.Epsilon, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-0.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(double.NaN, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(0.0, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(double.Epsilon, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(MaxSubnormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(MinNormal, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(1.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(double.MaxValue, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.NegativeInfinity, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.MinValue, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-1.0, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-MinNormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-MaxSubnormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-double.Epsilon, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-0.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.NaN, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(0.0, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.Epsilon, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(MaxSubnormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(MinNormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(1.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.MaxValue, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.PositiveInfinity, 1.0));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             AssertBitwiseEqual(double.NegativeInfinity, DecrementOperatorsHelper<double>.op_Decrement(double.NegativeInfinity));
@@ -271,6 +255,10 @@ namespace System.Tests
             AssertBitwiseEqual(double.MaxValue, DecrementOperatorsHelper<double>.op_CheckedDecrement(double.MaxValue));
             AssertBitwiseEqual(double.PositiveInfinity, DecrementOperatorsHelper<double>.op_CheckedDecrement(double.PositiveInfinity));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -312,6 +300,10 @@ namespace System.Tests
             AssertBitwiseEqual(double.PositiveInfinity, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(double.PositiveInfinity, 2.0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -351,6 +343,378 @@ namespace System.Tests
             Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(double.MaxValue, 1.0));
             Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(double.PositiveInfinity, 1.0));
         }
+
+        //
+        // IFloatingPoint
+        //
+
+        [Fact]
+        public static void GetExponentByteCountTest()
+        {
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.NegativeInfinity));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.MinValue));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(-1.0));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(-MinNormal));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(-MaxSubnormal));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(-double.Epsilon));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(-0.0));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.NaN));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(0.0));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.Epsilon));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(MaxSubnormal));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(MinNormal));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(1.0));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.MaxValue));
+            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void GetExponentShortestBitLengthTest()
+        {
+            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(double.NegativeInfinity));
+            Assert.Equal(10, FloatingPointHelper<double>.GetExponentShortestBitLength(double.MinValue));
+            Assert.Equal(0, FloatingPointHelper<double>.GetExponentShortestBitLength(-1.0));
+            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(-MinNormal));
+            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(-MaxSubnormal));
+            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(-double.Epsilon));
+            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(-0.0));
+            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(double.NaN));
+            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(0.0));
+            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(double.Epsilon));
+            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(MaxSubnormal));
+            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(MinNormal));
+            Assert.Equal(0, FloatingPointHelper<double>.GetExponentShortestBitLength(1.0));
+            Assert.Equal(10, FloatingPointHelper<double>.GetExponentShortestBitLength(double.MaxValue));
+            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void GetSignificandByteCountTest()
+        {
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.NegativeInfinity));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.MinValue));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(-1.0));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(-MinNormal));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(-MaxSubnormal));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(-double.Epsilon));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(-0.0));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.NaN));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(0.0));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.Epsilon));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(MaxSubnormal));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(MinNormal));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(1.0));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.MaxValue));
+            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void GetSignificandBitLengthTest()
+        {
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.NegativeInfinity));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.MinValue));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(-1.0));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(-MinNormal));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(-MaxSubnormal));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(-double.Epsilon));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(-0.0));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.NaN));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(0.0));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.Epsilon));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(MaxSubnormal));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(MinNormal));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(1.0));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.MaxValue));
+            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void TryWriteExponentBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[2];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.NegativeInfinity, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x04, 0x00 }, destination.ToArray()); // +1024
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.MinValue, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x03, 0xFF }, destination.ToArray()); // +1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(-1.0, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray()); // +0
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(-MinNormal, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFC, 0x02 }, destination.ToArray()); // -1022
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(-MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(-double.Epsilon, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(-0.0, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.NaN, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x04, 0x00 }, destination.ToArray()); // +1024
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(0.0, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.Epsilon, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(MinNormal, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFC, 0x02 }, destination.ToArray()); // -1022
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(1.0, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray()); // +0
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.MaxValue, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x03, 0xff }, destination.ToArray()); // +1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.PositiveInfinity, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x04, 0x00 }, destination.ToArray()); // +1024
+
+            Assert.False(FloatingPointHelper<double>.TryWriteExponentBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0x04, 0x00 }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteExponentLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[2];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.NegativeInfinity, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray()); // +1024
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.MinValue, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0x03 }, destination.ToArray()); // +1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(-1.0, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray()); // +0
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(-MinNormal, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x02, 0xFC }, destination.ToArray()); // -1022
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(-MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(-double.Epsilon, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(-0.0, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.NaN, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray()); // +1024
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(0.0, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.Epsilon, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(MinNormal, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x02, 0xFC }, destination.ToArray()); // -1022
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(1.0, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray()); // +0
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.MaxValue, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0x03 }, destination.ToArray()); // +1023
+
+            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.PositiveInfinity, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray()); // +1024
+
+            Assert.False(FloatingPointHelper<double>.TryWriteExponentLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteSignificandBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[8];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.NegativeInfinity, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.MinValue, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(-1.0, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(-MinNormal, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(-MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(-double.Epsilon, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(-0.0, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.NaN, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(0.0, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.Epsilon, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(MinNormal, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(1.0, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.MaxValue, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.PositiveInfinity, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.False(FloatingPointHelper<double>.TryWriteSignificandBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteSignificandLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[8];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.NegativeInfinity, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.MinValue, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x1F, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(-1.0, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(-MinNormal, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(-MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(-double.Epsilon, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(-0.0, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.NaN, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(0.0, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.Epsilon, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(MinNormal, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(1.0, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.MaxValue, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x1F, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.PositiveInfinity, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
+
+            Assert.False(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
+        }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -392,6 +756,26 @@ namespace System.Tests
             AssertBitwiseEqual(double.PositiveInfinity, IncrementOperatorsHelper<double>.op_CheckedIncrement(double.PositiveInfinity));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            AssertBitwiseEqual(double.MaxValue, MinMaxValueHelper<double>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            AssertBitwiseEqual(double.MinValue, MinMaxValueHelper<double>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -411,6 +795,20 @@ namespace System.Tests
             AssertBitwiseEqual(0.0, ModulusOperatorsHelper<double, double, double>.op_Modulus(double.MaxValue, 2.0));
             AssertBitwiseEqual(double.NaN, ModulusOperatorsHelper<double, double, double>.op_Modulus(double.PositiveInfinity, 2.0));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            AssertBitwiseEqual(1.0, MultiplicativeIdentityHelper<double, double>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -452,25 +850,9 @@ namespace System.Tests
             AssertBitwiseEqual(double.PositiveInfinity, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(double.PositiveInfinity, 2.0));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<double>.Abs(double.NegativeInfinity));
-            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<double>.Abs(double.MinValue));
-            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.Abs(-1.0));
-            AssertBitwiseEqual(MinNormal, NumberBaseHelper<double>.Abs(-MinNormal));
-            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<double>.Abs(-MaxSubnormal));
-            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<double>.Abs(-double.Epsilon));
-            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.Abs(-0.0));
-            AssertBitwiseEqual(double.NaN, NumberBaseHelper<double>.Abs(double.NaN));
-            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.Abs(0.0));
-            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<double>.Abs(double.Epsilon));
-            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<double>.Abs(MaxSubnormal));
-            AssertBitwiseEqual(MinNormal, NumberBaseHelper<double>.Abs(MinNormal));
-            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.Abs(1.0));
-            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<double>.Abs(double.MaxValue));
-            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<double>.Abs(double.PositiveInfinity));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -490,6 +872,105 @@ namespace System.Tests
             AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(1.0, 1.0, 63.0));
             AssertBitwiseEqual(63.0, NumberHelper<double>.Clamp(double.MaxValue, 1.0, 63.0));
             AssertBitwiseEqual(63.0, NumberHelper<double>.Clamp(double.PositiveInfinity, 1.0, 63.0));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(double.MinValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, NumberHelper<double>.Max(double.NaN, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(1.0, 1.0));
+            AssertBitwiseEqual(double.MaxValue, NumberHelper<double>.Max(double.MaxValue, 1.0));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberHelper<double>.Max(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, NumberHelper<double>.Min(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(double.MinValue, NumberHelper<double>.Min(double.MinValue, 1.0));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.Min(-1.0, 1.0));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<double>.Min(-MinNormal, 1.0));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<double>.Min(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(-double.Epsilon, NumberHelper<double>.Min(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(-0.0, NumberHelper<double>.Min(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, NumberHelper<double>.Min(double.NaN, 1.0));
+            AssertBitwiseEqual(0.0, NumberHelper<double>.Min(0.0, 1.0));
+            AssertBitwiseEqual(double.Epsilon, NumberHelper<double>.Min(double.Epsilon, 1.0));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<double>.Min(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(MinNormal, NumberHelper<double>.Min(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Min(1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Min(double.MaxValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Min(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(-1, NumberHelper<double>.Sign(double.NegativeInfinity));
+            Assert.Equal(-1, NumberHelper<double>.Sign(double.MinValue));
+            Assert.Equal(-1, NumberHelper<double>.Sign(-1.0));
+            Assert.Equal(-1, NumberHelper<double>.Sign(-MinNormal));
+            Assert.Equal(-1, NumberHelper<double>.Sign(-MaxSubnormal));
+            Assert.Equal(-1, NumberHelper<double>.Sign(-double.Epsilon));
+
+            Assert.Equal(0, NumberHelper<double>.Sign(-0.0));
+            Assert.Equal(0, NumberHelper<double>.Sign(0.0));
+
+            Assert.Equal(1, NumberHelper<double>.Sign(double.Epsilon));
+            Assert.Equal(1, NumberHelper<double>.Sign(MaxSubnormal));
+            Assert.Equal(1, NumberHelper<double>.Sign(MinNormal));
+            Assert.Equal(1, NumberHelper<double>.Sign(1.0));
+            Assert.Equal(1, NumberHelper<double>.Sign(double.MaxValue));
+            Assert.Equal(1, NumberHelper<double>.Sign(double.PositiveInfinity));
+
+            Assert.Throws<ArithmeticException>(() => NumberHelper<double>.Sign(double.NaN));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<double>.Abs(double.NegativeInfinity));
+            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<double>.Abs(double.MinValue));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.Abs(-1.0));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<double>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<double>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<double>.Abs(-double.Epsilon));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.Abs(-0.0));
+            AssertBitwiseEqual(double.NaN, NumberBaseHelper<double>.Abs(double.NaN));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.Abs(0.0));
+            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<double>.Abs(double.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<double>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<double>.Abs(MinNormal));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.Abs(1.0));
+            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<double>.Abs(double.MaxValue));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<double>.Abs(double.PositiveInfinity));
         }
 
         [Fact]
@@ -961,69 +1442,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void MaxTest()
-        {
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(double.NegativeInfinity, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(double.MinValue, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-1.0, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-MinNormal, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-MaxSubnormal, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-double.Epsilon, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-0.0, 1.0));
-            AssertBitwiseEqual(double.NaN, NumberHelper<double>.Max(double.NaN, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(0.0, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(double.Epsilon, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(MaxSubnormal, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(MinNormal, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(1.0, 1.0));
-            AssertBitwiseEqual(double.MaxValue, NumberHelper<double>.Max(double.MaxValue, 1.0));
-            AssertBitwiseEqual(double.PositiveInfinity, NumberHelper<double>.Max(double.PositiveInfinity, 1.0));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            AssertBitwiseEqual(double.NegativeInfinity, NumberHelper<double>.Min(double.NegativeInfinity, 1.0));
-            AssertBitwiseEqual(double.MinValue, NumberHelper<double>.Min(double.MinValue, 1.0));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.Min(-1.0, 1.0));
-            AssertBitwiseEqual(-MinNormal, NumberHelper<double>.Min(-MinNormal, 1.0));
-            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<double>.Min(-MaxSubnormal, 1.0));
-            AssertBitwiseEqual(-double.Epsilon, NumberHelper<double>.Min(-double.Epsilon, 1.0));
-            AssertBitwiseEqual(-0.0, NumberHelper<double>.Min(-0.0, 1.0));
-            AssertBitwiseEqual(double.NaN, NumberHelper<double>.Min(double.NaN, 1.0));
-            AssertBitwiseEqual(0.0, NumberHelper<double>.Min(0.0, 1.0));
-            AssertBitwiseEqual(double.Epsilon, NumberHelper<double>.Min(double.Epsilon, 1.0));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<double>.Min(MaxSubnormal, 1.0));
-            AssertBitwiseEqual(MinNormal, NumberHelper<double>.Min(MinNormal, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Min(1.0, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Min(double.MaxValue, 1.0));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Min(double.PositiveInfinity, 1.0));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(-1, NumberHelper<double>.Sign(double.NegativeInfinity));
-            Assert.Equal(-1, NumberHelper<double>.Sign(double.MinValue));
-            Assert.Equal(-1, NumberHelper<double>.Sign(-1.0));
-            Assert.Equal(-1, NumberHelper<double>.Sign(-MinNormal));
-            Assert.Equal(-1, NumberHelper<double>.Sign(-MaxSubnormal));
-            Assert.Equal(-1, NumberHelper<double>.Sign(-double.Epsilon));
-
-            Assert.Equal(0, NumberHelper<double>.Sign(-0.0));
-            Assert.Equal(0, NumberHelper<double>.Sign(0.0));
-
-            Assert.Equal(1, NumberHelper<double>.Sign(double.Epsilon));
-            Assert.Equal(1, NumberHelper<double>.Sign(MaxSubnormal));
-            Assert.Equal(1, NumberHelper<double>.Sign(MinNormal));
-            Assert.Equal(1, NumberHelper<double>.Sign(1.0));
-            Assert.Equal(1, NumberHelper<double>.Sign(double.MaxValue));
-            Assert.Equal(1, NumberHelper<double>.Sign(double.PositiveInfinity));
-
-            Assert.Throws<ArithmeticException>(() => NumberHelper<double>.Sign(double.NaN));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             double result;
@@ -1338,369 +1756,19 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetExponentByteCountTest()
-        {
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.NegativeInfinity));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.MinValue));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(-1.0));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(-MinNormal));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(-MaxSubnormal));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(-double.Epsilon));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(-0.0));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.NaN));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(0.0));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.Epsilon));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(MaxSubnormal));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(MinNormal));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(1.0));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.MaxValue));
-            Assert.Equal(2, FloatingPointHelper<double>.GetExponentByteCount(double.PositiveInfinity));
-        }
+        //
+        // ISignedNumber
+        //
 
         [Fact]
-        public static void GetExponentShortestBitLengthTest()
+        public static void NegativeOneTest()
         {
-            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(double.NegativeInfinity));
-            Assert.Equal(10, FloatingPointHelper<double>.GetExponentShortestBitLength(double.MinValue));
-            Assert.Equal(0, FloatingPointHelper<double>.GetExponentShortestBitLength(-1.0));
-            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(-MinNormal));
-            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(-MaxSubnormal));
-            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(-double.Epsilon));
-            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(-0.0));
-            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(double.NaN));
-            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(0.0));
-            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(double.Epsilon));
-            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(MaxSubnormal));
-            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(MinNormal));
-            Assert.Equal(0, FloatingPointHelper<double>.GetExponentShortestBitLength(1.0));
-            Assert.Equal(10, FloatingPointHelper<double>.GetExponentShortestBitLength(double.MaxValue));
-            Assert.Equal(11, FloatingPointHelper<double>.GetExponentShortestBitLength(double.PositiveInfinity));
+            Assert.Equal(-1.0, SignedNumberHelper<double>.NegativeOne);
         }
 
-        [Fact]
-        public static void GetSignificandByteCountTest()
-        {
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.NegativeInfinity));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.MinValue));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(-1.0));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(-MinNormal));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(-MaxSubnormal));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(-double.Epsilon));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(-0.0));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.NaN));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(0.0));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.Epsilon));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(MaxSubnormal));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(MinNormal));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(1.0));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.MaxValue));
-            Assert.Equal(8, FloatingPointHelper<double>.GetSignificandByteCount(double.PositiveInfinity));
-        }
-
-        [Fact]
-        public static void GetSignificandBitLengthTest()
-        {
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.NegativeInfinity));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.MinValue));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(-1.0));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(-MinNormal));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(-MaxSubnormal));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(-double.Epsilon));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(-0.0));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.NaN));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(0.0));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.Epsilon));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(MaxSubnormal));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(MinNormal));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(1.0));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.MaxValue));
-            Assert.Equal(53, FloatingPointHelper<double>.GetSignificandBitLength(double.PositiveInfinity));
-        }
-
-        [Fact]
-        public static void TryWriteExponentBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[2];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.NegativeInfinity, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x04, 0x00 }, destination.ToArray()); // +1024
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.MinValue, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x03, 0xFF }, destination.ToArray()); // +1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(-1.0, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray()); // +0
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(-MinNormal, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFC, 0x02 }, destination.ToArray()); // -1022
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(-MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(-double.Epsilon, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(-0.0, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.NaN, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x04, 0x00 }, destination.ToArray()); // +1024
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(0.0, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.Epsilon, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(MinNormal, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFC, 0x02 }, destination.ToArray()); // -1022
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(1.0, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray()); // +0
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.MaxValue, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x03, 0xff }, destination.ToArray()); // +1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentBigEndian(double.PositiveInfinity, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x04, 0x00 }, destination.ToArray()); // +1024
-
-            Assert.False(FloatingPointHelper<double>.TryWriteExponentBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0x04, 0x00 }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteExponentLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[2];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.NegativeInfinity, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray()); // +1024
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.MinValue, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0x03 }, destination.ToArray()); // +1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(-1.0, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray()); // +0
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(-MinNormal, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x02, 0xFC }, destination.ToArray()); // -1022
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(-MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(-double.Epsilon, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(-0.0, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.NaN, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray()); // +1024
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(0.0, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.Epsilon, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(MinNormal, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x02, 0xFC }, destination.ToArray()); // -1022
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(1.0, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray()); // +0
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.MaxValue, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0x03 }, destination.ToArray()); // +1023
-
-            Assert.True(FloatingPointHelper<double>.TryWriteExponentLittleEndian(double.PositiveInfinity, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray()); // +1024
-
-            Assert.False(FloatingPointHelper<double>.TryWriteExponentLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteSignificandBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[8];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.NegativeInfinity, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.MinValue, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(-1.0, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(-MinNormal, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(-MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(-double.Epsilon, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(-0.0, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.NaN, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(0.0, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.Epsilon, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(MinNormal, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(1.0, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.MaxValue, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandBigEndian(double.PositiveInfinity, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.False(FloatingPointHelper<double>.TryWriteSignificandBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteSignificandLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[8];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.NegativeInfinity, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.MinValue, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x1F, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(-1.0, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(-MinNormal, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(-MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(-double.Epsilon, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(-0.0, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.NaN, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(0.0, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.Epsilon, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(MinNormal, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(1.0, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.MaxValue, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x1F, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(double.PositiveInfinity, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
-
-            Assert.False(FloatingPointHelper<double>.TryWriteSignificandLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
-        }
+        //
+        // ISubtractionOperators
+        //
 
         [Fact]
         public static void op_SubtractionTest()
@@ -1742,6 +1810,10 @@ namespace System.Tests
             AssertBitwiseEqual(double.PositiveInfinity, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(double.PositiveInfinity, 1.0));
         }
 
+        //
+        // IUnaryNegationOperators
+        //
+
         [Fact]
         public static void op_UnaryNegationTest()
         {
@@ -1782,6 +1854,10 @@ namespace System.Tests
             AssertBitwiseEqual(double.NegativeInfinity, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(double.PositiveInfinity));
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1801,6 +1877,10 @@ namespace System.Tests
             AssertBitwiseEqual(double.MaxValue, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(double.MaxValue));
             AssertBitwiseEqual(double.PositiveInfinity, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(double.PositiveInfinity));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(DoubleTests.Parse_Valid_TestData), MemberType = typeof(DoubleTests))]

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
@@ -455,21 +455,21 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            AssertBitwiseEqual(double.PositiveInfinity, NumberHelper<double>.Abs(double.NegativeInfinity));
-            AssertBitwiseEqual(double.MaxValue, NumberHelper<double>.Abs(double.MinValue));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Abs(-1.0));
-            AssertBitwiseEqual(MinNormal, NumberHelper<double>.Abs(-MinNormal));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<double>.Abs(-MaxSubnormal));
-            AssertBitwiseEqual(double.Epsilon, NumberHelper<double>.Abs(-double.Epsilon));
-            AssertBitwiseEqual(0.0, NumberHelper<double>.Abs(-0.0));
-            AssertBitwiseEqual(double.NaN, NumberHelper<double>.Abs(double.NaN));
-            AssertBitwiseEqual(0.0, NumberHelper<double>.Abs(0.0));
-            AssertBitwiseEqual(double.Epsilon, NumberHelper<double>.Abs(double.Epsilon));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<double>.Abs(MaxSubnormal));
-            AssertBitwiseEqual(MinNormal, NumberHelper<double>.Abs(MinNormal));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.Abs(1.0));
-            AssertBitwiseEqual(double.MaxValue, NumberHelper<double>.Abs(double.MaxValue));
-            AssertBitwiseEqual(double.PositiveInfinity, NumberHelper<double>.Abs(double.PositiveInfinity));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<double>.Abs(double.NegativeInfinity));
+            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<double>.Abs(double.MinValue));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.Abs(-1.0));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<double>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<double>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<double>.Abs(-double.Epsilon));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.Abs(-0.0));
+            AssertBitwiseEqual(double.NaN, NumberBaseHelper<double>.Abs(double.NaN));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.Abs(0.0));
+            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<double>.Abs(double.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<double>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<double>.Abs(MinNormal));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.Abs(1.0));
+            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<double>.Abs(double.MaxValue));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<double>.Abs(double.PositiveInfinity));
         }
 
         [Fact]
@@ -495,61 +495,61 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<byte>(0x00));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<byte>(0x01));
-            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateChecked<byte>(0x7F));
-            AssertBitwiseEqual(128.0, NumberHelper<double>.CreateChecked<byte>(0x80));
-            AssertBitwiseEqual(255.0, NumberHelper<double>.CreateChecked<byte>(0xFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<byte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<byte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<double>.CreateChecked<byte>(0x7F));
+            AssertBitwiseEqual(128.0, NumberBaseHelper<double>.CreateChecked<byte>(0x80));
+            AssertBitwiseEqual(255.0, NumberBaseHelper<double>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<char>((char)0x0000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<char>((char)0x0001));
-            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateChecked<char>((char)0x7FFF));
-            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateChecked<char>((char)0x8000));
-            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateChecked<char>((char)0xFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<char>((char)0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<double>.CreateChecked<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<double>.CreateChecked<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<double>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<short>(0x0000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<short>(0x0001));
-            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateChecked<short>(0x7FFF));
-            AssertBitwiseEqual(-32768.0, NumberHelper<double>.CreateChecked<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<short>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<short>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<double>.CreateChecked<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0, NumberBaseHelper<double>.CreateChecked<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<int>(0x00000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<int>(0x00000001));
-            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateChecked<int>(0x7FFFFFFF));
-            AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateChecked<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<int>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateChecked<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<double>.CreateChecked<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<long>(0x0000000000000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<long>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<double>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateCheckedFromInt128Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberHelper<double>.CreateChecked<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(-170141183460469231731687303715884105728.0, NumberHelper<double>.CreateChecked<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberBaseHelper<double>.CreateChecked<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(-170141183460469231731687303715884105728.0, NumberBaseHelper<double>.CreateChecked<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateChecked<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -557,70 +557,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<double>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<nint>((nint)0x00000000));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<nint>((nint)0x00000001));
-                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<double>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<sbyte>(0x00));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<sbyte>(0x01));
-            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateChecked<sbyte>(0x7F));
-            AssertBitwiseEqual(-128.0, NumberHelper<double>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<sbyte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<sbyte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<double>.CreateChecked<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0, NumberBaseHelper<double>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<ushort>(0x0000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<ushort>(0x0001));
-            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateChecked<ushort>(0x7FFF));
-            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateChecked<ushort>(0x8000));
-            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateChecked<ushort>(0xFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<ushort>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<double>.CreateChecked<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<double>.CreateChecked<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<double>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<uint>(0x00000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<uint>(0x00000001));
-            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateChecked<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateChecked<uint>(0x80000000));
-            AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateChecked<uint>(0xFFFFFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<uint>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateChecked<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0, NumberBaseHelper<double>.CreateChecked<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0, NumberBaseHelper<double>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<ulong>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateChecked<ulong>(0x8000000000000000));
-            AssertBitwiseEqual(18446744073709551615.0, NumberHelper<double>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<double>.CreateChecked<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0, NumberBaseHelper<double>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt128Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberHelper<double>.CreateChecked<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(170141183460469231731687303715884105728.0, NumberHelper<double>.CreateChecked<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(340282366920938463463374607431768211455.0, NumberHelper<double>.CreateChecked<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberBaseHelper<double>.CreateChecked<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(170141183460469231731687303715884105728.0, NumberBaseHelper<double>.CreateChecked<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(340282366920938463463374607431768211455.0, NumberBaseHelper<double>.CreateChecked<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -628,84 +628,84 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual(18446744073709551615.0,NumberHelper<double>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0,NumberBaseHelper<double>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateChecked<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateChecked<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateChecked<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual(2147483648.0, NumberBaseHelper<double>.CreateChecked<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0, NumberBaseHelper<double>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<byte>(0x00));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<byte>(0x01));
-            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateSaturating<byte>(0x7F));
-            AssertBitwiseEqual(128.0, NumberHelper<double>.CreateSaturating<byte>(0x80));
-            AssertBitwiseEqual(255.0, NumberHelper<double>.CreateSaturating<byte>(0xFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<byte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<byte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<double>.CreateSaturating<byte>(0x7F));
+            AssertBitwiseEqual(128.0, NumberBaseHelper<double>.CreateSaturating<byte>(0x80));
+            AssertBitwiseEqual(255.0, NumberBaseHelper<double>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<char>((char)0x0000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<char>((char)0x0001));
-            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateSaturating<char>((char)0x7FFF));
-            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateSaturating<char>((char)0x8000));
-            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateSaturating<char>((char)0xFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<char>((char)0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<double>.CreateSaturating<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<double>.CreateSaturating<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<double>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<short>(0x0000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<short>(0x0001));
-            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateSaturating<short>(0x7FFF));
-            AssertBitwiseEqual(-32768.0, NumberHelper<double>.CreateSaturating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<short>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<short>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<double>.CreateSaturating<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0, NumberBaseHelper<double>.CreateSaturating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<int>(0x00000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<int>(0x00000001));
-            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateSaturating<int>(0x7FFFFFFF));
-            AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<int>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateSaturating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<double>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<long>(0x0000000000000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<long>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<double>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt128Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberHelper<double>.CreateSaturating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(-170141183460469231731687303715884105728.0, NumberHelper<double>.CreateSaturating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberBaseHelper<double>.CreateSaturating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(-170141183460469231731687303715884105728.0, NumberBaseHelper<double>.CreateSaturating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateSaturating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -713,70 +713,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<double>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<nint>((nint)0x00000001));
-                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<double>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<sbyte>(0x00));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<sbyte>(0x01));
-            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateSaturating<sbyte>(0x7F));
-            AssertBitwiseEqual(-128.0, NumberHelper<double>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<sbyte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<sbyte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<double>.CreateSaturating<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0, NumberBaseHelper<double>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<ushort>(0x0000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<ushort>(0x0001));
-            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateSaturating<ushort>(0x7FFF));
-            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateSaturating<ushort>(0x8000));
-            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateSaturating<ushort>(0xFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<ushort>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<double>.CreateSaturating<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<double>.CreateSaturating<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<double>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<uint>(0x00000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<uint>(0x00000001));
-            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateSaturating<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateSaturating<uint>(0x80000000));
-            AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateSaturating<uint>(0xFFFFFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<uint>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateSaturating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0, NumberBaseHelper<double>.CreateSaturating<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0, NumberBaseHelper<double>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<ulong>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateSaturating<ulong>(0x8000000000000000));
-            AssertBitwiseEqual(18446744073709551615.0, NumberHelper<double>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<double>.CreateSaturating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0, NumberBaseHelper<double>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt128Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberHelper<double>.CreateSaturating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(170141183460469231731687303715884105728.0, NumberHelper<double>.CreateSaturating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(340282366920938463463374607431768211455.0, NumberHelper<double>.CreateSaturating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberBaseHelper<double>.CreateSaturating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(170141183460469231731687303715884105728.0, NumberBaseHelper<double>.CreateSaturating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(340282366920938463463374607431768211455.0, NumberBaseHelper<double>.CreateSaturating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -784,84 +784,84 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual(18446744073709551615.0, NumberHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0, NumberBaseHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateSaturating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateSaturating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateSaturating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual(2147483648.0, NumberBaseHelper<double>.CreateSaturating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0, NumberBaseHelper<double>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<byte>(0x00));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<byte>(0x01));
-            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateTruncating<byte>(0x7F));
-            AssertBitwiseEqual(128.0, NumberHelper<double>.CreateTruncating<byte>(0x80));
-            AssertBitwiseEqual(255.0, NumberHelper<double>.CreateTruncating<byte>(0xFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<byte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<byte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<double>.CreateTruncating<byte>(0x7F));
+            AssertBitwiseEqual(128.0, NumberBaseHelper<double>.CreateTruncating<byte>(0x80));
+            AssertBitwiseEqual(255.0, NumberBaseHelper<double>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<char>((char)0x0000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<char>((char)0x0001));
-            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateTruncating<char>((char)0x7FFF));
-            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateTruncating<char>((char)0x8000));
-            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateTruncating<char>((char)0xFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<char>((char)0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<double>.CreateTruncating<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<double>.CreateTruncating<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<double>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<short>(0x0000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<short>(0x0001));
-            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateTruncating<short>(0x7FFF));
-            AssertBitwiseEqual(-32768.0, NumberHelper<double>.CreateTruncating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<short>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<short>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<double>.CreateTruncating<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0, NumberBaseHelper<double>.CreateTruncating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<int>(0x00000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<int>(0x00000001));
-            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateTruncating<int>(0x7FFFFFFF));
-            AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<int>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateTruncating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<double>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<long>(0x0000000000000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<long>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<double>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt128Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberHelper<double>.CreateTruncating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(-170141183460469231731687303715884105728.0, NumberHelper<double>.CreateTruncating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberBaseHelper<double>.CreateTruncating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(-170141183460469231731687303715884105728.0, NumberBaseHelper<double>.CreateTruncating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateTruncating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -869,70 +869,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0, NumberBaseHelper<double>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<nint>((nint)0x00000001));
-                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0, NumberBaseHelper<double>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<sbyte>(0x00));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<sbyte>(0x01));
-            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateTruncating<sbyte>(0x7F));
-            AssertBitwiseEqual(-128.0, NumberHelper<double>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<sbyte>(0x00));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<sbyte>(0x01));
+            AssertBitwiseEqual(127.0, NumberBaseHelper<double>.CreateTruncating<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0, NumberBaseHelper<double>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<ushort>(0x0000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<ushort>(0x0001));
-            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateTruncating<ushort>(0x7FFF));
-            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateTruncating<ushort>(0x8000));
-            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateTruncating<ushort>(0xFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<ushort>(0x0000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberBaseHelper<double>.CreateTruncating<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberBaseHelper<double>.CreateTruncating<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0, NumberBaseHelper<double>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<uint>(0x00000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<uint>(0x00000001));
-            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateTruncating<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateTruncating<uint>(0x80000000));
-            AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateTruncating<uint>(0xFFFFFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<uint>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateTruncating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0, NumberBaseHelper<double>.CreateTruncating<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0, NumberBaseHelper<double>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<ulong>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateTruncating<ulong>(0x8000000000000000));
-            AssertBitwiseEqual(18446744073709551615.0, NumberHelper<double>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<double>.CreateTruncating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0, NumberBaseHelper<double>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt128Test()
         {
-            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberHelper<double>.CreateTruncating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(170141183460469231731687303715884105728.0, NumberHelper<double>.CreateTruncating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(340282366920938463463374607431768211455.0, NumberHelper<double>.CreateTruncating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0, NumberBaseHelper<double>.CreateTruncating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(170141183460469231731687303715884105728.0, NumberBaseHelper<double>.CreateTruncating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(340282366920938463463374607431768211455.0, NumberBaseHelper<double>.CreateTruncating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -940,23 +940,23 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberBaseHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual(18446744073709551615.0, NumberHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual(9223372036854775808.0, NumberBaseHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0, NumberBaseHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(0.0, NumberBaseHelper<double>.CreateTruncating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberBaseHelper<double>.CreateTruncating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberBaseHelper<double>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateTruncating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual(2147483648.0, NumberBaseHelper<double>.CreateTruncating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0, NumberBaseHelper<double>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -1028,19 +1028,19 @@ namespace System.Tests
         {
             double result;
 
-            Assert.True(NumberHelper<double>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<byte>(0x00, out result));
             Assert.Equal(0.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<byte>(0x01, out result));
             Assert.Equal(1.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<byte>(0x7F, out result));
             Assert.Equal(127.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<byte>(0x80, out result));
             Assert.Equal(128.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<byte>(0xFF, out result));
             Assert.Equal(255.0, result);
         }
 
@@ -1049,19 +1049,19 @@ namespace System.Tests
         {
             double result;
 
-            Assert.True(NumberHelper<double>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal(0.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal(1.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal(32767.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal(32768.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal(65535.0, result);
         }
 
@@ -1070,19 +1070,19 @@ namespace System.Tests
         {
             double result;
 
-            Assert.True(NumberHelper<double>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<short>(0x0000, out result));
             Assert.Equal(0.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<short>(0x0001, out result));
             Assert.Equal(1.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal(32767.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal(-32768.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(-1.0, result);
         }
 
@@ -1091,19 +1091,19 @@ namespace System.Tests
         {
             double result;
 
-            Assert.True(NumberHelper<double>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<int>(0x00000000, out result));
             Assert.Equal(0.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<int>(0x00000001, out result));
             Assert.Equal(1.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal(2147483647.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal(-2147483648.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(-1.0, result);
         }
 
@@ -1112,19 +1112,19 @@ namespace System.Tests
         {
             double result;
 
-            Assert.True(NumberHelper<double>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal(0.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal(1.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(9223372036854775807.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
             Assert.Equal(-9223372036854775808.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
             Assert.Equal(-1.0, result);
         }
 
@@ -1133,19 +1133,19 @@ namespace System.Tests
         {
             double result;
 
-            Assert.True(NumberHelper<double>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(0.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
             Assert.Equal(1.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(170141183460469231731687303715884105727.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(-170141183460469231731687303715884105728.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(-1.0, result);
         }
 
@@ -1156,36 +1156,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal(0.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal(1.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(9223372036854775807.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal(-9223372036854775808.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(-1.0, result);
             }
             else
             {
-                Assert.True(NumberHelper<double>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal(0.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal(1.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal(2147483647.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal(-2147483648.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(-1.0, result);
             }
         }
@@ -1195,19 +1195,19 @@ namespace System.Tests
         {
             double result;
 
-            Assert.True(NumberHelper<double>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal(0.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal(1.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal(127.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal(-128.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(-1.0, result);
         }
 
@@ -1216,19 +1216,19 @@ namespace System.Tests
         {
             double result;
 
-            Assert.True(NumberHelper<double>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal(0.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal(1.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal(32767.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal(32768.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal(65535.0, result);
         }
 
@@ -1237,19 +1237,19 @@ namespace System.Tests
         {
             double result;
 
-            Assert.True(NumberHelper<double>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal(0.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal(1.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal(2147483647.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<uint>(0x80000000, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal(2147483648.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal(4294967295.0, result);
         }
 
@@ -1258,19 +1258,19 @@ namespace System.Tests
         {
             double result;
 
-            Assert.True(NumberHelper<double>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal(0.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal(1.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(9223372036854775807.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal(9223372036854775808.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal(18446744073709551615.0, result);
         }
 
@@ -1279,19 +1279,19 @@ namespace System.Tests
         {
             double result;
 
-            Assert.True(NumberHelper<double>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(0.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
             Assert.Equal(1.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(170141183460469231731687303715884105727.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(170141183460469231731687303715884105728.0, result);
 
-            Assert.True(NumberHelper<double>.TryCreate<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<double>.TryCreate<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(340282366920938463463374607431768211456.0, result);
         }
 
@@ -1302,38 +1302,38 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal(0.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal(1.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(9223372036854775807.0, result);
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                // Assert.True(NumberBaseHelper<double>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 // Assert.Equal(9223372036854775808.0, result);
                 //
-                // Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                // Assert.True(NumberBaseHelper<double>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 // Assert.Equal(18446744073709551615.0, result);
             }
             else
             {
-                Assert.True(NumberHelper<double>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal(0.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal(1.0, result);
 
-                Assert.True(NumberHelper<double>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<double>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal(2147483647.0, result);
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                // Assert.True(NumberBaseHelper<double>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 // Assert.Equal(2147483648.0, result);
                 //
-                // Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                // Assert.True(NumberBaseHelper<double>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 // Assert.Equal(4294967295.0, result);
             }
         }
@@ -1813,29 +1813,29 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.True(NumberHelper<double>.TryParse(value, null, out result));
+                    Assert.True(ParsableHelper<double>.TryParse(value, null, out result));
                     Assert.Equal(expected, result);
 
-                    Assert.Equal(expected, NumberHelper<double>.Parse(value, null));
+                    Assert.Equal(expected, ParsableHelper<double>.Parse(value, null));
                 }
 
-                Assert.Equal(expected, NumberHelper<double>.Parse(value, provider));
+                Assert.Equal(expected, ParsableHelper<double>.Parse(value, provider));
             }
 
             // Use Parse(string, NumberStyles, IFormatProvider)
-            Assert.True(NumberHelper<double>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<double>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
 
-            Assert.Equal(expected, NumberHelper<double>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<double>.Parse(value, style, provider));
 
             if (isDefaultProvider)
             {
                 // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.True(NumberHelper<double>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
+                Assert.True(NumberBaseHelper<double>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
                 Assert.Equal(expected, result);
 
-                Assert.Equal(expected, NumberHelper<double>.Parse(value, style, null));
-                Assert.Equal(expected, NumberHelper<double>.Parse(value, style, NumberFormatInfo.CurrentInfo));
+                Assert.Equal(expected, NumberBaseHelper<double>.Parse(value, style, null));
+                Assert.Equal(expected, NumberBaseHelper<double>.Parse(value, style, NumberFormatInfo.CurrentInfo));
             }
         }
 
@@ -1850,29 +1850,29 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.False(NumberHelper<double>.TryParse(value, null, out result));
+                    Assert.False(ParsableHelper<double>.TryParse(value, null, out result));
                     Assert.Equal(default(double), result);
 
-                    Assert.Throws(exceptionType, () => NumberHelper<double>.Parse(value, null));
+                    Assert.Throws(exceptionType, () => ParsableHelper<double>.Parse(value, null));
                 }
 
-                Assert.Throws(exceptionType, () => NumberHelper<double>.Parse(value, provider));
+                Assert.Throws(exceptionType, () => ParsableHelper<double>.Parse(value, provider));
             }
 
             // Use Parse(string, NumberStyles, IFormatProvider)
-            Assert.False(NumberHelper<double>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<double>.TryParse(value, style, provider, out result));
             Assert.Equal(default(double), result);
 
-            Assert.Throws(exceptionType, () => NumberHelper<double>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<double>.Parse(value, style, provider));
 
             if (isDefaultProvider)
             {
                 // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.False(NumberHelper<double>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
+                Assert.False(NumberBaseHelper<double>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
                 Assert.Equal(default(double), result);
 
-                Assert.Throws(exceptionType, () => NumberHelper<double>.Parse(value, style, null));
-                Assert.Throws(exceptionType, () => NumberHelper<double>.Parse(value, style, NumberFormatInfo.CurrentInfo));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<double>.Parse(value, style, null));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<double>.Parse(value, style, NumberFormatInfo.CurrentInfo));
             }
         }
 
@@ -1887,18 +1887,18 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.True(NumberHelper<double>.TryParse(value.AsSpan(offset, count), null, out result));
+                    Assert.True(SpanParsableHelper<double>.TryParse(value.AsSpan(offset, count), null, out result));
                     Assert.Equal(expected, result);
 
-                    Assert.Equal(expected, NumberHelper<double>.Parse(value.AsSpan(offset, count), null));
+                    Assert.Equal(expected, SpanParsableHelper<double>.Parse(value.AsSpan(offset, count), null));
                 }
 
-                Assert.Equal(expected, NumberHelper<double>.Parse(value.AsSpan(offset, count), provider: provider));
+                Assert.Equal(expected, SpanParsableHelper<double>.Parse(value.AsSpan(offset, count), provider: provider));
             }
 
-            Assert.Equal(expected, NumberHelper<double>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<double>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<double>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<double>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1908,9 +1908,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<double>.Parse(value.AsSpan(), style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<double>.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(NumberHelper<double>.TryParse(value.AsSpan(), style, provider, out double result));
+                Assert.False(NumberBaseHelper<double>.TryParse(value.AsSpan(), style, provider, out double result));
                 Assert.Equal(0, result);
             }
         }

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
@@ -895,6 +895,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(double.MinValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(-1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(-MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(-0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(double.NaN, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MaxNumber(1.0, 1.0));
+            AssertBitwiseEqual(double.MaxValue, NumberHelper<double>.MaxNumber(double.MaxValue, 1.0));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberHelper<double>.MaxNumber(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             AssertBitwiseEqual(double.NegativeInfinity, NumberHelper<double>.Min(double.NegativeInfinity, 1.0));
@@ -912,6 +932,26 @@ namespace System.Tests
             AssertBitwiseEqual(1.0, NumberHelper<double>.Min(1.0, 1.0));
             AssertBitwiseEqual(1.0, NumberHelper<double>.Min(double.MaxValue, 1.0));
             AssertBitwiseEqual(1.0, NumberHelper<double>.Min(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, NumberHelper<double>.MinNumber(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(double.MinValue, NumberHelper<double>.MinNumber(double.MinValue, 1.0));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.MinNumber(-1.0, 1.0));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<double>.MinNumber(-MinNormal, 1.0));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<double>.MinNumber(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(-double.Epsilon, NumberHelper<double>.MinNumber(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(-0.0, NumberHelper<double>.MinNumber(-0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MinNumber(double.NaN, 1.0));
+            AssertBitwiseEqual(0.0, NumberHelper<double>.MinNumber(0.0, 1.0));
+            AssertBitwiseEqual(double.Epsilon, NumberHelper<double>.MinNumber(double.Epsilon, 1.0));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<double>.MinNumber(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(MinNormal, NumberHelper<double>.MinNumber(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MinNumber(1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MinNumber(double.MaxValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.MinNumber(double.PositiveInfinity, 1.0));
         }
 
         [Fact]
@@ -1439,6 +1479,246 @@ namespace System.Tests
                 // AssertBitwiseEqual(2147483648.0, NumberBaseHelper<double>.CreateTruncating<nuint>((nuint)0x80000000));
                 // AssertBitwiseEqual(4294967295.0, NumberBaseHelper<double>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsFinite(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<double>.IsFinite(double.MinValue));
+            Assert.True(NumberBaseHelper<double>.IsFinite(-1.0f));
+            Assert.True(NumberBaseHelper<double>.IsFinite(-MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsFinite(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<double>.IsFinite(-double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsFinite(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsFinite(double.NaN));
+            Assert.True(NumberBaseHelper<double>.IsFinite(0.0f));
+            Assert.True(NumberBaseHelper<double>.IsFinite(double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsFinite(MaxSubnormal));
+            Assert.True(NumberBaseHelper<double>.IsFinite(MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsFinite(1.0f));
+            Assert.True(NumberBaseHelper<double>.IsFinite(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsFinite(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.True(NumberBaseHelper<double>.IsInfinity(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(double.MinValue));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(-1.0f));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(-double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(double.NaN));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(double.MaxValue));
+            Assert.True(NumberBaseHelper<double>.IsInfinity(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsNaN(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<double>.IsNaN(double.MinValue));
+            Assert.False(NumberBaseHelper<double>.IsNaN(-1.0f));
+            Assert.False(NumberBaseHelper<double>.IsNaN(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsNaN(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsNaN(-double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsNaN(-0.0f));
+            Assert.True(NumberBaseHelper<double>.IsNaN(double.NaN));
+            Assert.False(NumberBaseHelper<double>.IsNaN(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNaN(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsNaN(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsNaN(MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsNaN(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsNaN(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsNaN(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.True(NumberBaseHelper<double>.IsNegative(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<double>.IsNegative(double.MinValue));
+            Assert.True(NumberBaseHelper<double>.IsNegative(-1.0f));
+            Assert.True(NumberBaseHelper<double>.IsNegative(-MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsNegative(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<double>.IsNegative(-double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsNegative(-0.0f));
+            Assert.True(NumberBaseHelper<double>.IsNegative(double.NaN));
+            Assert.False(NumberBaseHelper<double>.IsNegative(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegative(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsNegative(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsNegative(MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsNegative(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegative(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsNegative(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.True(NumberBaseHelper<double>.IsNegativeInfinity(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(double.MinValue));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-1.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(double.NaN));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsNormal(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<double>.IsNormal(double.MinValue));
+            Assert.True(NumberBaseHelper<double>.IsNormal(-1.0f));
+            Assert.True(NumberBaseHelper<double>.IsNormal(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsNormal(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsNormal(-double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsNormal(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNormal(double.NaN));
+            Assert.False(NumberBaseHelper<double>.IsNormal(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNormal(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsNormal(MaxSubnormal));
+            Assert.True(NumberBaseHelper<double>.IsNormal(MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsNormal(1.0f));
+            Assert.True(NumberBaseHelper<double>.IsNormal(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsNormal(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(double.MinValue));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-1.0f));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(double.NaN));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(double.MaxValue));
+            Assert.True(NumberBaseHelper<double>.IsPositiveInfinity(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(double.MinValue));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(-1.0f));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(-MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsSubnormal(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<double>.IsSubnormal(-double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(double.NaN));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(0.0f));
+            Assert.True(NumberBaseHelper<double>.IsSubnormal(double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsSubnormal(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, NumberBaseHelper<double>.MaxMagnitude(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(double.MinValue, NumberBaseHelper<double>.MaxMagnitude(double.MinValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitude(-1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitude(-MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitude(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitude(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitude(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, NumberBaseHelper<double>.MaxMagnitude(double.NaN, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitude(0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitude(double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitude(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitude(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitude(1.0, 1.0));
+            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<double>.MaxMagnitude(double.MaxValue, 1.0));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<double>.MaxMagnitude(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, NumberBaseHelper<double>.MaxMagnitudeNumber(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(double.MinValue, NumberBaseHelper<double>.MaxMagnitudeNumber(double.MinValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitudeNumber(-1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitudeNumber(-MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitudeNumber(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitudeNumber(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitudeNumber(-0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitudeNumber(double.NaN, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitudeNumber(0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitudeNumber(double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitudeNumber(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitudeNumber(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MaxMagnitudeNumber(1.0, 1.0));
+            AssertBitwiseEqual(double.MaxValue, NumberBaseHelper<double>.MaxMagnitudeNumber(double.MaxValue, 1.0));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberBaseHelper<double>.MaxMagnitudeNumber(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MinMagnitude(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MinMagnitude(double.MinValue, 1.0));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.MinMagnitude(-1.0, 1.0));
+            AssertBitwiseEqual(-MinNormal, NumberBaseHelper<double>.MinMagnitude(-MinNormal, 1.0));
+            AssertBitwiseEqual(-MaxSubnormal, NumberBaseHelper<double>.MinMagnitude(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(-double.Epsilon, NumberBaseHelper<double>.MinMagnitude(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(-0.0, NumberBaseHelper<double>.MinMagnitude(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, NumberBaseHelper<double>.MinMagnitude(double.NaN, 1.0));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.MinMagnitude(0.0, 1.0));
+            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<double>.MinMagnitude(double.Epsilon, 1.0));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<double>.MinMagnitude(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<double>.MinMagnitude(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MinMagnitude(1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MinMagnitude(double.MaxValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MinMagnitude(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MinMagnitudeNumber(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MinMagnitudeNumber(double.MinValue, 1.0));
+            AssertBitwiseEqual(-1.0, NumberBaseHelper<double>.MinMagnitudeNumber(-1.0, 1.0));
+            AssertBitwiseEqual(-MinNormal, NumberBaseHelper<double>.MinMagnitudeNumber(-MinNormal, 1.0));
+            AssertBitwiseEqual(-MaxSubnormal, NumberBaseHelper<double>.MinMagnitudeNumber(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(-double.Epsilon, NumberBaseHelper<double>.MinMagnitudeNumber(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(-0.0, NumberBaseHelper<double>.MinMagnitudeNumber(-0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MinMagnitudeNumber(double.NaN, 1.0));
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.MinMagnitudeNumber(0.0, 1.0));
+            AssertBitwiseEqual(double.Epsilon, NumberBaseHelper<double>.MinMagnitudeNumber(double.Epsilon, 1.0));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<double>.MinMagnitudeNumber(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<double>.MinMagnitudeNumber(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MinMagnitudeNumber(1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MinMagnitudeNumber(double.MaxValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.MinMagnitudeNumber(double.PositiveInfinity, 1.0));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
@@ -18,11 +18,11 @@ namespace System.Tests
 
         private static Half NegativeZero => BitConverter.UInt16BitsToHalf(0x8000);
 
-        private static Half PositiveOne => BitConverter.UInt16BitsToHalf(0x3C00);
+        private static Half One => BitConverter.UInt16BitsToHalf(0x3C00);
 
-        private static Half PositiveTwo => BitConverter.UInt16BitsToHalf(0x4000);
+        private static Half Two => BitConverter.UInt16BitsToHalf(0x4000);
 
-        private static Half PositiveZero => BitConverter.UInt16BitsToHalf(0x0000);
+        private static Half Zero => BitConverter.UInt16BitsToHalf(0x0000);
 
         private static void AssertBitwiseEqual(Half expected, Half actual)
         {
@@ -42,87 +42,63 @@ namespace System.Tests
             throw new Xunit.Sdk.EqualException(expected, actual);
         }
 
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            AssertBitwiseEqual(PositiveZero, AdditiveIdentityHelper<Half, Half>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            AssertBitwiseEqual(Half.MinValue, MinMaxValueHelper<Half>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            AssertBitwiseEqual(Half.MaxValue, MinMaxValueHelper<Half>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            AssertBitwiseEqual(PositiveOne, MultiplicativeIdentityHelper<Half, Half>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            Assert.Equal(NegativeOne, SignedNumberHelper<Half>.NegativeOne);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
         {
-            AssertBitwiseEqual(Half.NegativeInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(Half.MinValue, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.MinValue, PositiveOne));
-            AssertBitwiseEqual(PositiveZero, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(-Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(Half.NaN, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.NaN, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveTwo, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(Half.MaxValue, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.MaxValue, PositiveOne));
-            AssertBitwiseEqual(Half.PositiveInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.PositiveInfinity, PositiveOne));
+            AssertBitwiseEqual(Half.NegativeInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(Half.MinValue, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.MinValue, One));
+            AssertBitwiseEqual(Zero, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(NegativeOne, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(-MinNormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(-Half.Epsilon, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(NegativeZero, One));
+            AssertBitwiseEqual(Half.NaN, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.NaN, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Zero, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.Epsilon, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(MaxSubnormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(MinNormal, One));
+            AssertBitwiseEqual(Two, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(One, One));
+            AssertBitwiseEqual(Half.MaxValue, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.MaxValue, One));
+            AssertBitwiseEqual(Half.PositiveInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.PositiveInfinity, One));
         }
 
         [Fact]
         public static void op_CheckedAdditionTest()
         {
-            AssertBitwiseEqual(Half.NegativeInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(Half.MinValue, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.MinValue, PositiveOne));
-            AssertBitwiseEqual(PositiveZero, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(-Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(Half.NaN, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.NaN, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveTwo, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(Half.MaxValue, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.MaxValue, PositiveOne));
-            AssertBitwiseEqual(Half.PositiveInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.PositiveInfinity, PositiveOne));
+            AssertBitwiseEqual(Half.NegativeInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(Half.MinValue, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.MinValue, One));
+            AssertBitwiseEqual(Zero, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(NegativeOne, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(-MinNormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(-Half.Epsilon, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(NegativeZero, One));
+            AssertBitwiseEqual(Half.NaN, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.NaN, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Zero, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.Epsilon, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(MaxSubnormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(MinNormal, One));
+            AssertBitwiseEqual(Two, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(One, One));
+            AssertBitwiseEqual(Half.MaxValue, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.MaxValue, One));
+            AssertBitwiseEqual(Half.PositiveInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.PositiveInfinity, One));
         }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            AssertBitwiseEqual(Zero, AdditiveIdentityHelper<Half, Half>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -135,11 +111,11 @@ namespace System.Tests
             Assert.False(BinaryNumberHelper<Half>.IsPow2(-Half.Epsilon));
             Assert.False(BinaryNumberHelper<Half>.IsPow2(NegativeZero));
             Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.NaN));
-            Assert.False(BinaryNumberHelper<Half>.IsPow2(PositiveZero));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(Zero));
             Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.Epsilon));
             Assert.False(BinaryNumberHelper<Half>.IsPow2(MaxSubnormal));
             Assert.True(BinaryNumberHelper<Half>.IsPow2(MinNormal));
-            Assert.True(BinaryNumberHelper<Half>.IsPow2(PositiveOne));
+            Assert.True(BinaryNumberHelper<Half>.IsPow2(One));
             Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.MaxValue));
             Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.PositiveInfinity));
         }
@@ -155,94 +131,102 @@ namespace System.Tests
             AssertBitwiseEqual(Half.NaN, BinaryNumberHelper<Half>.Log2(-Half.Epsilon));
             AssertBitwiseEqual(Half.NegativeInfinity, BinaryNumberHelper<Half>.Log2(NegativeZero));
             AssertBitwiseEqual(Half.NaN, BinaryNumberHelper<Half>.Log2(Half.NaN));
-            AssertBitwiseEqual(Half.NegativeInfinity, BinaryNumberHelper<Half>.Log2(PositiveZero));
+            AssertBitwiseEqual(Half.NegativeInfinity, BinaryNumberHelper<Half>.Log2(Zero));
             AssertBitwiseEqual((Half)(-24.0f), BinaryNumberHelper<Half>.Log2(Half.Epsilon));
             AssertBitwiseEqual((Half)(-14.0f), BinaryNumberHelper<Half>.Log2(MaxSubnormal));
             AssertBitwiseEqual((Half)(-14.0f), BinaryNumberHelper<Half>.Log2(MinNormal));
-            AssertBitwiseEqual(PositiveZero, BinaryNumberHelper<Half>.Log2(PositiveOne));
+            AssertBitwiseEqual(Zero, BinaryNumberHelper<Half>.Log2(One));
             AssertBitwiseEqual((Half)16.0f, BinaryNumberHelper<Half>.Log2(Half.MaxValue));
             AssertBitwiseEqual(Half.PositiveInfinity, BinaryNumberHelper<Half>.Log2(Half.PositiveInfinity));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.NegativeInfinity, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.MinValue, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(NegativeOne, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(-MinNormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(-MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(-Half.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(NegativeZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.NaN, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(PositiveZero, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(MinNormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(PositiveOne, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.MaxValue, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.PositiveInfinity, PositiveOne));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.NegativeInfinity, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.MinValue, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(NegativeOne, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(-MinNormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(-MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(-Half.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(NegativeZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.NaN, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(PositiveZero, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(MinNormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(PositiveOne, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.MaxValue, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.PositiveInfinity, PositiveOne));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
         {
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.NegativeInfinity, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.MinValue, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(NegativeOne, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(-MinNormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(-MaxSubnormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(-Half.Epsilon, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(NegativeZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.NaN, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(PositiveZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.Epsilon, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(MaxSubnormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(MinNormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(PositiveOne, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.MaxValue, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.PositiveInfinity, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.NegativeInfinity, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.MinValue, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(NegativeOne, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(-MinNormal, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(-MaxSubnormal, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(-Half.Epsilon, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(NegativeZero, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.NaN, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Zero, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.Epsilon, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(MaxSubnormal, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(MinNormal, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(One, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.MaxValue, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.PositiveInfinity, One));
         }
 
         [Fact]
         public static void op_GreaterThanOrEqualTest()
         {
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.NegativeInfinity, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.MinValue, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(NegativeOne, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(-MinNormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(-MaxSubnormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(-Half.Epsilon, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(NegativeZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.NaN, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(PositiveZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.Epsilon, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(MaxSubnormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(MinNormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(PositiveOne, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.MaxValue, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.PositiveInfinity, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.NegativeInfinity, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.MinValue, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(NegativeOne, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(-MinNormal, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(-MaxSubnormal, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(-Half.Epsilon, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(NegativeZero, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.NaN, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Zero, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.Epsilon, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(MaxSubnormal, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(MinNormal, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(One, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.MaxValue, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.PositiveInfinity, One));
         }
+
+        [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.NegativeInfinity, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.MinValue, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(NegativeOne, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(-MinNormal, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(-MaxSubnormal, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(-Half.Epsilon, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(NegativeZero, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.NaN, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Zero, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.Epsilon, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(MaxSubnormal, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(MinNormal, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(One, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.MaxValue, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.NegativeInfinity, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.MinValue, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(NegativeOne, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(-MinNormal, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(-MaxSubnormal, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(-Half.Epsilon, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(NegativeZero, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.NaN, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Zero, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.Epsilon, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(MaxSubnormal, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(MinNormal, One));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(One, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.MaxValue, One));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.PositiveInfinity, One));
+        }
+
+        //
+        // IDecrementOperators
+        //
 
         [Fact]
         public static void op_DecrementTest()
@@ -255,11 +239,11 @@ namespace System.Tests
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(-Half.Epsilon));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(NegativeZero));
             AssertBitwiseEqual(Half.NaN, DecrementOperatorsHelper<Half>.op_Decrement(Half.NaN));
-            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(PositiveZero));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(Zero));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(Half.Epsilon));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(MaxSubnormal));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(MinNormal));
-            AssertBitwiseEqual(PositiveZero, DecrementOperatorsHelper<Half>.op_Decrement(PositiveOne));
+            AssertBitwiseEqual(Zero, DecrementOperatorsHelper<Half>.op_Decrement(One));
             AssertBitwiseEqual(Half.MaxValue, DecrementOperatorsHelper<Half>.op_Decrement(Half.MaxValue));
             AssertBitwiseEqual(Half.PositiveInfinity, DecrementOperatorsHelper<Half>.op_Decrement(Half.PositiveInfinity));
         }
@@ -275,1086 +259,106 @@ namespace System.Tests
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(-Half.Epsilon));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(NegativeZero));
             AssertBitwiseEqual(Half.NaN, DecrementOperatorsHelper<Half>.op_CheckedDecrement(Half.NaN));
-            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(PositiveZero));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(Zero));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(Half.Epsilon));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(MaxSubnormal));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(MinNormal));
-            AssertBitwiseEqual(PositiveZero, DecrementOperatorsHelper<Half>.op_CheckedDecrement(PositiveOne));
+            AssertBitwiseEqual(Zero, DecrementOperatorsHelper<Half>.op_CheckedDecrement(One));
             AssertBitwiseEqual(Half.MaxValue, DecrementOperatorsHelper<Half>.op_CheckedDecrement(Half.MaxValue));
             AssertBitwiseEqual(Half.PositiveInfinity, DecrementOperatorsHelper<Half>.op_CheckedDecrement(Half.PositiveInfinity));
         }
 
+        //
+        // IDivisionOperators
+        //
+
         [Fact]
         public static void op_DivisionTest()
         {
-            AssertBitwiseEqual(Half.NegativeInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual((Half)(-32750.0f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.MinValue, PositiveTwo));
-            AssertBitwiseEqual((Half)(-0.5f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(-MinNormal, PositiveTwo));
-            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(-MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(-Half.Epsilon, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(Half.NaN, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.Epsilon, PositiveTwo));
-            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(MinNormal, PositiveTwo));
-            AssertBitwiseEqual((Half)0.5f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual((Half)32750.0f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.MaxValue, PositiveTwo));
-            AssertBitwiseEqual(Half.PositiveInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.PositiveInfinity, PositiveTwo));
+            AssertBitwiseEqual(Half.NegativeInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.NegativeInfinity, Two));
+            AssertBitwiseEqual((Half)(-32750.0f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.MinValue, Two));
+            AssertBitwiseEqual((Half)(-0.5f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(NegativeOne, Two));
+            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(-MinNormal, Two));
+            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(-MaxSubnormal, Two));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(-Half.Epsilon, Two));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(NegativeZero, Two));
+            AssertBitwiseEqual(Half.NaN, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.NaN, Two));
+            AssertBitwiseEqual(Zero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Zero, Two));
+            AssertBitwiseEqual(Zero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.Epsilon, Two));
+            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(MaxSubnormal, Two));
+            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(MinNormal, Two));
+            AssertBitwiseEqual((Half)0.5f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(One, Two));
+            AssertBitwiseEqual((Half)32750.0f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.MaxValue, Two));
+            AssertBitwiseEqual(Half.PositiveInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.PositiveInfinity, Two));
         }
 
         [Fact]
         public static void op_CheckedDivisionTest()
         {
-            AssertBitwiseEqual(Half.NegativeInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual((Half)(-32750.0f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.MinValue, PositiveTwo));
-            AssertBitwiseEqual((Half)(-0.5f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(-MinNormal, PositiveTwo));
-            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(-MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(-Half.Epsilon, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(Half.NaN, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.Epsilon, PositiveTwo));
-            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(MinNormal, PositiveTwo));
-            AssertBitwiseEqual((Half)0.5f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual((Half)32750.0f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.MaxValue, PositiveTwo));
-            AssertBitwiseEqual(Half.PositiveInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.PositiveInfinity, PositiveTwo));
+            AssertBitwiseEqual(Half.NegativeInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.NegativeInfinity, Two));
+            AssertBitwiseEqual((Half)(-32750.0f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.MinValue, Two));
+            AssertBitwiseEqual((Half)(-0.5f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(NegativeOne, Two));
+            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(-MinNormal, Two));
+            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(-MaxSubnormal, Two));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(-Half.Epsilon, Two));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(NegativeZero, Two));
+            AssertBitwiseEqual(Half.NaN, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.NaN, Two));
+            AssertBitwiseEqual(Zero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Zero, Two));
+            AssertBitwiseEqual(Zero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.Epsilon, Two));
+            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(MaxSubnormal, Two));
+            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(MinNormal, Two));
+            AssertBitwiseEqual((Half)0.5f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(One, Two));
+            AssertBitwiseEqual((Half)32750.0f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.MaxValue, Two));
+            AssertBitwiseEqual(Half.PositiveInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.PositiveInfinity, Two));
         }
+
+        //
+        // IEqualityOperators
+        //
 
         [Fact]
         public static void op_EqualityTest()
         {
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.NegativeInfinity, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.MinValue, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(NegativeOne, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(-MinNormal, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(-MaxSubnormal, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(-Half.Epsilon, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(NegativeZero, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.NaN, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(PositiveZero, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.Epsilon, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(MaxSubnormal, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(MinNormal, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Equality(PositiveOne, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.MaxValue, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.PositiveInfinity, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.NegativeInfinity, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.MinValue, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(NegativeOne, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(-MinNormal, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(-MaxSubnormal, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(-Half.Epsilon, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(NegativeZero, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.NaN, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Zero, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.Epsilon, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(MaxSubnormal, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(MinNormal, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Equality(One, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.MaxValue, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.PositiveInfinity, One));
         }
 
         [Fact]
         public static void op_InequalityTest()
         {
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.NegativeInfinity, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.MinValue, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(NegativeOne, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(-MinNormal, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(-MaxSubnormal, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(-Half.Epsilon, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(NegativeZero, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.NaN, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(PositiveZero, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.Epsilon, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(MaxSubnormal, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(MinNormal, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Inequality(PositiveOne, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.MaxValue, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.PositiveInfinity, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.NegativeInfinity, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.MinValue, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(NegativeOne, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(-MinNormal, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(-MaxSubnormal, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(-Half.Epsilon, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(NegativeZero, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.NaN, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Zero, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.Epsilon, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(MaxSubnormal, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(MinNormal, One));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Inequality(One, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.MaxValue, One));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.PositiveInfinity, One));
         }
 
-        [Fact]
-        public static void op_IncrementTest()
-        {
-            AssertBitwiseEqual(Half.NegativeInfinity, IncrementOperatorsHelper<Half>.op_Increment(Half.NegativeInfinity));
-            AssertBitwiseEqual(Half.MinValue, IncrementOperatorsHelper<Half>.op_Increment(Half.MinValue));
-            AssertBitwiseEqual(PositiveZero, IncrementOperatorsHelper<Half>.op_Increment(NegativeOne));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(-MinNormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(-MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(-Half.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(NegativeZero));
-            AssertBitwiseEqual(Half.NaN, IncrementOperatorsHelper<Half>.op_Increment(Half.NaN));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(PositiveZero));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(Half.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(MinNormal));
-            AssertBitwiseEqual(PositiveTwo, IncrementOperatorsHelper<Half>.op_Increment(PositiveOne));
-            AssertBitwiseEqual(Half.MaxValue, IncrementOperatorsHelper<Half>.op_Increment(Half.MaxValue));
-            AssertBitwiseEqual(Half.PositiveInfinity, IncrementOperatorsHelper<Half>.op_Increment(Half.PositiveInfinity));
-        }
-
-        [Fact]
-        public static void op_CheckedIncrementTest()
-        {
-            AssertBitwiseEqual(Half.NegativeInfinity, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.NegativeInfinity));
-            AssertBitwiseEqual(Half.MinValue, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.MinValue));
-            AssertBitwiseEqual(PositiveZero, IncrementOperatorsHelper<Half>.op_CheckedIncrement(NegativeOne));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(-MinNormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(-MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(-Half.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(NegativeZero));
-            AssertBitwiseEqual(Half.NaN, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.NaN));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(PositiveZero));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(MinNormal));
-            AssertBitwiseEqual(PositiveTwo, IncrementOperatorsHelper<Half>.op_CheckedIncrement(PositiveOne));
-            AssertBitwiseEqual(Half.MaxValue, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.MaxValue));
-            AssertBitwiseEqual(Half.PositiveInfinity, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.PositiveInfinity));
-        }
-
-        [Fact]
-        public static void op_ModulusTest()
-        {
-            AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NegativeInfinity, PositiveTwo));
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MinValue, PositiveTwo));
-
-            AssertBitwiseEqual(NegativeOne, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MinNormal, PositiveTwo));
-            AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual(-Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-Half.Epsilon, PositiveTwo)); ;
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeZero, PositiveTwo));
-
-            AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual(Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.Epsilon, PositiveTwo));
-            AssertBitwiseEqual(MaxSubnormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual(MinNormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(MinNormal, PositiveTwo));
-            AssertBitwiseEqual(PositiveOne, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MaxValue, PositiveTwo));
-            AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.PositiveInfinity, PositiveTwo));
-        }
-
-        [Fact]
-        public static void op_MultiplyTest()
-        {
-            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.MinValue, PositiveTwo));
-            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual((Half)(-0.0001221f), MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(-MinNormal, PositiveTwo));
-            AssertBitwiseEqual((Half)(-0.00012195f), MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(-MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual((Half)(-1E-07f), MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(-Half.Epsilon, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(Half.NaN, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual((Half)1E-07f, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.Epsilon, PositiveTwo));
-            AssertBitwiseEqual((Half)0.00012195f, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual((Half)0.0001221f, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(MinNormal, PositiveTwo));
-            AssertBitwiseEqual(PositiveTwo, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.MaxValue, PositiveTwo));
-            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.PositiveInfinity, PositiveTwo));
-        }
-
-        [Fact]
-        public static void op_CheckedMultiplyTest()
-        {
-            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.MinValue, PositiveTwo));
-            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual((Half)(-0.0001221f), MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(-MinNormal, PositiveTwo));
-            AssertBitwiseEqual((Half)(-0.00012195f), MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(-MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual((Half)(-1E-07f), MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(-Half.Epsilon, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(Half.NaN, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual((Half)1E-07f, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.Epsilon, PositiveTwo));
-            AssertBitwiseEqual((Half)0.00012195f, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual((Half)0.0001221f, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(MinNormal, PositiveTwo));
-            AssertBitwiseEqual(PositiveTwo, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.MaxValue, PositiveTwo));
-            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.PositiveInfinity, PositiveTwo));
-        }
-
-        [Fact]
-        public static void AbsTest()
-        {
-            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.Abs(Half.NegativeInfinity));
-            AssertBitwiseEqual(Half.MaxValue, NumberBaseHelper<Half>.Abs(Half.MinValue));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.Abs(NegativeOne));
-            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Half>.Abs(-MinNormal));
-            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Half>.Abs(-MaxSubnormal));
-            AssertBitwiseEqual(Half.Epsilon, NumberBaseHelper<Half>.Abs(-Half.Epsilon));
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.Abs(NegativeZero));
-            AssertBitwiseEqual(Half.NaN, NumberBaseHelper<Half>.Abs(Half.NaN));
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.Abs(PositiveZero));
-            AssertBitwiseEqual(Half.Epsilon, NumberBaseHelper<Half>.Abs(Half.Epsilon));
-            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Half>.Abs(MaxSubnormal));
-            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Half>.Abs(MinNormal));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.Abs(PositiveOne));
-            AssertBitwiseEqual(Half.MaxValue, NumberBaseHelper<Half>.Abs(Half.MaxValue));
-            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.Abs(Half.PositiveInfinity));
-        }
-
-        [Fact]
-        public static void ClampTest()
-        {
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(Half.NegativeInfinity, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(Half.MinValue, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(NegativeOne, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(-MinNormal, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(-MaxSubnormal, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(-Half.Epsilon, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(NegativeZero, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(Half.NaN, NumberHelper<Half>.Clamp(Half.NaN, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(PositiveZero, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(Half.Epsilon, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(MaxSubnormal, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(MinNormal, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(PositiveOne, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual((Half)63.0f, NumberHelper<Half>.Clamp(Half.MaxValue, PositiveOne, (Half)63.0f));
-            AssertBitwiseEqual((Half)63.0f, NumberHelper<Half>.Clamp(Half.PositiveInfinity, PositiveOne, (Half)63.0f));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<byte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateChecked<byte>(0x7F));
-            AssertBitwiseEqual((Half)128.0f, NumberBaseHelper<Half>.CreateChecked<byte>(0x80));
-            AssertBitwiseEqual((Half)255.0f, NumberBaseHelper<Half>.CreateChecked<byte>(0xFF));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromCharTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<char>((char)0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateChecked<char>((char)0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateChecked<char>((char)0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateChecked<char>((char)0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<short>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateChecked<short>(0x7FFF));
-            AssertBitwiseEqual((Half)(-32768.0f), NumberBaseHelper<Half>.CreateChecked<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<short>(unchecked((short)0xFFFF)));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<int>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<int>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateChecked<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<long>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromInt128Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<nint>((nint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
-            }
-        }
-
-        [Fact]
-        public static void CreateCheckedFromSByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<sbyte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateChecked<sbyte>(0x7F));
-            AssertBitwiseEqual((Half)(-128.0f), NumberBaseHelper<Half>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromUInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<ushort>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateChecked<ushort>(0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateChecked<ushort>(0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateChecked<ushort>(0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromUInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<uint>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateChecked<uint>(0x80000000));
-            AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateChecked<uint>(0xFFFFFFFF));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromUInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<ulong>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateChecked<ulong>(0x8000000000000000));
-            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromUInt128Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual((Half)340282366920938463463374607431768211455.0, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-        }
-
-        [Fact]
-        public static void CreateCheckedFromUIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((Half)18446744073709551615.0f,NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<byte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateSaturating<byte>(0x7F));
-            AssertBitwiseEqual((Half)128.0f, NumberBaseHelper<Half>.CreateSaturating<byte>(0x80));
-            AssertBitwiseEqual((Half)255.0f, NumberBaseHelper<Half>.CreateSaturating<byte>(0xFF));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromCharTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateSaturating<char>((char)0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<short>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateSaturating<short>(0x7FFF));
-            AssertBitwiseEqual((Half)(-32768.0f), NumberBaseHelper<Half>.CreateSaturating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<short>(unchecked((short)0xFFFF)));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<int>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<int>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<long>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromInt128Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<nint>((nint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
-            }
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromSByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<sbyte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateSaturating<sbyte>(0x7F));
-            AssertBitwiseEqual((Half)(-128.0f), NumberBaseHelper<Half>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromUInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateSaturating<ushort>(0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromUInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<uint>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateSaturating<uint>(0x80000000));
-            AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateSaturating<uint>(0xFFFFFFFF));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromUInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x8000000000000000));
-            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromUInt128Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0f, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-        }
-
-        [Fact]
-        public static void CreateSaturatingFromUIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<byte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateTruncating<byte>(0x7F));
-            AssertBitwiseEqual((Half)128.0f, NumberBaseHelper<Half>.CreateTruncating<byte>(0x80));
-            AssertBitwiseEqual((Half)255.0f, NumberBaseHelper<Half>.CreateTruncating<byte>(0xFF));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromCharTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateTruncating<char>((char)0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<short>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateTruncating<short>(0x7FFF));
-            AssertBitwiseEqual((Half)(-32768.0f), NumberBaseHelper<Half>.CreateTruncating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<short>(unchecked((short)0xFFFF)));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<int>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<int>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<long>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromInt128Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<nint>((nint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
-            }
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromSByteTest()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<sbyte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateTruncating<sbyte>(0x7F));
-            AssertBitwiseEqual((Half)(-128.0f), NumberBaseHelper<Half>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromUInt16Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateTruncating<ushort>(0xFFFF));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromUInt32Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<uint>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateTruncating<uint>(0x80000000));
-            AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateTruncating<uint>(0xFFFFFFFF));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromUInt64Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x8000000000000000));
-            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromUInt128Test()
-        {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0f, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-        }
-
-        [Fact]
-        public static void CreateTruncatingFromUIntPtrTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(Half.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(Half.MinValue, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(-Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(Half.NaN, NumberHelper<Half>.Max(Half.NaN, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(Half.MaxValue, NumberHelper<Half>.Max(Half.MaxValue, PositiveOne));
-            AssertBitwiseEqual(Half.PositiveInfinity, NumberHelper<Half>.Max(Half.PositiveInfinity, PositiveOne));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            AssertBitwiseEqual(Half.NegativeInfinity, NumberHelper<Half>.Min(Half.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(Half.MinValue, NumberHelper<Half>.Min(Half.MinValue, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.Min(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(-MinNormal, NumberHelper<Half>.Min(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<Half>.Min(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(-Half.Epsilon, NumberHelper<Half>.Min(-Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(NegativeZero, NumberHelper<Half>.Min(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(Half.NaN, NumberHelper<Half>.Min(Half.NaN, PositiveOne));
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.Min(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(Half.Epsilon, NumberHelper<Half>.Min(Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<Half>.Min(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(MinNormal, NumberHelper<Half>.Min(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Min(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Min(Half.MaxValue, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Min(Half.PositiveInfinity, PositiveOne));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(-1, NumberHelper<Half>.Sign(Half.NegativeInfinity));
-            Assert.Equal(-1, NumberHelper<Half>.Sign(Half.MinValue));
-            Assert.Equal(-1, NumberHelper<Half>.Sign(NegativeOne));
-            Assert.Equal(-1, NumberHelper<Half>.Sign(-MinNormal));
-            Assert.Equal(-1, NumberHelper<Half>.Sign(-MaxSubnormal));
-            Assert.Equal(-1, NumberHelper<Half>.Sign(-Half.Epsilon));
-
-            Assert.Equal(0, NumberHelper<Half>.Sign(NegativeZero));
-            Assert.Equal(0, NumberHelper<Half>.Sign(PositiveZero));
-
-            Assert.Equal(1, NumberHelper<Half>.Sign(Half.Epsilon));
-            Assert.Equal(1, NumberHelper<Half>.Sign(MaxSubnormal));
-            Assert.Equal(1, NumberHelper<Half>.Sign(MinNormal));
-            Assert.Equal(1, NumberHelper<Half>.Sign(PositiveOne));
-            Assert.Equal(1, NumberHelper<Half>.Sign(Half.MaxValue));
-            Assert.Equal(1, NumberHelper<Half>.Sign(Half.PositiveInfinity));
-
-            Assert.Throws<ArithmeticException>(() => NumberHelper<Half>.Sign(Half.NaN));
-        }
-
-        [Fact]
-        public static void TryCreateFromByteTest()
-        {
-            Half result;
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x00, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x01, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x7F, out result));
-            Assert.Equal((Half)127.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x80, out result));
-            Assert.Equal((Half)128.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0xFF, out result));
-            Assert.Equal((Half)255.0f, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromCharTest()
-        {
-            Half result;
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x0000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x0001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x7FFF, out result));
-            Assert.Equal((Half)32767.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x8000, out result));
-            Assert.Equal((Half)32768.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0xFFFF, out result));
-            Assert.Equal((Half)65535.0f, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromInt16Test()
-        {
-            Half result;
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(0x0000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(0x0001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(0x7FFF, out result));
-            Assert.Equal((Half)32767.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(unchecked((short)0x8000), out result));
-            Assert.Equal((Half)(-32768.0f), result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(unchecked((short)0xFFFF), out result));
-            Assert.Equal(NegativeOne, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromInt32Test()
-        {
-            Half result;
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(0x00000000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(0x00000001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(0x7FFFFFFF, out result));
-            Assert.Equal((Half)2147483647.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(unchecked((int)0x80000000), out result));
-            Assert.Equal((Half)(-2147483648.0f), result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
-            Assert.Equal(NegativeOne, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromInt64Test()
-        {
-            Half result;
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(0x0000000000000000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(0x0000000000000001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
-            Assert.Equal((Half)9223372036854775807.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
-            Assert.Equal((Half)(-9223372036854775808.0f), result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
-            Assert.Equal(NegativeOne, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromInt128Test()
-        {
-            Half result;
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
-            Assert.Equal((Half)170141183460469231731687303715884105727.0, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
-            Assert.Equal((Half)(-170141183460469231731687303715884105728.0), result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
-            Assert.Equal(NegativeOne, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromIntPtrTest()
-        {
-            Half result;
-
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
-                Assert.Equal(PositiveZero, result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
-                Assert.Equal(PositiveOne, result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
-                Assert.Equal((Half)9223372036854775807.0f, result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
-                Assert.Equal((Half)(-9223372036854775808.0f), result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
-                Assert.Equal(NegativeOne, result);
-            }
-            else
-            {
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>((nint)0x00000000, out result));
-                Assert.Equal(PositiveZero, result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>((nint)0x00000001, out result));
-                Assert.Equal(PositiveOne, result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
-                Assert.Equal((Half)2147483647.0f, result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
-                Assert.Equal((Half)(-2147483648.0f), result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
-                Assert.Equal(NegativeOne, result);
-            }
-        }
-
-        [Fact]
-        public static void TryCreateFromSByteTest()
-        {
-            Half result;
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(0x00, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(0x01, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(0x7F, out result));
-            Assert.Equal((Half)127.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
-            Assert.Equal((Half)(-128.0f), result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
-            Assert.Equal(NegativeOne, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromUInt16Test()
-        {
-            Half result;
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x0000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x0001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x7FFF, out result));
-            Assert.Equal((Half)32767.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x8000, out result));
-            Assert.Equal((Half)32768.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0xFFFF, out result));
-            Assert.Equal((Half)65535.0f, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromUInt32Test()
-        {
-            Half result;
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x00000000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x00000001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x7FFFFFFF, out result));
-            Assert.Equal((Half)2147483647.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x80000000, out result));
-            Assert.Equal((Half)2147483648.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0xFFFFFFFF, out result));
-            Assert.Equal((Half)4294967295.0f, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromUInt64Test()
-        {
-            Half result;
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x0000000000000000, out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x0000000000000001, out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
-            Assert.Equal((Half)9223372036854775807.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x8000000000000000, out result));
-            Assert.Equal((Half)9223372036854775808.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
-            Assert.Equal((Half)18446744073709551615.0f, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromUInt128Test()
-        {
-            Half result;
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
-            Assert.Equal(PositiveZero, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
-            Assert.Equal(PositiveOne, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
-            Assert.Equal((Half)170141183460469231731687303715884105727.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
-            Assert.Equal((Half)170141183460469231731687303715884105728.0f, result);
-
-            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
-            Assert.Equal(Half.PositiveInfinity, result);
-        }
-
-        [Fact]
-        public static void TryCreateFromUIntPtrTest()
-        {
-            Half result;
-
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
-                Assert.Equal(PositiveZero, result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
-                Assert.Equal(PositiveOne, result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
-                Assert.Equal((Half)9223372036854775807.0f, result);
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
-                // Assert.Equal((Half)9223372036854775808.0f, result);
-                //
-                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
-                // Assert.Equal((Half)18446744073709551615.0f, result);
-            }
-            else
-            {
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>((nuint)0x00000000, out result));
-                Assert.Equal(PositiveZero, result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>((nuint)0x00000001, out result));
-                Assert.Equal(PositiveOne, result);
-
-                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
-                Assert.Equal((Half)2147483647.0f, result);
-
-                // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
-                // Assert.Equal((Half)2147483648.0f, result);
-                //
-                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
-                // Assert.Equal((Half)4294967295.0f, result);
-            }
-        }
+        //
+        // IFloatingPoint
+        //
 
         [Fact]
         public static void GetExponentByteCountTest()
@@ -1367,11 +371,11 @@ namespace System.Tests
             Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(-Half.Epsilon));
             Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(NegativeZero));
             Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(Half.NaN));
-            Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(PositiveZero));
+            Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(Zero));
             Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(Half.Epsilon));
             Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(MaxSubnormal));
             Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(MinNormal));
-            Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(PositiveOne));
+            Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(One));
             Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(Half.MaxValue));
             Assert.Equal(1, FloatingPointHelper<Half>.GetExponentByteCount(Half.PositiveInfinity));
         }
@@ -1387,11 +391,11 @@ namespace System.Tests
             Assert.Equal(5, FloatingPointHelper<Half>.GetExponentShortestBitLength(-Half.Epsilon));
             Assert.Equal(5, FloatingPointHelper<Half>.GetExponentShortestBitLength(NegativeZero));
             Assert.Equal(5, FloatingPointHelper<Half>.GetExponentShortestBitLength(Half.NaN));
-            Assert.Equal(5, FloatingPointHelper<Half>.GetExponentShortestBitLength(PositiveZero));
+            Assert.Equal(5, FloatingPointHelper<Half>.GetExponentShortestBitLength(Zero));
             Assert.Equal(5, FloatingPointHelper<Half>.GetExponentShortestBitLength(Half.Epsilon));
             Assert.Equal(5, FloatingPointHelper<Half>.GetExponentShortestBitLength(MaxSubnormal));
             Assert.Equal(5, FloatingPointHelper<Half>.GetExponentShortestBitLength(MinNormal));
-            Assert.Equal(0, FloatingPointHelper<Half>.GetExponentShortestBitLength(PositiveOne));
+            Assert.Equal(0, FloatingPointHelper<Half>.GetExponentShortestBitLength(One));
             Assert.Equal(4, FloatingPointHelper<Half>.GetExponentShortestBitLength(Half.MaxValue));
             Assert.Equal(5, FloatingPointHelper<Half>.GetExponentShortestBitLength(Half.PositiveInfinity));
         }
@@ -1407,11 +411,11 @@ namespace System.Tests
             Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(-Half.Epsilon));
             Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(NegativeZero));
             Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(Half.NaN));
-            Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(PositiveZero));
+            Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(Zero));
             Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(Half.Epsilon));
             Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(MaxSubnormal));
             Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(MinNormal));
-            Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(PositiveOne));
+            Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(One));
             Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(Half.MaxValue));
             Assert.Equal(2, FloatingPointHelper<Half>.GetSignificandByteCount(Half.PositiveInfinity));
         }
@@ -1427,11 +431,11 @@ namespace System.Tests
             Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(-Half.Epsilon));
             Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(NegativeZero));
             Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(Half.NaN));
-            Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(PositiveZero));
+            Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(Zero));
             Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(Half.Epsilon));
             Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(MaxSubnormal));
             Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(MinNormal));
-            Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(PositiveOne));
+            Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(One));
             Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(Half.MaxValue));
             Assert.Equal(11, FloatingPointHelper<Half>.GetSignificandBitLength(Half.PositiveInfinity));
         }
@@ -1474,7 +478,7 @@ namespace System.Tests
             Assert.Equal(1, bytesWritten);
             Assert.Equal(new byte[] { 0x10 }, destination.ToArray()); // +16
 
-            Assert.True(FloatingPointHelper<Half>.TryWriteExponentBigEndian(PositiveZero, destination, out bytesWritten));
+            Assert.True(FloatingPointHelper<Half>.TryWriteExponentBigEndian(Zero, destination, out bytesWritten));
             Assert.Equal(1, bytesWritten);
             Assert.Equal(new byte[] { 0xF1 }, destination.ToArray()); // -15
 
@@ -1490,7 +494,7 @@ namespace System.Tests
             Assert.Equal(1, bytesWritten);
             Assert.Equal(new byte[] { 0xF2 }, destination.ToArray()); // -14
 
-            Assert.True(FloatingPointHelper<Half>.TryWriteExponentBigEndian(PositiveOne, destination, out bytesWritten));
+            Assert.True(FloatingPointHelper<Half>.TryWriteExponentBigEndian(One, destination, out bytesWritten));
             Assert.Equal(1, bytesWritten);
             Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
 
@@ -1545,7 +549,7 @@ namespace System.Tests
             Assert.Equal(1, bytesWritten);
             Assert.Equal(new byte[] { 0x10 }, destination.ToArray()); // +16
 
-            Assert.True(FloatingPointHelper<Half>.TryWriteExponentLittleEndian(PositiveZero, destination, out bytesWritten));
+            Assert.True(FloatingPointHelper<Half>.TryWriteExponentLittleEndian(Zero, destination, out bytesWritten));
             Assert.Equal(1, bytesWritten);
             Assert.Equal(new byte[] { 0xF1 }, destination.ToArray()); // -15
 
@@ -1561,7 +565,7 @@ namespace System.Tests
             Assert.Equal(1, bytesWritten);
             Assert.Equal(new byte[] { 0xF2 }, destination.ToArray()); // -14
 
-            Assert.True(FloatingPointHelper<Half>.TryWriteExponentLittleEndian(PositiveOne, destination, out bytesWritten));
+            Assert.True(FloatingPointHelper<Half>.TryWriteExponentLittleEndian(One, destination, out bytesWritten));
             Assert.Equal(1, bytesWritten);
             Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
 
@@ -1616,7 +620,7 @@ namespace System.Tests
             Assert.Equal(2, bytesWritten);
             Assert.Equal(new byte[] { 0x06, 0x00 }, destination.ToArray());
 
-            Assert.True(FloatingPointHelper<Half>.TryWriteSignificandBigEndian(PositiveZero, destination, out bytesWritten));
+            Assert.True(FloatingPointHelper<Half>.TryWriteSignificandBigEndian(Zero, destination, out bytesWritten));
             Assert.Equal(2, bytesWritten);
             Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
 
@@ -1632,7 +636,7 @@ namespace System.Tests
             Assert.Equal(2, bytesWritten);
             Assert.Equal(new byte[] { 0x04, 0x00 }, destination.ToArray());
 
-            Assert.True(FloatingPointHelper<Half>.TryWriteSignificandBigEndian(PositiveOne, destination, out bytesWritten));
+            Assert.True(FloatingPointHelper<Half>.TryWriteSignificandBigEndian(One, destination, out bytesWritten));
             Assert.Equal(2, bytesWritten);
             Assert.Equal(new byte[] { 0x04, 0x00 }, destination.ToArray());
 
@@ -1687,7 +691,7 @@ namespace System.Tests
             Assert.Equal(2, bytesWritten);
             Assert.Equal(new byte[] { 0x00, 0x06 }, destination.ToArray());
 
-            Assert.True(FloatingPointHelper<Half>.TryWriteSignificandLittleEndian(PositiveZero, destination, out bytesWritten));
+            Assert.True(FloatingPointHelper<Half>.TryWriteSignificandLittleEndian(Zero, destination, out bytesWritten));
             Assert.Equal(2, bytesWritten);
             Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
 
@@ -1703,7 +707,7 @@ namespace System.Tests
             Assert.Equal(2, bytesWritten);
             Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray());
 
-            Assert.True(FloatingPointHelper<Half>.TryWriteSignificandLittleEndian(PositiveOne, destination, out bytesWritten));
+            Assert.True(FloatingPointHelper<Half>.TryWriteSignificandLittleEndian(One, destination, out bytesWritten));
             Assert.Equal(2, bytesWritten);
             Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray());
 
@@ -1720,62 +724,1130 @@ namespace System.Tests
             Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray());
         }
 
+        //
+        // IIncrementOperators
+        //
+
+        [Fact]
+        public static void op_IncrementTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, IncrementOperatorsHelper<Half>.op_Increment(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MinValue, IncrementOperatorsHelper<Half>.op_Increment(Half.MinValue));
+            AssertBitwiseEqual(Zero, IncrementOperatorsHelper<Half>.op_Increment(NegativeOne));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_Increment(-MinNormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_Increment(-MaxSubnormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_Increment(-Half.Epsilon));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_Increment(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, IncrementOperatorsHelper<Half>.op_Increment(Half.NaN));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_Increment(Zero));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_Increment(Half.Epsilon));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_Increment(MaxSubnormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_Increment(MinNormal));
+            AssertBitwiseEqual(Two, IncrementOperatorsHelper<Half>.op_Increment(One));
+            AssertBitwiseEqual(Half.MaxValue, IncrementOperatorsHelper<Half>.op_Increment(Half.MaxValue));
+            AssertBitwiseEqual(Half.PositiveInfinity, IncrementOperatorsHelper<Half>.op_Increment(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_CheckedIncrementTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MinValue, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.MinValue));
+            AssertBitwiseEqual(Zero, IncrementOperatorsHelper<Half>.op_CheckedIncrement(NegativeOne));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_CheckedIncrement(-MinNormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_CheckedIncrement(-MaxSubnormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_CheckedIncrement(-Half.Epsilon));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_CheckedIncrement(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.NaN));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Zero));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.Epsilon));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_CheckedIncrement(MaxSubnormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<Half>.op_CheckedIncrement(MinNormal));
+            AssertBitwiseEqual(Two, IncrementOperatorsHelper<Half>.op_CheckedIncrement(One));
+            AssertBitwiseEqual(Half.MaxValue, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.MaxValue));
+            AssertBitwiseEqual(Half.PositiveInfinity, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.PositiveInfinity));
+        }
+
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            AssertBitwiseEqual(Half.MaxValue, MinMaxValueHelper<Half>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            AssertBitwiseEqual(Half.MinValue, MinMaxValueHelper<Half>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
+        [Fact]
+        public static void op_ModulusTest()
+        {
+            AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NegativeInfinity, Two));
+
+            // https://github.com/dotnet/runtime/issues/67993
+            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MinValue, PositiveTwo));
+
+            AssertBitwiseEqual(NegativeOne, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeOne, Two));
+            AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MinNormal, Two));
+            AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MaxSubnormal, Two));
+            AssertBitwiseEqual(-Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-Half.Epsilon, Two)); ;
+
+            // https://github.com/dotnet/runtime/issues/67993
+            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeZero, PositiveTwo));
+
+            AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NaN, Two));
+            AssertBitwiseEqual(Zero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Zero, Two));
+            AssertBitwiseEqual(Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.Epsilon, Two));
+            AssertBitwiseEqual(MaxSubnormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(MaxSubnormal, Two));
+            AssertBitwiseEqual(MinNormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(MinNormal, Two));
+            AssertBitwiseEqual(One, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(One, Two));
+            AssertBitwiseEqual(Zero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MaxValue, Two));
+            AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.PositiveInfinity, Two));
+        }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            AssertBitwiseEqual(One, MultiplicativeIdentityHelper<Half, Half>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
+
+        [Fact]
+        public static void op_MultiplyTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.NegativeInfinity, Two));
+            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.MinValue, Two));
+            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(NegativeOne, Two));
+            AssertBitwiseEqual((Half)(-0.0001221f), MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(-MinNormal, Two));
+            AssertBitwiseEqual((Half)(-0.00012195f), MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(-MaxSubnormal, Two));
+            AssertBitwiseEqual((Half)(-1E-07f), MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(-Half.Epsilon, Two));
+            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(NegativeZero, Two));
+            AssertBitwiseEqual(Half.NaN, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.NaN, Two));
+            AssertBitwiseEqual(Zero, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Zero, Two));
+            AssertBitwiseEqual((Half)1E-07f, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.Epsilon, Two));
+            AssertBitwiseEqual((Half)0.00012195f, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(MaxSubnormal, Two));
+            AssertBitwiseEqual((Half)0.0001221f, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(MinNormal, Two));
+            AssertBitwiseEqual(Two, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(One, Two));
+            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.MaxValue, Two));
+            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.PositiveInfinity, Two));
+        }
+
+        [Fact]
+        public static void op_CheckedMultiplyTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.NegativeInfinity, Two));
+            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.MinValue, Two));
+            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(NegativeOne, Two));
+            AssertBitwiseEqual((Half)(-0.0001221f), MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(-MinNormal, Two));
+            AssertBitwiseEqual((Half)(-0.00012195f), MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(-MaxSubnormal, Two));
+            AssertBitwiseEqual((Half)(-1E-07f), MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(-Half.Epsilon, Two));
+            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(NegativeZero, Two));
+            AssertBitwiseEqual(Half.NaN, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.NaN, Two));
+            AssertBitwiseEqual(Zero, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Zero, Two));
+            AssertBitwiseEqual((Half)1E-07f, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.Epsilon, Two));
+            AssertBitwiseEqual((Half)0.00012195f, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(MaxSubnormal, Two));
+            AssertBitwiseEqual((Half)0.0001221f, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(MinNormal, Two));
+            AssertBitwiseEqual(Two, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(One, Two));
+            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.MaxValue, Two));
+            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.PositiveInfinity, Two));
+        }
+
+        //
+        // INumber
+        //
+
+        [Fact]
+        public static void ClampTest()
+        {
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(Half.NegativeInfinity, One, (Half)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(Half.MinValue, One, (Half)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(NegativeOne, One, (Half)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(-MinNormal, One, (Half)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(-MaxSubnormal, One, (Half)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(-Half.Epsilon, One, (Half)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(NegativeZero, One, (Half)63.0f));
+            AssertBitwiseEqual(Half.NaN, NumberHelper<Half>.Clamp(Half.NaN, One, (Half)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(Zero, One, (Half)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(Half.Epsilon, One, (Half)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(MaxSubnormal, One, (Half)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(MinNormal, One, (Half)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Clamp(One, One, (Half)63.0f));
+            AssertBitwiseEqual((Half)63.0f, NumberHelper<Half>.Clamp(Half.MaxValue, One, (Half)63.0f));
+            AssertBitwiseEqual((Half)63.0f, NumberHelper<Half>.Clamp(Half.PositiveInfinity, One, (Half)63.0f));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(Half.MinValue, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(NegativeOne, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(-MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(-Half.Epsilon, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(NegativeZero, One));
+            AssertBitwiseEqual(Half.NaN, NumberHelper<Half>.Max(Half.NaN, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(Zero, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(Half.Epsilon, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Max(One, One));
+            AssertBitwiseEqual(Half.MaxValue, NumberHelper<Half>.Max(Half.MaxValue, One));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberHelper<Half>.Max(Half.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, NumberHelper<Half>.Min(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(Half.MinValue, NumberHelper<Half>.Min(Half.MinValue, One));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.Min(NegativeOne, One));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<Half>.Min(-MinNormal, One));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<Half>.Min(-MaxSubnormal, One));
+            AssertBitwiseEqual(-Half.Epsilon, NumberHelper<Half>.Min(-Half.Epsilon, One));
+            AssertBitwiseEqual(NegativeZero, NumberHelper<Half>.Min(NegativeZero, One));
+            AssertBitwiseEqual(Half.NaN, NumberHelper<Half>.Min(Half.NaN, One));
+            AssertBitwiseEqual(Zero, NumberHelper<Half>.Min(Zero, One));
+            AssertBitwiseEqual(Half.Epsilon, NumberHelper<Half>.Min(Half.Epsilon, One));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<Half>.Min(MaxSubnormal, One));
+            AssertBitwiseEqual(MinNormal, NumberHelper<Half>.Min(MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Min(One, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Min(Half.MaxValue, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.Min(Half.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(-1, NumberHelper<Half>.Sign(Half.NegativeInfinity));
+            Assert.Equal(-1, NumberHelper<Half>.Sign(Half.MinValue));
+            Assert.Equal(-1, NumberHelper<Half>.Sign(NegativeOne));
+            Assert.Equal(-1, NumberHelper<Half>.Sign(-MinNormal));
+            Assert.Equal(-1, NumberHelper<Half>.Sign(-MaxSubnormal));
+            Assert.Equal(-1, NumberHelper<Half>.Sign(-Half.Epsilon));
+
+            Assert.Equal(0, NumberHelper<Half>.Sign(NegativeZero));
+            Assert.Equal(0, NumberHelper<Half>.Sign(Zero));
+
+            Assert.Equal(1, NumberHelper<Half>.Sign(Half.Epsilon));
+            Assert.Equal(1, NumberHelper<Half>.Sign(MaxSubnormal));
+            Assert.Equal(1, NumberHelper<Half>.Sign(MinNormal));
+            Assert.Equal(1, NumberHelper<Half>.Sign(One));
+            Assert.Equal(1, NumberHelper<Half>.Sign(Half.MaxValue));
+            Assert.Equal(1, NumberHelper<Half>.Sign(Half.PositiveInfinity));
+
+            Assert.Throws<ArithmeticException>(() => NumberHelper<Half>.Sign(Half.NaN));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.Abs(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MaxValue, NumberBaseHelper<Half>.Abs(Half.MinValue));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.Abs(NegativeOne));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Half>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Half>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(Half.Epsilon, NumberBaseHelper<Half>.Abs(-Half.Epsilon));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.Abs(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, NumberBaseHelper<Half>.Abs(Half.NaN));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.Abs(Zero));
+            AssertBitwiseEqual(Half.Epsilon, NumberBaseHelper<Half>.Abs(Half.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Half>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Half>.Abs(MinNormal));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.Abs(One));
+            AssertBitwiseEqual(Half.MaxValue, NumberBaseHelper<Half>.Abs(Half.MaxValue));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.Abs(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromByteTest()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<byte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<byte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateChecked<byte>(0x7F));
+            AssertBitwiseEqual((Half)128.0f, NumberBaseHelper<Half>.CreateChecked<byte>(0x80));
+            AssertBitwiseEqual((Half)255.0f, NumberBaseHelper<Half>.CreateChecked<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromCharTest()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<char>((char)0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<char>((char)0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateChecked<char>((char)0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateChecked<char>((char)0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateChecked<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt16Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<short>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<short>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateChecked<short>(0x7FFF));
+            AssertBitwiseEqual((Half)(-32768.0f), NumberBaseHelper<Half>.CreateChecked<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt32Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<int>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<int>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<int>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateChecked<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt64Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<long>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<long>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt128Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<nint>((nint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<nint>((nint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateCheckedFromSByteTest()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<sbyte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<sbyte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateChecked<sbyte>(0x7F));
+            AssertBitwiseEqual((Half)(-128.0f), NumberBaseHelper<Half>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt16Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<ushort>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<ushort>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateChecked<ushort>(0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateChecked<ushort>(0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateChecked<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt32Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<uint>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<uint>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateChecked<uint>(0x80000000));
+            AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateChecked<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt64Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<ulong>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateChecked<ulong>(0x8000000000000000));
+            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt128Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0f, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((Half)18446744073709551615.0f,NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromByteTest()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<byte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<byte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateSaturating<byte>(0x7F));
+            AssertBitwiseEqual((Half)128.0f, NumberBaseHelper<Half>.CreateSaturating<byte>(0x80));
+            AssertBitwiseEqual((Half)255.0f, NumberBaseHelper<Half>.CreateSaturating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromCharTest()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateSaturating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt16Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<short>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<short>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateSaturating<short>(0x7FFF));
+            AssertBitwiseEqual((Half)(-32768.0f), NumberBaseHelper<Half>.CreateSaturating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt32Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<int>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<int>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt64Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<long>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<long>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt128Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<nint>((nint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromSByteTest()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<sbyte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<sbyte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateSaturating<sbyte>(0x7F));
+            AssertBitwiseEqual((Half)(-128.0f), NumberBaseHelper<Half>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateSaturating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<uint>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<uint>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateSaturating<uint>(0x80000000));
+            AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateSaturating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt128Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0f, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromByteTest()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<byte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<byte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateTruncating<byte>(0x7F));
+            AssertBitwiseEqual((Half)128.0f, NumberBaseHelper<Half>.CreateTruncating<byte>(0x80));
+            AssertBitwiseEqual((Half)255.0f, NumberBaseHelper<Half>.CreateTruncating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromCharTest()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateTruncating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt16Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<short>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<short>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateTruncating<short>(0x7FFF));
+            AssertBitwiseEqual((Half)(-32768.0f), NumberBaseHelper<Half>.CreateTruncating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt32Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<int>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<int>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt64Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<long>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<long>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt128Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<nint>((nint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromSByteTest()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<sbyte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<sbyte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateTruncating<sbyte>(0x7F));
+            AssertBitwiseEqual((Half)(-128.0f), NumberBaseHelper<Half>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateTruncating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<uint>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<uint>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateTruncating<uint>(0x80000000));
+            AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateTruncating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt128Test()
+        {
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0f, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromByteTest()
+        {
+            Half result;
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x00, out result));
+            Assert.Equal(Zero, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x01, out result));
+            Assert.Equal(One, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x7F, out result));
+            Assert.Equal((Half)127.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x80, out result));
+            Assert.Equal((Half)128.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0xFF, out result));
+            Assert.Equal((Half)255.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromCharTest()
+        {
+            Half result;
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x0000, out result));
+            Assert.Equal(Zero, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x0001, out result));
+            Assert.Equal(One, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.Equal((Half)32767.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x8000, out result));
+            Assert.Equal((Half)32768.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.Equal((Half)65535.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt16Test()
+        {
+            Half result;
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(0x0000, out result));
+            Assert.Equal(Zero, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(0x0001, out result));
+            Assert.Equal(One, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(0x7FFF, out result));
+            Assert.Equal((Half)32767.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.Equal((Half)(-32768.0f), result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.Equal(NegativeOne, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt32Test()
+        {
+            Half result;
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(0x00000000, out result));
+            Assert.Equal(Zero, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(0x00000001, out result));
+            Assert.Equal(One, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.Equal((Half)2147483647.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.Equal((Half)(-2147483648.0f), result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.Equal(NegativeOne, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt64Test()
+        {
+            Half result;
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.Equal(Zero, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.Equal(One, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal((Half)9223372036854775807.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+            Assert.Equal((Half)(-9223372036854775808.0f), result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.Equal(NegativeOne, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt128Test()
+        {
+            Half result;
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.Equal(Zero, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
+            Assert.Equal(One, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.Equal((Half)170141183460469231731687303715884105727.0, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.Equal((Half)(-170141183460469231731687303715884105728.0), result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.Equal(NegativeOne, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromIntPtrTest()
+        {
+            Half result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.Equal(Zero, result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.Equal(One, result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal((Half)9223372036854775807.0f, result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.Equal((Half)(-9223372036854775808.0f), result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.Equal(NegativeOne, result);
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.Equal(Zero, result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.Equal(One, result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.Equal((Half)2147483647.0f, result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.Equal((Half)(-2147483648.0f), result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.Equal(NegativeOne, result);
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromSByteTest()
+        {
+            Half result;
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(0x00, out result));
+            Assert.Equal(Zero, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(0x01, out result));
+            Assert.Equal(One, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(0x7F, out result));
+            Assert.Equal((Half)127.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.Equal((Half)(-128.0f), result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.Equal(NegativeOne, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt16Test()
+        {
+            Half result;
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x0000, out result));
+            Assert.Equal(Zero, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x0001, out result));
+            Assert.Equal(One, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.Equal((Half)32767.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x8000, out result));
+            Assert.Equal((Half)32768.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.Equal((Half)65535.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt32Test()
+        {
+            Half result;
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x00000000, out result));
+            Assert.Equal(Zero, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x00000001, out result));
+            Assert.Equal(One, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.Equal((Half)2147483647.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x80000000, out result));
+            Assert.Equal((Half)2147483648.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.Equal((Half)4294967295.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt64Test()
+        {
+            Half result;
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.Equal(Zero, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.Equal(One, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal((Half)9223372036854775807.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.Equal((Half)9223372036854775808.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.Equal((Half)18446744073709551615.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt128Test()
+        {
+            Half result;
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.Equal(Zero, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
+            Assert.Equal(One, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.Equal((Half)170141183460469231731687303715884105727.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.Equal((Half)170141183460469231731687303715884105728.0f, result);
+
+            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.Equal(Half.PositiveInfinity, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUIntPtrTest()
+        {
+            Half result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.Equal(Zero, result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.Equal(One, result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal((Half)9223372036854775807.0f, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                // Assert.Equal((Half)9223372036854775808.0f, result);
+                //
+                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                // Assert.Equal((Half)18446744073709551615.0f, result);
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.Equal(Zero, result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.Equal(One, result);
+
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.Equal((Half)2147483647.0f, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                // Assert.Equal((Half)2147483648.0f, result);
+                //
+                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                // Assert.Equal((Half)4294967295.0f, result);
+            }
+        }
+
+        //
+        // ISignedNumber
+        //
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(NegativeOne, SignedNumberHelper<Half>.NegativeOne);
+        }
+
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
-            AssertBitwiseEqual(Half.NegativeInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(Half.MinValue, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.MinValue, PositiveOne));
-            AssertBitwiseEqual(NegativeTwo, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(-Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(Half.NaN, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.NaN, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveZero, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(Half.MaxValue, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.MaxValue, PositiveOne));
-            AssertBitwiseEqual(Half.PositiveInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.PositiveInfinity, PositiveOne));
+            AssertBitwiseEqual(Half.NegativeInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(Half.MinValue, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.MinValue, One));
+            AssertBitwiseEqual(NegativeTwo, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(NegativeOne, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(-MinNormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(-MaxSubnormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(-Half.Epsilon, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(NegativeZero, One));
+            AssertBitwiseEqual(Half.NaN, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.NaN, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Zero, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.Epsilon, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(MaxSubnormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(MinNormal, One));
+            AssertBitwiseEqual(Zero, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(One, One));
+            AssertBitwiseEqual(Half.MaxValue, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.MaxValue, One));
+            AssertBitwiseEqual(Half.PositiveInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.PositiveInfinity, One));
         }
 
         [Fact]
         public static void op_CheckedSubtractionTest()
         {
-            AssertBitwiseEqual(Half.NegativeInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(Half.MinValue, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.MinValue, PositiveOne));
-            AssertBitwiseEqual(NegativeTwo, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(-Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(Half.NaN, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.NaN, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.Epsilon, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveZero, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(Half.MaxValue, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.MaxValue, PositiveOne));
-            AssertBitwiseEqual(Half.PositiveInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.PositiveInfinity, PositiveOne));
+            AssertBitwiseEqual(Half.NegativeInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(Half.MinValue, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.MinValue, One));
+            AssertBitwiseEqual(NegativeTwo, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(NegativeOne, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(-MinNormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(-MaxSubnormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(-Half.Epsilon, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(NegativeZero, One));
+            AssertBitwiseEqual(Half.NaN, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.NaN, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Zero, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.Epsilon, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(MaxSubnormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(MinNormal, One));
+            AssertBitwiseEqual(Zero, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(One, One));
+            AssertBitwiseEqual(Half.MaxValue, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.MaxValue, One));
+            AssertBitwiseEqual(Half.PositiveInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.PositiveInfinity, One));
         }
+
+        //
+        // IUnaryNegationOperators
+        //
 
         [Fact]
         public static void op_UnaryNegationTest()
         {
             AssertBitwiseEqual(Half.PositiveInfinity, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.NegativeInfinity));
             AssertBitwiseEqual(Half.MaxValue, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.MinValue));
-            AssertBitwiseEqual(PositiveOne, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(NegativeOne));
+            AssertBitwiseEqual(One, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(NegativeOne));
             AssertBitwiseEqual(MinNormal, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(-MinNormal));
             AssertBitwiseEqual(MaxSubnormal, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(-MaxSubnormal));
             AssertBitwiseEqual(Half.Epsilon, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(-Half.Epsilon));
-            AssertBitwiseEqual(PositiveZero, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(NegativeZero));
+            AssertBitwiseEqual(Zero, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(NegativeZero));
             AssertBitwiseEqual(Half.NaN, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.NaN));
-            AssertBitwiseEqual(NegativeZero, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(PositiveZero));
+            AssertBitwiseEqual(NegativeZero, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Zero));
             AssertBitwiseEqual(-Half.Epsilon, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.Epsilon));
             AssertBitwiseEqual(-MaxSubnormal, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(MaxSubnormal));
             AssertBitwiseEqual(-MinNormal, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(MinNormal));
-            AssertBitwiseEqual(NegativeOne, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(PositiveOne));
+            AssertBitwiseEqual(NegativeOne, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(One));
             AssertBitwiseEqual(Half.MinValue, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.MaxValue));
             AssertBitwiseEqual(Half.NegativeInfinity, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.PositiveInfinity));
         }
@@ -1785,20 +1857,24 @@ namespace System.Tests
         {
             AssertBitwiseEqual(Half.PositiveInfinity, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.NegativeInfinity));
             AssertBitwiseEqual(Half.MaxValue, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.MinValue));
-            AssertBitwiseEqual(PositiveOne, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(NegativeOne));
+            AssertBitwiseEqual(One, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(NegativeOne));
             AssertBitwiseEqual(MinNormal, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(-MinNormal));
             AssertBitwiseEqual(MaxSubnormal, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(-MaxSubnormal));
             AssertBitwiseEqual(Half.Epsilon, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(-Half.Epsilon));
-            AssertBitwiseEqual(PositiveZero, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(NegativeZero));
+            AssertBitwiseEqual(Zero, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(NegativeZero));
             AssertBitwiseEqual(Half.NaN, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.NaN));
-            AssertBitwiseEqual(NegativeZero, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(PositiveZero));
+            AssertBitwiseEqual(NegativeZero, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Zero));
             AssertBitwiseEqual(-Half.Epsilon, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.Epsilon));
             AssertBitwiseEqual(-MaxSubnormal, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(MaxSubnormal));
             AssertBitwiseEqual(-MinNormal, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(MinNormal));
-            AssertBitwiseEqual(NegativeOne, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(PositiveOne));
+            AssertBitwiseEqual(NegativeOne, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(One));
             AssertBitwiseEqual(Half.MinValue, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.MaxValue));
             AssertBitwiseEqual(Half.NegativeInfinity, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.PositiveInfinity));
         }
+
+        //
+        // IUnaryPlusOperators
+        //
 
         [Fact]
         public static void op_UnaryPlusTest()
@@ -1811,14 +1887,18 @@ namespace System.Tests
             AssertBitwiseEqual(-Half.Epsilon, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(-Half.Epsilon));
             AssertBitwiseEqual(NegativeZero, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(NegativeZero));
             AssertBitwiseEqual(Half.NaN, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(Half.NaN));
-            AssertBitwiseEqual(PositiveZero, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(PositiveZero));
+            AssertBitwiseEqual(Zero, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(Zero));
             AssertBitwiseEqual(Half.Epsilon, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(Half.Epsilon));
             AssertBitwiseEqual(MaxSubnormal, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(MaxSubnormal));
             AssertBitwiseEqual(MinNormal, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(MinNormal));
-            AssertBitwiseEqual(PositiveOne, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(PositiveOne));
+            AssertBitwiseEqual(One, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(One));
             AssertBitwiseEqual(Half.MaxValue, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(Half.MaxValue));
             AssertBitwiseEqual(Half.PositiveInfinity, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(Half.PositiveInfinity));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(HalfTests.Parse_Valid_TestData), MemberType = typeof(HalfTests))]

--- a/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
@@ -473,21 +473,21 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            AssertBitwiseEqual(Half.PositiveInfinity, NumberHelper<Half>.Abs(Half.NegativeInfinity));
-            AssertBitwiseEqual(Half.MaxValue, NumberHelper<Half>.Abs(Half.MinValue));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Abs(NegativeOne));
-            AssertBitwiseEqual(MinNormal, NumberHelper<Half>.Abs(-MinNormal));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<Half>.Abs(-MaxSubnormal));
-            AssertBitwiseEqual(Half.Epsilon, NumberHelper<Half>.Abs(-Half.Epsilon));
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.Abs(NegativeZero));
-            AssertBitwiseEqual(Half.NaN, NumberHelper<Half>.Abs(Half.NaN));
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.Abs(PositiveZero));
-            AssertBitwiseEqual(Half.Epsilon, NumberHelper<Half>.Abs(Half.Epsilon));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<Half>.Abs(MaxSubnormal));
-            AssertBitwiseEqual(MinNormal, NumberHelper<Half>.Abs(MinNormal));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Abs(PositiveOne));
-            AssertBitwiseEqual(Half.MaxValue, NumberHelper<Half>.Abs(Half.MaxValue));
-            AssertBitwiseEqual(Half.PositiveInfinity, NumberHelper<Half>.Abs(Half.PositiveInfinity));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.Abs(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MaxValue, NumberBaseHelper<Half>.Abs(Half.MinValue));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.Abs(NegativeOne));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Half>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Half>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(Half.Epsilon, NumberBaseHelper<Half>.Abs(-Half.Epsilon));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.Abs(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, NumberBaseHelper<Half>.Abs(Half.NaN));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.Abs(PositiveZero));
+            AssertBitwiseEqual(Half.Epsilon, NumberBaseHelper<Half>.Abs(Half.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Half>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Half>.Abs(MinNormal));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.Abs(PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, NumberBaseHelper<Half>.Abs(Half.MaxValue));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.Abs(Half.PositiveInfinity));
         }
 
         [Fact]
@@ -513,61 +513,61 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<byte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateChecked<byte>(0x7F));
-            AssertBitwiseEqual((Half)128.0f, NumberHelper<Half>.CreateChecked<byte>(0x80));
-            AssertBitwiseEqual((Half)255.0f, NumberHelper<Half>.CreateChecked<byte>(0xFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<byte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateChecked<byte>(0x7F));
+            AssertBitwiseEqual((Half)128.0f, NumberBaseHelper<Half>.CreateChecked<byte>(0x80));
+            AssertBitwiseEqual((Half)255.0f, NumberBaseHelper<Half>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<char>((char)0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateChecked<char>((char)0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateChecked<char>((char)0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateChecked<char>((char)0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<char>((char)0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateChecked<char>((char)0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateChecked<char>((char)0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<short>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateChecked<short>(0x7FFF));
-            AssertBitwiseEqual((Half)(-32768.0f), NumberHelper<Half>.CreateChecked<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<short>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateChecked<short>(0x7FFF));
+            AssertBitwiseEqual((Half)(-32768.0f), NumberBaseHelper<Half>.CreateChecked<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<int>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateChecked<int>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateChecked<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<int>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<int>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateChecked<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<long>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<long>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateCheckedFromInt128Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0, NumberHelper<Half>.CreateChecked<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberHelper<Half>.CreateChecked<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -575,70 +575,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<nint>((nint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<nint>((nint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<sbyte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateChecked<sbyte>(0x7F));
-            AssertBitwiseEqual((Half)(-128.0f), NumberHelper<Half>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<sbyte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateChecked<sbyte>(0x7F));
+            AssertBitwiseEqual((Half)(-128.0f), NumberBaseHelper<Half>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<ushort>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateChecked<ushort>(0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateChecked<ushort>(0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateChecked<ushort>(0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<ushort>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateChecked<ushort>(0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateChecked<ushort>(0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<uint>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateChecked<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateChecked<uint>(0x80000000));
-            AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateChecked<uint>(0xFFFFFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<uint>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateChecked<uint>(0x80000000));
+            AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<ulong>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateChecked<ulong>(0x8000000000000000));
-            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberHelper<Half>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<ulong>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateChecked<ulong>(0x8000000000000000));
+            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt128Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0, NumberHelper<Half>.CreateChecked<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0, NumberHelper<Half>.CreateChecked<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual((Half)340282366920938463463374607431768211455.0, NumberHelper<Half>.CreateChecked<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual((Half)340282366920938463463374607431768211455.0, NumberBaseHelper<Half>.CreateChecked<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -646,84 +646,84 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((Half)18446744073709551615.0f,NumberHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((Half)18446744073709551615.0f,NumberBaseHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateChecked<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<byte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateSaturating<byte>(0x7F));
-            AssertBitwiseEqual((Half)128.0f, NumberHelper<Half>.CreateSaturating<byte>(0x80));
-            AssertBitwiseEqual((Half)255.0f, NumberHelper<Half>.CreateSaturating<byte>(0xFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<byte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateSaturating<byte>(0x7F));
+            AssertBitwiseEqual((Half)128.0f, NumberBaseHelper<Half>.CreateSaturating<byte>(0x80));
+            AssertBitwiseEqual((Half)255.0f, NumberBaseHelper<Half>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<char>((char)0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateSaturating<char>((char)0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateSaturating<char>((char)0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateSaturating<char>((char)0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateSaturating<char>((char)0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<short>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateSaturating<short>(0x7FFF));
-            AssertBitwiseEqual((Half)(-32768.0f), NumberHelper<Half>.CreateSaturating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<short>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateSaturating<short>(0x7FFF));
+            AssertBitwiseEqual((Half)(-32768.0f), NumberBaseHelper<Half>.CreateSaturating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<int>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateSaturating<int>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<int>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<long>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<long>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt128Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberHelper<Half>.CreateSaturating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberHelper<Half>.CreateSaturating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -731,70 +731,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<nint>((nint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<nint>((nint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<sbyte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateSaturating<sbyte>(0x7F));
-            AssertBitwiseEqual((Half)(-128.0f), NumberHelper<Half>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<sbyte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateSaturating<sbyte>(0x7F));
+            AssertBitwiseEqual((Half)(-128.0f), NumberBaseHelper<Half>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<ushort>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateSaturating<ushort>(0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateSaturating<ushort>(0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateSaturating<ushort>(0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateSaturating<ushort>(0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<uint>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateSaturating<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateSaturating<uint>(0x80000000));
-            AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateSaturating<uint>(0xFFFFFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<uint>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateSaturating<uint>(0x80000000));
+            AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<ulong>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateSaturating<ulong>(0x8000000000000000));
-            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberHelper<Half>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateSaturating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt128Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0f, NumberHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(Half.PositiveInfinity, NumberHelper<Half>.CreateSaturating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0f, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.CreateSaturating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -802,84 +802,84 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((Half)18446744073709551615.0f, NumberHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateSaturating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<byte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateTruncating<byte>(0x7F));
-            AssertBitwiseEqual((Half)128.0f, NumberHelper<Half>.CreateTruncating<byte>(0x80));
-            AssertBitwiseEqual((Half)255.0f, NumberHelper<Half>.CreateTruncating<byte>(0xFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<byte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateTruncating<byte>(0x7F));
+            AssertBitwiseEqual((Half)128.0f, NumberBaseHelper<Half>.CreateTruncating<byte>(0x80));
+            AssertBitwiseEqual((Half)255.0f, NumberBaseHelper<Half>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<char>((char)0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateTruncating<char>((char)0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateTruncating<char>((char)0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateTruncating<char>((char)0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateTruncating<char>((char)0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<short>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateTruncating<short>(0x7FFF));
-            AssertBitwiseEqual((Half)(-32768.0f), NumberHelper<Half>.CreateTruncating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<short>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateTruncating<short>(0x7FFF));
+            AssertBitwiseEqual((Half)(-32768.0f), NumberBaseHelper<Half>.CreateTruncating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<int>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateTruncating<int>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<int>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<long>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<long>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt128Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberHelper<Half>.CreateTruncating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberHelper<Half>.CreateTruncating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)(-170141183460469231731687303715884105728.0f), NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -887,70 +887,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<nint>((nint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<nint>((nint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((Half)(-2147483648.0f), NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<sbyte>(0x01));
-            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateTruncating<sbyte>(0x7F));
-            AssertBitwiseEqual((Half)(-128.0f), NumberHelper<Half>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<sbyte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberBaseHelper<Half>.CreateTruncating<sbyte>(0x7F));
+            AssertBitwiseEqual((Half)(-128.0f), NumberBaseHelper<Half>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<ushort>(0x0001));
-            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateTruncating<ushort>(0x7FFF));
-            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateTruncating<ushort>(0x8000));
-            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateTruncating<ushort>(0xFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberBaseHelper<Half>.CreateTruncating<ushort>(0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberBaseHelper<Half>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<uint>(0x00000001));
-            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateTruncating<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateTruncating<uint>(0x80000000));
-            AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateTruncating<uint>(0xFFFFFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<uint>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateTruncating<uint>(0x80000000));
+            AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<ulong>(0x0000000000000001));
-            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateTruncating<ulong>(0x8000000000000000));
-            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberHelper<Half>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateTruncating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt128Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0f, NumberHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(Half.PositiveInfinity, NumberHelper<Half>.CreateTruncating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105727.0f, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual((Half)170141183460469231731687303715884105728.0f, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.CreateTruncating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -958,23 +958,23 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual((Half)18446744073709551615.0f, NumberHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((Half)18446744073709551615.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateTruncating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -1046,19 +1046,19 @@ namespace System.Tests
         {
             Half result;
 
-            Assert.True(NumberHelper<Half>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x00, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x01, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((Half)127.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0x80, out result));
             Assert.Equal((Half)128.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((Half)255.0f, result);
         }
 
@@ -1067,19 +1067,19 @@ namespace System.Tests
         {
             Half result;
 
-            Assert.True(NumberHelper<Half>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((Half)32767.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((Half)32768.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((Half)65535.0f, result);
         }
 
@@ -1088,19 +1088,19 @@ namespace System.Tests
         {
             Half result;
 
-            Assert.True(NumberHelper<Half>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(0x0000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(0x0001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((Half)32767.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal((Half)(-32768.0f), result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1109,19 +1109,19 @@ namespace System.Tests
         {
             Half result;
 
-            Assert.True(NumberHelper<Half>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(0x00000000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(0x00000001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((Half)2147483647.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal((Half)(-2147483648.0f), result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1130,19 +1130,19 @@ namespace System.Tests
         {
             Half result;
 
-            Assert.True(NumberHelper<Half>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((Half)9223372036854775807.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
             Assert.Equal((Half)(-9223372036854775808.0f), result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1151,19 +1151,19 @@ namespace System.Tests
         {
             Half result;
 
-            Assert.True(NumberHelper<Half>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal((Half)170141183460469231731687303715884105727.0, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal((Half)(-170141183460469231731687303715884105728.0), result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1174,36 +1174,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal(PositiveZero, result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal(PositiveOne, result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((Half)9223372036854775807.0f, result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal((Half)(-9223372036854775808.0f), result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(NegativeOne, result);
             }
             else
             {
-                Assert.True(NumberHelper<Half>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal(PositiveZero, result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal(PositiveOne, result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((Half)2147483647.0f, result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal((Half)(-2147483648.0f), result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(NegativeOne, result);
             }
         }
@@ -1213,19 +1213,19 @@ namespace System.Tests
         {
             Half result;
 
-            Assert.True(NumberHelper<Half>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((Half)127.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal((Half)(-128.0f), result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1234,19 +1234,19 @@ namespace System.Tests
         {
             Half result;
 
-            Assert.True(NumberHelper<Half>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((Half)32767.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((Half)32768.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((Half)65535.0f, result);
         }
 
@@ -1255,19 +1255,19 @@ namespace System.Tests
         {
             Half result;
 
-            Assert.True(NumberHelper<Half>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal((Half)2147483647.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<uint>(0x80000000, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal((Half)2147483648.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal((Half)4294967295.0f, result);
         }
 
@@ -1276,19 +1276,19 @@ namespace System.Tests
         {
             Half result;
 
-            Assert.True(NumberHelper<Half>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((Half)9223372036854775807.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal((Half)9223372036854775808.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal((Half)18446744073709551615.0f, result);
         }
 
@@ -1297,19 +1297,19 @@ namespace System.Tests
         {
             Half result;
 
-            Assert.True(NumberHelper<Half>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(PositiveZero, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
             Assert.Equal(PositiveOne, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal((Half)170141183460469231731687303715884105727.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal((Half)170141183460469231731687303715884105728.0f, result);
 
-            Assert.True(NumberHelper<Half>.TryCreate<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<Half>.TryCreate<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(Half.PositiveInfinity, result);
         }
 
@@ -1320,38 +1320,38 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal(PositiveZero, result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal(PositiveOne, result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((Half)9223372036854775807.0f, result);
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 // Assert.Equal((Half)9223372036854775808.0f, result);
                 //
-                // Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 // Assert.Equal((Half)18446744073709551615.0f, result);
             }
             else
             {
-                Assert.True(NumberHelper<Half>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal(PositiveZero, result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal(PositiveOne, result);
 
-                Assert.True(NumberHelper<Half>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((Half)2147483647.0f, result);
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 // Assert.Equal((Half)2147483648.0f, result);
                 //
-                // Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                // Assert.True(NumberBaseHelper<Half>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 // Assert.Equal((Half)4294967295.0f, result);
             }
         }
@@ -1831,29 +1831,29 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.True(NumberHelper<Half>.TryParse(value, null, out result));
+                    Assert.True(ParsableHelper<Half>.TryParse(value, null, out result));
                     Assert.Equal(expected, result);
 
-                    Assert.Equal(expected, NumberHelper<Half>.Parse(value, null));
+                    Assert.Equal(expected, ParsableHelper<Half>.Parse(value, null));
                 }
 
-                Assert.Equal(expected, NumberHelper<Half>.Parse(value, provider));
+                Assert.Equal(expected, ParsableHelper<Half>.Parse(value, provider));
             }
 
             // Use Parse(string, NumberStyles, IFormatProvider)
-            Assert.True(NumberHelper<Half>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<Half>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
 
-            Assert.Equal(expected, NumberHelper<Half>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<Half>.Parse(value, style, provider));
 
             if (isDefaultProvider)
             {
                 // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.True(NumberHelper<Half>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
+                Assert.True(NumberBaseHelper<Half>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
                 Assert.Equal(expected, result);
 
-                Assert.Equal(expected, NumberHelper<Half>.Parse(value, style, null));
-                Assert.Equal(expected, NumberHelper<Half>.Parse(value, style, NumberFormatInfo.CurrentInfo));
+                Assert.Equal(expected, NumberBaseHelper<Half>.Parse(value, style, null));
+                Assert.Equal(expected, NumberBaseHelper<Half>.Parse(value, style, NumberFormatInfo.CurrentInfo));
             }
         }
 
@@ -1868,29 +1868,29 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.False(NumberHelper<Half>.TryParse(value, null, out result));
+                    Assert.False(ParsableHelper<Half>.TryParse(value, null, out result));
                     Assert.Equal(default(Half), result);
 
-                    Assert.Throws(exceptionType, () => NumberHelper<Half>.Parse(value, null));
+                    Assert.Throws(exceptionType, () => ParsableHelper<Half>.Parse(value, null));
                 }
 
-                Assert.Throws(exceptionType, () => NumberHelper<Half>.Parse(value, provider));
+                Assert.Throws(exceptionType, () => ParsableHelper<Half>.Parse(value, provider));
             }
 
             // Use Parse(string, NumberStyles, IFormatProvider)
-            Assert.False(NumberHelper<Half>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<Half>.TryParse(value, style, provider, out result));
             Assert.Equal(default(Half), result);
 
-            Assert.Throws(exceptionType, () => NumberHelper<Half>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<Half>.Parse(value, style, provider));
 
             if (isDefaultProvider)
             {
                 // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.False(NumberHelper<Half>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
+                Assert.False(NumberBaseHelper<Half>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
                 Assert.Equal(default(Half), result);
 
-                Assert.Throws(exceptionType, () => NumberHelper<Half>.Parse(value, style, null));
-                Assert.Throws(exceptionType, () => NumberHelper<Half>.Parse(value, style, NumberFormatInfo.CurrentInfo));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<Half>.Parse(value, style, null));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<Half>.Parse(value, style, NumberFormatInfo.CurrentInfo));
             }
         }
 
@@ -1905,18 +1905,18 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.True(NumberHelper<Half>.TryParse(value.AsSpan(offset, count), null, out result));
+                    Assert.True(SpanParsableHelper<Half>.TryParse(value.AsSpan(offset, count), null, out result));
                     Assert.Equal(expected, result);
 
-                    Assert.Equal(expected, NumberHelper<Half>.Parse(value.AsSpan(offset, count), null));
+                    Assert.Equal(expected, SpanParsableHelper<Half>.Parse(value.AsSpan(offset, count), null));
                 }
 
-                Assert.Equal(expected, NumberHelper<Half>.Parse(value.AsSpan(offset, count), provider: provider));
+                Assert.Equal(expected, SpanParsableHelper<Half>.Parse(value.AsSpan(offset, count), provider: provider));
             }
 
-            Assert.Equal(expected, NumberHelper<Half>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<Half>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<Half>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<Half>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1926,9 +1926,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<Half>.Parse(value.AsSpan(), style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<Half>.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(NumberHelper<Half>.TryParse(value.AsSpan(), style, provider, out Half result));
+                Assert.False(NumberBaseHelper<Half>.TryParse(value.AsSpan(), style, provider, out Half result));
                 Assert.Equal((Half)0, result);
             }
         }

--- a/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
@@ -913,6 +913,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(Half.MinValue, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(NegativeOne, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(-MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(-Half.Epsilon, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(NegativeZero, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(Half.NaN, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(Zero, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(Half.Epsilon, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MaxNumber(One, One));
+            AssertBitwiseEqual(Half.MaxValue, NumberHelper<Half>.MaxNumber(Half.MaxValue, One));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberHelper<Half>.MaxNumber(Half.PositiveInfinity, One));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             AssertBitwiseEqual(Half.NegativeInfinity, NumberHelper<Half>.Min(Half.NegativeInfinity, One));
@@ -930,6 +950,26 @@ namespace System.Tests
             AssertBitwiseEqual(One, NumberHelper<Half>.Min(One, One));
             AssertBitwiseEqual(One, NumberHelper<Half>.Min(Half.MaxValue, One));
             AssertBitwiseEqual(One, NumberHelper<Half>.Min(Half.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, NumberHelper<Half>.MinNumber(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(Half.MinValue, NumberHelper<Half>.MinNumber(Half.MinValue, One));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.MinNumber(NegativeOne, One));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<Half>.MinNumber(-MinNormal, One));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<Half>.MinNumber(-MaxSubnormal, One));
+            AssertBitwiseEqual(-Half.Epsilon, NumberHelper<Half>.MinNumber(-Half.Epsilon, One));
+            AssertBitwiseEqual(NegativeZero, NumberHelper<Half>.MinNumber(NegativeZero, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MinNumber(Half.NaN, One));
+            AssertBitwiseEqual(Zero, NumberHelper<Half>.MinNumber(Zero, One));
+            AssertBitwiseEqual(Half.Epsilon, NumberHelper<Half>.MinNumber(Half.Epsilon, One));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<Half>.MinNumber(MaxSubnormal, One));
+            AssertBitwiseEqual(MinNormal, NumberHelper<Half>.MinNumber(MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MinNumber(One, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MinNumber(Half.MaxValue, One));
+            AssertBitwiseEqual(One, NumberHelper<Half>.MinNumber(Half.PositiveInfinity, One));
         }
 
         [Fact]
@@ -1457,6 +1497,246 @@ namespace System.Tests
                 // AssertBitwiseEqual((Half)2147483648.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0x80000000));
                 // AssertBitwiseEqual((Half)4294967295.0f, NumberBaseHelper<Half>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsFinite(Half.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(Half.MinValue));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(NegativeOne));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(-MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(-Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsFinite(Half.NaN));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(Zero));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(MaxSubnormal));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(One));
+            Assert.True(NumberBaseHelper<Half>.IsFinite(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsFinite(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.True(NumberBaseHelper<Half>.IsInfinity(Half.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(Half.MinValue));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(-Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(Half.NaN));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(One));
+            Assert.False(NumberBaseHelper<Half>.IsInfinity(Half.MaxValue));
+            Assert.True(NumberBaseHelper<Half>.IsInfinity(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsNaN(Half.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(Half.MinValue));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(-Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(NegativeZero));
+            Assert.True(NumberBaseHelper<Half>.IsNaN(Half.NaN));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(One));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsNaN(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.True(NumberBaseHelper<Half>.IsNegative(Half.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Half>.IsNegative(Half.MinValue));
+            Assert.True(NumberBaseHelper<Half>.IsNegative(NegativeOne));
+            Assert.True(NumberBaseHelper<Half>.IsNegative(-MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsNegative(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<Half>.IsNegative(-Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsNegative(NegativeZero));
+            Assert.True(NumberBaseHelper<Half>.IsNegative(Half.NaN));
+            Assert.False(NumberBaseHelper<Half>.IsNegative(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsNegative(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsNegative(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsNegative(MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsNegative(One));
+            Assert.False(NumberBaseHelper<Half>.IsNegative(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsNegative(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.True(NumberBaseHelper<Half>.IsNegativeInfinity(Half.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(Half.MinValue));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(-Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(Half.NaN));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(One));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsNegativeInfinity(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsNormal(Half.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Half>.IsNormal(Half.MinValue));
+            Assert.True(NumberBaseHelper<Half>.IsNormal(NegativeOne));
+            Assert.True(NumberBaseHelper<Half>.IsNormal(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsNormal(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsNormal(-Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsNormal(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsNormal(Half.NaN));
+            Assert.False(NumberBaseHelper<Half>.IsNormal(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsNormal(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsNormal(MaxSubnormal));
+            Assert.True(NumberBaseHelper<Half>.IsNormal(MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsNormal(One));
+            Assert.True(NumberBaseHelper<Half>.IsNormal(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsNormal(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(Half.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(Half.MinValue));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(-Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(Half.NaN));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(One));
+            Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(Half.MaxValue));
+            Assert.True(NumberBaseHelper<Half>.IsPositiveInfinity(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsSubnormal(Half.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Half>.IsSubnormal(Half.MinValue));
+            Assert.False(NumberBaseHelper<Half>.IsSubnormal(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsSubnormal(-MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsSubnormal(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<Half>.IsSubnormal(-Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsSubnormal(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsSubnormal(Half.NaN));
+            Assert.False(NumberBaseHelper<Half>.IsSubnormal(Zero));
+            Assert.True(NumberBaseHelper<Half>.IsSubnormal(Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsSubnormal(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsSubnormal(MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsSubnormal(One));
+            Assert.False(NumberBaseHelper<Half>.IsSubnormal(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsSubnormal(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, NumberBaseHelper<Half>.MaxMagnitude(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(Half.MinValue, NumberBaseHelper<Half>.MaxMagnitude(Half.MinValue, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitude(NegativeOne, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitude(-MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitude(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitude(-Half.Epsilon, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitude(NegativeZero, One));
+            AssertBitwiseEqual(Half.NaN, NumberBaseHelper<Half>.MaxMagnitude(Half.NaN, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitude(Zero, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitude(Half.Epsilon, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitude(MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitude(MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitude(One, One));
+            AssertBitwiseEqual(Half.MaxValue, NumberBaseHelper<Half>.MaxMagnitude(Half.MaxValue, One));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.MaxMagnitude(Half.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, NumberBaseHelper<Half>.MaxMagnitudeNumber(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(Half.MinValue, NumberBaseHelper<Half>.MaxMagnitudeNumber(Half.MinValue, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitudeNumber(NegativeOne, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitudeNumber(-MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitudeNumber(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitudeNumber(-Half.Epsilon, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitudeNumber(NegativeZero, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitudeNumber(Half.NaN, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitudeNumber(Zero, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitudeNumber(Half.Epsilon, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitudeNumber(MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitudeNumber(MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MaxMagnitudeNumber(One, One));
+            AssertBitwiseEqual(Half.MaxValue, NumberBaseHelper<Half>.MaxMagnitudeNumber(Half.MaxValue, One));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberBaseHelper<Half>.MaxMagnitudeNumber(Half.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MinMagnitude(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MinMagnitude(Half.MinValue, One));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.MinMagnitude(NegativeOne, One));
+            AssertBitwiseEqual(-MinNormal, NumberBaseHelper<Half>.MinMagnitude(-MinNormal, One));
+            AssertBitwiseEqual(-MaxSubnormal, NumberBaseHelper<Half>.MinMagnitude(-MaxSubnormal, One));
+            AssertBitwiseEqual(-Half.Epsilon, NumberBaseHelper<Half>.MinMagnitude(-Half.Epsilon, One));
+            AssertBitwiseEqual(NegativeZero, NumberBaseHelper<Half>.MinMagnitude(NegativeZero, One));
+            AssertBitwiseEqual(Half.NaN, NumberBaseHelper<Half>.MinMagnitude(Half.NaN, One));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.MinMagnitude(Zero, One));
+            AssertBitwiseEqual(Half.Epsilon, NumberBaseHelper<Half>.MinMagnitude(Half.Epsilon, One));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Half>.MinMagnitude(MaxSubnormal, One));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Half>.MinMagnitude(MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MinMagnitude(One, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MinMagnitude(Half.MaxValue, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MinMagnitude(Half.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MinMagnitudeNumber(Half.NegativeInfinity, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MinMagnitudeNumber(Half.MinValue, One));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<Half>.MinMagnitudeNumber(NegativeOne, One));
+            AssertBitwiseEqual(-MinNormal, NumberBaseHelper<Half>.MinMagnitudeNumber(-MinNormal, One));
+            AssertBitwiseEqual(-MaxSubnormal, NumberBaseHelper<Half>.MinMagnitudeNumber(-MaxSubnormal, One));
+            AssertBitwiseEqual(-Half.Epsilon, NumberBaseHelper<Half>.MinMagnitudeNumber(-Half.Epsilon, One));
+            AssertBitwiseEqual(NegativeZero, NumberBaseHelper<Half>.MinMagnitudeNumber(NegativeZero, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MinMagnitudeNumber(Half.NaN, One));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.MinMagnitudeNumber(Zero, One));
+            AssertBitwiseEqual(Half.Epsilon, NumberBaseHelper<Half>.MinMagnitudeNumber(Half.Epsilon, One));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<Half>.MinMagnitudeNumber(MaxSubnormal, One));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<Half>.MinMagnitudeNumber(MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MinMagnitudeNumber(One, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MinMagnitudeNumber(Half.MaxValue, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<Half>.MinMagnitudeNumber(Half.PositiveInfinity, One));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int128Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int128Tests.GenericMath.cs
@@ -583,119 +583,119 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.Abs(Zero));
-            Assert.Equal(One, NumberHelper<Int128>.Abs(One));
-            Assert.Equal(MaxValue, NumberHelper<Int128>.Abs(MaxValue));
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.Abs(MinValue));
-            Assert.Equal(One, NumberHelper<Int128>.Abs(NegativeOne));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.Abs(Zero));
+            Assert.Equal(One, NumberBaseHelper<Int128>.Abs(One));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.Abs(MaxValue));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.Abs(MinValue));
+            Assert.Equal(One, NumberBaseHelper<Int128>.Abs(NegativeOne));
         }
 
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<byte>(0x00));
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<byte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<Int128>.CreateChecked<byte>(0x7F));
-            Assert.Equal(SByteMaxValuePlusOne, NumberHelper<Int128>.CreateChecked<byte>(0x80));
-            Assert.Equal(ByteMaxValue, NumberHelper<Int128>.CreateChecked<byte>(0xFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<byte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<byte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<Int128>.CreateChecked<byte>(0x7F));
+            Assert.Equal(SByteMaxValuePlusOne, NumberBaseHelper<Int128>.CreateChecked<byte>(0x80));
+            Assert.Equal(ByteMaxValue, NumberBaseHelper<Int128>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<char>((char)0x0000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<char>((char)0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<Int128>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<Int128>.CreateChecked<char>((char)0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<Int128>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<char>((char)0x0000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<char>((char)0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<Int128>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<Int128>.CreateChecked<char>((char)0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<Int128>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromDecimalTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<decimal>(decimal.Zero));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<decimal>(decimal.Zero));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<decimal>(decimal.One));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateChecked<decimal>(decimal.MinusOne));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<decimal>(decimal.One));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateChecked<decimal>(decimal.MinusOne));
 
-            Assert.Equal(new Int128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberHelper<Int128>.CreateChecked<decimal>(decimal.MaxValue));
-            Assert.Equal(new Int128(0xFFFF_FFFF_0000_0000, 0x0000_0000_0000_0001), NumberHelper<Int128>.CreateChecked<decimal>(decimal.MinValue));
+            Assert.Equal(new Int128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberBaseHelper<Int128>.CreateChecked<decimal>(decimal.MaxValue));
+            Assert.Equal(new Int128(0xFFFF_FFFF_0000_0000, 0x0000_0000_0000_0001), NumberBaseHelper<Int128>.CreateChecked<decimal>(decimal.MinValue));
         }
 
         [Fact]
         public static void CreateCheckedFromDoubleTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<double>(+0.0));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<double>(-0.0));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<double>(+0.0));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<double>(-0.0));
 
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<double>(+double.Epsilon));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<double>(-double.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<double>(+double.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<double>(-double.Epsilon));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<double>(+1.0));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateChecked<double>(-1.0));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<double>(+1.0));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateChecked<double>(-1.0));
 
-            Assert.Equal(new Int128(0x7FFF_FFFF_FFFF_FC00, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateChecked<double>(+170141183460469212842221372237303250944.0));
-            Assert.Equal(new Int128(0x8000_0000_0000_0400, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateChecked<double>(-170141183460469212842221372237303250944.0));
+            Assert.Equal(new Int128(0x7FFF_FFFF_FFFF_FC00, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateChecked<double>(+170141183460469212842221372237303250944.0));
+            Assert.Equal(new Int128(0x8000_0000_0000_0400, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateChecked<double>(-170141183460469212842221372237303250944.0));
 
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateChecked<double>(-170141183460469231731687303715884105728.0));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateChecked<double>(-170141183460469231731687303715884105728.0));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<double>(+170141183460469231731687303715884105728.0));
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<double>(-170141183460469269510619166673045815296.0));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<double>(+170141183460469231731687303715884105728.0));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<double>(-170141183460469269510619166673045815296.0));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<double>(double.MaxValue));
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<double>(double.MinValue));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<double>(double.MaxValue));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<double>(double.MinValue));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<double>(double.PositiveInfinity));
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<double>(double.NegativeInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<double>(double.PositiveInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<double>(double.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateCheckedFromHalfTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<Half>((Half)(+0.0)));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<Half>((Half)(-0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<Half>((Half)(+0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<Half>((Half)(-0.0)));
 
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<Half>(+Half.Epsilon));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<Half>(-Half.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<Half>(+Half.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<Half>(-Half.Epsilon));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<Half>((Half)(+1.0)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateChecked<Half>((Half)(-1.0)));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<Half>((Half)(+1.0)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateChecked<Half>((Half)(-1.0)));
 
-            Assert.Equal(+65504, NumberHelper<Int128>.CreateChecked<Half>(Half.MaxValue));
-            Assert.Equal(-65504, NumberHelper<Int128>.CreateChecked<Half>(Half.MinValue));
+            Assert.Equal(+65504, NumberBaseHelper<Int128>.CreateChecked<Half>(Half.MaxValue));
+            Assert.Equal(-65504, NumberBaseHelper<Int128>.CreateChecked<Half>(Half.MinValue));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<Half>(Half.PositiveInfinity));
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<Half>(Half.NegativeInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<Half>(Half.PositiveInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<Half>(Half.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<short>(0x0000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<short>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<Int128>.CreateChecked<short>(0x7FFF));
-            Assert.Equal(Int16MinValue, NumberHelper<Int128>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<short>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<short>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<Int128>.CreateChecked<short>(0x7FFF));
+            Assert.Equal(Int16MinValue, NumberBaseHelper<Int128>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<int>(0x00000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<int>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Equal(Int32MinValue, NumberHelper<Int128>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<int>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<int>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Equal(Int32MinValue, NumberBaseHelper<Int128>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<long>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MinValue, NumberHelper<Int128>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<long>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MinValue, NumberBaseHelper<Int128>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -703,87 +703,87 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<Int128>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MinValue, NumberHelper<Int128>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MinValue, NumberBaseHelper<Int128>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal(One, NumberHelper<Int128>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(Int32MinValue, NumberHelper<Int128>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(Int32MinValue, NumberBaseHelper<Int128>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<sbyte>(0x00));
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<sbyte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<Int128>.CreateChecked<sbyte>(0x7F));
-            Assert.Equal(SByteMinValue, NumberHelper<Int128>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<sbyte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<sbyte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<Int128>.CreateChecked<sbyte>(0x7F));
+            Assert.Equal(SByteMinValue, NumberBaseHelper<Int128>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromSingleTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<float>(+0.0f));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<float>(-0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<float>(+0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<float>(-0.0f));
 
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<float>(+float.Epsilon));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<float>(-float.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<float>(+float.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<float>(-float.Epsilon));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<float>(+1.0f));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateChecked<float>(-1.0f));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<float>(+1.0f));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateChecked<float>(-1.0f));
 
-            Assert.Equal(new Int128(0x7FFF_FF80_0000_0000, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateChecked<float>(+170141173319264429905852091742258462720.0f));
-            Assert.Equal(new Int128(0x8000_0080_0000_0000, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateChecked<float>(-170141173319264429905852091742258462720.0f));
+            Assert.Equal(new Int128(0x7FFF_FF80_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateChecked<float>(+170141173319264429905852091742258462720.0f));
+            Assert.Equal(new Int128(0x8000_0080_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateChecked<float>(-170141173319264429905852091742258462720.0f));
 
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateChecked<float>(-170141183460469231731687303715884105728.0f));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateChecked<float>(-170141183460469231731687303715884105728.0f));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<float>(+170141183460469231731687303715884105728.0f));
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<float>(-170141203742878835383357727663135391744.0f));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<float>(+170141183460469231731687303715884105728.0f));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<float>(-170141203742878835383357727663135391744.0f));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<float>(float.MaxValue));
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<float>(float.MinValue));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<float>(float.MaxValue));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<float>(float.MinValue));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<float>(float.PositiveInfinity));
-            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CreateChecked<float>(float.NegativeInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<float>(float.PositiveInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<Int128>.CreateChecked<float>(float.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<ushort>(0x0000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<ushort>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<Int128>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<Int128>.CreateChecked<ushort>(0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<Int128>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<ushort>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<ushort>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<Int128>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<Int128>.CreateChecked<ushort>(0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<Int128>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<uint>(0x00000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<uint>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Equal(Int32MaxValuePlusOne, NumberHelper<Int128>.CreateChecked<uint>(0x80000000));
-            Assert.Equal(UInt32MaxValue, NumberHelper<Int128>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<uint>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<uint>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<Int128>.CreateChecked<uint>(0x80000000));
+            Assert.Equal(UInt32MaxValue, NumberBaseHelper<Int128>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<Int128>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Equal(UInt64MaxValue, NumberHelper<Int128>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<Int128>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<Int128>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -791,127 +791,127 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<Int128>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MaxValuePlusOne, NumberHelper<Int128>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(UInt64MaxValue, NumberHelper<Int128>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<Int128>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(UInt64MaxValue, NumberBaseHelper<Int128>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal(One, NumberHelper<Int128>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(Int32MaxValuePlusOne, NumberHelper<Int128>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Equal(UInt32MaxValue, NumberHelper<Int128>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<Int128>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Equal(UInt32MaxValue, NumberBaseHelper<Int128>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<byte>(0x00));
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<byte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<Int128>.CreateSaturating<byte>(0x7F));
-            Assert.Equal(SByteMaxValuePlusOne, NumberHelper<Int128>.CreateSaturating<byte>(0x80));
-            Assert.Equal(ByteMaxValue, NumberHelper<Int128>.CreateSaturating<byte>(0xFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<byte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<byte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<Int128>.CreateSaturating<byte>(0x7F));
+            Assert.Equal(SByteMaxValuePlusOne, NumberBaseHelper<Int128>.CreateSaturating<byte>(0x80));
+            Assert.Equal(ByteMaxValue, NumberBaseHelper<Int128>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<Int128>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<Int128>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<Int128>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<Int128>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<Int128>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<Int128>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromDecimalTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<decimal>(decimal.Zero));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<decimal>(decimal.Zero));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<decimal>(decimal.One));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateSaturating<decimal>(decimal.MinusOne));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<decimal>(decimal.One));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateSaturating<decimal>(decimal.MinusOne));
 
-            Assert.Equal(new Int128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberHelper<Int128>.CreateSaturating<decimal>(decimal.MaxValue));
-            Assert.Equal(new Int128(0xFFFF_FFFF_0000_0000, 0x0000_0000_0000_0001), NumberHelper<Int128>.CreateSaturating<decimal>(decimal.MinValue));
+            Assert.Equal(new Int128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberBaseHelper<Int128>.CreateSaturating<decimal>(decimal.MaxValue));
+            Assert.Equal(new Int128(0xFFFF_FFFF_0000_0000, 0x0000_0000_0000_0001), NumberBaseHelper<Int128>.CreateSaturating<decimal>(decimal.MinValue));
         }
 
         [Fact]
         public static void CreateSaturatingFromDoubleTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<double>(+0.0));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<double>(-0.0));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<double>(+0.0));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<double>(-0.0));
 
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<double>(+double.Epsilon));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<double>(-double.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<double>(+double.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<double>(-double.Epsilon));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<double>(+1.0));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateSaturating<double>(-1.0));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<double>(+1.0));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateSaturating<double>(-1.0));
 
-            Assert.Equal(new Int128(0x7FFF_FFFF_FFFF_FC00, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateSaturating<double>(+170141183460469212842221372237303250944.0));
-            Assert.Equal(new Int128(0x8000_0000_0000_0400, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateSaturating<double>(-170141183460469212842221372237303250944.0));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateSaturating<double>(-170141183460469231731687303715884105728.0));
+            Assert.Equal(new Int128(0x7FFF_FFFF_FFFF_FC00, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateSaturating<double>(+170141183460469212842221372237303250944.0));
+            Assert.Equal(new Int128(0x8000_0000_0000_0400, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateSaturating<double>(-170141183460469212842221372237303250944.0));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateSaturating<double>(-170141183460469231731687303715884105728.0));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateSaturating<double>(+170141183460469231731687303715884105728.0));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateSaturating<double>(-170141183460469269510619166673045815296.0));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateSaturating<double>(+170141183460469231731687303715884105728.0));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateSaturating<double>(-170141183460469269510619166673045815296.0));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateSaturating<double>(double.MaxValue));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateSaturating<double>(double.MinValue));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateSaturating<double>(double.MaxValue));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateSaturating<double>(double.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateSaturating<double>(double.PositiveInfinity));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateSaturating<double>(double.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateSaturating<double>(double.PositiveInfinity));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateSaturating<double>(double.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateSaturatingFromHalfTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<Half>((Half)(+0.0)));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<Half>((Half)(-0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<Half>((Half)(+0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<Half>((Half)(-0.0)));
 
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<Half>(+Half.Epsilon));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<Half>(-Half.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<Half>(+Half.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<Half>(-Half.Epsilon));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<Half>((Half)(+1.0)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateSaturating<Half>((Half)(-1.0)));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<Half>((Half)(+1.0)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateSaturating<Half>((Half)(-1.0)));
 
-            Assert.Equal(+65504, NumberHelper<Int128>.CreateSaturating<Half>(Half.MaxValue));
-            Assert.Equal(-65504, NumberHelper<Int128>.CreateSaturating<Half>(Half.MinValue));
+            Assert.Equal(+65504, NumberBaseHelper<Int128>.CreateSaturating<Half>(Half.MaxValue));
+            Assert.Equal(-65504, NumberBaseHelper<Int128>.CreateSaturating<Half>(Half.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateSaturating<Half>(Half.PositiveInfinity));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateSaturating<Half>(Half.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateSaturating<Half>(Half.PositiveInfinity));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateSaturating<Half>(Half.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<short>(0x0000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<short>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<Int128>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal(Int16MinValue, NumberHelper<Int128>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<short>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<short>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<Int128>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal(Int16MinValue, NumberBaseHelper<Int128>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<int>(0x00000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<int>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal(Int32MinValue, NumberHelper<Int128>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<int>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<int>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal(Int32MinValue, NumberBaseHelper<Int128>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MinValue, NumberHelper<Int128>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MinValue, NumberBaseHelper<Int128>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -919,86 +919,86 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MinValue, NumberHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MinValue, NumberBaseHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(Int32MinValue, NumberHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(Int32MinValue, NumberBaseHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<Int128>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal(SByteMinValue, NumberHelper<Int128>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<Int128>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal(SByteMinValue, NumberBaseHelper<Int128>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromSingleTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<float>(+0.0f));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<float>(-0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<float>(+0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<float>(-0.0f));
 
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<float>(+float.Epsilon));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<float>(-float.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<float>(+float.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<float>(-float.Epsilon));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<float>(+1.0f));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateSaturating<float>(-1.0f));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<float>(+1.0f));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateSaturating<float>(-1.0f));
 
-            Assert.Equal(new Int128(0x7FFF_FF80_0000_0000, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateSaturating<float>(+170141173319264429905852091742258462720.0f));
-            Assert.Equal(new Int128(0x8000_0080_0000_0000, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateSaturating<float>(-170141173319264429905852091742258462720.0f));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateSaturating<float>(-170141183460469231731687303715884105728.0f));
+            Assert.Equal(new Int128(0x7FFF_FF80_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateSaturating<float>(+170141173319264429905852091742258462720.0f));
+            Assert.Equal(new Int128(0x8000_0080_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateSaturating<float>(-170141173319264429905852091742258462720.0f));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateSaturating<float>(-170141183460469231731687303715884105728.0f));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateSaturating<float>(+170141183460469231731687303715884105728.0f));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateSaturating<float>(-170141203742878835383357727663135391744.0f));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateSaturating<float>(+170141183460469231731687303715884105728.0f));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateSaturating<float>(-170141203742878835383357727663135391744.0f));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateSaturating<float>(float.MaxValue));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateSaturating<float>(float.MinValue));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateSaturating<float>(float.MaxValue));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateSaturating<float>(float.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateSaturating<float>(float.PositiveInfinity));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateSaturating<float>(float.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateSaturating<float>(float.PositiveInfinity));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateSaturating<float>(float.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<Int128>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<Int128>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<Int128>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<Int128>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<Int128>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<Int128>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal(Int32MaxValuePlusOne, NumberHelper<Int128>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal(UInt32MaxValue, NumberHelper<Int128>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<Int128>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal(UInt32MaxValue, NumberBaseHelper<Int128>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<Int128>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal(UInt64MaxValue, NumberHelper<Int128>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<Int128>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<Int128>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -1006,127 +1006,127 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MaxValuePlusOne, NumberHelper<Int128>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(UInt64MaxValue, NumberHelper<Int128>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<Int128>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(UInt64MaxValue, NumberBaseHelper<Int128>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal(One, NumberHelper<Int128>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(Int32MaxValuePlusOne, NumberHelper<Int128>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal(UInt32MaxValue, NumberHelper<Int128>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<Int128>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal(UInt32MaxValue, NumberBaseHelper<Int128>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<byte>(0x00));
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<byte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<Int128>.CreateTruncating<byte>(0x7F));
-            Assert.Equal(SByteMaxValuePlusOne, NumberHelper<Int128>.CreateTruncating<byte>(0x80));
-            Assert.Equal(ByteMaxValue, NumberHelper<Int128>.CreateTruncating<byte>(0xFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<byte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<byte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<Int128>.CreateTruncating<byte>(0x7F));
+            Assert.Equal(SByteMaxValuePlusOne, NumberBaseHelper<Int128>.CreateTruncating<byte>(0x80));
+            Assert.Equal(ByteMaxValue, NumberBaseHelper<Int128>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<Int128>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<Int128>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<Int128>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<Int128>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<Int128>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<Int128>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromDecimalTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<decimal>(decimal.Zero));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<decimal>(decimal.Zero));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<decimal>(decimal.One));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateTruncating<decimal>(decimal.MinusOne));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<decimal>(decimal.One));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<decimal>(decimal.MinusOne));
 
-            Assert.Equal(new Int128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberHelper<Int128>.CreateTruncating<decimal>(decimal.MaxValue));
-            Assert.Equal(new Int128(0xFFFF_FFFF_0000_0000, 0x0000_0000_0000_0001), NumberHelper<Int128>.CreateTruncating<decimal>(decimal.MinValue));
+            Assert.Equal(new Int128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberBaseHelper<Int128>.CreateTruncating<decimal>(decimal.MaxValue));
+            Assert.Equal(new Int128(0xFFFF_FFFF_0000_0000, 0x0000_0000_0000_0001), NumberBaseHelper<Int128>.CreateTruncating<decimal>(decimal.MinValue));
         }
 
         [Fact]
         public static void CreateTruncatingFromDoubleTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<double>(+0.0));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<double>(-0.0));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<double>(+0.0));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<double>(-0.0));
 
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<double>(+double.Epsilon));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<double>(-double.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<double>(+double.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<double>(-double.Epsilon));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<double>(+1.0));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateTruncating<double>(-1.0));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<double>(+1.0));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<double>(-1.0));
 
-            Assert.Equal(new Int128(0x7FFF_FFFF_FFFF_FC00, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateTruncating<double>(+170141183460469212842221372237303250944.0));
-            Assert.Equal(new Int128(0x8000_0000_0000_0400, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateTruncating<double>(-170141183460469212842221372237303250944.0));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateTruncating<double>(-170141183460469231731687303715884105728.0));
+            Assert.Equal(new Int128(0x7FFF_FFFF_FFFF_FC00, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateTruncating<double>(+170141183460469212842221372237303250944.0));
+            Assert.Equal(new Int128(0x8000_0000_0000_0400, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateTruncating<double>(-170141183460469212842221372237303250944.0));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateTruncating<double>(-170141183460469231731687303715884105728.0));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateTruncating<double>(+170141183460469231731687303715884105728.0));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateTruncating<double>(-170141183460469269510619166673045815296.0));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateTruncating<double>(+170141183460469231731687303715884105728.0));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateTruncating<double>(-170141183460469269510619166673045815296.0));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateTruncating<double>(double.MaxValue));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateTruncating<double>(double.MinValue));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateTruncating<double>(double.MaxValue));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateTruncating<double>(double.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateTruncating<double>(double.PositiveInfinity));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateTruncating<double>(double.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateTruncating<double>(double.PositiveInfinity));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateTruncating<double>(double.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateTruncatingFromHalfTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<Half>((Half)(+0.0)));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<Half>((Half)(-0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<Half>((Half)(+0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<Half>((Half)(-0.0)));
 
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<Half>(+Half.Epsilon));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<Half>(-Half.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<Half>(+Half.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<Half>(-Half.Epsilon));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<Half>((Half)(+1.0)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateTruncating<Half>((Half)(-1.0)));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<Half>((Half)(+1.0)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<Half>((Half)(-1.0)));
 
-            Assert.Equal(+65504, NumberHelper<Int128>.CreateTruncating<Half>(Half.MaxValue));
-            Assert.Equal(-65504, NumberHelper<Int128>.CreateTruncating<Half>(Half.MinValue));
+            Assert.Equal(+65504, NumberBaseHelper<Int128>.CreateTruncating<Half>(Half.MaxValue));
+            Assert.Equal(-65504, NumberBaseHelper<Int128>.CreateTruncating<Half>(Half.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateTruncating<Half>(Half.PositiveInfinity));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateTruncating<Half>(Half.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateTruncating<Half>(Half.PositiveInfinity));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateTruncating<Half>(Half.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<short>(0x0000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<short>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<Int128>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal(Int16MinValue, NumberHelper<Int128>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<short>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<short>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<Int128>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal(Int16MinValue, NumberBaseHelper<Int128>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<int>(0x00000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<int>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal(Int32MinValue, NumberHelper<Int128>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<int>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<int>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal(Int32MinValue, NumberBaseHelper<Int128>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MinValue, NumberHelper<Int128>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MinValue, NumberBaseHelper<Int128>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -1134,86 +1134,86 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MinValue, NumberHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MinValue, NumberBaseHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(Int32MinValue, NumberHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(Int32MinValue, NumberBaseHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<Int128>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal(SByteMinValue, NumberHelper<Int128>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<Int128>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal(SByteMinValue, NumberBaseHelper<Int128>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromSingleTest()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<float>(+0.0f));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<float>(-0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<float>(+0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<float>(-0.0f));
 
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<float>(+float.Epsilon));
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<float>(-float.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<float>(+float.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<float>(-float.Epsilon));
 
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<float>(+1.0f));
-            Assert.Equal(NegativeOne, NumberHelper<Int128>.CreateTruncating<float>(-1.0f));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<float>(+1.0f));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<float>(-1.0f));
 
-            Assert.Equal(new Int128(0x7FFF_FF80_0000_0000, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateTruncating<float>(+170141173319264429905852091742258462720.0f));
-            Assert.Equal(new Int128(0x8000_0080_0000_0000, 0x0000_0000_0000_0000), NumberHelper<Int128>.CreateTruncating<float>(-170141173319264429905852091742258462720.0f));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateTruncating<float>(-170141183460469231731687303715884105728.0f));
+            Assert.Equal(new Int128(0x7FFF_FF80_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateTruncating<float>(+170141173319264429905852091742258462720.0f));
+            Assert.Equal(new Int128(0x8000_0080_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<Int128>.CreateTruncating<float>(-170141173319264429905852091742258462720.0f));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateTruncating<float>(-170141183460469231731687303715884105728.0f));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateTruncating<float>(+170141183460469231731687303715884105728.0f));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateTruncating<float>(-170141203742878835383357727663135391744.0f));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateTruncating<float>(+170141183460469231731687303715884105728.0f));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateTruncating<float>(-170141203742878835383357727663135391744.0f));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateTruncating<float>(float.MaxValue));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateTruncating<float>(float.MinValue));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateTruncating<float>(float.MaxValue));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateTruncating<float>(float.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<Int128>.CreateTruncating<float>(float.PositiveInfinity));
-            Assert.Equal(MinValue, NumberHelper<Int128>.CreateTruncating<float>(float.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.CreateTruncating<float>(float.PositiveInfinity));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.CreateTruncating<float>(float.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<Int128>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<Int128>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<Int128>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<Int128>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<Int128>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<Int128>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal(Int32MaxValuePlusOne, NumberHelper<Int128>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal(UInt32MaxValue, NumberHelper<Int128>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<Int128>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal(UInt32MaxValue, NumberBaseHelper<Int128>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<Int128>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal(UInt64MaxValue, NumberHelper<Int128>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<Int128>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<Int128>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -1221,19 +1221,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<Int128>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MaxValuePlusOne, NumberHelper<Int128>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(UInt64MaxValue, NumberHelper<Int128>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<Int128>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<Int128>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(UInt64MaxValue, NumberBaseHelper<Int128>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<Int128>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal(One, NumberHelper<Int128>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<Int128>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(Int32MaxValuePlusOne, NumberHelper<Int128>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal(UInt32MaxValue, NumberHelper<Int128>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<Int128>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<Int128>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal(UInt32MaxValue, NumberBaseHelper<Int128>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -1242,19 +1242,19 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<byte>(0x00, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<byte>(0x01, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<byte>(0x7F, out result));
             Assert.Equal(SByteMaxValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<byte>(0x80, out result));
             Assert.Equal(SByteMaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<byte>(0xFF, out result));
             Assert.Equal(ByteMaxValue, result);
         }
 
@@ -1263,19 +1263,19 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal(Int16MaxValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal(Int16MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal(UInt16MaxValue, result);
         }
 
@@ -1284,19 +1284,19 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<decimal>(decimal.Zero, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<decimal>(decimal.Zero, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<decimal>(decimal.One, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<decimal>(decimal.One, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<decimal>(decimal.MinusOne, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<decimal>(decimal.MinusOne, out result));
             Assert.Equal(NegativeOne, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<decimal>(decimal.MaxValue, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<decimal>(decimal.MaxValue, out result));
             Assert.Equal(new Int128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<decimal>(decimal.MinValue, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<decimal>(decimal.MinValue, out result));
             Assert.Equal(new Int128(0xFFFF_FFFF_0000_0000, 0x0000_0000_0000_0001), result);
         }
 
@@ -1305,49 +1305,49 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<double>(+0.0, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<double>(+0.0, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<double>(-0.0, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<double>(-0.0, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<double>(+double.Epsilon, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<double>(+double.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<double>(-double.Epsilon, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<double>(-double.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<double>(+1.0, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<double>(+1.0, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<double>(-1.0, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<double>(-1.0, out result));
             Assert.Equal(NegativeOne, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<double>(+170141183460469212842221372237303250944.0, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<double>(+170141183460469212842221372237303250944.0, out result));
             Assert.Equal(new Int128(0x7FFF_FFFF_FFFF_FC00, 0x0000_0000_0000_0000), result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<double>(-170141183460469212842221372237303250944.0, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<double>(-170141183460469212842221372237303250944.0, out result));
             Assert.Equal(new Int128(0x8000_0000_0000_0400, 0x0000_0000_0000_0000), result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<double>(-170141183460469231731687303715884105728.0, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<double>(-170141183460469231731687303715884105728.0, out result));
             Assert.Equal(MinValue, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<double>(+170141183460469231731687303715884105728.0, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<double>(+170141183460469231731687303715884105728.0, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<double>(-170141183460469269510619166673045815296.0, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<double>(-170141183460469269510619166673045815296.0, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<double>(double.MaxValue, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<double>(double.MaxValue, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<double>(double.MinValue, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<double>(double.MinValue, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<double>(double.PositiveInfinity, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<double>(double.PositiveInfinity, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<double>(double.NegativeInfinity, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<double>(double.NegativeInfinity, out result));
             Assert.Equal(Zero, result);
         }
 
@@ -1356,34 +1356,34 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<Half>((Half)(+0.0), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<Half>((Half)(+0.0), out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<Half>((Half)(-0.0), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<Half>((Half)(-0.0), out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<Half>(+Half.Epsilon, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<Half>(+Half.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<Half>(-Half.Epsilon, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<Half>(-Half.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<Half>((Half)(+1.0), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<Half>((Half)(+1.0), out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<Half>((Half)(-1.0), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<Half>((Half)(-1.0), out result));
             Assert.Equal(NegativeOne, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<Half>(Half.MaxValue, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<Half>(Half.MaxValue, out result));
             Assert.Equal(+65504, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<Half>(Half.MinValue, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<Half>(Half.MinValue, out result));
             Assert.Equal(-65504, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<Half>(Half.PositiveInfinity, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<Half>(Half.PositiveInfinity, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<Half>(Half.NegativeInfinity, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<Half>(Half.NegativeInfinity, out result));
             Assert.Equal(Zero, result);
         }
 
@@ -1392,19 +1392,19 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<short>(0x0000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<short>(0x0001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal(Int16MaxValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal(Int16MinValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1413,19 +1413,19 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<int>(0x00000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<int>(0x00000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal(Int32MaxValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal(Int32MinValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1434,19 +1434,19 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(Int64MaxValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
             Assert.Equal(Int64MinValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1457,36 +1457,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<Int128>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(Int64MaxValue, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal(Int64MinValue, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(NegativeOne, result);
             }
             else
             {
-                Assert.True(NumberHelper<Int128>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal(Int32MaxValue, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal(Int32MinValue, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(NegativeOne, result);
             }
         }
@@ -1496,19 +1496,19 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal(SByteMaxValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal(SByteMinValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(NegativeOne, result);
         }
 
@@ -1517,49 +1517,49 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<float>(+0.0f, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<float>(+0.0f, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<float>(-0.0f, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<float>(-0.0f, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<float>(+float.Epsilon, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<float>(+float.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<float>(-float.Epsilon, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<float>(-float.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<float>(+1.0f, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<float>(+1.0f, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<float>(-1.0f, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<float>(-1.0f, out result));
             Assert.Equal(NegativeOne, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<float>(+170141173319264429905852091742258462720.0f, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<float>(+170141173319264429905852091742258462720.0f, out result));
             Assert.Equal(new Int128(0x7FFF_FF80_0000_0000, 0x0000_0000_0000_0000), result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<float>(-170141173319264429905852091742258462720.0f, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<float>(-170141173319264429905852091742258462720.0f, out result));
             Assert.Equal(new Int128(0x8000_0080_0000_0000, 0x0000_0000_0000_0000), result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<float>(-170141183460469231731687303715884105728.0f, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<float>(-170141183460469231731687303715884105728.0f, out result));
             Assert.Equal(MinValue, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<float>(+170141183460469231731687303715884105728.0f, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<float>(+170141183460469231731687303715884105728.0f, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<float>(-170141203742878835383357727663135391744.0f, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<float>(-170141203742878835383357727663135391744.0f, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<float>(float.MaxValue, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<float>(float.MaxValue, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<float>(float.MinValue, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<float>(float.MinValue, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<float>(float.PositiveInfinity, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<float>(float.PositiveInfinity, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<Int128>.TryCreate<float>(float.NegativeInfinity, out result));
+            Assert.False(NumberBaseHelper<Int128>.TryCreate<float>(float.NegativeInfinity, out result));
             Assert.Equal(Zero, result);
         }
 
@@ -1568,19 +1568,19 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal(Int16MaxValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal(Int16MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal(UInt16MaxValue, result);
         }
 
@@ -1589,19 +1589,19 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal(Int32MaxValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<uint>(0x80000000, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal(Int32MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal(UInt32MaxValue, result);
         }
 
@@ -1610,19 +1610,19 @@ namespace System.Tests
         {
             Int128 result;
 
-            Assert.True(NumberHelper<Int128>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(Int64MaxValue, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal(Int64MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<Int128>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<Int128>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal(UInt64MaxValue, result);
         }
 
@@ -1633,36 +1633,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(Int64MaxValue, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal(Int64MaxValuePlusOne, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(UInt64MaxValue, result);
             }
             else
             {
-                Assert.True(NumberHelper<Int128>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal(Int32MaxValue, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal(Int32MaxValuePlusOne, result);
 
-                Assert.True(NumberHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<Int128>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal(UInt32MaxValue, result);
             }
         }

--- a/src/libraries/System.Runtime/tests/System/Int128Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int128Tests.GenericMath.cs
@@ -545,6 +545,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal(One, NumberHelper<Int128>.MaxNumber(Zero, 1));
+            Assert.Equal(One, NumberHelper<Int128>.MaxNumber(One, 1));
+            Assert.Equal(MaxValue, NumberHelper<Int128>.MaxNumber(MaxValue, 1));
+            Assert.Equal(One, NumberHelper<Int128>.MaxNumber(MinValue, 1));
+            Assert.Equal(One, NumberHelper<Int128>.MaxNumber(NegativeOne, 1));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal(Zero, NumberHelper<Int128>.Min(Zero, 1));
@@ -552,6 +562,16 @@ namespace System.Tests
             Assert.Equal(One, NumberHelper<Int128>.Min(MaxValue, 1));
             Assert.Equal(MinValue, NumberHelper<Int128>.Min(MinValue, 1));
             Assert.Equal(NegativeOne, NumberHelper<Int128>.Min(NegativeOne, 1));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal(Zero, NumberHelper<Int128>.MinNumber(Zero, 1));
+            Assert.Equal(One, NumberHelper<Int128>.MinNumber(One, 1));
+            Assert.Equal(One, NumberHelper<Int128>.MinNumber(MaxValue, 1));
+            Assert.Equal(MinValue, NumberHelper<Int128>.MinNumber(MinValue, 1));
+            Assert.Equal(NegativeOne, NumberHelper<Int128>.MinNumber(NegativeOne, 1));
         }
 
         [Fact]
@@ -1235,6 +1255,126 @@ namespace System.Tests
                 Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<Int128>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal(UInt32MaxValue, NumberBaseHelper<Int128>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<Int128>.IsFinite(Zero));
+            Assert.True(NumberBaseHelper<Int128>.IsFinite(One));
+            Assert.True(NumberBaseHelper<Int128>.IsFinite(MaxValue));
+            Assert.True(NumberBaseHelper<Int128>.IsFinite(MinValue));
+            Assert.True(NumberBaseHelper<Int128>.IsFinite(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<Int128>.IsInfinity(Zero));
+            Assert.False(NumberBaseHelper<Int128>.IsInfinity(One));
+            Assert.False(NumberBaseHelper<Int128>.IsInfinity(MaxValue));
+            Assert.False(NumberBaseHelper<Int128>.IsInfinity(MinValue));
+            Assert.False(NumberBaseHelper<Int128>.IsInfinity(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<Int128>.IsNaN(Zero));
+            Assert.False(NumberBaseHelper<Int128>.IsNaN(One));
+            Assert.False(NumberBaseHelper<Int128>.IsNaN(MaxValue));
+            Assert.False(NumberBaseHelper<Int128>.IsNaN(MinValue));
+            Assert.False(NumberBaseHelper<Int128>.IsNaN(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<Int128>.IsNegative(Zero));
+            Assert.False(NumberBaseHelper<Int128>.IsNegative(One));
+            Assert.False(NumberBaseHelper<Int128>.IsNegative(MaxValue));
+            Assert.True(NumberBaseHelper<Int128>.IsNegative(MinValue));
+            Assert.True(NumberBaseHelper<Int128>.IsNegative(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<Int128>.IsNegativeInfinity(Zero));
+            Assert.False(NumberBaseHelper<Int128>.IsNegativeInfinity(One));
+            Assert.False(NumberBaseHelper<Int128>.IsNegativeInfinity(MaxValue));
+            Assert.False(NumberBaseHelper<Int128>.IsNegativeInfinity(MinValue));
+            Assert.False(NumberBaseHelper<Int128>.IsNegativeInfinity(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<Int128>.IsNormal(Zero));
+            Assert.True(NumberBaseHelper<Int128>.IsNormal(One));
+            Assert.True(NumberBaseHelper<Int128>.IsNormal(MaxValue));
+            Assert.True(NumberBaseHelper<Int128>.IsNormal(MinValue));
+            Assert.True(NumberBaseHelper<Int128>.IsNormal(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<Int128>.IsPositiveInfinity(Zero));
+            Assert.False(NumberBaseHelper<Int128>.IsPositiveInfinity(One));
+            Assert.False(NumberBaseHelper<Int128>.IsPositiveInfinity(MaxValue));
+            Assert.False(NumberBaseHelper<Int128>.IsPositiveInfinity(MinValue));
+            Assert.False(NumberBaseHelper<Int128>.IsPositiveInfinity(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<Int128>.IsSubnormal(Zero));
+            Assert.False(NumberBaseHelper<Int128>.IsSubnormal(One));
+            Assert.False(NumberBaseHelper<Int128>.IsSubnormal(MaxValue));
+            Assert.False(NumberBaseHelper<Int128>.IsSubnormal(MinValue));
+            Assert.False(NumberBaseHelper<Int128>.IsSubnormal(NegativeOne));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal(One, NumberBaseHelper<Int128>.MaxMagnitude(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<Int128>.MaxMagnitude(One, 1));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.MaxMagnitude(MaxValue, 1));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.MaxMagnitude(MinValue, 1));
+            Assert.Equal(One, NumberBaseHelper<Int128>.MaxMagnitude(NegativeOne, 1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal(One, NumberBaseHelper<Int128>.MaxMagnitudeNumber(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<Int128>.MaxMagnitudeNumber(One, 1));
+            Assert.Equal(MaxValue, NumberBaseHelper<Int128>.MaxMagnitudeNumber(MaxValue, 1));
+            Assert.Equal(MinValue, NumberBaseHelper<Int128>.MaxMagnitudeNumber(MinValue, 1));
+            Assert.Equal(One, NumberBaseHelper<Int128>.MaxMagnitudeNumber(NegativeOne, 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.MinMagnitude(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<Int128>.MinMagnitude(One, 1));
+            Assert.Equal(One, NumberBaseHelper<Int128>.MinMagnitude(MaxValue, 1));
+            Assert.Equal(One, NumberBaseHelper<Int128>.MinMagnitude(MinValue, 1));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.MinMagnitude(NegativeOne, 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal(Zero, NumberBaseHelper<Int128>.MinMagnitudeNumber(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<Int128>.MinMagnitudeNumber(One, 1));
+            Assert.Equal(One, NumberBaseHelper<Int128>.MinMagnitudeNumber(MaxValue, 1));
+            Assert.Equal(One, NumberBaseHelper<Int128>.MinMagnitudeNumber(MinValue, 1));
+            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.MinMagnitudeNumber(NegativeOne, 1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
@@ -8,47 +8,9 @@ namespace System.Tests
 {
     public class Int16Tests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal((short)0x0000, AdditiveIdentityHelper<short, short>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            Assert.Equal(unchecked((short)0x8000), MinMaxValueHelper<short>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            Assert.Equal((short)0x7FFF, MinMaxValueHelper<short>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal((short)0x0001, MultiplicativeIdentityHelper<short, short>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            Assert.Equal(unchecked((short)0xFFFF), SignedNumberHelper<short>.NegativeOne);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal((short)0x0001, NumberBaseHelper<short>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal((short)0x0000, NumberBaseHelper<short>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -69,6 +31,30 @@ namespace System.Tests
             Assert.Equal((short)0x0000, AdditionOperatorsHelper<short, short, short>.op_CheckedAddition(unchecked((short)0xFFFF), (short)1));
 
             Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<short, short, short>.op_CheckedAddition((short)0x7FFF, (short)1));
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal((short)0x0000, AdditiveIdentityHelper<short, short>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            Assert.Equal(((short)0x0000, (short)0x0000), BinaryIntegerHelper<short>.DivRem((short)0x0000, (short)2));
+            Assert.Equal(((short)0x0000, (short)0x0001), BinaryIntegerHelper<short>.DivRem((short)0x0001, (short)2));
+            Assert.Equal(((short)0x3FFF, (short)0x0001), BinaryIntegerHelper<short>.DivRem((short)0x7FFF, (short)2));
+            Assert.Equal((unchecked((short)0xC000), (short)0x0000), BinaryIntegerHelper<short>.DivRem(unchecked((short)0x8000), (short)2));
+            Assert.Equal(((short)0x0000, unchecked((short)0xFFFF)), BinaryIntegerHelper<short>.DivRem(unchecked((short)0xFFFF), (short)2));
         }
 
         [Fact]
@@ -122,6 +108,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            Assert.Equal(2, BinaryIntegerHelper<short>.GetByteCount((short)0x0000));
+            Assert.Equal(2, BinaryIntegerHelper<short>.GetByteCount((short)0x0001));
+            Assert.Equal(2, BinaryIntegerHelper<short>.GetByteCount((short)0x7FFF));
+            Assert.Equal(2, BinaryIntegerHelper<short>.GetByteCount(unchecked((short)0x8000)));
+            Assert.Equal(2, BinaryIntegerHelper<short>.GetByteCount(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             Assert.Equal(0x00, BinaryIntegerHelper<short>.GetShortestBitLength((short)0x0000));
@@ -130,6 +126,72 @@ namespace System.Tests
             Assert.Equal(0x10, BinaryIntegerHelper<short>.GetShortestBitLength(unchecked((short)0x8000)));
             Assert.Equal(0x01, BinaryIntegerHelper<short>.GetShortestBitLength(unchecked((short)0xFFFF)));
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[2];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<short>.TryWriteBigEndian((short)0x0000, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<short>.TryWriteBigEndian((short)0x0001, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x01 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<short>.TryWriteBigEndian((short)0x7FFF, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F, 0xFF }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<short>.TryWriteBigEndian(unchecked((short)0x8000), destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<short>.TryWriteBigEndian(unchecked((short)0xFFFF), destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<short>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[2];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<short>.TryWriteLittleEndian((short)0x0000, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<short>.TryWriteLittleEndian((short)0x0001, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<short>.TryWriteLittleEndian((short)0x7FFF, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0x7F }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<short>.TryWriteLittleEndian(unchecked((short)0x8000), destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x80 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<short>.TryWriteLittleEndian(unchecked((short)0xFFFF), destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<short>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -150,6 +212,10 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => BinaryNumberHelper<short>.Log2(unchecked((short)0x8000)));
             Assert.Throws<ArgumentOutOfRangeException>(() => BinaryNumberHelper<short>.Log2(unchecked((short)0xFFFF)));
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -191,25 +257,9 @@ namespace System.Tests
             Assert.Equal((short)0x0000, BitwiseOperatorsHelper<short, short, short>.op_OnesComplement(unchecked((short)0xFFFF)));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThan((short)0x0000, (short)1));
-            Assert.False(ComparisonOperatorsHelper<short, short>.op_LessThan((short)0x0001, (short)1));
-            Assert.False(ComparisonOperatorsHelper<short, short>.op_LessThan((short)0x7FFF, (short)1));
-            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThan(unchecked((short)0x8000), (short)1));
-            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThan(unchecked((short)0xFFFF), (short)1));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThanOrEqual((short)0x0000, (short)1));
-            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThanOrEqual((short)0x0001, (short)1));
-            Assert.False(ComparisonOperatorsHelper<short, short>.op_LessThanOrEqual((short)0x7FFF, (short)1));
-            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThanOrEqual(unchecked((short)0x8000), (short)1));
-            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThanOrEqual(unchecked((short)0xFFFF), (short)1));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -232,6 +282,30 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThan((short)0x0000, (short)1));
+            Assert.False(ComparisonOperatorsHelper<short, short>.op_LessThan((short)0x0001, (short)1));
+            Assert.False(ComparisonOperatorsHelper<short, short>.op_LessThan((short)0x7FFF, (short)1));
+            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThan(unchecked((short)0x8000), (short)1));
+            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThan(unchecked((short)0xFFFF), (short)1));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThanOrEqual((short)0x0000, (short)1));
+            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThanOrEqual((short)0x0001, (short)1));
+            Assert.False(ComparisonOperatorsHelper<short, short>.op_LessThanOrEqual((short)0x7FFF, (short)1));
+            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThanOrEqual(unchecked((short)0x8000), (short)1));
+            Assert.True(ComparisonOperatorsHelper<short, short>.op_LessThanOrEqual(unchecked((short)0xFFFF), (short)1));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             Assert.Equal(unchecked((short)0xFFFF), DecrementOperatorsHelper<short>.op_Decrement((short)0x0000));
@@ -251,6 +325,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<short>.op_CheckedDecrement(unchecked((short)0x8000)));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -276,6 +354,10 @@ namespace System.Tests
             Assert.Throws<DivideByZeroException>(() => DivisionOperatorsHelper<short, short, short>.op_CheckedDivision((short)0x0001, (short)0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -295,6 +377,10 @@ namespace System.Tests
             Assert.True(EqualityOperatorsHelper<short, short>.op_Inequality(unchecked((short)0x8000), (short)1));
             Assert.True(EqualityOperatorsHelper<short, short>.op_Inequality(unchecked((short)0xFFFF), (short)1));
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -317,6 +403,26 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<short>.op_CheckedIncrement((short)0x7FFF));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            Assert.Equal((short)0x7FFF, MinMaxValueHelper<short>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal(unchecked((short)0x8000), MinMaxValueHelper<short>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -328,6 +434,20 @@ namespace System.Tests
 
             Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<short, short, short>.op_Modulus((short)0x0001, (short)0));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal((short)0x0001, MultiplicativeIdentityHelper<short, short>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -350,15 +470,9 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<short, short, short>.op_CheckedMultiply(unchecked((short)0x8000), (short)2));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            Assert.Equal((short)0x0000, NumberBaseHelper<short>.Abs((short)0x0000));
-            Assert.Equal((short)0x0001, NumberBaseHelper<short>.Abs((short)0x0001));
-            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.Abs((short)0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.Abs(unchecked((short)0x8000)));
-            Assert.Equal((short)0x0001, NumberBaseHelper<short>.Abs(unchecked((short)0xFFFF)));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -368,6 +482,62 @@ namespace System.Tests
             Assert.Equal((short)0x003F, NumberHelper<short>.Clamp((short)0x7FFF, unchecked((short)0xFFC0), (short)0x003F));
             Assert.Equal(unchecked((short)0xFFC0), NumberHelper<short>.Clamp(unchecked((short)0x8000), unchecked((short)0xFFC0), (short)0x003F));
             Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.Clamp(unchecked((short)0xFFFF), unchecked((short)0xFFC0), (short)0x003F));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal((short)0x0001, NumberHelper<short>.Max((short)0x0000, (short)1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.Max((short)0x0001, (short)1));
+            Assert.Equal((short)0x7FFF, NumberHelper<short>.Max((short)0x7FFF, (short)1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.Max(unchecked((short)0x8000), (short)1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.Max(unchecked((short)0xFFFF), (short)1));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal((short)0x0000, NumberHelper<short>.Min((short)0x0000, (short)1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.Min((short)0x0001, (short)1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.Min((short)0x7FFF, (short)1));
+            Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.Min(unchecked((short)0x8000), (short)1));
+            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.Min(unchecked((short)0xFFFF), (short)1));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(0, NumberHelper<short>.Sign((short)0x0000));
+            Assert.Equal(1, NumberHelper<short>.Sign((short)0x0001));
+            Assert.Equal(1, NumberHelper<short>.Sign((short)0x7FFF));
+            Assert.Equal(-1, NumberHelper<short>.Sign(unchecked((short)0x8000)));
+            Assert.Equal(-1, NumberHelper<short>.Sign(unchecked((short)0xFFFF)));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.Abs((short)0x0000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.Abs((short)0x0001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.Abs((short)0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.Abs(unchecked((short)0x8000)));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.Abs(unchecked((short)0xFFFF)));
         }
 
         [Fact]
@@ -767,46 +937,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            Assert.Equal(((short)0x0000, (short)0x0000), BinaryIntegerHelper<short>.DivRem((short)0x0000, (short)2));
-            Assert.Equal(((short)0x0000, (short)0x0001), BinaryIntegerHelper<short>.DivRem((short)0x0001, (short)2));
-            Assert.Equal(((short)0x3FFF, (short)0x0001), BinaryIntegerHelper<short>.DivRem((short)0x7FFF, (short)2));
-            Assert.Equal((unchecked((short)0xC000), (short)0x0000), BinaryIntegerHelper<short>.DivRem(unchecked((short)0x8000), (short)2));
-            Assert.Equal(((short)0x0000, unchecked((short)0xFFFF)), BinaryIntegerHelper<short>.DivRem(unchecked((short)0xFFFF), (short)2));
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            Assert.Equal((short)0x0001, NumberHelper<short>.Max((short)0x0000, (short)1));
-            Assert.Equal((short)0x0001, NumberHelper<short>.Max((short)0x0001, (short)1));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.Max((short)0x7FFF, (short)1));
-            Assert.Equal((short)0x0001, NumberHelper<short>.Max(unchecked((short)0x8000), (short)1));
-            Assert.Equal((short)0x0001, NumberHelper<short>.Max(unchecked((short)0xFFFF), (short)1));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            Assert.Equal((short)0x0000, NumberHelper<short>.Min((short)0x0000, (short)1));
-            Assert.Equal((short)0x0001, NumberHelper<short>.Min((short)0x0001, (short)1));
-            Assert.Equal((short)0x0001, NumberHelper<short>.Min((short)0x7FFF, (short)1));
-            Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.Min(unchecked((short)0x8000), (short)1));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.Min(unchecked((short)0xFFFF), (short)1));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(0, NumberHelper<short>.Sign((short)0x0000));
-            Assert.Equal(1, NumberHelper<short>.Sign((short)0x0001));
-            Assert.Equal(1, NumberHelper<short>.Sign((short)0x7FFF));
-            Assert.Equal(-1, NumberHelper<short>.Sign(unchecked((short)0x8000)));
-            Assert.Equal(-1, NumberHelper<short>.Sign(unchecked((short)0xFFFF)));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             short result;
@@ -1077,77 +1207,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            Assert.Equal(2, BinaryIntegerHelper<short>.GetByteCount((short)0x0000));
-            Assert.Equal(2, BinaryIntegerHelper<short>.GetByteCount((short)0x0001));
-            Assert.Equal(2, BinaryIntegerHelper<short>.GetByteCount((short)0x7FFF));
-            Assert.Equal(2, BinaryIntegerHelper<short>.GetByteCount(unchecked((short)0x8000)));
-            Assert.Equal(2, BinaryIntegerHelper<short>.GetByteCount(unchecked((short)0xFFFF)));
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[2];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<short>.TryWriteBigEndian((short)0x0000, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<short>.TryWriteBigEndian((short)0x0001, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x01 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<short>.TryWriteBigEndian((short)0x7FFF, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F, 0xFF }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<short>.TryWriteBigEndian(unchecked((short)0x8000), destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<short>.TryWriteBigEndian(unchecked((short)0xFFFF), destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<short>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[2];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<short>.TryWriteLittleEndian((short)0x0000, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<short>.TryWriteLittleEndian((short)0x0001, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<short>.TryWriteLittleEndian((short)0x7FFF, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0x7F }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<short>.TryWriteLittleEndian(unchecked((short)0x8000), destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x80 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<short>.TryWriteLittleEndian(unchecked((short)0xFFFF), destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<short>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1179,6 +1241,20 @@ namespace System.Tests
             Assert.Equal((short)0x7FFF, ShiftOperatorsHelper<short, short>.op_UnsignedRightShift(unchecked((short)0xFFFF), 1));
         }
 
+        //
+        // ISignedNumber
+        //
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(unchecked((short)0xFFFF), SignedNumberHelper<short>.NegativeOne);
+        }
+
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1199,6 +1275,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<short, short, short>.op_CheckedSubtraction(unchecked((short)0x8000), (short)1));
         }
+
+        //
+        // IUnaryNegationOperators
+        //
 
         [Fact]
         public static void op_UnaryNegationTest()
@@ -1221,6 +1301,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => UnaryNegationOperatorsHelper<short, short>.op_CheckedUnaryNegation(unchecked((short)0x8000)));
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1230,6 +1314,10 @@ namespace System.Tests
             Assert.Equal(unchecked((short)0x8000), UnaryPlusOperatorsHelper<short, short>.op_UnaryPlus(unchecked((short)0x8000)));
             Assert.Equal(unchecked((short)0xFFFF), UnaryPlusOperatorsHelper<short, short>.op_UnaryPlus(unchecked((short)0xFFFF)));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(Int16Tests.Parse_Valid_TestData), MemberType = typeof(Int16Tests))]

--- a/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
@@ -495,6 +495,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal((short)0x0001, NumberHelper<short>.MaxNumber((short)0x0000, (short)1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.MaxNumber((short)0x0001, (short)1));
+            Assert.Equal((short)0x7FFF, NumberHelper<short>.MaxNumber((short)0x7FFF, (short)1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.MaxNumber(unchecked((short)0x8000), (short)1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.MaxNumber(unchecked((short)0xFFFF), (short)1));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal((short)0x0000, NumberHelper<short>.Min((short)0x0000, (short)1));
@@ -502,6 +512,16 @@ namespace System.Tests
             Assert.Equal((short)0x0001, NumberHelper<short>.Min((short)0x7FFF, (short)1));
             Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.Min(unchecked((short)0x8000), (short)1));
             Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.Min(unchecked((short)0xFFFF), (short)1));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal((short)0x0000, NumberHelper<short>.MinNumber((short)0x0000, (short)1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.MinNumber((short)0x0001, (short)1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.MinNumber((short)0x7FFF, (short)1));
+            Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.MinNumber(unchecked((short)0x8000), (short)1));
+            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.MinNumber(unchecked((short)0xFFFF), (short)1));
         }
 
         [Fact]
@@ -934,6 +954,126 @@ namespace System.Tests
                 Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<short>.IsFinite((short)0x0000));
+            Assert.True(NumberBaseHelper<short>.IsFinite((short)0x0001));
+            Assert.True(NumberBaseHelper<short>.IsFinite((short)0x7FFF));
+            Assert.True(NumberBaseHelper<short>.IsFinite(unchecked((short)0x8000)));
+            Assert.True(NumberBaseHelper<short>.IsFinite(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<short>.IsInfinity((short)0x0000));
+            Assert.False(NumberBaseHelper<short>.IsInfinity((short)0x0001));
+            Assert.False(NumberBaseHelper<short>.IsInfinity((short)0x7FFF));
+            Assert.False(NumberBaseHelper<short>.IsInfinity(unchecked((short)0x8000)));
+            Assert.False(NumberBaseHelper<short>.IsInfinity(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<short>.IsNaN((short)0x0000));
+            Assert.False(NumberBaseHelper<short>.IsNaN((short)0x0001));
+            Assert.False(NumberBaseHelper<short>.IsNaN((short)0x7FFF));
+            Assert.False(NumberBaseHelper<short>.IsNaN(unchecked((short)0x8000)));
+            Assert.False(NumberBaseHelper<short>.IsNaN(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<short>.IsNegative((short)0x0000));
+            Assert.False(NumberBaseHelper<short>.IsNegative((short)0x0001));
+            Assert.False(NumberBaseHelper<short>.IsNegative((short)0x7FFF));
+            Assert.True(NumberBaseHelper<short>.IsNegative(unchecked((short)0x8000)));
+            Assert.True(NumberBaseHelper<short>.IsNegative(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<short>.IsNegativeInfinity((short)0x0000));
+            Assert.False(NumberBaseHelper<short>.IsNegativeInfinity((short)0x0001));
+            Assert.False(NumberBaseHelper<short>.IsNegativeInfinity((short)0x7FFF));
+            Assert.False(NumberBaseHelper<short>.IsNegativeInfinity(unchecked((short)0x8000)));
+            Assert.False(NumberBaseHelper<short>.IsNegativeInfinity(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<short>.IsNormal((short)0x0000));
+            Assert.True(NumberBaseHelper<short>.IsNormal((short)0x0001));
+            Assert.True(NumberBaseHelper<short>.IsNormal((short)0x7FFF));
+            Assert.True(NumberBaseHelper<short>.IsNormal(unchecked((short)0x8000)));
+            Assert.True(NumberBaseHelper<short>.IsNormal(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<short>.IsPositiveInfinity((short)0x0000));
+            Assert.False(NumberBaseHelper<short>.IsPositiveInfinity((short)0x0001));
+            Assert.False(NumberBaseHelper<short>.IsPositiveInfinity((short)0x7FFF));
+            Assert.False(NumberBaseHelper<short>.IsPositiveInfinity(unchecked((short)0x8000)));
+            Assert.False(NumberBaseHelper<short>.IsPositiveInfinity(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<short>.IsSubnormal((short)0x0000));
+            Assert.False(NumberBaseHelper<short>.IsSubnormal((short)0x0001));
+            Assert.False(NumberBaseHelper<short>.IsSubnormal((short)0x7FFF));
+            Assert.False(NumberBaseHelper<short>.IsSubnormal(unchecked((short)0x8000)));
+            Assert.False(NumberBaseHelper<short>.IsSubnormal(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MaxMagnitude((short)0x0000, (short)1));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MaxMagnitude((short)0x0001, (short)1));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.MaxMagnitude((short)0x7FFF, (short)1));
+            Assert.Equal(unchecked((short)0x8000), NumberBaseHelper<short>.MaxMagnitude(unchecked((short)0x8000), (short)1));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MaxMagnitude(unchecked((short)0xFFFF), (short)1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MaxMagnitudeNumber((short)0x0000, (short)1));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MaxMagnitudeNumber((short)0x0001, (short)1));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.MaxMagnitudeNumber((short)0x7FFF, (short)1));
+            Assert.Equal(unchecked((short)0x8000), NumberBaseHelper<short>.MaxMagnitudeNumber(unchecked((short)0x8000), (short)1));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MaxMagnitudeNumber(unchecked((short)0xFFFF), (short)1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.MinMagnitude((short)0x0000, (short)1));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MinMagnitude((short)0x0001, (short)1));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MinMagnitude((short)0x7FFF, (short)1));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MinMagnitude(unchecked((short)0x8000), (short)1));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.MinMagnitude(unchecked((short)0xFFFF), (short)1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.MinMagnitudeNumber((short)0x0000, (short)1));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MinMagnitudeNumber((short)0x0001, (short)1));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MinMagnitudeNumber((short)0x7FFF, (short)1));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.MinMagnitudeNumber(unchecked((short)0x8000), (short)1));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.MinMagnitudeNumber(unchecked((short)0xFFFF), (short)1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
@@ -353,11 +353,11 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.Abs((short)0x0000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.Abs((short)0x0001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.Abs((short)0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.Abs(unchecked((short)0x8000)));
-            Assert.Equal((short)0x0001, NumberHelper<short>.Abs(unchecked((short)0xFFFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.Abs((short)0x0000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.Abs((short)0x0001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.Abs((short)0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.Abs(unchecked((short)0x8000)));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.Abs(unchecked((short)0xFFFF)));
         }
 
         [Fact]
@@ -373,51 +373,51 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<byte>(0x00));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<byte>(0x01));
-            Assert.Equal((short)0x007F, NumberHelper<short>.CreateChecked<byte>(0x7F));
-            Assert.Equal((short)0x0080, NumberHelper<short>.CreateChecked<byte>(0x80));
-            Assert.Equal((short)0x00FF, NumberHelper<short>.CreateChecked<byte>(0xFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<byte>(0x00));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<byte>(0x01));
+            Assert.Equal((short)0x007F, NumberBaseHelper<short>.CreateChecked<byte>(0x7F));
+            Assert.Equal((short)0x0080, NumberBaseHelper<short>.CreateChecked<byte>(0x80));
+            Assert.Equal((short)0x00FF, NumberBaseHelper<short>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<char>((char)0x0000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<char>((char)0x0001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateChecked<char>((char)0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<char>((char)0x8000));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<char>((char)0x0000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<char>((char)0x0001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateChecked<char>((char)0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<char>((char)0x8000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<short>(0x0000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<short>(0x0001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateChecked<short>(0x7FFF));
-            Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<short>(0x0000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<short>(0x0001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateChecked<short>(0x7FFF));
+            Assert.Equal(unchecked((short)0x8000), NumberBaseHelper<short>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<int>(0x00000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<int>(0x00000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<int>(0x00000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<int>(0x00000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<long>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<long>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -425,60 +425,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<sbyte>(0x00));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<sbyte>(0x01));
-            Assert.Equal((short)0x007F, NumberHelper<short>.CreateChecked<sbyte>(0x7F));
-            Assert.Equal(unchecked((short)0xFF80), NumberHelper<short>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<sbyte>(0x00));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<sbyte>(0x01));
+            Assert.Equal((short)0x007F, NumberBaseHelper<short>.CreateChecked<sbyte>(0x7F));
+            Assert.Equal(unchecked((short)0xFF80), NumberBaseHelper<short>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<ushort>(0x0000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<ushort>(0x0001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateChecked<ushort>(0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<ushort>(0x8000));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<ushort>(0x0000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<ushort>(0x0001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateChecked<ushort>(0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<ushort>(0x8000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<uint>(0x00000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<uint>(0x00000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<uint>(0x80000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<uint>(0x00000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<uint>(0x00000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<uint>(0x80000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -486,70 +486,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Throws<OverflowException>(() => NumberHelper<short>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<short>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<byte>(0x00));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<byte>(0x01));
-            Assert.Equal((short)0x007F, NumberHelper<short>.CreateSaturating<byte>(0x7F));
-            Assert.Equal((short)0x0080, NumberHelper<short>.CreateSaturating<byte>(0x80));
-            Assert.Equal((short)0x00FF, NumberHelper<short>.CreateSaturating<byte>(0xFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<byte>(0x00));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<byte>(0x01));
+            Assert.Equal((short)0x007F, NumberBaseHelper<short>.CreateSaturating<byte>(0x7F));
+            Assert.Equal((short)0x0080, NumberBaseHelper<short>.CreateSaturating<byte>(0x80));
+            Assert.Equal((short)0x00FF, NumberBaseHelper<short>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<short>(0x0000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<short>(0x0001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<short>(0x0000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<short>(0x0001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal(unchecked((short)0x8000), NumberBaseHelper<short>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<int>(0x00000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<int>(0x00000001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<int>(0x00000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<int>(0x00000001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal(unchecked((short)0x8000), NumberBaseHelper<short>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(unchecked((short)0x8000), NumberBaseHelper<short>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -557,60 +557,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((short)0x8000), NumberBaseHelper<short>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(unchecked((short)0x8000), NumberBaseHelper<short>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal((short)0x007F, NumberHelper<short>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal(unchecked((short)0xFF80), NumberHelper<short>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal((short)0x007F, NumberBaseHelper<short>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal(unchecked((short)0xFF80), NumberBaseHelper<short>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -618,70 +618,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<byte>(0x00));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<byte>(0x01));
-            Assert.Equal((short)0x007F, NumberHelper<short>.CreateTruncating<byte>(0x7F));
-            Assert.Equal((short)0x0080, NumberHelper<short>.CreateTruncating<byte>(0x80));
-            Assert.Equal((short)0x00FF, NumberHelper<short>.CreateTruncating<byte>(0xFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<byte>(0x00));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<byte>(0x01));
+            Assert.Equal((short)0x007F, NumberBaseHelper<short>.CreateTruncating<byte>(0x7F));
+            Assert.Equal((short)0x0080, NumberBaseHelper<short>.CreateTruncating<byte>(0x80));
+            Assert.Equal((short)0x00FF, NumberBaseHelper<short>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal(unchecked((short)0x8000), NumberBaseHelper<short>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<short>(0x0000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<short>(0x0001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<short>(0x0000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<short>(0x0001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal(unchecked((short)0x8000), NumberBaseHelper<short>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<int>(0x00000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<int>(0x00000001));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<int>(0x00000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<int>(0x00000001));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -689,60 +689,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal((short)0x007F, NumberHelper<short>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal(unchecked((short)0xFF80), NumberHelper<short>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal((short)0x007F, NumberBaseHelper<short>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal(unchecked((short)0xFF80), NumberBaseHelper<short>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal((short)0x7FFF, NumberHelper<short>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal((short)0x7FFF, NumberBaseHelper<short>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal(unchecked((short)0x8000), NumberBaseHelper<short>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -750,19 +750,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal((short)0x0001, NumberHelper<short>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((short)0x0000, NumberHelper<short>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal((short)0x0001, NumberBaseHelper<short>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((short)0x0000, NumberBaseHelper<short>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal(unchecked((short)0xFFFF), NumberBaseHelper<short>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -811,19 +811,19 @@ namespace System.Tests
         {
             short result;
 
-            Assert.True(NumberHelper<short>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<byte>(0x00, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<byte>(0x01, out result));
             Assert.Equal((short)0x0001, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((short)0x007F, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<byte>(0x80, out result));
             Assert.Equal((short)0x0080, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((short)0x00FF, result);
         }
 
@@ -832,19 +832,19 @@ namespace System.Tests
         {
             short result;
 
-            Assert.True(NumberHelper<short>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal((short)0x0001, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((short)0x7FFF, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<char>((char)0x8000, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((short)0x0000, result);
         }
 
@@ -853,19 +853,19 @@ namespace System.Tests
         {
             short result;
 
-            Assert.True(NumberHelper<short>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<short>(0x0000, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<short>(0x0001, out result));
             Assert.Equal((short)0x0001, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((short)0x7FFF, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal(unchecked((short)0x8000), result);
 
-            Assert.True(NumberHelper<short>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(unchecked((short)0xFFFF), result);
         }
 
@@ -874,19 +874,19 @@ namespace System.Tests
         {
             short result;
 
-            Assert.True(NumberHelper<short>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<int>(0x00000000, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<int>(0x00000001, out result));
             Assert.Equal((short)0x0001, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(unchecked((short)0xFFFF), result);
         }
 
@@ -895,19 +895,19 @@ namespace System.Tests
         {
             short result;
 
-            Assert.True(NumberHelper<short>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal((short)0x0001, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
             Assert.Equal(unchecked((short)0xFFFF), result);
         }
 
@@ -918,36 +918,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<short>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<short>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.True(NumberHelper<short>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<short>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal((short)0x0001, result);
 
-                Assert.False(NumberHelper<short>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<short>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.False(NumberHelper<short>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<short>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.True(NumberHelper<short>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<short>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((short)0xFFFF), result);
             }
             else
             {
-                Assert.True(NumberHelper<short>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<short>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.True(NumberHelper<short>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<short>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal((short)0x0001, result);
 
-                Assert.False(NumberHelper<short>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.False(NumberBaseHelper<short>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.False(NumberHelper<short>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<short>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.True(NumberHelper<short>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<short>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(unchecked((short)0xFFFF), result);
             }
         }
@@ -957,19 +957,19 @@ namespace System.Tests
         {
             short result;
 
-            Assert.True(NumberHelper<short>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal((short)0x0001, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((short)0x007F, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal(unchecked((short)0xFF80), result);
 
-            Assert.True(NumberHelper<short>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(unchecked((short)0xFFFF), result);
         }
 
@@ -978,19 +978,19 @@ namespace System.Tests
         {
             short result;
 
-            Assert.True(NumberHelper<short>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal((short)0x0001, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((short)0x7FFF, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<ushort>(0x8000, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((short)0x0000, result);
         }
 
@@ -999,19 +999,19 @@ namespace System.Tests
         {
             short result;
 
-            Assert.True(NumberHelper<short>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal((short)0x0001, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<uint>(0x80000000, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal((short)0x0000, result);
         }
 
@@ -1020,19 +1020,19 @@ namespace System.Tests
         {
             short result;
 
-            Assert.True(NumberHelper<short>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.True(NumberHelper<short>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<short>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal((short)0x0001, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal((short)0x0000, result);
 
-            Assert.False(NumberHelper<short>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<short>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal((short)0x0000, result);
         }
 
@@ -1043,36 +1043,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<short>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<short>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.True(NumberHelper<short>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<short>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal((short)0x0001, result);
 
-                Assert.False(NumberHelper<short>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<short>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.False(NumberHelper<short>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<short>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.False(NumberHelper<short>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<short>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((short)0x0000, result);
             }
             else
             {
-                Assert.True(NumberHelper<short>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<short>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.True(NumberHelper<short>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<short>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal((short)0x0001, result);
 
-                Assert.False(NumberHelper<short>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.False(NumberBaseHelper<short>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.False(NumberHelper<short>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<short>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal((short)0x0000, result);
 
-                Assert.False(NumberHelper<short>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<short>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal((short)0x0000, result);
             }
         }
@@ -1248,12 +1248,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Equal(expected, NumberHelper<short>.Parse(value, style, provider));
+                Assert.Equal(expected, NumberBaseHelper<short>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.True(NumberHelper<short>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.True(NumberBaseHelper<short>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(expected, result);
-                Assert.Equal(expected, NumberHelper<short>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Equal(expected, NumberBaseHelper<short>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1263,9 +1263,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.True(NumberHelper<short>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<short>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
-            Assert.Equal(expected, NumberHelper<short>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<short>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1285,12 +1285,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<short>.Parse(value, style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<short>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.False(NumberHelper<short>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.False(NumberBaseHelper<short>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(default(short), result);
-                Assert.Throws(exceptionType, () => NumberHelper<short>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<short>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1300,9 +1300,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.False(NumberHelper<short>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<short>.TryParse(value, style, provider, out result));
             Assert.Equal(default(short), result);
-            Assert.Throws(exceptionType, () => NumberHelper<short>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<short>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1318,9 +1318,9 @@ namespace System.Tests
                 Assert.Equal(expected, result);
             }
 
-            Assert.Equal(expected, NumberHelper<short>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<short>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<short>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<short>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1342,9 +1342,9 @@ namespace System.Tests
                 Assert.Equal(default(short), result);
             }
 
-            Assert.Throws(exceptionType, () => NumberHelper<short>.Parse(value.AsSpan(), style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<short>.Parse(value.AsSpan(), style, provider));
 
-            Assert.False(NumberHelper<short>.TryParse(value.AsSpan(), style, provider, out result));
+            Assert.False(NumberBaseHelper<short>.TryParse(value.AsSpan(), style, provider, out result));
             Assert.Equal(default(short), result);
         }
     }

--- a/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
@@ -495,6 +495,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal((int)0x00000001, NumberHelper<int>.MaxNumber((int)0x00000000, 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.MaxNumber((int)0x00000001, 1));
+            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.MaxNumber((int)0x7FFFFFFF, 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.MaxNumber(unchecked((int)0x80000000), 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.MaxNumber(unchecked((int)0xFFFFFFFF), 1));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal((int)0x00000000, NumberHelper<int>.Min((int)0x00000000, 1));
@@ -502,6 +512,16 @@ namespace System.Tests
             Assert.Equal((int)0x00000001, NumberHelper<int>.Min((int)0x7FFFFFFF, 1));
             Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.Min(unchecked((int)0x80000000), 1));
             Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.Min(unchecked((int)0xFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal((int)0x00000000, NumberHelper<int>.MinNumber((int)0x00000000, 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.MinNumber((int)0x00000001, 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.MinNumber((int)0x7FFFFFFF, 1));
+            Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.MinNumber(unchecked((int)0x80000000), 1));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.MinNumber(unchecked((int)0xFFFFFFFF), 1));
         }
 
         [Fact]
@@ -934,6 +954,126 @@ namespace System.Tests
                 Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<int>.IsFinite((int)0x00000000));
+            Assert.True(NumberBaseHelper<int>.IsFinite((int)0x00000001));
+            Assert.True(NumberBaseHelper<int>.IsFinite((int)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<int>.IsFinite(unchecked((int)0x80000000)));
+            Assert.True(NumberBaseHelper<int>.IsFinite(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<int>.IsInfinity((int)0x00000000));
+            Assert.False(NumberBaseHelper<int>.IsInfinity((int)0x00000001));
+            Assert.False(NumberBaseHelper<int>.IsInfinity((int)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<int>.IsInfinity(unchecked((int)0x80000000)));
+            Assert.False(NumberBaseHelper<int>.IsInfinity(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<int>.IsNaN((int)0x00000000));
+            Assert.False(NumberBaseHelper<int>.IsNaN((int)0x00000001));
+            Assert.False(NumberBaseHelper<int>.IsNaN((int)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<int>.IsNaN(unchecked((int)0x80000000)));
+            Assert.False(NumberBaseHelper<int>.IsNaN(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<int>.IsNegative((int)0x00000000));
+            Assert.False(NumberBaseHelper<int>.IsNegative((int)0x00000001));
+            Assert.False(NumberBaseHelper<int>.IsNegative((int)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<int>.IsNegative(unchecked((int)0x80000000)));
+            Assert.True(NumberBaseHelper<int>.IsNegative(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<int>.IsNegativeInfinity((int)0x00000000));
+            Assert.False(NumberBaseHelper<int>.IsNegativeInfinity((int)0x00000001));
+            Assert.False(NumberBaseHelper<int>.IsNegativeInfinity((int)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<int>.IsNegativeInfinity(unchecked((int)0x80000000)));
+            Assert.False(NumberBaseHelper<int>.IsNegativeInfinity(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<int>.IsNormal((int)0x00000000));
+            Assert.True(NumberBaseHelper<int>.IsNormal((int)0x00000001));
+            Assert.True(NumberBaseHelper<int>.IsNormal((int)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<int>.IsNormal(unchecked((int)0x80000000)));
+            Assert.True(NumberBaseHelper<int>.IsNormal(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<int>.IsPositiveInfinity((int)0x00000000));
+            Assert.False(NumberBaseHelper<int>.IsPositiveInfinity((int)0x00000001));
+            Assert.False(NumberBaseHelper<int>.IsPositiveInfinity((int)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<int>.IsPositiveInfinity(unchecked((int)0x80000000)));
+            Assert.False(NumberBaseHelper<int>.IsPositiveInfinity(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<int>.IsSubnormal((int)0x00000000));
+            Assert.False(NumberBaseHelper<int>.IsSubnormal((int)0x00000001));
+            Assert.False(NumberBaseHelper<int>.IsSubnormal((int)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<int>.IsSubnormal(unchecked((int)0x80000000)));
+            Assert.False(NumberBaseHelper<int>.IsSubnormal(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MaxMagnitude((int)0x00000000, 1));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MaxMagnitude((int)0x00000001, 1));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.MaxMagnitude((int)0x7FFFFFFF, 1));
+            Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.MaxMagnitude(unchecked((int)0x80000000), 1));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MaxMagnitude(unchecked((int)0xFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MaxMagnitudeNumber((int)0x00000000, 1));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MaxMagnitudeNumber((int)0x00000001, 1));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.MaxMagnitudeNumber((int)0x7FFFFFFF, 1));
+            Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.MaxMagnitudeNumber(unchecked((int)0x80000000), 1));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MaxMagnitudeNumber(unchecked((int)0xFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.MinMagnitude((int)0x00000000, 1));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MinMagnitude((int)0x00000001, 1));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MinMagnitude((int)0x7FFFFFFF, 1));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MinMagnitude(unchecked((int)0x80000000), 1));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.MinMagnitude(unchecked((int)0xFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.MinMagnitudeNumber((int)0x00000000, 1));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MinMagnitudeNumber((int)0x00000001, 1));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MinMagnitudeNumber((int)0x7FFFFFFF, 1));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.MinMagnitudeNumber(unchecked((int)0x80000000), 1));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.MinMagnitudeNumber(unchecked((int)0xFFFFFFFF), 1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
@@ -353,11 +353,11 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.Abs((int)0x00000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.Abs((int)0x00000001));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.Abs((int)0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<int>.Abs(unchecked((int)0x80000000)));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.Abs(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.Abs((int)0x00000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.Abs((int)0x00000001));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.Abs((int)0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.Abs(unchecked((int)0x80000000)));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.Abs(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
@@ -373,51 +373,51 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<byte>(0x00));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<byte>(0x01));
-            Assert.Equal((int)0x0000007F, NumberHelper<int>.CreateChecked<byte>(0x7F));
-            Assert.Equal((int)0x00000080, NumberHelper<int>.CreateChecked<byte>(0x80));
-            Assert.Equal((int)0x000000FF, NumberHelper<int>.CreateChecked<byte>(0xFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<byte>(0x00));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<byte>(0x01));
+            Assert.Equal((int)0x0000007F, NumberBaseHelper<int>.CreateChecked<byte>(0x7F));
+            Assert.Equal((int)0x00000080, NumberBaseHelper<int>.CreateChecked<byte>(0x80));
+            Assert.Equal((int)0x000000FF, NumberBaseHelper<int>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<char>((char)0x0000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<char>((char)0x0001));
-            Assert.Equal((int)0x00007FFF, NumberHelper<int>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal((int)0x00008000, NumberHelper<int>.CreateChecked<char>((char)0x8000));
-            Assert.Equal((int)0x0000FFFF, NumberHelper<int>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<char>((char)0x0000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<char>((char)0x0001));
+            Assert.Equal((int)0x00007FFF, NumberBaseHelper<int>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal((int)0x00008000, NumberBaseHelper<int>.CreateChecked<char>((char)0x8000));
+            Assert.Equal((int)0x0000FFFF, NumberBaseHelper<int>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<short>(0x0000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<short>(0x0001));
-            Assert.Equal((int)0x00007FFF, NumberHelper<int>.CreateChecked<short>(0x7FFF));
-            Assert.Equal(unchecked((int)0xFFFF8000), NumberHelper<int>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<short>(0x0000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<short>(0x0001));
+            Assert.Equal((int)0x00007FFF, NumberBaseHelper<int>.CreateChecked<short>(0x7FFF));
+            Assert.Equal(unchecked((int)0xFFFF8000), NumberBaseHelper<int>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<int>(0x00000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<int>(0x00000001));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.CreateChecked<int>(unchecked(unchecked((int)0x80000000))));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateChecked<int>(unchecked(unchecked((int)0xFFFFFFFF))));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<int>(0x00000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<int>(0x00000001));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.CreateChecked<int>(unchecked(unchecked((int)0x80000000))));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateChecked<int>(unchecked(unchecked((int)0xFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<long>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<long>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -425,60 +425,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<sbyte>(0x00));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<sbyte>(0x01));
-            Assert.Equal((int)0x0000007F, NumberHelper<int>.CreateChecked<sbyte>(0x7F));
-            Assert.Equal(unchecked((int)0xFFFFFF80), NumberHelper<int>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<sbyte>(0x00));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<sbyte>(0x01));
+            Assert.Equal((int)0x0000007F, NumberBaseHelper<int>.CreateChecked<sbyte>(0x7F));
+            Assert.Equal(unchecked((int)0xFFFFFF80), NumberBaseHelper<int>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<ushort>(0x0000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<ushort>(0x0001));
-            Assert.Equal((int)0x00007FFF, NumberHelper<int>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal((int)0x00008000, NumberHelper<int>.CreateChecked<ushort>(0x8000));
-            Assert.Equal((int)0x0000FFFF, NumberHelper<int>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<ushort>(0x0000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<ushort>(0x0001));
+            Assert.Equal((int)0x00007FFF, NumberBaseHelper<int>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal((int)0x00008000, NumberBaseHelper<int>.CreateChecked<ushort>(0x8000));
+            Assert.Equal((int)0x0000FFFF, NumberBaseHelper<int>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<uint>(0x00000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<uint>(0x00000001));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<uint>(0x80000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<uint>(0x00000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<uint>(0x00000001));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<uint>(0x80000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -486,70 +486,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Throws<OverflowException>(() => NumberHelper<int>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<byte>(0x00));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<byte>(0x01));
-            Assert.Equal((int)0x0000007F, NumberHelper<int>.CreateSaturating<byte>(0x7F));
-            Assert.Equal((int)0x00000080, NumberHelper<int>.CreateSaturating<byte>(0x80));
-            Assert.Equal((int)0x000000FF, NumberHelper<int>.CreateSaturating<byte>(0xFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<byte>(0x00));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<byte>(0x01));
+            Assert.Equal((int)0x0000007F, NumberBaseHelper<int>.CreateSaturating<byte>(0x7F));
+            Assert.Equal((int)0x00000080, NumberBaseHelper<int>.CreateSaturating<byte>(0x80));
+            Assert.Equal((int)0x000000FF, NumberBaseHelper<int>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal((int)0x00007FFF, NumberHelper<int>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal((int)0x00008000, NumberHelper<int>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal((int)0x0000FFFF, NumberHelper<int>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal((int)0x00007FFF, NumberBaseHelper<int>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal((int)0x00008000, NumberBaseHelper<int>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal((int)0x0000FFFF, NumberBaseHelper<int>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<short>(0x0000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<short>(0x0001));
-            Assert.Equal((int)0x00007FFF, NumberHelper<int>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal(unchecked((int)0xFFFF8000), NumberHelper<int>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<short>(0x0000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<short>(0x0001));
+            Assert.Equal((int)0x00007FFF, NumberBaseHelper<int>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal(unchecked((int)0xFFFF8000), NumberBaseHelper<int>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<int>(0x00000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<int>(0x00000001));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.CreateSaturating<int>(unchecked(unchecked((int)0x80000000))));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateSaturating<int>(unchecked(unchecked((int)0xFFFFFFFF))));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<int>(0x00000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<int>(0x00000001));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.CreateSaturating<int>(unchecked(unchecked((int)0x80000000))));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateSaturating<int>(unchecked(unchecked((int)0xFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal(unchecked((int)0x7FFFFFFF), NumberHelper<int>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal(unchecked((int)0x7FFFFFFF), NumberBaseHelper<int>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -557,60 +557,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((int)0x7FFFFFFF), NumberHelper<int>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((int)0x7FFFFFFF), NumberBaseHelper<int>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal((int)0x0000007F, NumberHelper<int>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal(unchecked((int)0xFFFFFF80), NumberHelper<int>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal((int)0x0000007F, NumberBaseHelper<int>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal(unchecked((int)0xFFFFFF80), NumberBaseHelper<int>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal((int)0x00007FFF, NumberHelper<int>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal((int)0x00008000, NumberHelper<int>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal((int)0x0000FFFF, NumberHelper<int>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal((int)0x00007FFF, NumberBaseHelper<int>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal((int)0x00008000, NumberBaseHelper<int>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal((int)0x0000FFFF, NumberBaseHelper<int>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -618,70 +618,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<byte>(0x00));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<byte>(0x01));
-            Assert.Equal((int)0x0000007F, NumberHelper<int>.CreateTruncating<byte>(0x7F));
-            Assert.Equal((int)0x00000080, NumberHelper<int>.CreateTruncating<byte>(0x80));
-            Assert.Equal((int)0x000000FF, NumberHelper<int>.CreateTruncating<byte>(0xFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<byte>(0x00));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<byte>(0x01));
+            Assert.Equal((int)0x0000007F, NumberBaseHelper<int>.CreateTruncating<byte>(0x7F));
+            Assert.Equal((int)0x00000080, NumberBaseHelper<int>.CreateTruncating<byte>(0x80));
+            Assert.Equal((int)0x000000FF, NumberBaseHelper<int>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal((int)0x00007FFF, NumberHelper<int>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal((int)0x00008000, NumberHelper<int>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal((int)0x0000FFFF, NumberHelper<int>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal((int)0x00007FFF, NumberBaseHelper<int>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal((int)0x00008000, NumberBaseHelper<int>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal((int)0x0000FFFF, NumberBaseHelper<int>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<short>(0x0000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<short>(0x0001));
-            Assert.Equal((int)0x00007FFF, NumberHelper<int>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal(unchecked((int)0xFFFF8000), NumberHelper<int>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<short>(0x0000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<short>(0x0001));
+            Assert.Equal((int)0x00007FFF, NumberBaseHelper<int>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal(unchecked((int)0xFFFF8000), NumberBaseHelper<int>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<int>(0x00000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<int>(0x00000001));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.CreateTruncating<int>(unchecked(unchecked((int)0x80000000))));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<int>(unchecked(unchecked((int)0xFFFFFFFF))));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<int>(0x00000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<int>(0x00000001));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.CreateTruncating<int>(unchecked(unchecked((int)0x80000000))));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<int>(unchecked(unchecked((int)0xFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -689,60 +689,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal((int)0x0000007F, NumberHelper<int>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal(unchecked((int)0xFFFFFF80), NumberHelper<int>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal((int)0x0000007F, NumberBaseHelper<int>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal(unchecked((int)0xFFFFFF80), NumberBaseHelper<int>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal((int)0x00007FFF, NumberHelper<int>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal((int)0x00008000, NumberHelper<int>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal((int)0x0000FFFF, NumberHelper<int>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal((int)0x00007FFF, NumberBaseHelper<int>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal((int)0x00008000, NumberBaseHelper<int>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal((int)0x0000FFFF, NumberBaseHelper<int>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -750,19 +750,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((int)0x00000000, NumberHelper<int>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal((int)0x00000001, NumberHelper<int>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((int)0x00000000, NumberBaseHelper<int>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal((int)0x00000001, NumberBaseHelper<int>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(unchecked((int)0x80000000), NumberBaseHelper<int>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal(unchecked((int)0xFFFFFFFF), NumberBaseHelper<int>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -811,19 +811,19 @@ namespace System.Tests
         {
             int result;
 
-            Assert.True(NumberHelper<int>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<byte>(0x00, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<byte>(0x01, out result));
             Assert.Equal((int)0x00000001, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((int)0x0000007F, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<byte>(0x80, out result));
             Assert.Equal((int)0x00000080, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((int)0x000000FF, result);
         }
 
@@ -832,19 +832,19 @@ namespace System.Tests
         {
             int result;
 
-            Assert.True(NumberHelper<int>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal((int)0x00000001, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((int)0x00007FFF, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((int)0x00008000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((int)0x0000FFFF, result);
         }
 
@@ -853,19 +853,19 @@ namespace System.Tests
         {
             int result;
 
-            Assert.True(NumberHelper<int>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<short>(0x0000, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<short>(0x0001, out result));
             Assert.Equal((int)0x00000001, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((int)0x00007FFF, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal(unchecked((int)0xFFFF8000), result);
 
-            Assert.True(NumberHelper<int>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(unchecked((int)0xFFFFFFFF), result);
         }
 
@@ -874,19 +874,19 @@ namespace System.Tests
         {
             int result;
 
-            Assert.True(NumberHelper<int>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<int>(0x00000000, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<int>(0x00000001, out result));
             Assert.Equal((int)0x00000001, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((int)0x7FFFFFFF, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<int>(unchecked(unchecked((int)0x80000000)), out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<int>(unchecked(unchecked((int)0x80000000)), out result));
             Assert.Equal(unchecked((int)0x80000000), result);
 
-            Assert.True(NumberHelper<int>.TryCreate<int>(unchecked(unchecked((int)0xFFFFFFFF)), out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<int>(unchecked(unchecked((int)0xFFFFFFFF)), out result));
             Assert.Equal(unchecked((int)0xFFFFFFFF), result);
         }
 
@@ -895,19 +895,19 @@ namespace System.Tests
         {
             int result;
 
-            Assert.True(NumberHelper<int>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal((int)0x00000001, result);
 
-            Assert.False(NumberHelper<int>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<int>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.False(NumberHelper<int>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+            Assert.False(NumberBaseHelper<int>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
             Assert.Equal(unchecked((int)0xFFFFFFFF), result);
         }
 
@@ -918,36 +918,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<int>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal((int)0x00000000, result);
 
-                Assert.True(NumberHelper<int>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal((int)0x00000001, result);
 
-                Assert.False(NumberHelper<int>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<int>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((int)0x00000000, result);
 
-                Assert.False(NumberHelper<int>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<int>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal((int)0x00000000, result);
 
-                Assert.True(NumberHelper<int>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((int)0xFFFFFFFF), result);
             }
             else
             {
-                Assert.True(NumberHelper<int>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal((int)0x00000000, result);
 
-                Assert.True(NumberHelper<int>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal((int)0x00000001, result);
 
-                Assert.True(NumberHelper<int>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((int)0x7FFFFFFF, result);
 
-                Assert.True(NumberHelper<int>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal(unchecked((int)0x80000000), result);
 
-                Assert.True(NumberHelper<int>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(unchecked((int)0xFFFFFFFF), result);
             }
         }
@@ -957,19 +957,19 @@ namespace System.Tests
         {
             int result;
 
-            Assert.True(NumberHelper<int>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal((int)0x00000001, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((int)0x0000007F, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal(unchecked((int)0xFFFFFF80), result);
 
-            Assert.True(NumberHelper<int>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(unchecked((int)0xFFFFFFFF), result);
         }
 
@@ -978,19 +978,19 @@ namespace System.Tests
         {
             int result;
 
-            Assert.True(NumberHelper<int>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal((int)0x00000001, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((int)0x00007FFF, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((int)0x00008000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((int)0x0000FFFF, result);
         }
 
@@ -999,19 +999,19 @@ namespace System.Tests
         {
             int result;
 
-            Assert.True(NumberHelper<int>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal((int)0x00000001, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal((int)0x7FFFFFFF, result);
 
-            Assert.False(NumberHelper<int>.TryCreate<uint>(0x80000000, out result));
+            Assert.False(NumberBaseHelper<int>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal(unchecked((int)0x00000000), result);
 
-            Assert.False(NumberHelper<int>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<int>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal(unchecked((int)0x00000000), result);
         }
 
@@ -1020,19 +1020,19 @@ namespace System.Tests
         {
             int result;
 
-            Assert.True(NumberHelper<int>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.True(NumberHelper<int>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<int>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal((int)0x00000001, result);
 
-            Assert.False(NumberHelper<int>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<int>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.False(NumberHelper<int>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.False(NumberBaseHelper<int>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal((int)0x00000000, result);
 
-            Assert.False(NumberHelper<int>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<int>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal((int)0x00000000, result);
         }
 
@@ -1043,36 +1043,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<int>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal((int)0x00000000, result);
 
-                Assert.True(NumberHelper<int>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal((int)0x00000001, result);
 
-                Assert.False(NumberHelper<int>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<int>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((int)0x00000000, result);
 
-                Assert.False(NumberHelper<int>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<int>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal((int)0x00000000, result);
 
-                Assert.False(NumberHelper<int>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<int>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((int)0x00000000, result);
             }
             else
             {
-                Assert.True(NumberHelper<int>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal((int)0x00000000, result);
 
-                Assert.True(NumberHelper<int>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal((int)0x00000001, result);
 
-                Assert.True(NumberHelper<int>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<int>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((int)0x7FFFFFFF, result);
 
-                Assert.False(NumberHelper<int>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<int>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal(unchecked((int)0x00000000), result);
 
-                Assert.False(NumberHelper<int>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<int>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal(unchecked((int)0x00000000), result);
             }
         }
@@ -1248,12 +1248,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Equal(expected, NumberHelper<int>.Parse(value, style, provider));
+                Assert.Equal(expected, NumberBaseHelper<int>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.True(NumberHelper<int>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.True(NumberBaseHelper<int>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(expected, result);
-                Assert.Equal(expected, NumberHelper<int>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Equal(expected, NumberBaseHelper<int>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1263,9 +1263,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.True(NumberHelper<int>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<int>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
-            Assert.Equal(expected, NumberHelper<int>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<int>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1285,12 +1285,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<int>.Parse(value, style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<int>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.False(NumberHelper<int>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.False(NumberBaseHelper<int>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(default(int), result);
-                Assert.Throws(exceptionType, () => NumberHelper<int>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<int>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1300,9 +1300,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.False(NumberHelper<int>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<int>.TryParse(value, style, provider, out result));
             Assert.Equal(default(int), result);
-            Assert.Throws(exceptionType, () => NumberHelper<int>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<int>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1318,9 +1318,9 @@ namespace System.Tests
                 Assert.Equal(expected, result);
             }
 
-            Assert.Equal(expected, NumberHelper<int>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<int>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<int>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<int>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1342,9 +1342,9 @@ namespace System.Tests
                 Assert.Equal(default(int), result);
             }
 
-            Assert.Throws(exceptionType, () => NumberHelper<int>.Parse(value.AsSpan(), style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<int>.Parse(value.AsSpan(), style, provider));
 
-            Assert.False(NumberHelper<int>.TryParse(value.AsSpan(), style, provider, out result));
+            Assert.False(NumberBaseHelper<int>.TryParse(value.AsSpan(), style, provider, out result));
             Assert.Equal(default(int), result);
         }
     }

--- a/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
@@ -8,47 +8,9 @@ namespace System.Tests
 {
     public class Int32Tests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal((int)0x00000000, AdditiveIdentityHelper<int, int>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            Assert.Equal(unchecked((int)0x80000000), MinMaxValueHelper<int>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            Assert.Equal((int)0x7FFFFFFF, MinMaxValueHelper<int>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal((int)0x00000001, MultiplicativeIdentityHelper<int, int>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            Assert.Equal(unchecked((int)0xFFFFFFFF), SignedNumberHelper<int>.NegativeOne);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -69,6 +31,30 @@ namespace System.Tests
             Assert.Equal((int)0x00000000, AdditionOperatorsHelper<int, int, int>.op_CheckedAddition(unchecked((int)0xFFFFFFFF), 1));
 
             Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<int, int, int>.op_CheckedAddition((int)0x7FFFFFFF, 1));
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal((int)0x00000000, AdditiveIdentityHelper<int, int>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            Assert.Equal(((int)0x00000000, (int)0x00000000), BinaryIntegerHelper<int>.DivRem((int)0x00000000, 2));
+            Assert.Equal(((int)0x00000000, (int)0x00000001), BinaryIntegerHelper<int>.DivRem((int)0x00000001, 2));
+            Assert.Equal(((int)0x3FFFFFFF, (int)0x00000001), BinaryIntegerHelper<int>.DivRem((int)0x7FFFFFFF, 2));
+            Assert.Equal((unchecked((int)0xC0000000), (int)0x00000000), BinaryIntegerHelper<int>.DivRem(unchecked((int)0x80000000), 2));
+            Assert.Equal(((int)0x00000000, unchecked((int)0xFFFFFFFF)), BinaryIntegerHelper<int>.DivRem(unchecked((int)0xFFFFFFFF), 2));
         }
 
         [Fact]
@@ -122,6 +108,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            Assert.Equal(4, BinaryIntegerHelper<int>.GetByteCount((int)0x00000000));
+            Assert.Equal(4, BinaryIntegerHelper<int>.GetByteCount((int)0x00000001));
+            Assert.Equal(4, BinaryIntegerHelper<int>.GetByteCount((int)0x7FFFFFFF));
+            Assert.Equal(4, BinaryIntegerHelper<int>.GetByteCount(unchecked((int)0x80000000)));
+            Assert.Equal(4, BinaryIntegerHelper<int>.GetByteCount(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             Assert.Equal(0x00, BinaryIntegerHelper<int>.GetShortestBitLength((int)0x00000000));
@@ -130,6 +126,72 @@ namespace System.Tests
             Assert.Equal(0x20, BinaryIntegerHelper<int>.GetShortestBitLength(unchecked((int)0x80000000)));
             Assert.Equal(0x01, BinaryIntegerHelper<int>.GetShortestBitLength(unchecked((int)0xFFFFFFFF)));
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[4];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<int>.TryWriteBigEndian((int)0x00000000, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<int>.TryWriteBigEndian((int)0x00000001, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<int>.TryWriteBigEndian((int)0x7FFFFFFF, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<int>.TryWriteBigEndian(unchecked((int)0x80000000), destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<int>.TryWriteBigEndian(unchecked((int)0xFFFFFFFF), destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<int>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[4];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<int>.TryWriteLittleEndian((int)0x00000000, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<int>.TryWriteLittleEndian((int)0x00000001, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<int>.TryWriteLittleEndian((int)0x7FFFFFFF, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<int>.TryWriteLittleEndian(unchecked((int)0x80000000), destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<int>.TryWriteLittleEndian(unchecked((int)0xFFFFFFFF), destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<int>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -150,6 +212,10 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => BinaryNumberHelper<int>.Log2(unchecked((int)0x80000000)));
             Assert.Throws<ArgumentOutOfRangeException>(() => BinaryNumberHelper<int>.Log2(unchecked((int)0xFFFFFFFF)));
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -191,25 +257,9 @@ namespace System.Tests
             Assert.Equal((int)0x00000000, BitwiseOperatorsHelper<int, int, int>.op_OnesComplement(unchecked((int)0xFFFFFFFF)));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThan((int)0x00000000, 1));
-            Assert.False(ComparisonOperatorsHelper<int, int>.op_LessThan((int)0x00000001, 1));
-            Assert.False(ComparisonOperatorsHelper<int, int>.op_LessThan((int)0x7FFFFFFF, 1));
-            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThan(unchecked((int)0x80000000), 1));
-            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThan(unchecked((int)0xFFFFFFFF), 1));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThanOrEqual((int)0x00000000, 1));
-            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThanOrEqual((int)0x00000001, 1));
-            Assert.False(ComparisonOperatorsHelper<int, int>.op_LessThanOrEqual((int)0x7FFFFFFF, 1));
-            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThanOrEqual(unchecked((int)0x80000000), 1));
-            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThanOrEqual(unchecked((int)0xFFFFFFFF), 1));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -232,6 +282,30 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThan((int)0x00000000, 1));
+            Assert.False(ComparisonOperatorsHelper<int, int>.op_LessThan((int)0x00000001, 1));
+            Assert.False(ComparisonOperatorsHelper<int, int>.op_LessThan((int)0x7FFFFFFF, 1));
+            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThan(unchecked((int)0x80000000), 1));
+            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThan(unchecked((int)0xFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThanOrEqual((int)0x00000000, 1));
+            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThanOrEqual((int)0x00000001, 1));
+            Assert.False(ComparisonOperatorsHelper<int, int>.op_LessThanOrEqual((int)0x7FFFFFFF, 1));
+            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThanOrEqual(unchecked((int)0x80000000), 1));
+            Assert.True(ComparisonOperatorsHelper<int, int>.op_LessThanOrEqual(unchecked((int)0xFFFFFFFF), 1));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             Assert.Equal(unchecked((int)0xFFFFFFFF), DecrementOperatorsHelper<int>.op_Decrement((int)0x00000000));
@@ -251,6 +325,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<int>.op_CheckedDecrement(unchecked((int)0x80000000)));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -276,6 +354,10 @@ namespace System.Tests
             Assert.Throws<DivideByZeroException>(() => DivisionOperatorsHelper<int, int, int>.op_CheckedDivision((int)0x00000001, 0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -295,6 +377,10 @@ namespace System.Tests
             Assert.True(EqualityOperatorsHelper<int, int>.op_Inequality(unchecked((int)0x80000000), 1));
             Assert.True(EqualityOperatorsHelper<int, int>.op_Inequality(unchecked((int)0xFFFFFFFF), 1));
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -317,6 +403,26 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<int>.op_CheckedIncrement((int)0x7FFFFFFF));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            Assert.Equal((int)0x7FFFFFFF, MinMaxValueHelper<int>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal(unchecked((int)0x80000000), MinMaxValueHelper<int>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -328,6 +434,20 @@ namespace System.Tests
 
             Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<int, int, int>.op_Modulus((int)0x00000001, 0));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal((int)0x00000001, MultiplicativeIdentityHelper<int, int>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -350,15 +470,9 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<int, int, int>.op_CheckedMultiply(unchecked((int)0x80000000), 2));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.Abs((int)0x00000000));
-            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.Abs((int)0x00000001));
-            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.Abs((int)0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.Abs(unchecked((int)0x80000000)));
-            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.Abs(unchecked((int)0xFFFFFFFF)));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -368,6 +482,62 @@ namespace System.Tests
             Assert.Equal((int)0x0000003F, NumberHelper<int>.Clamp((int)0x7FFFFFFF, unchecked((int)0xFFFFFFC0), 0x003F));
             Assert.Equal(unchecked((int)0xFFFFFFC0), NumberHelper<int>.Clamp(unchecked((int)0x80000000), unchecked((int)0xFFFFFFC0), 0x003F));
             Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.Clamp(unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFC0), 0x003F));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal((int)0x00000001, NumberHelper<int>.Max((int)0x00000000, 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.Max((int)0x00000001, 1));
+            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.Max((int)0x7FFFFFFF, 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.Max(unchecked((int)0x80000000), 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.Max(unchecked((int)0xFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal((int)0x00000000, NumberHelper<int>.Min((int)0x00000000, 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.Min((int)0x00000001, 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.Min((int)0x7FFFFFFF, 1));
+            Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.Min(unchecked((int)0x80000000), 1));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.Min(unchecked((int)0xFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(0, NumberHelper<int>.Sign((int)0x00000000));
+            Assert.Equal(1, NumberHelper<int>.Sign((int)0x00000001));
+            Assert.Equal(1, NumberHelper<int>.Sign((int)0x7FFFFFFF));
+            Assert.Equal(-1, NumberHelper<int>.Sign(unchecked((int)0x80000000)));
+            Assert.Equal(-1, NumberHelper<int>.Sign(unchecked((int)0xFFFFFFFF)));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal((int)0x00000000, NumberBaseHelper<int>.Abs((int)0x00000000));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.Abs((int)0x00000001));
+            Assert.Equal((int)0x7FFFFFFF, NumberBaseHelper<int>.Abs((int)0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<int>.Abs(unchecked((int)0x80000000)));
+            Assert.Equal((int)0x00000001, NumberBaseHelper<int>.Abs(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
@@ -767,46 +937,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            Assert.Equal(((int)0x00000000, (int)0x00000000), BinaryIntegerHelper<int>.DivRem((int)0x00000000, 2));
-            Assert.Equal(((int)0x00000000, (int)0x00000001), BinaryIntegerHelper<int>.DivRem((int)0x00000001, 2));
-            Assert.Equal(((int)0x3FFFFFFF, (int)0x00000001), BinaryIntegerHelper<int>.DivRem((int)0x7FFFFFFF, 2));
-            Assert.Equal((unchecked((int)0xC0000000), (int)0x00000000), BinaryIntegerHelper<int>.DivRem(unchecked((int)0x80000000), 2));
-            Assert.Equal(((int)0x00000000, unchecked((int)0xFFFFFFFF)), BinaryIntegerHelper<int>.DivRem(unchecked((int)0xFFFFFFFF), 2));
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            Assert.Equal((int)0x00000001, NumberHelper<int>.Max((int)0x00000000, 1));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.Max((int)0x00000001, 1));
-            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.Max((int)0x7FFFFFFF, 1));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.Max(unchecked((int)0x80000000), 1));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.Max(unchecked((int)0xFFFFFFFF), 1));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            Assert.Equal((int)0x00000000, NumberHelper<int>.Min((int)0x00000000, 1));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.Min((int)0x00000001, 1));
-            Assert.Equal((int)0x00000001, NumberHelper<int>.Min((int)0x7FFFFFFF, 1));
-            Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.Min(unchecked((int)0x80000000), 1));
-            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.Min(unchecked((int)0xFFFFFFFF), 1));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(0, NumberHelper<int>.Sign((int)0x00000000));
-            Assert.Equal(1, NumberHelper<int>.Sign((int)0x00000001));
-            Assert.Equal(1, NumberHelper<int>.Sign((int)0x7FFFFFFF));
-            Assert.Equal(-1, NumberHelper<int>.Sign(unchecked((int)0x80000000)));
-            Assert.Equal(-1, NumberHelper<int>.Sign(unchecked((int)0xFFFFFFFF)));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             int result;
@@ -1077,77 +1207,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            Assert.Equal(4, BinaryIntegerHelper<int>.GetByteCount((int)0x00000000));
-            Assert.Equal(4, BinaryIntegerHelper<int>.GetByteCount((int)0x00000001));
-            Assert.Equal(4, BinaryIntegerHelper<int>.GetByteCount((int)0x7FFFFFFF));
-            Assert.Equal(4, BinaryIntegerHelper<int>.GetByteCount(unchecked((int)0x80000000)));
-            Assert.Equal(4, BinaryIntegerHelper<int>.GetByteCount(unchecked((int)0xFFFFFFFF)));
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[4];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<int>.TryWriteBigEndian((int)0x00000000, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<int>.TryWriteBigEndian((int)0x00000001, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<int>.TryWriteBigEndian((int)0x7FFFFFFF, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<int>.TryWriteBigEndian(unchecked((int)0x80000000), destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<int>.TryWriteBigEndian(unchecked((int)0xFFFFFFFF), destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<int>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[4];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<int>.TryWriteLittleEndian((int)0x00000000, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<int>.TryWriteLittleEndian((int)0x00000001, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<int>.TryWriteLittleEndian((int)0x7FFFFFFF, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<int>.TryWriteLittleEndian(unchecked((int)0x80000000), destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<int>.TryWriteLittleEndian(unchecked((int)0xFFFFFFFF), destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<int>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1179,6 +1241,20 @@ namespace System.Tests
             Assert.Equal((int)0x7FFFFFFF, ShiftOperatorsHelper<int, int>.op_UnsignedRightShift(unchecked((int)0xFFFFFFFF), 1));
         }
 
+        //
+        // ISignedNumber
+        //
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(unchecked((int)0xFFFFFFFF), SignedNumberHelper<int>.NegativeOne);
+        }
+
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1199,6 +1275,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<int, int, int>.op_CheckedSubtraction(unchecked((int)0x80000000), 1));
         }
+
+        //
+        // IUnaryNegationOperators
+        //
 
         [Fact]
         public static void op_UnaryNegationTest()
@@ -1221,6 +1301,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => UnaryNegationOperatorsHelper<int, int>.op_CheckedUnaryNegation(unchecked((int)0x80000000)));
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1230,6 +1314,10 @@ namespace System.Tests
             Assert.Equal(unchecked((int)0x80000000), UnaryPlusOperatorsHelper<int, int>.op_UnaryPlus(unchecked((int)0x80000000)));
             Assert.Equal(unchecked((int)0xFFFFFFFF), UnaryPlusOperatorsHelper<int, int>.op_UnaryPlus(unchecked((int)0xFFFFFFFF)));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(Int32Tests.Parse_Valid_TestData), MemberType = typeof(Int32Tests))]

--- a/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
@@ -495,6 +495,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.MaxNumber((long)0x0000000000000000, 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.MaxNumber((long)0x0000000000000001, 1));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.MaxNumber((long)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.MaxNumber(unchecked((long)0x8000000000000000), 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.MaxNumber(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal((long)0x0000000000000000, NumberHelper<long>.Min((long)0x0000000000000000, 1));
@@ -502,6 +512,16 @@ namespace System.Tests
             Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Min((long)0x7FFFFFFFFFFFFFFF, 1));
             Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.Min(unchecked((long)0x8000000000000000), 1));
             Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.Min(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.MinNumber((long)0x0000000000000000, 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.MinNumber((long)0x0000000000000001, 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.MinNumber((long)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.MinNumber(unchecked((long)0x8000000000000000), 1));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.MinNumber(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
         }
 
         [Fact]
@@ -934,6 +954,126 @@ namespace System.Tests
                 Assert.Equal((long)0x0000000080000000, NumberBaseHelper<long>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal((long)0x00000000FFFFFFFF, NumberBaseHelper<long>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<long>.IsFinite((long)0x0000000000000000));
+            Assert.True(NumberBaseHelper<long>.IsFinite((long)0x0000000000000001));
+            Assert.True(NumberBaseHelper<long>.IsFinite((long)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<long>.IsFinite(unchecked((long)0x8000000000000000)));
+            Assert.True(NumberBaseHelper<long>.IsFinite(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<long>.IsInfinity((long)0x0000000000000000));
+            Assert.False(NumberBaseHelper<long>.IsInfinity((long)0x0000000000000001));
+            Assert.False(NumberBaseHelper<long>.IsInfinity((long)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<long>.IsInfinity(unchecked((long)0x8000000000000000)));
+            Assert.False(NumberBaseHelper<long>.IsInfinity(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<long>.IsNaN((long)0x0000000000000000));
+            Assert.False(NumberBaseHelper<long>.IsNaN((long)0x0000000000000001));
+            Assert.False(NumberBaseHelper<long>.IsNaN((long)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<long>.IsNaN(unchecked((long)0x8000000000000000)));
+            Assert.False(NumberBaseHelper<long>.IsNaN(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<long>.IsNegative((long)0x0000000000000000));
+            Assert.False(NumberBaseHelper<long>.IsNegative((long)0x0000000000000001));
+            Assert.False(NumberBaseHelper<long>.IsNegative((long)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<long>.IsNegative(unchecked((long)0x8000000000000000)));
+            Assert.True(NumberBaseHelper<long>.IsNegative(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<long>.IsNegativeInfinity((long)0x0000000000000000));
+            Assert.False(NumberBaseHelper<long>.IsNegativeInfinity((long)0x0000000000000001));
+            Assert.False(NumberBaseHelper<long>.IsNegativeInfinity((long)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<long>.IsNegativeInfinity(unchecked((long)0x8000000000000000)));
+            Assert.False(NumberBaseHelper<long>.IsNegativeInfinity(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<long>.IsNormal((long)0x0000000000000000));
+            Assert.True(NumberBaseHelper<long>.IsNormal((long)0x0000000000000001));
+            Assert.True(NumberBaseHelper<long>.IsNormal((long)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<long>.IsNormal(unchecked((long)0x8000000000000000)));
+            Assert.True(NumberBaseHelper<long>.IsNormal(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<long>.IsPositiveInfinity((long)0x0000000000000000));
+            Assert.False(NumberBaseHelper<long>.IsPositiveInfinity((long)0x0000000000000001));
+            Assert.False(NumberBaseHelper<long>.IsPositiveInfinity((long)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<long>.IsPositiveInfinity(unchecked((long)0x8000000000000000)));
+            Assert.False(NumberBaseHelper<long>.IsPositiveInfinity(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<long>.IsSubnormal((long)0x0000000000000000));
+            Assert.False(NumberBaseHelper<long>.IsSubnormal((long)0x0000000000000001));
+            Assert.False(NumberBaseHelper<long>.IsSubnormal((long)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<long>.IsSubnormal(unchecked((long)0x8000000000000000)));
+            Assert.False(NumberBaseHelper<long>.IsSubnormal(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MaxMagnitude((long)0x0000000000000000, 1));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MaxMagnitude((long)0x0000000000000001, 1));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.MaxMagnitude((long)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal(unchecked((long)0x8000000000000000), NumberBaseHelper<long>.MaxMagnitude(unchecked((long)0x8000000000000000), 1));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MaxMagnitude(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MaxMagnitudeNumber((long)0x0000000000000000, 1));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MaxMagnitudeNumber((long)0x0000000000000001, 1));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.MaxMagnitudeNumber((long)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal(unchecked((long)0x8000000000000000), NumberBaseHelper<long>.MaxMagnitudeNumber(unchecked((long)0x8000000000000000), 1));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MaxMagnitudeNumber(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.MinMagnitude((long)0x0000000000000000, 1));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MinMagnitude((long)0x0000000000000001, 1));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MinMagnitude((long)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MinMagnitude(unchecked((long)0x8000000000000000), 1));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.MinMagnitude(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.MinMagnitudeNumber((long)0x0000000000000000, 1));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MinMagnitudeNumber((long)0x0000000000000001, 1));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MinMagnitudeNumber((long)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.MinMagnitudeNumber(unchecked((long)0x8000000000000000), 1));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.MinMagnitudeNumber(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
@@ -8,47 +8,9 @@ namespace System.Tests
 {
     public class Int64Tests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal((long)0x0000000000000000, AdditiveIdentityHelper<long, long>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            Assert.Equal(unchecked((long)0x8000000000000000), MinMaxValueHelper<long>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, MinMaxValueHelper<long>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal((long)0x0000000000000001, MultiplicativeIdentityHelper<long, long>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), SignedNumberHelper<long>.NegativeOne);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -69,6 +31,30 @@ namespace System.Tests
             Assert.Equal((long)0x0000000000000000, AdditionOperatorsHelper<long, long, long>.op_CheckedAddition(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
 
             Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<long, long, long>.op_CheckedAddition((long)0x7FFFFFFFFFFFFFFF, 1));
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal((long)0x0000000000000000, AdditiveIdentityHelper<long, long>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            Assert.Equal(((long)0x0000000000000000, (long)0x0000000000000000), BinaryIntegerHelper<long>.DivRem((long)0x0000000000000000, 2));
+            Assert.Equal(((long)0x0000000000000000, (long)0x0000000000000001), BinaryIntegerHelper<long>.DivRem((long)0x0000000000000001, 2));
+            Assert.Equal(((long)0x3FFFFFFFFFFFFFFF, (long)0x0000000000000001), BinaryIntegerHelper<long>.DivRem((long)0x7FFFFFFFFFFFFFFF, 2));
+            Assert.Equal((unchecked((long)0xC000000000000000), (long)0x0000000000000000), BinaryIntegerHelper<long>.DivRem(unchecked((long)0x8000000000000000), 2));
+            Assert.Equal(((long)0x0000000000000000, unchecked((long)0xFFFFFFFFFFFFFFFF)), BinaryIntegerHelper<long>.DivRem(unchecked((long)0xFFFFFFFFFFFFFFFF), 2));
         }
 
         [Fact]
@@ -122,6 +108,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            Assert.Equal(8, BinaryIntegerHelper<long>.GetByteCount((long)0x0000000000000000));
+            Assert.Equal(8, BinaryIntegerHelper<long>.GetByteCount((long)0x0000000000000001));
+            Assert.Equal(8, BinaryIntegerHelper<long>.GetByteCount((long)0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(8, BinaryIntegerHelper<long>.GetByteCount(unchecked((long)0x8000000000000000)));
+            Assert.Equal(8, BinaryIntegerHelper<long>.GetByteCount(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             Assert.Equal(0x00, BinaryIntegerHelper<long>.GetShortestBitLength((long)0x0000000000000000));
@@ -130,6 +126,72 @@ namespace System.Tests
             Assert.Equal(0x40, BinaryIntegerHelper<long>.GetShortestBitLength(unchecked((long)0x8000000000000000)));
             Assert.Equal(0x01, BinaryIntegerHelper<long>.GetShortestBitLength(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[8];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<long>.TryWriteBigEndian((long)0x0000000000000000, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<long>.TryWriteBigEndian((long)0x0000000000000001, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<long>.TryWriteBigEndian((long)0x7FFFFFFFFFFFFFFF, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<long>.TryWriteBigEndian(unchecked((long)0x8000000000000000), destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<long>.TryWriteBigEndian(unchecked((long)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<long>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[8];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<long>.TryWriteLittleEndian((long)0x0000000000000000, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<long>.TryWriteLittleEndian((long)0x0000000000000001, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<long>.TryWriteLittleEndian((long)0x7FFFFFFFFFFFFFFF, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<long>.TryWriteLittleEndian(unchecked((long)0x8000000000000000), destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<long>.TryWriteLittleEndian(unchecked((long)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<long>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -150,6 +212,10 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => BinaryNumberHelper<long>.Log2(unchecked((long)0x8000000000000000)));
             Assert.Throws<ArgumentOutOfRangeException>(() => BinaryNumberHelper<long>.Log2(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -191,25 +257,9 @@ namespace System.Tests
             Assert.Equal((long)0x0000000000000000, BitwiseOperatorsHelper<long, long, long>.op_OnesComplement(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThan((long)0x0000000000000000, 1));
-            Assert.False(ComparisonOperatorsHelper<long, long>.op_LessThan((long)0x0000000000000001, 1));
-            Assert.False(ComparisonOperatorsHelper<long, long>.op_LessThan((long)0x7FFFFFFFFFFFFFFF, 1));
-            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThan(unchecked((long)0x8000000000000000), 1));
-            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThan(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThanOrEqual((long)0x0000000000000000, 1));
-            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThanOrEqual((long)0x0000000000000001, 1));
-            Assert.False(ComparisonOperatorsHelper<long, long>.op_LessThanOrEqual((long)0x7FFFFFFFFFFFFFFF, 1));
-            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThanOrEqual(unchecked((long)0x8000000000000000), 1));
-            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThanOrEqual(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -232,6 +282,30 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThan((long)0x0000000000000000, 1));
+            Assert.False(ComparisonOperatorsHelper<long, long>.op_LessThan((long)0x0000000000000001, 1));
+            Assert.False(ComparisonOperatorsHelper<long, long>.op_LessThan((long)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThan(unchecked((long)0x8000000000000000), 1));
+            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThan(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThanOrEqual((long)0x0000000000000000, 1));
+            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThanOrEqual((long)0x0000000000000001, 1));
+            Assert.False(ComparisonOperatorsHelper<long, long>.op_LessThanOrEqual((long)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThanOrEqual(unchecked((long)0x8000000000000000), 1));
+            Assert.True(ComparisonOperatorsHelper<long, long>.op_LessThanOrEqual(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), DecrementOperatorsHelper<long>.op_Decrement((long)0x0000000000000000));
@@ -251,6 +325,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<long>.op_CheckedDecrement(unchecked((long)0x8000000000000000)));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -276,6 +354,10 @@ namespace System.Tests
             Assert.Throws<DivideByZeroException>(() => DivisionOperatorsHelper<long, long, long>.op_CheckedDivision((long)0x0000000000000001, 0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -295,6 +377,10 @@ namespace System.Tests
             Assert.True(EqualityOperatorsHelper<long, long>.op_Inequality(unchecked((long)0x8000000000000000), 1));
             Assert.True(EqualityOperatorsHelper<long, long>.op_Inequality(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -317,6 +403,26 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<long>.op_CheckedIncrement((long)0x7FFFFFFFFFFFFFFF));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, MinMaxValueHelper<long>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal(unchecked((long)0x8000000000000000), MinMaxValueHelper<long>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -328,6 +434,20 @@ namespace System.Tests
 
             Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<long, long, long>.op_Modulus((long)0x0000000000000001, 0));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal((long)0x0000000000000001, MultiplicativeIdentityHelper<long, long>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -350,15 +470,9 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<long, long, long>.op_CheckedMultiply(unchecked((long)0x8000000000000000), 2));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.Abs((long)0x0000000000000000));
-            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.Abs((long)0x0000000000000001));
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.Abs((long)0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberBaseHelper<long>.Abs(unchecked((long)0x8000000000000000)));
-            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.Abs(unchecked((long)0xFFFFFFFFFFFFFFFF)));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -368,6 +482,62 @@ namespace System.Tests
             Assert.Equal((long)0x000000000000003F, NumberHelper<long>.Clamp((long)0x7FFFFFFFFFFFFFFF, unchecked((long)0xFFFFFFFFFFFFFFC0), 0x003F));
             Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFC0), NumberHelper<long>.Clamp(unchecked((long)0x8000000000000000), unchecked((long)0xFFFFFFFFFFFFFFC0), 0x003F));
             Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.Clamp(unchecked((long)0xFFFFFFFFFFFFFFFF), unchecked((long)0xFFFFFFFFFFFFFFC0), 0x003F));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Max((long)0x0000000000000000, 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Max((long)0x0000000000000001, 1));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.Max((long)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Max(unchecked((long)0x8000000000000000), 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Max(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.Min((long)0x0000000000000000, 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Min((long)0x0000000000000001, 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Min((long)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.Min(unchecked((long)0x8000000000000000), 1));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.Min(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(0, NumberHelper<long>.Sign((long)0x0000000000000000));
+            Assert.Equal(1, NumberHelper<long>.Sign((long)0x0000000000000001));
+            Assert.Equal(1, NumberHelper<long>.Sign((long)0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(-1, NumberHelper<long>.Sign(unchecked((long)0x8000000000000000)));
+            Assert.Equal(-1, NumberHelper<long>.Sign(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.Abs((long)0x0000000000000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.Abs((long)0x0000000000000001));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.Abs((long)0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<long>.Abs(unchecked((long)0x8000000000000000)));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.Abs(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -767,46 +937,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            Assert.Equal(((long)0x0000000000000000, (long)0x0000000000000000), BinaryIntegerHelper<long>.DivRem((long)0x0000000000000000, 2));
-            Assert.Equal(((long)0x0000000000000000, (long)0x0000000000000001), BinaryIntegerHelper<long>.DivRem((long)0x0000000000000001, 2));
-            Assert.Equal(((long)0x3FFFFFFFFFFFFFFF, (long)0x0000000000000001), BinaryIntegerHelper<long>.DivRem((long)0x7FFFFFFFFFFFFFFF, 2));
-            Assert.Equal((unchecked((long)0xC000000000000000), (long)0x0000000000000000), BinaryIntegerHelper<long>.DivRem(unchecked((long)0x8000000000000000), 2));
-            Assert.Equal(((long)0x0000000000000000, unchecked((long)0xFFFFFFFFFFFFFFFF)), BinaryIntegerHelper<long>.DivRem(unchecked((long)0xFFFFFFFFFFFFFFFF), 2));
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Max((long)0x0000000000000000, 1));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Max((long)0x0000000000000001, 1));
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.Max((long)0x7FFFFFFFFFFFFFFF, 1));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Max(unchecked((long)0x8000000000000000), 1));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Max(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.Min((long)0x0000000000000000, 1));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Min((long)0x0000000000000001, 1));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Min((long)0x7FFFFFFFFFFFFFFF, 1));
-            Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.Min(unchecked((long)0x8000000000000000), 1));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.Min(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(0, NumberHelper<long>.Sign((long)0x0000000000000000));
-            Assert.Equal(1, NumberHelper<long>.Sign((long)0x0000000000000001));
-            Assert.Equal(1, NumberHelper<long>.Sign((long)0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(-1, NumberHelper<long>.Sign(unchecked((long)0x8000000000000000)));
-            Assert.Equal(-1, NumberHelper<long>.Sign(unchecked((long)0xFFFFFFFFFFFFFFFF)));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             long result;
@@ -1077,77 +1207,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            Assert.Equal(8, BinaryIntegerHelper<long>.GetByteCount((long)0x0000000000000000));
-            Assert.Equal(8, BinaryIntegerHelper<long>.GetByteCount((long)0x0000000000000001));
-            Assert.Equal(8, BinaryIntegerHelper<long>.GetByteCount((long)0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(8, BinaryIntegerHelper<long>.GetByteCount(unchecked((long)0x8000000000000000)));
-            Assert.Equal(8, BinaryIntegerHelper<long>.GetByteCount(unchecked((long)0xFFFFFFFFFFFFFFFF)));
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[8];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<long>.TryWriteBigEndian((long)0x0000000000000000, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<long>.TryWriteBigEndian((long)0x0000000000000001, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<long>.TryWriteBigEndian((long)0x7FFFFFFFFFFFFFFF, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<long>.TryWriteBigEndian(unchecked((long)0x8000000000000000), destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<long>.TryWriteBigEndian(unchecked((long)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<long>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[8];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<long>.TryWriteLittleEndian((long)0x0000000000000000, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<long>.TryWriteLittleEndian((long)0x0000000000000001, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<long>.TryWriteLittleEndian((long)0x7FFFFFFFFFFFFFFF, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<long>.TryWriteLittleEndian(unchecked((long)0x8000000000000000), destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<long>.TryWriteLittleEndian(unchecked((long)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<long>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1179,6 +1241,20 @@ namespace System.Tests
             Assert.Equal((long)0x7FFFFFFFFFFFFFFF, ShiftOperatorsHelper<long, long>.op_UnsignedRightShift(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
         }
 
+        //
+        // ISignedNumber
+        //
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), SignedNumberHelper<long>.NegativeOne);
+        }
+
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1199,6 +1275,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<long, long, long>.op_CheckedSubtraction(unchecked((long)0x8000000000000000), 1));
         }
+
+        //
+        // IUnaryNegationOperators
+        //
 
         [Fact]
         public static void op_UnaryNegationTest()
@@ -1221,6 +1301,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => UnaryNegationOperatorsHelper<long, long>.op_CheckedUnaryNegation(unchecked((long)0x8000000000000000)));
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1230,6 +1314,10 @@ namespace System.Tests
             Assert.Equal(unchecked((long)0x8000000000000000), UnaryPlusOperatorsHelper<long, long>.op_UnaryPlus(unchecked((long)0x8000000000000000)));
             Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), UnaryPlusOperatorsHelper<long, long>.op_UnaryPlus(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(Int64Tests.Parse_Valid_TestData), MemberType = typeof(Int64Tests))]

--- a/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
@@ -353,11 +353,11 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.Abs((long)0x0000000000000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Abs((long)0x0000000000000001));
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.Abs((long)0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<long>.Abs(unchecked((long)0x8000000000000000)));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Abs(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.Abs((long)0x0000000000000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.Abs((long)0x0000000000000001));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.Abs((long)0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<long>.Abs(unchecked((long)0x8000000000000000)));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.Abs(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -373,51 +373,51 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<byte>(0x00));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<byte>(0x01));
-            Assert.Equal((long)0x000000000000007F, NumberHelper<long>.CreateChecked<byte>(0x7F));
-            Assert.Equal((long)0x0000000000000080, NumberHelper<long>.CreateChecked<byte>(0x80));
-            Assert.Equal((long)0x00000000000000FF, NumberHelper<long>.CreateChecked<byte>(0xFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<byte>(0x00));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<byte>(0x01));
+            Assert.Equal((long)0x000000000000007F, NumberBaseHelper<long>.CreateChecked<byte>(0x7F));
+            Assert.Equal((long)0x0000000000000080, NumberBaseHelper<long>.CreateChecked<byte>(0x80));
+            Assert.Equal((long)0x00000000000000FF, NumberBaseHelper<long>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<char>((char)0x0000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<char>((char)0x0001));
-            Assert.Equal((long)0x0000000000007FFF, NumberHelper<long>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal((long)0x0000000000008000, NumberHelper<long>.CreateChecked<char>((char)0x8000));
-            Assert.Equal((long)0x000000000000FFFF, NumberHelper<long>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<char>((char)0x0000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<char>((char)0x0001));
+            Assert.Equal((long)0x0000000000007FFF, NumberBaseHelper<long>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal((long)0x0000000000008000, NumberBaseHelper<long>.CreateChecked<char>((char)0x8000));
+            Assert.Equal((long)0x000000000000FFFF, NumberBaseHelper<long>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<short>(0x0000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<short>(0x0001));
-            Assert.Equal((long)0x0000000000007FFF, NumberHelper<long>.CreateChecked<short>(0x7FFF));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFF8000), NumberHelper<long>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<short>(0x0000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<short>(0x0001));
+            Assert.Equal((long)0x0000000000007FFF, NumberBaseHelper<long>.CreateChecked<short>(0x7FFF));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFF8000), NumberBaseHelper<long>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<int>(0x00000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<int>(0x00000001));
-            Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberHelper<long>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<int>(0x00000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<int>(0x00000001));
+            Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberBaseHelper<long>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<long>(0x0000000000000001));
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<long>(0x0000000000000001));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(unchecked((long)0x8000000000000000), NumberBaseHelper<long>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
@@ -425,60 +425,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((long)0x8000000000000000), NumberBaseHelper<long>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberHelper<long>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberBaseHelper<long>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<sbyte>(0x00));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<sbyte>(0x01));
-            Assert.Equal((long)0x000000000000007F, NumberHelper<long>.CreateChecked<sbyte>(0x7F));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFF80), NumberHelper<long>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<sbyte>(0x00));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<sbyte>(0x01));
+            Assert.Equal((long)0x000000000000007F, NumberBaseHelper<long>.CreateChecked<sbyte>(0x7F));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFF80), NumberBaseHelper<long>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<ushort>(0x0000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<ushort>(0x0001));
-            Assert.Equal((long)0x0000000000007FFF, NumberHelper<long>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal((long)0x0000000000008000, NumberHelper<long>.CreateChecked<ushort>(0x8000));
-            Assert.Equal((long)0x000000000000FFFF, NumberHelper<long>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<ushort>(0x0000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<ushort>(0x0001));
+            Assert.Equal((long)0x0000000000007FFF, NumberBaseHelper<long>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal((long)0x0000000000008000, NumberBaseHelper<long>.CreateChecked<ushort>(0x8000));
+            Assert.Equal((long)0x000000000000FFFF, NumberBaseHelper<long>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<uint>(0x00000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<uint>(0x00000001));
-            Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Equal((long)0x0000000080000000, NumberHelper<long>.CreateChecked<uint>(0x80000000));
-            Assert.Equal((long)0x00000000FFFFFFFF, NumberHelper<long>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<uint>(0x00000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<uint>(0x00000001));
+            Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Equal((long)0x0000000080000000, NumberBaseHelper<long>.CreateChecked<uint>(0x80000000));
+            Assert.Equal((long)0x00000000FFFFFFFF, NumberBaseHelper<long>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<long>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<long>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<long>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<long>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -486,70 +486,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<long>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<long>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<long>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<long>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((long)0x0000000080000000, NumberHelper<long>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Equal((long)0x00000000FFFFFFFF, NumberHelper<long>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((long)0x0000000080000000, NumberBaseHelper<long>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Equal((long)0x00000000FFFFFFFF, NumberBaseHelper<long>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<byte>(0x00));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<byte>(0x01));
-            Assert.Equal((long)0x000000000000007F, NumberHelper<long>.CreateSaturating<byte>(0x7F));
-            Assert.Equal((long)0x0000000000000080, NumberHelper<long>.CreateSaturating<byte>(0x80));
-            Assert.Equal((long)0x00000000000000FF, NumberHelper<long>.CreateSaturating<byte>(0xFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<byte>(0x00));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<byte>(0x01));
+            Assert.Equal((long)0x000000000000007F, NumberBaseHelper<long>.CreateSaturating<byte>(0x7F));
+            Assert.Equal((long)0x0000000000000080, NumberBaseHelper<long>.CreateSaturating<byte>(0x80));
+            Assert.Equal((long)0x00000000000000FF, NumberBaseHelper<long>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal((long)0x0000000000007FFF, NumberHelper<long>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal((long)0x0000000000008000, NumberHelper<long>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal((long)0x000000000000FFFF, NumberHelper<long>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal((long)0x0000000000007FFF, NumberBaseHelper<long>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal((long)0x0000000000008000, NumberBaseHelper<long>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal((long)0x000000000000FFFF, NumberBaseHelper<long>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<short>(0x0000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<short>(0x0001));
-            Assert.Equal((long)0x0000000000007FFF, NumberHelper<long>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFF8000), NumberHelper<long>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<short>(0x0000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<short>(0x0001));
+            Assert.Equal((long)0x0000000000007FFF, NumberBaseHelper<long>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFF8000), NumberBaseHelper<long>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<int>(0x00000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<int>(0x00000001));
-            Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberHelper<long>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<int>(0x00000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<int>(0x00000001));
+            Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberBaseHelper<long>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(unchecked((long)0x8000000000000000), NumberBaseHelper<long>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
@@ -557,60 +557,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((long)0x8000000000000000), NumberBaseHelper<long>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberHelper<long>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberBaseHelper<long>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal((long)0x000000000000007F, NumberHelper<long>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFF80), NumberHelper<long>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal((long)0x000000000000007F, NumberBaseHelper<long>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFF80), NumberBaseHelper<long>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal((long)0x0000000000007FFF, NumberHelper<long>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal((long)0x0000000000008000, NumberHelper<long>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal((long)0x000000000000FFFF, NumberHelper<long>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal((long)0x0000000000007FFF, NumberBaseHelper<long>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal((long)0x0000000000008000, NumberBaseHelper<long>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal((long)0x000000000000FFFF, NumberBaseHelper<long>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal((long)0x0000000080000000, NumberHelper<long>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal((long)0x00000000FFFFFFFF, NumberHelper<long>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal((long)0x0000000080000000, NumberBaseHelper<long>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal((long)0x00000000FFFFFFFF, NumberBaseHelper<long>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -618,70 +618,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((long)0x0000000080000000, NumberHelper<long>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal((long)0x00000000FFFFFFFF, NumberHelper<long>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((long)0x0000000080000000, NumberBaseHelper<long>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal((long)0x00000000FFFFFFFF, NumberBaseHelper<long>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<byte>(0x00));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<byte>(0x01));
-            Assert.Equal((long)0x000000000000007F, NumberHelper<long>.CreateTruncating<byte>(0x7F));
-            Assert.Equal((long)0x0000000000000080, NumberHelper<long>.CreateTruncating<byte>(0x80));
-            Assert.Equal((long)0x00000000000000FF, NumberHelper<long>.CreateTruncating<byte>(0xFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<byte>(0x00));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<byte>(0x01));
+            Assert.Equal((long)0x000000000000007F, NumberBaseHelper<long>.CreateTruncating<byte>(0x7F));
+            Assert.Equal((long)0x0000000000000080, NumberBaseHelper<long>.CreateTruncating<byte>(0x80));
+            Assert.Equal((long)0x00000000000000FF, NumberBaseHelper<long>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal((long)0x0000000000007FFF, NumberHelper<long>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal((long)0x0000000000008000, NumberHelper<long>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal((long)0x000000000000FFFF, NumberHelper<long>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal((long)0x0000000000007FFF, NumberBaseHelper<long>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal((long)0x0000000000008000, NumberBaseHelper<long>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal((long)0x000000000000FFFF, NumberBaseHelper<long>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<short>(0x0000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<short>(0x0001));
-            Assert.Equal((long)0x0000000000007FFF, NumberHelper<long>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFF8000), NumberHelper<long>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<short>(0x0000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<short>(0x0001));
+            Assert.Equal((long)0x0000000000007FFF, NumberBaseHelper<long>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFF8000), NumberBaseHelper<long>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<int>(0x00000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<int>(0x00000001));
-            Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberHelper<long>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<int>(0x00000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<int>(0x00000001));
+            Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberBaseHelper<long>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(unchecked((long)0x8000000000000000), NumberBaseHelper<long>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
@@ -689,60 +689,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((long)0x8000000000000000), NumberBaseHelper<long>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberHelper<long>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(unchecked((long)0xFFFFFFFF80000000), NumberBaseHelper<long>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal((long)0x000000000000007F, NumberHelper<long>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFF80), NumberHelper<long>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal((long)0x000000000000007F, NumberBaseHelper<long>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFF80), NumberBaseHelper<long>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal((long)0x0000000000007FFF, NumberHelper<long>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal((long)0x0000000000008000, NumberHelper<long>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal((long)0x000000000000FFFF, NumberHelper<long>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal((long)0x0000000000007FFF, NumberBaseHelper<long>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal((long)0x0000000000008000, NumberBaseHelper<long>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal((long)0x000000000000FFFF, NumberBaseHelper<long>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal((long)0x0000000080000000, NumberHelper<long>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal((long)0x00000000FFFFFFFF, NumberHelper<long>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal((long)0x0000000080000000, NumberBaseHelper<long>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal((long)0x00000000FFFFFFFF, NumberBaseHelper<long>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(unchecked((long)0x8000000000000000), NumberBaseHelper<long>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -750,19 +750,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<long>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((long)0x8000000000000000), NumberBaseHelper<long>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<long>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal((long)0x000000007FFFFFFF, NumberHelper<long>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((long)0x0000000080000000, NumberHelper<long>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal((long)0x00000000FFFFFFFF, NumberHelper<long>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal((long)0x0000000000000001, NumberBaseHelper<long>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal((long)0x000000007FFFFFFF, NumberBaseHelper<long>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((long)0x0000000080000000, NumberBaseHelper<long>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal((long)0x00000000FFFFFFFF, NumberBaseHelper<long>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -811,19 +811,19 @@ namespace System.Tests
         {
             long result;
 
-            Assert.True(NumberHelper<long>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<byte>(0x00, out result));
             Assert.Equal((long)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<byte>(0x01, out result));
             Assert.Equal((long)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((long)0x000000000000007F, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<byte>(0x80, out result));
             Assert.Equal((long)0x0000000000000080, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((long)0x00000000000000FF, result);
         }
 
@@ -832,19 +832,19 @@ namespace System.Tests
         {
             long result;
 
-            Assert.True(NumberHelper<long>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal((long)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal((long)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((long)0x0000000000007FFF, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((long)0x0000000000008000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((long)0x000000000000FFFF, result);
         }
 
@@ -853,19 +853,19 @@ namespace System.Tests
         {
             long result;
 
-            Assert.True(NumberHelper<long>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<short>(0x0000, out result));
             Assert.Equal((long)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<short>(0x0001, out result));
             Assert.Equal((long)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((long)0x0000000000007FFF, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal(unchecked((long)0xFFFFFFFFFFFF8000), result);
 
-            Assert.True(NumberHelper<long>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), result);
         }
 
@@ -874,19 +874,19 @@ namespace System.Tests
         {
             long result;
 
-            Assert.True(NumberHelper<long>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<int>(0x00000000, out result));
             Assert.Equal((long)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<int>(0x00000001, out result));
             Assert.Equal((long)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((long)0x000000007FFFFFFF, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal(unchecked((long)0xFFFFFFFF80000000), result);
 
-            Assert.True(NumberHelper<long>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), result);
         }
 
@@ -895,19 +895,19 @@ namespace System.Tests
         {
             long result;
 
-            Assert.True(NumberHelper<long>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal((long)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal((long)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((long)0x7FFFFFFFFFFFFFFF, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
             Assert.Equal(unchecked((long)0x8000000000000000), result);
 
-            Assert.True(NumberHelper<long>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
             Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), result);
         }
 
@@ -918,36 +918,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<long>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal((long)0x0000000000000000, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal((long)0x0000000000000001, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((long)0x7FFFFFFFFFFFFFFF, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal(unchecked((long)0x8000000000000000), result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), result);
             }
             else
             {
-                Assert.True(NumberHelper<long>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal((long)0x0000000000000000, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal((long)0x0000000000000001, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((long)0x000000007FFFFFFF, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal(unchecked((long)0xFFFFFFFF80000000), result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), result);
             }
         }
@@ -957,19 +957,19 @@ namespace System.Tests
         {
             long result;
 
-            Assert.True(NumberHelper<long>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal((long)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal((long)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((long)0x000000000000007F, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFF80), result);
 
-            Assert.True(NumberHelper<long>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), result);
         }
 
@@ -978,19 +978,19 @@ namespace System.Tests
         {
             long result;
 
-            Assert.True(NumberHelper<long>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal((long)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal((long)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((long)0x0000000000007FFF, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((long)0x0000000000008000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((long)0x000000000000FFFF, result);
         }
 
@@ -999,19 +999,19 @@ namespace System.Tests
         {
             long result;
 
-            Assert.True(NumberHelper<long>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal((long)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal((long)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal((long)0x000000007FFFFFFF, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<uint>(0x80000000, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal((long)0x0000000080000000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal((long)0x00000000FFFFFFFF, result);
         }
 
@@ -1020,19 +1020,19 @@ namespace System.Tests
         {
             long result;
 
-            Assert.True(NumberHelper<long>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal((long)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal((long)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<long>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<long>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((long)0x7FFFFFFFFFFFFFFF, result);
 
-            Assert.False(NumberHelper<long>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.False(NumberBaseHelper<long>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal((long)0x0000000000000000, result);
 
-            Assert.False(NumberHelper<long>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<long>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal((long)0x0000000000000000, result);
         }
 
@@ -1043,36 +1043,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<long>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal((long)0x0000000000000000, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal((long)0x0000000000000001, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((long)0x7FFFFFFFFFFFFFFF, result);
 
-                Assert.False(NumberHelper<long>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<long>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal((long)0x0000000000000000, result);
 
-                Assert.False(NumberHelper<long>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<long>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((long)0x0000000000000000, result);
             }
             else
             {
-                Assert.True(NumberHelper<long>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal((long)0x0000000000000000, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal((long)0x0000000000000001, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((long)0x000000007FFFFFFF, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal((long)0x0000000080000000, result);
 
-                Assert.True(NumberHelper<long>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<long>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal((long)0x00000000FFFFFFFF, result);
             }
         }
@@ -1248,12 +1248,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Equal(expected, NumberHelper<long>.Parse(value, style, provider));
+                Assert.Equal(expected, NumberBaseHelper<long>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.True(NumberHelper<long>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.True(NumberBaseHelper<long>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(expected, result);
-                Assert.Equal(expected, NumberHelper<long>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Equal(expected, NumberBaseHelper<long>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1263,9 +1263,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.True(NumberHelper<long>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<long>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
-            Assert.Equal(expected, NumberHelper<long>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<long>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1285,12 +1285,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<long>.Parse(value, style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<long>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.False(NumberHelper<long>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.False(NumberBaseHelper<long>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(default(long), result);
-                Assert.Throws(exceptionType, () => NumberHelper<long>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<long>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1300,9 +1300,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.False(NumberHelper<long>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<long>.TryParse(value, style, provider, out result));
             Assert.Equal(default(long), result);
-            Assert.Throws(exceptionType, () => NumberHelper<long>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<long>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1318,9 +1318,9 @@ namespace System.Tests
                 Assert.Equal(expected, result);
             }
 
-            Assert.Equal(expected, NumberHelper<long>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<long>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<long>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<long>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1342,9 +1342,9 @@ namespace System.Tests
                 Assert.Equal(default(long), result);
             }
 
-            Assert.Throws(exceptionType, () => NumberHelper<long>.Parse(value.AsSpan(), style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<long>.Parse(value.AsSpan(), style, provider));
 
-            Assert.False(NumberHelper<long>.TryParse(value.AsSpan(), style, provider, out result));
+            Assert.False(NumberBaseHelper<long>.TryParse(value.AsSpan(), style, provider, out result));
             Assert.Equal(default(long), result);
         }
     }

--- a/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
@@ -706,19 +706,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.Abs(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Abs(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.Abs(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.Abs(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Abs(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.Abs(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.Abs(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.Abs(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.Abs(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.Abs(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.Abs((nint)0x00000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Abs((nint)0x00000001));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.Abs((nint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.Abs(unchecked((nint)0x80000000)));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Abs(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.Abs((nint)0x00000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.Abs((nint)0x00000001));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.Abs((nint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.Abs(unchecked((nint)0x80000000)));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.Abs(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
@@ -746,41 +746,41 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateChecked<byte>(0x00));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateChecked<byte>(0x01));
-            Assert.Equal((nint)0x0000007F, NumberHelper<nint>.CreateChecked<byte>(0x7F));
-            Assert.Equal((nint)0x00000080, NumberHelper<nint>.CreateChecked<byte>(0x80));
-            Assert.Equal((nint)0x000000FF, NumberHelper<nint>.CreateChecked<byte>(0xFF));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<byte>(0x00));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<byte>(0x01));
+            Assert.Equal((nint)0x0000007F, NumberBaseHelper<nint>.CreateChecked<byte>(0x7F));
+            Assert.Equal((nint)0x00000080, NumberBaseHelper<nint>.CreateChecked<byte>(0x80));
+            Assert.Equal((nint)0x000000FF, NumberBaseHelper<nint>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateChecked<char>((char)0x0000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateChecked<char>((char)0x0001));
-            Assert.Equal((nint)0x00007FFF, NumberHelper<nint>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal((nint)0x00008000, NumberHelper<nint>.CreateChecked<char>((char)0x8000));
-            Assert.Equal((nint)0x0000FFFF, NumberHelper<nint>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<char>((char)0x0000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<char>((char)0x0001));
+            Assert.Equal((nint)0x00007FFF, NumberBaseHelper<nint>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal((nint)0x00008000, NumberBaseHelper<nint>.CreateChecked<char>((char)0x8000));
+            Assert.Equal((nint)0x0000FFFF, NumberBaseHelper<nint>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateChecked<short>(0x0000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateChecked<short>(0x0001));
-            Assert.Equal((nint)0x00007FFF, NumberHelper<nint>.CreateChecked<short>(0x7FFF));
-            Assert.Equal(unchecked((nint)(int)0xFFFF8000), NumberHelper<nint>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberHelper<nint>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<short>(0x0000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<short>(0x0001));
+            Assert.Equal((nint)0x00007FFF, NumberBaseHelper<nint>.CreateChecked<short>(0x7FFF));
+            Assert.Equal(unchecked((nint)(int)0xFFFF8000), NumberBaseHelper<nint>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberBaseHelper<nint>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateChecked<int>(0x00000000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateChecked<int>(0x00000001));
-            Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Equal(unchecked((nint)(int)0x80000000), NumberHelper<nint>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberHelper<nint>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<int>(0x00000000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<int>(0x00000001));
+            Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Equal(unchecked((nint)(int)0x80000000), NumberBaseHelper<nint>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberBaseHelper<nint>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
@@ -788,19 +788,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateChecked<long>(0x0000000000000000));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateChecked<long>(0x0000000000000001));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateChecked<long>(0x0000000000000000));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateChecked<long>(0x0000000000000001));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberBaseHelper<nint>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateChecked<long>(0x0000000000000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateChecked<long>(0x0000000000000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<long>(0x0000000000000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<long>(0x0000000000000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
         }
 
@@ -809,40 +809,40 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberBaseHelper<nint>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(unchecked((nint)0x80000000), NumberHelper<nint>.CreateChecked<nint>(unchecked(unchecked((nint)0x80000000))));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateChecked<nint>(unchecked(unchecked((nint)0xFFFFFFFF))));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(unchecked((nint)0x80000000), NumberBaseHelper<nint>.CreateChecked<nint>(unchecked(unchecked((nint)0x80000000))));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateChecked<nint>(unchecked(unchecked((nint)0xFFFFFFFF))));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateChecked<sbyte>(0x00));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateChecked<sbyte>(0x01));
-            Assert.Equal((nint)0x0000007F, NumberHelper<nint>.CreateChecked<sbyte>(0x7F));
-            Assert.Equal(unchecked((nint)(int)0xFFFFFF80), NumberHelper<nint>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberHelper<nint>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<sbyte>(0x00));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<sbyte>(0x01));
+            Assert.Equal((nint)0x0000007F, NumberBaseHelper<nint>.CreateChecked<sbyte>(0x7F));
+            Assert.Equal(unchecked((nint)(int)0xFFFFFF80), NumberBaseHelper<nint>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberBaseHelper<nint>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateChecked<ushort>(0x0000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateChecked<ushort>(0x0001));
-            Assert.Equal((nint)0x00007FFF, NumberHelper<nint>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal((nint)0x00008000, NumberHelper<nint>.CreateChecked<ushort>(0x8000));
-            Assert.Equal((nint)0x0000FFFF, NumberHelper<nint>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<ushort>(0x0000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<ushort>(0x0001));
+            Assert.Equal((nint)0x00007FFF, NumberBaseHelper<nint>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal((nint)0x00008000, NumberBaseHelper<nint>.CreateChecked<ushort>(0x8000));
+            Assert.Equal((nint)0x0000FFFF, NumberBaseHelper<nint>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
@@ -850,19 +850,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateChecked<uint>(0x00000000));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateChecked<uint>(0x00000001));
-                Assert.Equal(unchecked((nint)0x000000007FFFFFFF), NumberHelper<nint>.CreateChecked<uint>(0x7FFFFFFF));
-                Assert.Equal(unchecked((nint)0x0000000080000000), NumberHelper<nint>.CreateChecked<uint>(0x80000000));
-                Assert.Equal(unchecked((nint)0x00000000FFFFFFFF), NumberHelper<nint>.CreateChecked<uint>(0xFFFFFFFF));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateChecked<uint>(0x00000000));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateChecked<uint>(0x00000001));
+                Assert.Equal(unchecked((nint)0x000000007FFFFFFF), NumberBaseHelper<nint>.CreateChecked<uint>(0x7FFFFFFF));
+                Assert.Equal(unchecked((nint)0x0000000080000000), NumberBaseHelper<nint>.CreateChecked<uint>(0x80000000));
+                Assert.Equal(unchecked((nint)0x00000000FFFFFFFF), NumberBaseHelper<nint>.CreateChecked<uint>(0xFFFFFFFF));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateChecked<uint>(0x00000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateChecked<uint>(0x00000001));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateChecked<uint>(0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<uint>(0x80000000));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<uint>(0xFFFFFFFF));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<uint>(0x00000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<uint>(0x00000001));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateChecked<uint>(0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<uint>(0x80000000));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<uint>(0xFFFFFFFF));
             }
         }
 
@@ -871,19 +871,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateChecked<ulong>(0x0000000000000000));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateChecked<ulong>(0x0000000000000001));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<ulong>(0x8000000000000000));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateChecked<ulong>(0x0000000000000000));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateChecked<ulong>(0x0000000000000001));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<ulong>(0x8000000000000000));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateChecked<ulong>(0x0000000000000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateChecked<ulong>(0x0000000000000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<ulong>(0x8000000000000000));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<ulong>(0x0000000000000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<ulong>(0x0000000000000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<ulong>(0x8000000000000000));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
             }
         }
 
@@ -892,60 +892,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0x80000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFF)));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0x80000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<byte>(0x00));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateSaturating<byte>(0x01));
-            Assert.Equal((nint)0x0000007F, NumberHelper<nint>.CreateSaturating<byte>(0x7F));
-            Assert.Equal((nint)0x00000080, NumberHelper<nint>.CreateSaturating<byte>(0x80));
-            Assert.Equal((nint)0x000000FF, NumberHelper<nint>.CreateSaturating<byte>(0xFF));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<byte>(0x00));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<byte>(0x01));
+            Assert.Equal((nint)0x0000007F, NumberBaseHelper<nint>.CreateSaturating<byte>(0x7F));
+            Assert.Equal((nint)0x00000080, NumberBaseHelper<nint>.CreateSaturating<byte>(0x80));
+            Assert.Equal((nint)0x000000FF, NumberBaseHelper<nint>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal((nint)0x00007FFF, NumberHelper<nint>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal((nint)0x00008000, NumberHelper<nint>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal((nint)0x0000FFFF, NumberHelper<nint>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal((nint)0x00007FFF, NumberBaseHelper<nint>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal((nint)0x00008000, NumberBaseHelper<nint>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal((nint)0x0000FFFF, NumberBaseHelper<nint>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<short>(0x0000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateSaturating<short>(0x0001));
-            Assert.Equal((nint)0x00007FFF, NumberHelper<nint>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal(unchecked((nint)(int)0xFFFF8000), NumberHelper<nint>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberHelper<nint>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<short>(0x0000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<short>(0x0001));
+            Assert.Equal((nint)0x00007FFF, NumberBaseHelper<nint>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal(unchecked((nint)(int)0xFFFF8000), NumberBaseHelper<nint>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<int>(0x00000000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateSaturating<int>(0x00000001));
-            Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal(unchecked((nint)(int)0x80000000), NumberHelper<nint>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberHelper<nint>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<int>(0x00000000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<int>(0x00000001));
+            Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal(unchecked((nint)(int)0x80000000), NumberBaseHelper<nint>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
@@ -953,19 +953,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateSaturating<long>(0x0000000000000000));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateSaturating<long>(0x0000000000000001));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateSaturating<long>(0x0000000000000000));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateSaturating<long>(0x0000000000000001));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberBaseHelper<nint>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<long>(0x0000000000000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateSaturating<long>(0x0000000000000001));
-                Assert.Equal(unchecked((nint)0x7FFFFFFF), NumberHelper<nint>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal(unchecked((nint)0x80000000), NumberHelper<nint>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<long>(0x0000000000000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<long>(0x0000000000000001));
+                Assert.Equal(unchecked((nint)0x7FFFFFFF), NumberBaseHelper<nint>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nint)0x80000000), NumberBaseHelper<nint>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
         }
 
@@ -974,40 +974,40 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberBaseHelper<nint>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(unchecked((nint)0x80000000), NumberHelper<nint>.CreateSaturating<nint>(unchecked(unchecked((nint)0x80000000))));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateSaturating<nint>(unchecked(unchecked((nint)0xFFFFFFFF))));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(unchecked((nint)0x80000000), NumberBaseHelper<nint>.CreateSaturating<nint>(unchecked(unchecked((nint)0x80000000))));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<nint>(unchecked(unchecked((nint)0xFFFFFFFF))));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal((nint)0x0000007F, NumberHelper<nint>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal(unchecked((nint)(int)0xFFFFFF80), NumberHelper<nint>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberHelper<nint>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal((nint)0x0000007F, NumberBaseHelper<nint>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal(unchecked((nint)(int)0xFFFFFF80), NumberBaseHelper<nint>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal((nint)0x00007FFF, NumberHelper<nint>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal((nint)0x00008000, NumberHelper<nint>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal((nint)0x0000FFFF, NumberHelper<nint>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal((nint)0x00007FFF, NumberBaseHelper<nint>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal((nint)0x00008000, NumberBaseHelper<nint>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal((nint)0x0000FFFF, NumberBaseHelper<nint>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
@@ -1015,19 +1015,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateSaturating<uint>(0x00000000));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateSaturating<uint>(0x00000001));
-                Assert.Equal(unchecked((nint)0x000000007FFFFFFF), NumberHelper<nint>.CreateSaturating<uint>(0x7FFFFFFF));
-                Assert.Equal(unchecked((nint)0x0000000080000000), NumberHelper<nint>.CreateSaturating<uint>(0x80000000));
-                Assert.Equal(unchecked((nint)0x00000000FFFFFFFF), NumberHelper<nint>.CreateSaturating<uint>(0xFFFFFFFF));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateSaturating<uint>(0x00000000));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateSaturating<uint>(0x00000001));
+                Assert.Equal(unchecked((nint)0x000000007FFFFFFF), NumberBaseHelper<nint>.CreateSaturating<uint>(0x7FFFFFFF));
+                Assert.Equal(unchecked((nint)0x0000000080000000), NumberBaseHelper<nint>.CreateSaturating<uint>(0x80000000));
+                Assert.Equal(unchecked((nint)0x00000000FFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<uint>(0xFFFFFFFF));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<uint>(0x00000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateSaturating<uint>(0x00000001));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateSaturating<uint>(0x7FFFFFFF));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateSaturating<uint>(0x80000000));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateSaturating<uint>(0xFFFFFFFF));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<uint>(0x00000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<uint>(0x00000001));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateSaturating<uint>(0x7FFFFFFF));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateSaturating<uint>(0x80000000));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateSaturating<uint>(0xFFFFFFFF));
             }
         }
 
@@ -1036,19 +1036,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateSaturating<ulong>(0x0000000000000000));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateSaturating<ulong>(0x0000000000000001));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateSaturating<ulong>(0x8000000000000000));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateSaturating<ulong>(0x0000000000000000));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateSaturating<ulong>(0x0000000000000001));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<ulong>(0x8000000000000000));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<ulong>(0x0000000000000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateSaturating<ulong>(0x0000000000000001));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateSaturating<ulong>(0x8000000000000000));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<ulong>(0x0000000000000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<ulong>(0x0000000000000001));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateSaturating<ulong>(0x8000000000000000));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
         }
 
@@ -1057,40 +1057,40 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0x80000000)));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFF)));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0x80000000)));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<byte>(0x00));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateTruncating<byte>(0x01));
-            Assert.Equal((nint)0x0000007F, NumberHelper<nint>.CreateTruncating<byte>(0x7F));
-            Assert.Equal((nint)0x00000080, NumberHelper<nint>.CreateTruncating<byte>(0x80));
-            Assert.Equal((nint)0x000000FF, NumberHelper<nint>.CreateTruncating<byte>(0xFF));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<byte>(0x00));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<byte>(0x01));
+            Assert.Equal((nint)0x0000007F, NumberBaseHelper<nint>.CreateTruncating<byte>(0x7F));
+            Assert.Equal((nint)0x00000080, NumberBaseHelper<nint>.CreateTruncating<byte>(0x80));
+            Assert.Equal((nint)0x000000FF, NumberBaseHelper<nint>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal((nint)0x00007FFF, NumberHelper<nint>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal((nint)0x00008000, NumberHelper<nint>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal((nint)0x0000FFFF, NumberHelper<nint>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal((nint)0x00007FFF, NumberBaseHelper<nint>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal((nint)0x00008000, NumberBaseHelper<nint>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal((nint)0x0000FFFF, NumberBaseHelper<nint>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
@@ -1098,30 +1098,30 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateTruncating<short>(0x0000));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateTruncating<short>(0x0001));
-                Assert.Equal(unchecked((nint)0x0000000000007FFF), NumberHelper<nint>.CreateTruncating<short>(0x7FFF));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFF8000), NumberHelper<nint>.CreateTruncating<short>(unchecked((short)0x8000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateTruncating<short>(0x0000));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateTruncating<short>(0x0001));
+                Assert.Equal(unchecked((nint)0x0000000000007FFF), NumberBaseHelper<nint>.CreateTruncating<short>(0x7FFF));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFF8000), NumberBaseHelper<nint>.CreateTruncating<short>(unchecked((short)0x8000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<short>(unchecked((short)0xFFFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<short>(0x0000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateTruncating<short>(0x0001));
-                Assert.Equal((nint)0x00007FFF, NumberHelper<nint>.CreateTruncating<short>(0x7FFF));
-                Assert.Equal(unchecked((nint)0xFFFF8000), NumberHelper<nint>.CreateTruncating<short>(unchecked((short)0x8000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<short>(0x0000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<short>(0x0001));
+                Assert.Equal((nint)0x00007FFF, NumberBaseHelper<nint>.CreateTruncating<short>(0x7FFF));
+                Assert.Equal(unchecked((nint)0xFFFF8000), NumberBaseHelper<nint>.CreateTruncating<short>(unchecked((short)0x8000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<short>(unchecked((short)0xFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<int>(0x00000000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateTruncating<int>(0x00000001));
-            Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal(unchecked((nint)(int)0x80000000), NumberHelper<nint>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberHelper<nint>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<int>(0x00000000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<int>(0x00000001));
+            Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal(unchecked((nint)(int)0x80000000), NumberBaseHelper<nint>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
@@ -1129,19 +1129,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateTruncating<long>(0x0000000000000000));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateTruncating<long>(0x0000000000000001));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateTruncating<long>(0x0000000000000000));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateTruncating<long>(0x0000000000000001));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberBaseHelper<nint>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<long>(0x0000000000000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateTruncating<long>(0x0000000000000001));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<long>(0x0000000000000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<long>(0x0000000000000001));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
         }
 
@@ -1150,19 +1150,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberBaseHelper<nint>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(unchecked((nint)0x80000000), NumberHelper<nint>.CreateTruncating<nint>(unchecked(unchecked((nint)0x80000000))));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateTruncating<nint>(unchecked(unchecked((nint)0xFFFFFFFF))));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(unchecked((nint)0x80000000), NumberBaseHelper<nint>.CreateTruncating<nint>(unchecked(unchecked((nint)0x80000000))));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<nint>(unchecked(unchecked((nint)0xFFFFFFFF))));
             }
         }
 
@@ -1171,40 +1171,40 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateTruncating<sbyte>(0x00));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateTruncating<sbyte>(0x01));
-                Assert.Equal(unchecked((nint)0x000000000000007F), NumberHelper<nint>.CreateTruncating<sbyte>(0x7F));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFF80), NumberHelper<nint>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateTruncating<sbyte>(0x00));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateTruncating<sbyte>(0x01));
+                Assert.Equal(unchecked((nint)0x000000000000007F), NumberBaseHelper<nint>.CreateTruncating<sbyte>(0x7F));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFF80), NumberBaseHelper<nint>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<sbyte>(0x00));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateTruncating<sbyte>(0x01));
-                Assert.Equal((nint)0x0000007F, NumberHelper<nint>.CreateTruncating<sbyte>(0x7F));
-                Assert.Equal(unchecked((nint)0xFFFFFF80), NumberHelper<nint>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<sbyte>(0x00));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<sbyte>(0x01));
+                Assert.Equal((nint)0x0000007F, NumberBaseHelper<nint>.CreateTruncating<sbyte>(0x7F));
+                Assert.Equal(unchecked((nint)0xFFFFFF80), NumberBaseHelper<nint>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal((nint)0x00007FFF, NumberHelper<nint>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal((nint)0x00008000, NumberHelper<nint>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal((nint)0x0000FFFF, NumberHelper<nint>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal((nint)0x00007FFF, NumberBaseHelper<nint>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal((nint)0x00008000, NumberBaseHelper<nint>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal((nint)0x0000FFFF, NumberBaseHelper<nint>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal(unchecked((nint)0x80000000), NumberHelper<nint>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal(unchecked((nint)0x80000000), NumberBaseHelper<nint>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
@@ -1212,19 +1212,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateTruncating<ulong>(0x0000000000000000));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateTruncating<ulong>(0x0000000000000001));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.CreateTruncating<ulong>(0x8000000000000000));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateTruncating<ulong>(0x0000000000000000));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateTruncating<ulong>(0x0000000000000001));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberBaseHelper<nint>.CreateTruncating<ulong>(0x8000000000000000));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<ulong>(0x0000000000000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateTruncating<ulong>(0x0000000000000001));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<ulong>(0x8000000000000000));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<ulong>(0x0000000000000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<ulong>(0x0000000000000001));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<ulong>(0x8000000000000000));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
         }
 
@@ -1233,19 +1233,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberBaseHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(unchecked((nint)0x80000000), NumberHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0x80000000)));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFF)));
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(unchecked((nint)0x80000000), NumberBaseHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0x80000000)));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFF)));
             }
         }
 
@@ -1338,19 +1338,19 @@ namespace System.Tests
         {
             nint result;
 
-            Assert.True(NumberHelper<nint>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<byte>(0x00, out result));
             Assert.Equal((nint)0x00000000, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<byte>(0x01, out result));
             Assert.Equal((nint)0x00000001, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((nint)0x0000007F, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<byte>(0x80, out result));
             Assert.Equal((nint)0x00000080, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((nint)0x000000FF, result);
         }
 
@@ -1359,19 +1359,19 @@ namespace System.Tests
         {
             nint result;
 
-            Assert.True(NumberHelper<nint>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal((nint)0x00000000, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal((nint)0x00000001, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((nint)0x00007FFF, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((nint)0x00008000, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((nint)0x0000FFFF, result);
         }
 
@@ -1380,19 +1380,19 @@ namespace System.Tests
         {
             nint result;
 
-            Assert.True(NumberHelper<nint>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<short>(0x0000, out result));
             Assert.Equal((nint)0x00000000, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<short>(0x0001, out result));
             Assert.Equal((nint)0x00000001, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((nint)0x00007FFF, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal(unchecked((nint)(int)0xFFFF8000), result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), result);
         }
 
@@ -1401,19 +1401,19 @@ namespace System.Tests
         {
             nint result;
 
-            Assert.True(NumberHelper<nint>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<int>(0x00000000, out result));
             Assert.Equal((nint)0x00000000, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<int>(0x00000001, out result));
             Assert.Equal((nint)0x00000001, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((nint)0x7FFFFFFF, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal(unchecked((nint)(int)0x80000000), result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), result);
         }
 
@@ -1424,36 +1424,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<nint>.TryCreate<long>(0x0000000000000000, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<long>(0x0000000000000000, out result));
                 Assert.Equal(unchecked((nint)0x0000000000000000), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<long>(0x0000000000000001, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<long>(0x0000000000000001, out result));
                 Assert.Equal(unchecked((nint)0x0000000000000001), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
                 Assert.Equal(unchecked((nint)0x8000000000000000), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), result);
             }
             else
             {
-                Assert.True(NumberHelper<nint>.TryCreate<long>(0x0000000000000000, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<long>(0x0000000000000000, out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<long>(0x0000000000000001, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<long>(0x0000000000000001, out result));
                 Assert.Equal((nint)0x00000001, result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((nint)0xFFFFFFFF), result);
             }
         }
@@ -1465,36 +1465,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<nint>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal(unchecked((nint)0x0000000000000000), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal(unchecked((nint)0x0000000000000001), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal(unchecked((nint)0x8000000000000000), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), result);
             }
             else
             {
-                Assert.True(NumberHelper<nint>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal((nint)0x00000001, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((nint)0x7FFFFFFF, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nint>(unchecked(unchecked((nint)0x80000000)), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nint>(unchecked(unchecked((nint)0x80000000)), out result));
                 Assert.Equal(unchecked((nint)0x80000000), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nint>(unchecked(unchecked((nint)0xFFFFFFFF)), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nint>(unchecked(unchecked((nint)0xFFFFFFFF)), out result));
                 Assert.Equal(unchecked((nint)0xFFFFFFFF), result);
             }
         }
@@ -1504,19 +1504,19 @@ namespace System.Tests
         {
             nint result;
 
-            Assert.True(NumberHelper<nint>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal((nint)0x00000000, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal((nint)0x00000001, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((nint)0x0000007F, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal(unchecked((nint)(int)0xFFFFFF80), result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(unchecked((nint)(int)0xFFFFFFFF), result);
         }
 
@@ -1525,19 +1525,19 @@ namespace System.Tests
         {
             nint result;
 
-            Assert.True(NumberHelper<nint>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal((nint)0x00000000, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal((nint)0x00000001, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((nint)0x00007FFF, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((nint)0x00008000, result);
 
-            Assert.True(NumberHelper<nint>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<nint>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((nint)0x0000FFFF, result);
         }
 
@@ -1548,36 +1548,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<nint>.TryCreate<uint>(0x00000000, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<uint>(0x00000000, out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<uint>(0x00000001, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<uint>(0x00000001, out result));
                 Assert.Equal((nint)0x00000001, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<uint>(0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<uint>(0x7FFFFFFF, out result));
                 Assert.Equal((nint)0x7FFFFFFF, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<uint>(0x80000000, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<uint>(0x80000000, out result));
                 Assert.Equal(unchecked((nint)0x0000000080000000), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<uint>(0xFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<uint>(0xFFFFFFFF, out result));
                 Assert.Equal(unchecked((nint)0x00000000FFFFFFFF), result);
             }
             else
             {
-                Assert.True(NumberHelper<nint>.TryCreate<uint>(0x00000000, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<uint>(0x00000000, out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<uint>(0x00000001, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<uint>(0x00000001, out result));
                 Assert.Equal((nint)0x00000001, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<uint>(0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<uint>(0x7FFFFFFF, out result));
                 Assert.Equal((nint)0x7FFFFFFF, result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<uint>(0x80000000, out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<uint>(0x80000000, out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<uint>(0xFFFFFFFF, out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<uint>(0xFFFFFFFF, out result));
                 Assert.Equal((nint)0x00000000, result);
             }
         }
@@ -1589,36 +1589,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<nint>.TryCreate<ulong>(0x0000000000000000, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<ulong>(0x0000000000000000, out result));
                 Assert.Equal(unchecked((nint)0x0000000000000000), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<ulong>(0x0000000000000001, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<ulong>(0x0000000000000001, out result));
                 Assert.Equal(unchecked((nint)0x00000000000000001), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<ulong>(0x8000000000000000, out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<ulong>(0x8000000000000000, out result));
                 Assert.Equal((nint)0x0000000000000000, result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
                 Assert.Equal((nint)0x0000000000000000, result);
             }
             else
             {
-                Assert.True(NumberHelper<nint>.TryCreate<ulong>(0x0000000000000000, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<ulong>(0x0000000000000000, out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<ulong>(0x0000000000000001, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<ulong>(0x0000000000000001, out result));
                 Assert.Equal((nint)0x00000001, result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<ulong>(0x8000000000000000, out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<ulong>(0x8000000000000000, out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
                 Assert.Equal((nint)0x00000000, result);
             }
         }
@@ -1630,36 +1630,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<nint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal(unchecked((nint)0x0000000000000000), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal(unchecked((nint)0x0000000000000001), result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal((nint)0x0000000000000000, result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((nint)0x0000000000000000, result);
             }
             else
             {
-                Assert.True(NumberHelper<nint>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal((nint)0x00000001, result);
 
-                Assert.True(NumberHelper<nint>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nint>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((nint)0x7FFFFFFF, result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<nuint>(unchecked(unchecked((nuint)0x80000000)), out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<nuint>(unchecked(unchecked((nuint)0x80000000)), out result));
                 Assert.Equal((nint)0x00000000, result);
 
-                Assert.False(NumberHelper<nint>.TryCreate<nuint>(unchecked(unchecked((nuint)0xFFFFFFFF)), out result));
+                Assert.False(NumberBaseHelper<nint>.TryCreate<nuint>(unchecked(unchecked((nuint)0xFFFFFFFF)), out result));
                 Assert.Equal((nint)0x00000000, result);
             }
         }
@@ -2000,12 +2000,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Equal(expected, NumberHelper<nint>.Parse(value, style, provider));
+                Assert.Equal(expected, NumberBaseHelper<nint>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.True(NumberHelper<nint>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.True(NumberBaseHelper<nint>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(expected, result);
-                Assert.Equal(expected, NumberHelper<nint>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Equal(expected, NumberBaseHelper<nint>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -2015,9 +2015,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.True(NumberHelper<nint>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<nint>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
-            Assert.Equal(expected, NumberHelper<nint>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<nint>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -2037,12 +2037,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<nint>.Parse(value, style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<nint>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.False(NumberHelper<nint>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.False(NumberBaseHelper<nint>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(default(nint), result);
-                Assert.Throws(exceptionType, () => NumberHelper<nint>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<nint>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -2052,9 +2052,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.False(NumberHelper<nint>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<nint>.TryParse(value, style, provider, out result));
             Assert.Equal(default(nint), result);
-            Assert.Throws(exceptionType, () => NumberHelper<nint>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<nint>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -2070,9 +2070,9 @@ namespace System.Tests
                 Assert.Equal(expected, result);
             }
 
-            Assert.Equal(expected, NumberHelper<nint>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<nint>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<nint>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<nint>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -2094,9 +2094,9 @@ namespace System.Tests
                 Assert.Equal(default(nint), result);
             }
 
-            Assert.Throws(exceptionType, () => NumberHelper<nint>.Parse(value.AsSpan(), style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<nint>.Parse(value.AsSpan(), style, provider));
 
-            Assert.False(NumberHelper<nint>.TryParse(value.AsSpan(), style, provider, out result));
+            Assert.False(NumberBaseHelper<nint>.TryParse(value.AsSpan(), style, provider, out result));
             Assert.Equal(default(nint), result);
         }
     }

--- a/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
@@ -8,68 +8,9 @@ namespace System.Tests
 {
     public class IntPtrTests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal((nint)0x00000000, AdditiveIdentityHelper<nint, nint>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(unchecked((nint)0x8000000000000000), MinMaxValueHelper<nint>.MinValue);
-            }
-            else
-            {
-                Assert.Equal(unchecked((nint)0x80000000), MinMaxValueHelper<nint>.MinValue);
-            }
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), MinMaxValueHelper<nint>.MaxValue);
-            }
-            else
-            {
-                Assert.Equal((nint)0x7FFFFFFF, MinMaxValueHelper<nint>.MaxValue);
-            }
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal((nint)0x00000001, MultiplicativeIdentityHelper<nint, nint>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), SignedNumberHelper<nint>.NegativeOne);
-            }
-            else
-            {
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), SignedNumberHelper<nint>.NegativeOne);
-            }
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -112,6 +53,41 @@ namespace System.Tests
                 Assert.Equal((nint)0x00000000, AdditionOperatorsHelper<nint, nint, nint>.op_CheckedAddition(unchecked((nint)0xFFFFFFFF), (nint)1));
 
                 Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<nint, nint, nint>.op_CheckedAddition((nint)0x7FFFFFFF, (nint)1));
+            }
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal((nint)0x00000000, AdditiveIdentityHelper<nint, nint>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal((unchecked((nint)0x0000000000000000), unchecked((nint)0x0000000000000000)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0x0000000000000000), (nint)2));
+                Assert.Equal((unchecked((nint)0x0000000000000000), unchecked((nint)0x0000000000000001)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0x0000000000000001), (nint)2));
+                Assert.Equal((unchecked((nint)0x3FFFFFFFFFFFFFFF), unchecked((nint)0x0000000000000001)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)2));
+                Assert.Equal((unchecked((nint)0xC000000000000000), unchecked((nint)0x0000000000000000)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0x8000000000000000), (nint)2));
+                Assert.Equal((unchecked((nint)0x0000000000000000), unchecked((nint)0xFFFFFFFFFFFFFFFF)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)2));
+            }
+            else
+            {
+                Assert.Equal(((nint)0x00000000, (nint)0x00000000), BinaryIntegerHelper<nint>.DivRem((nint)0x00000000, (nint)2));
+                Assert.Equal(((nint)0x00000000, (nint)0x00000001), BinaryIntegerHelper<nint>.DivRem((nint)0x00000001, (nint)2));
+                Assert.Equal(((nint)0x3FFFFFFF, (nint)0x00000001), BinaryIntegerHelper<nint>.DivRem((nint)0x7FFFFFFF, (nint)2));
+                Assert.Equal((unchecked((nint)0xC0000000), (nint)0x00000000), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0x80000000), (nint)2));
+                Assert.Equal(((nint)0x00000000, unchecked((nint)0xFFFFFFFF)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0xFFFFFFFF), (nint)2));
             }
         }
 
@@ -221,6 +197,27 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(8, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(8, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(8, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(8, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(8, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal(4, BinaryIntegerHelper<nint>.GetByteCount((nint)0x00000000));
+                Assert.Equal(4, BinaryIntegerHelper<nint>.GetByteCount((nint)0x00000001));
+                Assert.Equal(4, BinaryIntegerHelper<nint>.GetByteCount((nint)0x7FFFFFFF));
+                Assert.Equal(4, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0x80000000)));
+                Assert.Equal(4, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             if (Environment.Is64BitProcess)
@@ -240,6 +237,136 @@ namespace System.Tests
                 Assert.Equal(0x01, BinaryIntegerHelper<nint>.GetShortestBitLength(unchecked((nint)0xFFFFFFFF)));
             }
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Span<byte> destination = stackalloc byte[8];
+                int bytesWritten = 0;
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0x0000000000000000), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0x0000000000000001), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0x7FFFFFFFFFFFFFFF), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0x8000000000000000), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.False(BinaryIntegerHelper<nint>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+            }
+            else
+            {
+                Span<byte> destination = stackalloc byte[4];
+                int bytesWritten = 0;
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian((nint)0x00000000, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian((nint)0x00000001, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian((nint)0x7FFFFFFF, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0x80000000), destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0xFFFFFFFF), destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.False(BinaryIntegerHelper<nint>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+            }
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Span<byte> destination = stackalloc byte[8];
+                int bytesWritten = 0;
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0x0000000000000000), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0x0000000000000001), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0x7FFFFFFFFFFFFFFF), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0x8000000000000000), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.False(BinaryIntegerHelper<nint>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+            }
+            else
+            {
+                Span<byte> destination = stackalloc byte[4];
+                int bytesWritten = 0;
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian((nint)0x00000000, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian((nint)0x00000001, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian((nint)0x7FFFFFFF, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0x80000000), destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0xFFFFFFFF), destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.False(BinaryIntegerHelper<nint>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+            }
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -282,6 +409,10 @@ namespace System.Tests
                 Assert.Throws<ArgumentOutOfRangeException>(() => BinaryNumberHelper<nint>.Log2(unchecked((nint)0xFFFFFFFF)));
             }
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -367,47 +498,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0x0000000000000000), (nint)1));
-                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0x0000000000000001), (nint)1));
-                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0x8000000000000000), (nint)1));
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
-            }
-            else
-            {
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan((nint)0x00000000, (nint)1));
-                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThan((nint)0x00000001, (nint)1));
-                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThan((nint)0x7FFFFFFF, (nint)1));
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0x80000000), (nint)1));
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0xFFFFFFFF), (nint)1));
-            }
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0x0000000000000000), (nint)1));
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0x0000000000000001), (nint)1));
-                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0x8000000000000000), (nint)1));
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
-            }
-            else
-            {
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual((nint)0x00000000, (nint)1));
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual((nint)0x00000001, (nint)1));
-                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual((nint)0x7FFFFFFF, (nint)1));
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0x80000000), (nint)1));
-                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0xFFFFFFFF), (nint)1));
-            }
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -452,6 +545,52 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0x0000000000000000), (nint)1));
+                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0x0000000000000001), (nint)1));
+                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0x8000000000000000), (nint)1));
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
+            }
+            else
+            {
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan((nint)0x00000000, (nint)1));
+                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThan((nint)0x00000001, (nint)1));
+                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThan((nint)0x7FFFFFFF, (nint)1));
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0x80000000), (nint)1));
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThan(unchecked((nint)0xFFFFFFFF), (nint)1));
+            }
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0x0000000000000000), (nint)1));
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0x0000000000000001), (nint)1));
+                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0x8000000000000000), (nint)1));
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
+            }
+            else
+            {
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual((nint)0x00000000, (nint)1));
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual((nint)0x00000001, (nint)1));
+                Assert.False(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual((nint)0x7FFFFFFF, (nint)1));
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0x80000000), (nint)1));
+                Assert.True(ComparisonOperatorsHelper<nint, nint>.op_LessThanOrEqual(unchecked((nint)0xFFFFFFFF), (nint)1));
+            }
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             if (Environment.Is64BitProcess)
@@ -494,6 +633,10 @@ namespace System.Tests
                 Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<nint>.op_CheckedDecrement(unchecked((nint)0x80000000)));
             }
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -545,6 +688,10 @@ namespace System.Tests
             }
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -586,6 +733,10 @@ namespace System.Tests
                 Assert.True(EqualityOperatorsHelper<nint, nint>.op_Inequality(unchecked((nint)0xFFFFFFFF), (nint)1));
             }
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -632,6 +783,40 @@ namespace System.Tests
             }
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), MinMaxValueHelper<nint>.MaxValue);
+            }
+            else
+            {
+                Assert.Equal((nint)0x7FFFFFFF, MinMaxValueHelper<nint>.MaxValue);
+            }
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x8000000000000000), MinMaxValueHelper<nint>.MinValue);
+            }
+            else
+            {
+                Assert.Equal(unchecked((nint)0x80000000), MinMaxValueHelper<nint>.MinValue);
+            }
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -656,6 +841,20 @@ namespace System.Tests
                 Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<nint, nint, nint>.op_Modulus((nint)0x00000001, (nint)0));
             }
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal((nint)0x00000001, MultiplicativeIdentityHelper<nint, nint>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -701,26 +900,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.Abs(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.Abs(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.Abs(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.Abs(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.Abs(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.Abs((nint)0x00000000));
-                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.Abs((nint)0x00000001));
-                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.Abs((nint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.Abs(unchecked((nint)0x80000000)));
-                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.Abs(unchecked((nint)0xFFFFFFFF)));
-            }
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -740,6 +922,106 @@ namespace System.Tests
                 Assert.Equal((nint)0x0000003F, NumberHelper<nint>.Clamp((nint)0x7FFFFFFF, unchecked((nint)0xFFFFFFC0), (nint)0x0000003F));
                 Assert.Equal(unchecked((nint)0xFFFFFFC0), NumberHelper<nint>.Clamp(unchecked((nint)0x80000000), unchecked((nint)0xFFFFFFC0), (nint)0x0000003F));
                 Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.Clamp(unchecked((nint)0xFFFFFFFF), unchecked((nint)0xFFFFFFC0), (nint)0x0000003F));
+            }
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Max(unchecked((nint)0x0000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Max(unchecked((nint)0x0000000000000001), (nint)1));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.Max(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Max(unchecked((nint)0x8000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Max(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
+            }
+            else
+            {
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Max((nint)0x00000000, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Max((nint)0x00000001, (nint)1));
+                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.Max((nint)0x7FFFFFFF, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Max(unchecked((nint)0x80000000), (nint)1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Max(unchecked((nint)0xFFFFFFFF), (nint)1));
+            }
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.Min(unchecked((nint)0x0000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Min(unchecked((nint)0x0000000000000001), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Min(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.Min(unchecked((nint)0x8000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.Min(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
+            }
+            else
+            {
+                Assert.Equal((nint)0x00000000, NumberHelper<nint>.Min((nint)0x00000000, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Min((nint)0x00000001, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Min((nint)0x7FFFFFFF, (nint)1));
+                Assert.Equal(unchecked((nint)0x80000000), NumberHelper<nint>.Min(unchecked((nint)0x80000000), (nint)1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.Min(unchecked((nint)0xFFFFFFFF), (nint)1));
+            }
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(0, NumberHelper<nint>.Sign(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(1, NumberHelper<nint>.Sign(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(1, NumberHelper<nint>.Sign(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(-1, NumberHelper<nint>.Sign(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(-1, NumberHelper<nint>.Sign(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal(0, NumberHelper<nint>.Sign((nint)0x00000000));
+                Assert.Equal(1, NumberHelper<nint>.Sign((nint)0x00000001));
+                Assert.Equal(1, NumberHelper<nint>.Sign((nint)0x7FFFFFFF));
+                Assert.Equal(-1, NumberHelper<nint>.Sign(unchecked((nint)0x80000000)));
+                Assert.Equal(-1, NumberHelper<nint>.Sign(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.Abs(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.Abs(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.Abs(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.Abs(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.Abs(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.Abs((nint)0x00000000));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.Abs((nint)0x00000001));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.Abs((nint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nint>.Abs(unchecked((nint)0x80000000)));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.Abs(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
@@ -1250,90 +1532,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal((unchecked((nint)0x0000000000000000), unchecked((nint)0x0000000000000000)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0x0000000000000000), (nint)2));
-                Assert.Equal((unchecked((nint)0x0000000000000000), unchecked((nint)0x0000000000000001)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0x0000000000000001), (nint)2));
-                Assert.Equal((unchecked((nint)0x3FFFFFFFFFFFFFFF), unchecked((nint)0x0000000000000001)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)2));
-                Assert.Equal((unchecked((nint)0xC000000000000000), unchecked((nint)0x0000000000000000)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0x8000000000000000), (nint)2));
-                Assert.Equal((unchecked((nint)0x0000000000000000), unchecked((nint)0xFFFFFFFFFFFFFFFF)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)2));
-            }
-            else
-            {
-                Assert.Equal(((nint)0x00000000, (nint)0x00000000), BinaryIntegerHelper<nint>.DivRem((nint)0x00000000, (nint)2));
-                Assert.Equal(((nint)0x00000000, (nint)0x00000001), BinaryIntegerHelper<nint>.DivRem((nint)0x00000001, (nint)2));
-                Assert.Equal(((nint)0x3FFFFFFF, (nint)0x00000001), BinaryIntegerHelper<nint>.DivRem((nint)0x7FFFFFFF, (nint)2));
-                Assert.Equal((unchecked((nint)0xC0000000), (nint)0x00000000), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0x80000000), (nint)2));
-                Assert.Equal(((nint)0x00000000, unchecked((nint)0xFFFFFFFF)), BinaryIntegerHelper<nint>.DivRem(unchecked((nint)0xFFFFFFFF), (nint)2));
-            }
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Max(unchecked((nint)0x0000000000000000), (nint)1));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Max(unchecked((nint)0x0000000000000001), (nint)1));
-                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.Max(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Max(unchecked((nint)0x8000000000000000), (nint)1));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Max(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
-            }
-            else
-            {
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Max((nint)0x00000000, (nint)1));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Max((nint)0x00000001, (nint)1));
-                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.Max((nint)0x7FFFFFFF, (nint)1));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Max(unchecked((nint)0x80000000), (nint)1));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Max(unchecked((nint)0xFFFFFFFF), (nint)1));
-            }
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.Min(unchecked((nint)0x0000000000000000), (nint)1));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Min(unchecked((nint)0x0000000000000001), (nint)1));
-                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.Min(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
-                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.Min(unchecked((nint)0x8000000000000000), (nint)1));
-                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.Min(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
-            }
-            else
-            {
-                Assert.Equal((nint)0x00000000, NumberHelper<nint>.Min((nint)0x00000000, (nint)1));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Min((nint)0x00000001, (nint)1));
-                Assert.Equal((nint)0x00000001, NumberHelper<nint>.Min((nint)0x7FFFFFFF, (nint)1));
-                Assert.Equal(unchecked((nint)0x80000000), NumberHelper<nint>.Min(unchecked((nint)0x80000000), (nint)1));
-                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.Min(unchecked((nint)0xFFFFFFFF), (nint)1));
-            }
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(0, NumberHelper<nint>.Sign(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(1, NumberHelper<nint>.Sign(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(1, NumberHelper<nint>.Sign(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(-1, NumberHelper<nint>.Sign(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(-1, NumberHelper<nint>.Sign(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                Assert.Equal(0, NumberHelper<nint>.Sign((nint)0x00000000));
-                Assert.Equal(1, NumberHelper<nint>.Sign((nint)0x00000001));
-                Assert.Equal(1, NumberHelper<nint>.Sign((nint)0x7FFFFFFF));
-                Assert.Equal(-1, NumberHelper<nint>.Sign(unchecked((nint)0x80000000)));
-                Assert.Equal(-1, NumberHelper<nint>.Sign(unchecked((nint)0xFFFFFFFF)));
-            }
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             nint result;
@@ -1664,152 +1862,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(8, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(8, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(8, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(8, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(8, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                Assert.Equal(4, BinaryIntegerHelper<nint>.GetByteCount((nint)0x00000000));
-                Assert.Equal(4, BinaryIntegerHelper<nint>.GetByteCount((nint)0x00000001));
-                Assert.Equal(4, BinaryIntegerHelper<nint>.GetByteCount((nint)0x7FFFFFFF));
-                Assert.Equal(4, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0x80000000)));
-                Assert.Equal(4, BinaryIntegerHelper<nint>.GetByteCount(unchecked((nint)0xFFFFFFFF)));
-            }
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Span<byte> destination = stackalloc byte[8];
-                int bytesWritten = 0;
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0x0000000000000000), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0x0000000000000001), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0x7FFFFFFFFFFFFFFF), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0x8000000000000000), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.False(BinaryIntegerHelper<nint>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-                Assert.Equal(0, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-            }
-            else
-            {
-                Span<byte> destination = stackalloc byte[4];
-                int bytesWritten = 0;
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian((nint)0x00000000, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian((nint)0x00000001, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian((nint)0x7FFFFFFF, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0x80000000), destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteBigEndian(unchecked((nint)0xFFFFFFFF), destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.False(BinaryIntegerHelper<nint>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-                Assert.Equal(0, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-            }
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Span<byte> destination = stackalloc byte[8];
-                int bytesWritten = 0;
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0x0000000000000000), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0x0000000000000001), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0x7FFFFFFFFFFFFFFF), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0x8000000000000000), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.False(BinaryIntegerHelper<nint>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-                Assert.Equal(0, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-            }
-            else
-            {
-                Span<byte> destination = stackalloc byte[4];
-                int bytesWritten = 0;
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian((nint)0x00000000, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian((nint)0x00000001, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian((nint)0x7FFFFFFF, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0x80000000), destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nint>.TryWriteLittleEndian(unchecked((nint)0xFFFFFFFF), destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.False(BinaryIntegerHelper<nint>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-                Assert.Equal(0, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-            }
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1874,6 +1929,27 @@ namespace System.Tests
             }
         }
 
+        //
+        // ISignedNumber
+        //
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), SignedNumberHelper<nint>.NegativeOne);
+            }
+            else
+            {
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), SignedNumberHelper<nint>.NegativeOne);
+            }
+        }
+
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1917,6 +1993,10 @@ namespace System.Tests
                 Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<nint, nint, nint>.op_CheckedSubtraction(unchecked((nint)0x80000000), (nint)1));
             }
         }
+
+        //
+        // IUnaryNegationOperators
+        //
 
         [Fact]
         public static void op_UnaryNegationTest()
@@ -1962,6 +2042,10 @@ namespace System.Tests
             }
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1982,6 +2066,10 @@ namespace System.Tests
                 Assert.Equal(unchecked((nint)0xFFFFFFFF), UnaryPlusOperatorsHelper<nint, nint>.op_UnaryPlus(unchecked((nint)0xFFFFFFFF)));
             }
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(IntPtrTests.Parse_Valid_TestData), MemberType = typeof(IntPtrTests))]

--- a/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
@@ -784,7 +784,7 @@ namespace System.Tests
         }
 
         //
-        // IMinMaxValue
+        // IMinMagnitudeMaxValue
         //
 
         [Fact]
@@ -947,6 +947,27 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.MaxNumber(unchecked((nint)0x0000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.MaxNumber(unchecked((nint)0x0000000000000001), (nint)1));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.MaxNumber(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.MaxNumber(unchecked((nint)0x8000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.MaxNumber(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
+            }
+            else
+            {
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.MaxNumber((nint)0x00000000, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.MaxNumber((nint)0x00000001, (nint)1));
+                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.MaxNumber((nint)0x7FFFFFFF, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.MaxNumber(unchecked((nint)0x80000000), (nint)1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.MaxNumber(unchecked((nint)0xFFFFFFFF), (nint)1));
+            }
+        }
+
+        [Fact]
         public static void MinTest()
         {
             if (Environment.Is64BitProcess)
@@ -964,6 +985,27 @@ namespace System.Tests
                 Assert.Equal((nint)0x00000001, NumberHelper<nint>.Min((nint)0x7FFFFFFF, (nint)1));
                 Assert.Equal(unchecked((nint)0x80000000), NumberHelper<nint>.Min(unchecked((nint)0x80000000), (nint)1));
                 Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.Min(unchecked((nint)0xFFFFFFFF), (nint)1));
+            }
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.MinNumber(unchecked((nint)0x0000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.MinNumber(unchecked((nint)0x0000000000000001), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.MinNumber(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.MinNumber(unchecked((nint)0x8000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.MinNumber(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
+            }
+            else
+            {
+                Assert.Equal((nint)0x00000000, NumberHelper<nint>.MinNumber((nint)0x00000000, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.MinNumber((nint)0x00000001, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.MinNumber((nint)0x7FFFFFFF, (nint)1));
+                Assert.Equal(unchecked((nint)0x80000000), NumberHelper<nint>.MinNumber(unchecked((nint)0x80000000), (nint)1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.MinNumber(unchecked((nint)0xFFFFFFFF), (nint)1));
             }
         }
 
@@ -1046,7 +1088,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateCheckedFromInt16Test()
+        public static void CreateCheckedFroMinMagnitudet16Test()
         {
             Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<short>(0x0000));
             Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<short>(0x0001));
@@ -1056,7 +1098,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateCheckedFromInt32Test()
+        public static void CreateCheckedFroMinMagnitudet32Test()
         {
             Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateChecked<int>(0x00000000));
             Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateChecked<int>(0x00000001));
@@ -1066,7 +1108,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateCheckedFromInt64Test()
+        public static void CreateCheckedFroMinMagnitudet64Test()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1087,7 +1129,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateCheckedFromIntPtrTest()
+        public static void CreateCheckedFroMinMagnitudetPtrTest()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1211,7 +1253,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateSaturatingFromInt16Test()
+        public static void CreateSaturatingFroMinMagnitudet16Test()
         {
             Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<short>(0x0000));
             Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<short>(0x0001));
@@ -1221,7 +1263,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateSaturatingFromInt32Test()
+        public static void CreateSaturatingFroMinMagnitudet32Test()
         {
             Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateSaturating<int>(0x00000000));
             Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateSaturating<int>(0x00000001));
@@ -1231,7 +1273,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateSaturatingFromInt64Test()
+        public static void CreateSaturatingFroMinMagnitudet64Test()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1252,7 +1294,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateSaturatingFromIntPtrTest()
+        public static void CreateSaturatingFroMinMagnitudetPtrTest()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1376,7 +1418,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateTruncatingFromInt16Test()
+        public static void CreateTruncatingFroMinMagnitudet16Test()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1397,7 +1439,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateTruncatingFromInt32Test()
+        public static void CreateTruncatingFroMinMagnitudet32Test()
         {
             Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.CreateTruncating<int>(0x00000000));
             Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.CreateTruncating<int>(0x00000001));
@@ -1407,7 +1449,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateTruncatingFromInt64Test()
+        public static void CreateTruncatingFroMinMagnitudet64Test()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1428,7 +1470,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateTruncatingFromIntPtrTest()
+        public static void CreateTruncatingFroMinMagnitudetPtrTest()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1532,6 +1574,258 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsFiniteTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nint>.IsFinite(unchecked((nint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsFinite(unchecked((nint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nint>.IsFinite(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nint>.IsFinite(unchecked((nint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsFinite(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nint>.IsFinite((nint)0x00000000));
+                Assert.True(NumberBaseHelper<nint>.IsFinite((nint)0x00000001));
+                Assert.True(NumberBaseHelper<nint>.IsFinite((nint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nint>.IsFinite(unchecked((nint)0x80000000)));
+                Assert.True(NumberBaseHelper<nint>.IsFinite(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nint>.IsInfinity(unchecked((nint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsInfinity(unchecked((nint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nint>.IsInfinity(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nint>.IsInfinity(unchecked((nint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsInfinity(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nint>.IsInfinity((nint)0x00000000));
+                Assert.False(NumberBaseHelper<nint>.IsInfinity((nint)0x00000001));
+                Assert.False(NumberBaseHelper<nint>.IsInfinity((nint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nint>.IsInfinity(unchecked((nint)0x80000000)));
+                Assert.False(NumberBaseHelper<nint>.IsInfinity(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nint>.IsNaN(unchecked((nint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsNaN(unchecked((nint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nint>.IsNaN(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nint>.IsNaN(unchecked((nint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsNaN(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nint>.IsNaN((nint)0x00000000));
+                Assert.False(NumberBaseHelper<nint>.IsNaN((nint)0x00000001));
+                Assert.False(NumberBaseHelper<nint>.IsNaN((nint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nint>.IsNaN(unchecked((nint)0x80000000)));
+                Assert.False(NumberBaseHelper<nint>.IsNaN(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nint>.IsNegative(unchecked((nint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsNegative(unchecked((nint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nint>.IsNegative(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nint>.IsNegative(unchecked((nint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsNegative(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nint>.IsNegative((nint)0x00000000));
+                Assert.False(NumberBaseHelper<nint>.IsNegative((nint)0x00000001));
+                Assert.False(NumberBaseHelper<nint>.IsNegative((nint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nint>.IsNegative(unchecked((nint)0x80000000)));
+                Assert.True(NumberBaseHelper<nint>.IsNegative(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nint>.IsNegativeInfinity(unchecked((nint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsNegativeInfinity(unchecked((nint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nint>.IsNegativeInfinity(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nint>.IsNegativeInfinity(unchecked((nint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsNegativeInfinity(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nint>.IsNegativeInfinity((nint)0x00000000));
+                Assert.False(NumberBaseHelper<nint>.IsNegativeInfinity((nint)0x00000001));
+                Assert.False(NumberBaseHelper<nint>.IsNegativeInfinity((nint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nint>.IsNegativeInfinity(unchecked((nint)0x80000000)));
+                Assert.False(NumberBaseHelper<nint>.IsNegativeInfinity(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nint>.IsNormal(unchecked((nint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsNormal(unchecked((nint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nint>.IsNormal(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nint>.IsNormal(unchecked((nint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsNormal(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nint>.IsNormal((nint)0x00000000));
+                Assert.True(NumberBaseHelper<nint>.IsNormal((nint)0x00000001));
+                Assert.True(NumberBaseHelper<nint>.IsNormal((nint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nint>.IsNormal(unchecked((nint)0x80000000)));
+                Assert.True(NumberBaseHelper<nint>.IsNormal(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nint>.IsPositiveInfinity(unchecked((nint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsPositiveInfinity(unchecked((nint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nint>.IsPositiveInfinity(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nint>.IsPositiveInfinity(unchecked((nint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsPositiveInfinity(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nint>.IsPositiveInfinity((nint)0x00000000));
+                Assert.False(NumberBaseHelper<nint>.IsPositiveInfinity((nint)0x00000001));
+                Assert.False(NumberBaseHelper<nint>.IsPositiveInfinity((nint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nint>.IsPositiveInfinity(unchecked((nint)0x80000000)));
+                Assert.False(NumberBaseHelper<nint>.IsPositiveInfinity(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nint>.IsSubnormal(unchecked((nint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsSubnormal(unchecked((nint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nint>.IsSubnormal(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nint>.IsSubnormal(unchecked((nint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsSubnormal(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nint>.IsSubnormal((nint)0x00000000));
+                Assert.False(NumberBaseHelper<nint>.IsSubnormal((nint)0x00000001));
+                Assert.False(NumberBaseHelper<nint>.IsSubnormal((nint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nint>.IsSubnormal(unchecked((nint)0x80000000)));
+                Assert.False(NumberBaseHelper<nint>.IsSubnormal(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MaxMagnitude(unchecked((nint)0x0000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MaxMagnitude(unchecked((nint)0x0000000000000001), (nint)1));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.MaxMagnitude(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberBaseHelper<nint>.MaxMagnitude(unchecked((nint)0x8000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MaxMagnitude(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
+            }
+            else
+            {
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MaxMagnitude((nint)0x00000000, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MaxMagnitude((nint)0x00000001, (nint)1));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.MaxMagnitude((nint)0x7FFFFFFF, (nint)1));
+                Assert.Equal(unchecked((nint)0x80000000), NumberBaseHelper<nint>.MaxMagnitude(unchecked((nint)0x80000000), (nint)1));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MaxMagnitude(unchecked((nint)0xFFFFFFFF), (nint)1));
+            }
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MaxMagnitudeNumber(unchecked((nint)0x0000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MaxMagnitudeNumber(unchecked((nint)0x0000000000000001), (nint)1));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nint>.MaxMagnitudeNumber(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberBaseHelper<nint>.MaxMagnitudeNumber(unchecked((nint)0x8000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MaxMagnitudeNumber(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
+            }
+            else
+            {
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MaxMagnitudeNumber((nint)0x00000000, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MaxMagnitudeNumber((nint)0x00000001, (nint)1));
+                Assert.Equal((nint)0x7FFFFFFF, NumberBaseHelper<nint>.MaxMagnitudeNumber((nint)0x7FFFFFFF, (nint)1));
+                Assert.Equal(unchecked((nint)0x80000000), NumberBaseHelper<nint>.MaxMagnitudeNumber(unchecked((nint)0x80000000), (nint)1));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MaxMagnitudeNumber(unchecked((nint)0xFFFFFFFF), (nint)1));
+            }
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.MinMagnitude(unchecked((nint)0x0000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MinMagnitude(unchecked((nint)0x0000000000000001), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MinMagnitude(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MinMagnitude(unchecked((nint)0x8000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.MinMagnitude(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
+            }
+            else
+            {
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.MinMagnitude((nint)0x00000000, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MinMagnitude((nint)0x00000001, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MinMagnitude((nint)0x7FFFFFFF, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MinMagnitude(unchecked((nint)0x80000000), (nint)1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.MinMagnitude(unchecked((nint)0xFFFFFFFF), (nint)1));
+            }
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberBaseHelper<nint>.MinMagnitudeNumber(unchecked((nint)0x0000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MinMagnitudeNumber(unchecked((nint)0x0000000000000001), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MinMagnitudeNumber(unchecked((nint)0x7FFFFFFFFFFFFFFF), (nint)1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberBaseHelper<nint>.MinMagnitudeNumber(unchecked((nint)0x8000000000000000), (nint)1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nint>.MinMagnitudeNumber(unchecked((nint)0xFFFFFFFFFFFFFFFF), (nint)1));
+            }
+            else
+            {
+                Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.MinMagnitudeNumber((nint)0x00000000, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MinMagnitudeNumber((nint)0x00000001, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MinMagnitudeNumber((nint)0x7FFFFFFF, (nint)1));
+                Assert.Equal((nint)0x00000001, NumberBaseHelper<nint>.MinMagnitudeNumber(unchecked((nint)0x80000000), (nint)1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberBaseHelper<nint>.MinMagnitudeNumber(unchecked((nint)0xFFFFFFFF), (nint)1));
+            }
+        }
+
+        [Fact]
         public static void TryCreateFromByteTest()
         {
             nint result;
@@ -1574,7 +1868,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void TryCreateFromInt16Test()
+        public static void TryCreateFroMinMagnitudet16Test()
         {
             nint result;
 
@@ -1595,7 +1889,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void TryCreateFromInt32Test()
+        public static void TryCreateFroMinMagnitudet32Test()
         {
             nint result;
 
@@ -1616,7 +1910,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void TryCreateFromInt64Test()
+        public static void TryCreateFroMinMagnitudet64Test()
         {
             nint result;
 
@@ -1657,7 +1951,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void TryCreateFromIntPtrTest()
+        public static void TryCreateFroMinMagnitudetPtrTest()
         {
             nint result;
 

--- a/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
@@ -8,47 +8,9 @@ namespace System.Tests
 {
     public class SByteTests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal((sbyte)0x00, AdditiveIdentityHelper<sbyte, sbyte>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            Assert.Equal(unchecked((sbyte)0x80), MinMaxValueHelper<sbyte>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            Assert.Equal((sbyte)0x7F, MinMaxValueHelper<sbyte>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal((sbyte)0x01, MultiplicativeIdentityHelper<sbyte, sbyte>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            Assert.Equal(unchecked((sbyte)0xFF), SignedNumberHelper<sbyte>.NegativeOne);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -69,6 +31,30 @@ namespace System.Tests
             Assert.Equal((sbyte)0x00, AdditionOperatorsHelper<sbyte, sbyte, sbyte>.op_CheckedAddition(unchecked((sbyte)0xFF), (sbyte)1));
 
             Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<sbyte, sbyte, sbyte>.op_CheckedAddition((sbyte)0x7F, (sbyte)1));
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal((sbyte)0x00, AdditiveIdentityHelper<sbyte, sbyte>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            Assert.Equal(((sbyte)0x00, (sbyte)0x00), BinaryIntegerHelper<sbyte>.DivRem((sbyte)0x00, (sbyte)2));
+            Assert.Equal(((sbyte)0x00, (sbyte)0x01), BinaryIntegerHelper<sbyte>.DivRem((sbyte)0x01, (sbyte)2));
+            Assert.Equal(((sbyte)0x3F, (sbyte)0x01), BinaryIntegerHelper<sbyte>.DivRem((sbyte)0x7F, (sbyte)2));
+            Assert.Equal((unchecked((sbyte)0xC0), (sbyte)0x00), BinaryIntegerHelper<sbyte>.DivRem(unchecked((sbyte)0x80), (sbyte)2));
+            Assert.Equal(((sbyte)0x00, unchecked((sbyte)0xFF)), BinaryIntegerHelper<sbyte>.DivRem(unchecked((sbyte)0xFF), (sbyte)2));
         }
 
         [Fact]
@@ -122,6 +108,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            Assert.Equal(1, BinaryIntegerHelper<sbyte>.GetByteCount((sbyte)0x00));
+            Assert.Equal(1, BinaryIntegerHelper<sbyte>.GetByteCount((sbyte)0x01));
+            Assert.Equal(1, BinaryIntegerHelper<sbyte>.GetByteCount((sbyte)0x7F));
+            Assert.Equal(1, BinaryIntegerHelper<sbyte>.GetByteCount(unchecked((sbyte)0x80)));
+            Assert.Equal(1, BinaryIntegerHelper<sbyte>.GetByteCount(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             Assert.Equal(0x00, BinaryIntegerHelper<sbyte>.GetShortestBitLength((sbyte)0x00));
@@ -130,6 +126,72 @@ namespace System.Tests
             Assert.Equal(0x08, BinaryIntegerHelper<sbyte>.GetShortestBitLength(unchecked((sbyte)0x80)));
             Assert.Equal(0x01, BinaryIntegerHelper<sbyte>.GetShortestBitLength(unchecked((sbyte)0xFF)));
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[1];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteBigEndian((sbyte)0x00, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteBigEndian((sbyte)0x01, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x01 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteBigEndian((sbyte)0x7F, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteBigEndian(unchecked((sbyte)0x80), destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteBigEndian(unchecked((sbyte)0xFF), destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<sbyte>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[1];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian((sbyte)0x00, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian((sbyte)0x01, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x01 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian((sbyte)0x7F, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian(unchecked((sbyte)0x80), destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian(unchecked((sbyte)0xFF), destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -150,6 +212,10 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => BinaryNumberHelper<sbyte>.Log2(unchecked((sbyte)0x80)));
             Assert.Throws<ArgumentOutOfRangeException>(() => BinaryNumberHelper<sbyte>.Log2(unchecked((sbyte)0xFF)));
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -191,25 +257,9 @@ namespace System.Tests
             Assert.Equal((sbyte)0x00, BitwiseOperatorsHelper<sbyte, sbyte, sbyte>.op_OnesComplement(unchecked((sbyte)0xFF)));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThan((sbyte)0x00, (sbyte)1));
-            Assert.False(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThan((sbyte)0x01, (sbyte)1));
-            Assert.False(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThan((sbyte)0x7F, (sbyte)1));
-            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThan(unchecked((sbyte)0x80), (sbyte)1));
-            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThan(unchecked((sbyte)0xFF), (sbyte)1));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThanOrEqual((sbyte)0x00, (sbyte)1));
-            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThanOrEqual((sbyte)0x01, (sbyte)1));
-            Assert.False(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThanOrEqual((sbyte)0x7F, (sbyte)1));
-            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThanOrEqual(unchecked((sbyte)0x80), (sbyte)1));
-            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThanOrEqual(unchecked((sbyte)0xFF), (sbyte)1));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -232,6 +282,30 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThan((sbyte)0x00, (sbyte)1));
+            Assert.False(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThan((sbyte)0x01, (sbyte)1));
+            Assert.False(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThan((sbyte)0x7F, (sbyte)1));
+            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThan(unchecked((sbyte)0x80), (sbyte)1));
+            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThan(unchecked((sbyte)0xFF), (sbyte)1));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThanOrEqual((sbyte)0x00, (sbyte)1));
+            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThanOrEqual((sbyte)0x01, (sbyte)1));
+            Assert.False(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThanOrEqual((sbyte)0x7F, (sbyte)1));
+            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThanOrEqual(unchecked((sbyte)0x80), (sbyte)1));
+            Assert.True(ComparisonOperatorsHelper<sbyte, sbyte>.op_LessThanOrEqual(unchecked((sbyte)0xFF), (sbyte)1));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             Assert.Equal(unchecked((sbyte)0xFF), DecrementOperatorsHelper<sbyte>.op_Decrement((sbyte)0x00));
@@ -251,6 +325,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<sbyte>.op_CheckedDecrement(unchecked((sbyte)0x80)));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -276,6 +354,10 @@ namespace System.Tests
             Assert.Throws<DivideByZeroException>(() => DivisionOperatorsHelper<sbyte, sbyte, sbyte>.op_CheckedDivision((sbyte)0x01, (sbyte)0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -295,6 +377,10 @@ namespace System.Tests
             Assert.True(EqualityOperatorsHelper<sbyte, sbyte>.op_Inequality(unchecked((sbyte)0x80), (sbyte)1));
             Assert.True(EqualityOperatorsHelper<sbyte, sbyte>.op_Inequality(unchecked((sbyte)0xFF), (sbyte)1));
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -317,6 +403,26 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<sbyte>.op_CheckedIncrement((sbyte)0x7F));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            Assert.Equal((sbyte)0x7F, MinMaxValueHelper<sbyte>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal(unchecked((sbyte)0x80), MinMaxValueHelper<sbyte>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -328,6 +434,20 @@ namespace System.Tests
 
             Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<sbyte, sbyte, sbyte>.op_Modulus((sbyte)0x01, (sbyte)0));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal((sbyte)0x01, MultiplicativeIdentityHelper<sbyte, sbyte>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -350,15 +470,9 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<sbyte, sbyte, sbyte>.op_CheckedMultiply(unchecked((sbyte)0x80), (sbyte)2));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.Abs((sbyte)0x00));
-            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.Abs((sbyte)0x01));
-            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.Abs((sbyte)0x7F));
-            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.Abs(unchecked((sbyte)0x80)));
-            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.Abs(unchecked((sbyte)0xFF)));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -368,6 +482,62 @@ namespace System.Tests
             Assert.Equal((sbyte)0x3F, NumberHelper<sbyte>.Clamp((sbyte)0x7F, unchecked((sbyte)0xC0), (sbyte)0x3F));
             Assert.Equal(unchecked((sbyte)0xC0), NumberHelper<sbyte>.Clamp(unchecked((sbyte)0x80), unchecked((sbyte)0xC0), (sbyte)0x3F));
             Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.Clamp(unchecked((sbyte)0xFF), unchecked((sbyte)0xC0), (sbyte)0x3F));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Max((sbyte)0x00, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Max((sbyte)0x01, (sbyte)1));
+            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.Max((sbyte)0x7F, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Max(unchecked((sbyte)0x80), (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Max(unchecked((sbyte)0xFF), (sbyte)1));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.Min((sbyte)0x00, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Min((sbyte)0x01, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Min((sbyte)0x7F, (sbyte)1));
+            Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.Min(unchecked((sbyte)0x80), (sbyte)1));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.Min(unchecked((sbyte)0xFF), (sbyte)1));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(0, NumberHelper<sbyte>.Sign((sbyte)0x00));
+            Assert.Equal(1, NumberHelper<sbyte>.Sign((sbyte)0x01));
+            Assert.Equal(1, NumberHelper<sbyte>.Sign((sbyte)0x7F));
+            Assert.Equal(-1, NumberHelper<sbyte>.Sign(unchecked((sbyte)0x80)));
+            Assert.Equal(-1, NumberHelper<sbyte>.Sign(unchecked((sbyte)0xFF)));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.Abs((sbyte)0x00));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.Abs((sbyte)0x01));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.Abs((sbyte)0x7F));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.Abs(unchecked((sbyte)0x80)));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.Abs(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
@@ -767,46 +937,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            Assert.Equal(((sbyte)0x00, (sbyte)0x00), BinaryIntegerHelper<sbyte>.DivRem((sbyte)0x00, (sbyte)2));
-            Assert.Equal(((sbyte)0x00, (sbyte)0x01), BinaryIntegerHelper<sbyte>.DivRem((sbyte)0x01, (sbyte)2));
-            Assert.Equal(((sbyte)0x3F, (sbyte)0x01), BinaryIntegerHelper<sbyte>.DivRem((sbyte)0x7F, (sbyte)2));
-            Assert.Equal((unchecked((sbyte)0xC0), (sbyte)0x00), BinaryIntegerHelper<sbyte>.DivRem(unchecked((sbyte)0x80), (sbyte)2));
-            Assert.Equal(((sbyte)0x00, unchecked((sbyte)0xFF)), BinaryIntegerHelper<sbyte>.DivRem(unchecked((sbyte)0xFF), (sbyte)2));
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Max((sbyte)0x00, (sbyte)1));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Max((sbyte)0x01, (sbyte)1));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.Max((sbyte)0x7F, (sbyte)1));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Max(unchecked((sbyte)0x80), (sbyte)1));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Max(unchecked((sbyte)0xFF), (sbyte)1));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.Min((sbyte)0x00, (sbyte)1));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Min((sbyte)0x01, (sbyte)1));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Min((sbyte)0x7F, (sbyte)1));
-            Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.Min(unchecked((sbyte)0x80), (sbyte)1));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.Min(unchecked((sbyte)0xFF), (sbyte)1));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(0, NumberHelper<sbyte>.Sign((sbyte)0x00));
-            Assert.Equal(1, NumberHelper<sbyte>.Sign((sbyte)0x01));
-            Assert.Equal(1, NumberHelper<sbyte>.Sign((sbyte)0x7F));
-            Assert.Equal(-1, NumberHelper<sbyte>.Sign(unchecked((sbyte)0x80)));
-            Assert.Equal(-1, NumberHelper<sbyte>.Sign(unchecked((sbyte)0xFF)));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             sbyte result;
@@ -1077,77 +1207,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            Assert.Equal(1, BinaryIntegerHelper<sbyte>.GetByteCount((sbyte)0x00));
-            Assert.Equal(1, BinaryIntegerHelper<sbyte>.GetByteCount((sbyte)0x01));
-            Assert.Equal(1, BinaryIntegerHelper<sbyte>.GetByteCount((sbyte)0x7F));
-            Assert.Equal(1, BinaryIntegerHelper<sbyte>.GetByteCount(unchecked((sbyte)0x80)));
-            Assert.Equal(1, BinaryIntegerHelper<sbyte>.GetByteCount(unchecked((sbyte)0xFF)));
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[1];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteBigEndian((sbyte)0x00, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteBigEndian((sbyte)0x01, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x01 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteBigEndian((sbyte)0x7F, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteBigEndian(unchecked((sbyte)0x80), destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteBigEndian(unchecked((sbyte)0xFF), destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<sbyte>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[1];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian((sbyte)0x00, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian((sbyte)0x01, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x01 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian((sbyte)0x7F, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian(unchecked((sbyte)0x80), destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian(unchecked((sbyte)0xFF), destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<sbyte>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF }, destination.ToArray());
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1179,6 +1241,20 @@ namespace System.Tests
             Assert.Equal((sbyte)0x7F, ShiftOperatorsHelper<sbyte, sbyte>.op_UnsignedRightShift(unchecked((sbyte)0xFF), 1));
         }
 
+        //
+        // ISignedNumber
+        //
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(unchecked((sbyte)0xFF), SignedNumberHelper<sbyte>.NegativeOne);
+        }
+
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1199,6 +1275,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<sbyte, sbyte, sbyte>.op_CheckedSubtraction(unchecked((sbyte)0x80), (sbyte)1));
         }
+
+        //
+        // IUnaryNegationOperators
+        //
 
         [Fact]
         public static void op_UnaryNegationTest()
@@ -1221,6 +1301,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => UnaryNegationOperatorsHelper<sbyte, sbyte>.op_CheckedUnaryNegation(unchecked((sbyte)0x80)));
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1230,6 +1314,10 @@ namespace System.Tests
             Assert.Equal(unchecked((sbyte)0x80), UnaryPlusOperatorsHelper<sbyte, sbyte>.op_UnaryPlus(unchecked((sbyte)0x80)));
             Assert.Equal(unchecked((sbyte)0xFF), UnaryPlusOperatorsHelper<sbyte, sbyte>.op_UnaryPlus(unchecked((sbyte)0xFF)));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(SByteTests.Parse_Valid_TestData), MemberType = typeof(SByteTests))]

--- a/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
@@ -353,11 +353,11 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.Abs((sbyte)0x00));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Abs((sbyte)0x01));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.Abs((sbyte)0x7F));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.Abs(unchecked((sbyte)0x80)));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Abs(unchecked((sbyte)0xFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.Abs((sbyte)0x00));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.Abs((sbyte)0x01));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.Abs((sbyte)0x7F));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.Abs(unchecked((sbyte)0x80)));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.Abs(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
@@ -373,51 +373,51 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<byte>(0x00));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<byte>(0x01));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CreateChecked<byte>(0x7F));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<byte>(0x80));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<byte>(0xFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<byte>(0x00));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<byte>(0x01));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.CreateChecked<byte>(0x7F));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<byte>(0x80));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<char>((char)0x0000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<char>((char)0x0001));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<char>((char)0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<char>((char)0x8000));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<char>((char)0x0000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<char>((char)0x0001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<char>((char)0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<char>((char)0x8000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<short>(0x0000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<short>(0x0001));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<short>(0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<short>(0x0000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<short>(0x0001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<short>(0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<int>(0x00000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<int>(0x00000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<int>(0x00000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<int>(0x00000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<long>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<long>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -425,60 +425,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<sbyte>(0x00));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<sbyte>(0x01));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CreateChecked<sbyte>(0x7F));
-            Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<sbyte>(0x00));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<sbyte>(0x01));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.CreateChecked<sbyte>(0x7F));
+            Assert.Equal(unchecked((sbyte)0x80), NumberBaseHelper<sbyte>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<ushort>(0x0000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<ushort>(0x0001));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<ushort>(0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<ushort>(0x8000));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<ushort>(0x0000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<ushort>(0x0001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<ushort>(0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<ushort>(0x8000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<uint>(0x00000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<uint>(0x00000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<uint>(0x80000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<uint>(0x00000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<uint>(0x00000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<uint>(0x80000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -486,70 +486,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<sbyte>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<byte>(0x00));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<byte>(0x01));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CreateSaturating<byte>(0x7F));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CreateSaturating<byte>(0x80));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CreateSaturating<byte>(0xFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<byte>(0x00));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<byte>(0x01));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.CreateSaturating<byte>(0x7F));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.CreateSaturating<byte>(0x80));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<short>(0x0000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<short>(0x0001));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<short>(0x0000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<short>(0x0001));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal(unchecked((sbyte)0x80), NumberBaseHelper<sbyte>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<int>(0x00000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<int>(0x00000001));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<int>(0x00000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<int>(0x00000001));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal(unchecked((sbyte)0x80), NumberBaseHelper<sbyte>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(unchecked((sbyte)0x80), NumberBaseHelper<sbyte>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -557,60 +557,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((sbyte)0x80), NumberBaseHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(unchecked((sbyte)0x80), NumberBaseHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal(unchecked((sbyte)0x80), NumberBaseHelper<sbyte>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -618,70 +618,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal(unchecked((sbyte)0x7F), NumberHelper<sbyte>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal(unchecked((sbyte)0x7F), NumberBaseHelper<sbyte>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<byte>(0x00));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<byte>(0x01));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CreateTruncating<byte>(0x7F));
-            Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.CreateTruncating<byte>(0x80));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<byte>(0xFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<byte>(0x00));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<byte>(0x01));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.CreateTruncating<byte>(0x7F));
+            Assert.Equal(unchecked((sbyte)0x80), NumberBaseHelper<sbyte>.CreateTruncating<byte>(0x80));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<short>(0x0000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<short>(0x0001));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<short>(0x0000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<short>(0x0001));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<int>(0x00000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<int>(0x00000001));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<int>(0x00000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<int>(0x00000001));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -689,60 +689,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal(unchecked((sbyte)0x80), NumberBaseHelper<sbyte>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -750,19 +750,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -811,19 +811,19 @@ namespace System.Tests
         {
             sbyte result;
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<byte>(0x00, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<byte>(0x01, out result));
             Assert.Equal((sbyte)0x01, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((sbyte)0x7F, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<byte>(0x80, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<byte>(0x80, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<byte>(0xFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((sbyte)0x00, result);
         }
 
@@ -832,19 +832,19 @@ namespace System.Tests
         {
             sbyte result;
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal((sbyte)0x01, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<char>((char)0x8000, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((sbyte)0x00, result);
         }
 
@@ -853,19 +853,19 @@ namespace System.Tests
         {
             sbyte result;
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<short>(0x0000, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<short>(0x0001, out result));
             Assert.Equal((sbyte)0x01, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<short>(0x7FFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(unchecked((sbyte)0xFF), result);
         }
 
@@ -874,19 +874,19 @@ namespace System.Tests
         {
             sbyte result;
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<int>(0x00000000, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<int>(0x00000001, out result));
             Assert.Equal((sbyte)0x01, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(unchecked((sbyte)0xFF), result);
         }
 
@@ -895,19 +895,19 @@ namespace System.Tests
         {
             sbyte result;
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal((sbyte)0x01, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
             Assert.Equal(unchecked((sbyte)0xFF), result);
         }
 
@@ -918,36 +918,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<sbyte>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<sbyte>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.True(NumberHelper<sbyte>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<sbyte>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal((sbyte)0x01, result);
 
-                Assert.False(NumberHelper<sbyte>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<sbyte>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.False(NumberHelper<sbyte>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<sbyte>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.True(NumberHelper<sbyte>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<sbyte>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((sbyte)0xFF), result);
             }
             else
             {
-                Assert.True(NumberHelper<sbyte>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<sbyte>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.True(NumberHelper<sbyte>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<sbyte>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal((sbyte)0x01, result);
 
-                Assert.False(NumberHelper<sbyte>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.False(NumberBaseHelper<sbyte>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.False(NumberHelper<sbyte>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<sbyte>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.True(NumberHelper<sbyte>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<sbyte>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(unchecked((sbyte)0xFF), result);
             }
         }
@@ -957,19 +957,19 @@ namespace System.Tests
         {
             sbyte result;
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal((sbyte)0x01, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((sbyte)0x7F, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal(unchecked((sbyte)0x80), result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(unchecked((sbyte)0xFF), result);
         }
 
@@ -978,19 +978,19 @@ namespace System.Tests
         {
             sbyte result;
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal((sbyte)0x01, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<ushort>(0x8000, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((sbyte)0x00, result);
         }
 
@@ -999,19 +999,19 @@ namespace System.Tests
         {
             sbyte result;
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal((sbyte)0x01, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<uint>(0x80000000, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal((sbyte)0x00, result);
         }
 
@@ -1020,19 +1020,19 @@ namespace System.Tests
         {
             sbyte result;
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.True(NumberHelper<sbyte>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal((sbyte)0x01, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal((sbyte)0x00, result);
 
-            Assert.False(NumberHelper<sbyte>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal((sbyte)0x00, result);
         }
 
@@ -1043,36 +1043,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.True(NumberHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal((sbyte)0x01, result);
 
-                Assert.False(NumberHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.False(NumberHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.False(NumberHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((sbyte)0x00, result);
             }
             else
             {
-                Assert.True(NumberHelper<sbyte>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<sbyte>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.True(NumberHelper<sbyte>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<sbyte>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal((sbyte)0x01, result);
 
-                Assert.False(NumberHelper<sbyte>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.False(NumberBaseHelper<sbyte>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.False(NumberHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal((sbyte)0x00, result);
 
-                Assert.False(NumberHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<sbyte>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal((sbyte)0x00, result);
             }
         }
@@ -1248,12 +1248,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Equal(expected, NumberHelper<sbyte>.Parse(value, style, provider));
+                Assert.Equal(expected, NumberBaseHelper<sbyte>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.True(NumberHelper<sbyte>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.True(NumberBaseHelper<sbyte>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(expected, result);
-                Assert.Equal(expected, NumberHelper<sbyte>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Equal(expected, NumberBaseHelper<sbyte>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1263,9 +1263,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.True(NumberHelper<sbyte>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
-            Assert.Equal(expected, NumberHelper<sbyte>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<sbyte>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1285,12 +1285,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<sbyte>.Parse(value, style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<sbyte>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.False(NumberHelper<sbyte>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.False(NumberBaseHelper<sbyte>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(default(sbyte), result);
-                Assert.Throws(exceptionType, () => NumberHelper<sbyte>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<sbyte>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1300,9 +1300,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.False(NumberHelper<sbyte>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryParse(value, style, provider, out result));
             Assert.Equal(default(sbyte), result);
-            Assert.Throws(exceptionType, () => NumberHelper<sbyte>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<sbyte>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1318,9 +1318,9 @@ namespace System.Tests
                 Assert.Equal(expected, result);
             }
 
-            Assert.Equal(expected, NumberHelper<sbyte>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<sbyte>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<sbyte>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<sbyte>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1342,9 +1342,9 @@ namespace System.Tests
                 Assert.Equal(default(sbyte), result);
             }
 
-            Assert.Throws(exceptionType, () => NumberHelper<sbyte>.Parse(value.AsSpan(), style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<sbyte>.Parse(value.AsSpan(), style, provider));
 
-            Assert.False(NumberHelper<sbyte>.TryParse(value.AsSpan(), style, provider, out result));
+            Assert.False(NumberBaseHelper<sbyte>.TryParse(value.AsSpan(), style, provider, out result));
             Assert.Equal(default(sbyte), result);
         }
     }

--- a/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
@@ -495,6 +495,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.MaxNumber((sbyte)0x00, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.MaxNumber((sbyte)0x01, (sbyte)1));
+            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.MaxNumber((sbyte)0x7F, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.MaxNumber(unchecked((sbyte)0x80), (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.MaxNumber(unchecked((sbyte)0xFF), (sbyte)1));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.Min((sbyte)0x00, (sbyte)1));
@@ -502,6 +512,16 @@ namespace System.Tests
             Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Min((sbyte)0x7F, (sbyte)1));
             Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.Min(unchecked((sbyte)0x80), (sbyte)1));
             Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.Min(unchecked((sbyte)0xFF), (sbyte)1));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.MinNumber((sbyte)0x00, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.MinNumber((sbyte)0x01, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.MinNumber((sbyte)0x7F, (sbyte)1));
+            Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.MinNumber(unchecked((sbyte)0x80), (sbyte)1));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.MinNumber(unchecked((sbyte)0xFF), (sbyte)1));
         }
 
         [Fact]
@@ -934,6 +954,126 @@ namespace System.Tests
                 Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<sbyte>.IsFinite((sbyte)0x00));
+            Assert.True(NumberBaseHelper<sbyte>.IsFinite((sbyte)0x01));
+            Assert.True(NumberBaseHelper<sbyte>.IsFinite((sbyte)0x7F));
+            Assert.True(NumberBaseHelper<sbyte>.IsFinite(unchecked((sbyte)0x80)));
+            Assert.True(NumberBaseHelper<sbyte>.IsFinite(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<sbyte>.IsInfinity((sbyte)0x00));
+            Assert.False(NumberBaseHelper<sbyte>.IsInfinity((sbyte)0x01));
+            Assert.False(NumberBaseHelper<sbyte>.IsInfinity((sbyte)0x7F));
+            Assert.False(NumberBaseHelper<sbyte>.IsInfinity(unchecked((sbyte)0x80)));
+            Assert.False(NumberBaseHelper<sbyte>.IsInfinity(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<sbyte>.IsNaN((sbyte)0x00));
+            Assert.False(NumberBaseHelper<sbyte>.IsNaN((sbyte)0x01));
+            Assert.False(NumberBaseHelper<sbyte>.IsNaN((sbyte)0x7F));
+            Assert.False(NumberBaseHelper<sbyte>.IsNaN(unchecked((sbyte)0x80)));
+            Assert.False(NumberBaseHelper<sbyte>.IsNaN(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<sbyte>.IsNegative((sbyte)0x00));
+            Assert.False(NumberBaseHelper<sbyte>.IsNegative((sbyte)0x01));
+            Assert.False(NumberBaseHelper<sbyte>.IsNegative((sbyte)0x7F));
+            Assert.True(NumberBaseHelper<sbyte>.IsNegative(unchecked((sbyte)0x80)));
+            Assert.True(NumberBaseHelper<sbyte>.IsNegative(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<sbyte>.IsNegativeInfinity((sbyte)0x00));
+            Assert.False(NumberBaseHelper<sbyte>.IsNegativeInfinity((sbyte)0x01));
+            Assert.False(NumberBaseHelper<sbyte>.IsNegativeInfinity((sbyte)0x7F));
+            Assert.False(NumberBaseHelper<sbyte>.IsNegativeInfinity(unchecked((sbyte)0x80)));
+            Assert.False(NumberBaseHelper<sbyte>.IsNegativeInfinity(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<sbyte>.IsNormal((sbyte)0x00));
+            Assert.True(NumberBaseHelper<sbyte>.IsNormal((sbyte)0x01));
+            Assert.True(NumberBaseHelper<sbyte>.IsNormal((sbyte)0x7F));
+            Assert.True(NumberBaseHelper<sbyte>.IsNormal(unchecked((sbyte)0x80)));
+            Assert.True(NumberBaseHelper<sbyte>.IsNormal(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<sbyte>.IsPositiveInfinity((sbyte)0x00));
+            Assert.False(NumberBaseHelper<sbyte>.IsPositiveInfinity((sbyte)0x01));
+            Assert.False(NumberBaseHelper<sbyte>.IsPositiveInfinity((sbyte)0x7F));
+            Assert.False(NumberBaseHelper<sbyte>.IsPositiveInfinity(unchecked((sbyte)0x80)));
+            Assert.False(NumberBaseHelper<sbyte>.IsPositiveInfinity(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<sbyte>.IsSubnormal((sbyte)0x00));
+            Assert.False(NumberBaseHelper<sbyte>.IsSubnormal((sbyte)0x01));
+            Assert.False(NumberBaseHelper<sbyte>.IsSubnormal((sbyte)0x7F));
+            Assert.False(NumberBaseHelper<sbyte>.IsSubnormal(unchecked((sbyte)0x80)));
+            Assert.False(NumberBaseHelper<sbyte>.IsSubnormal(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MaxMagnitude((sbyte)0x00, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MaxMagnitude((sbyte)0x01, (sbyte)1));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.MaxMagnitude((sbyte)0x7F, (sbyte)1));
+            Assert.Equal(unchecked((sbyte)0x80), NumberBaseHelper<sbyte>.MaxMagnitude(unchecked((sbyte)0x80), (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MaxMagnitude(unchecked((sbyte)0xFF), (sbyte)1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MaxMagnitudeNumber((sbyte)0x00, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MaxMagnitudeNumber((sbyte)0x01, (sbyte)1));
+            Assert.Equal((sbyte)0x7F, NumberBaseHelper<sbyte>.MaxMagnitudeNumber((sbyte)0x7F, (sbyte)1));
+            Assert.Equal(unchecked((sbyte)0x80), NumberBaseHelper<sbyte>.MaxMagnitudeNumber(unchecked((sbyte)0x80), (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MaxMagnitudeNumber(unchecked((sbyte)0xFF), (sbyte)1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.MinMagnitude((sbyte)0x00, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MinMagnitude((sbyte)0x01, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MinMagnitude((sbyte)0x7F, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MinMagnitude(unchecked((sbyte)0x80), (sbyte)1));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.MinMagnitude(unchecked((sbyte)0xFF), (sbyte)1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.MinMagnitudeNumber((sbyte)0x00, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MinMagnitudeNumber((sbyte)0x01, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MinMagnitudeNumber((sbyte)0x7F, (sbyte)1));
+            Assert.Equal((sbyte)0x01, NumberBaseHelper<sbyte>.MinMagnitudeNumber(unchecked((sbyte)0x80), (sbyte)1));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberBaseHelper<sbyte>.MinMagnitudeNumber(unchecked((sbyte)0xFF), (sbyte)1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
@@ -895,6 +895,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(float.MinValue, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(-1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(-MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(-0.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(float.NaN, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(0.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MaxNumber(1.0f, 1.0f));
+            AssertBitwiseEqual(float.MaxValue, NumberHelper<float>.MaxNumber(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberHelper<float>.MaxNumber(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             AssertBitwiseEqual(float.NegativeInfinity, NumberHelper<float>.Min(float.NegativeInfinity, 1.0f));
@@ -912,6 +932,26 @@ namespace System.Tests
             AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(1.0f, 1.0f));
             AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(float.MaxValue, 1.0f));
             AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, NumberHelper<float>.MinNumber(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(float.MinValue, NumberHelper<float>.MinNumber(float.MinValue, 1.0f));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.MinNumber(-1.0f, 1.0f));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<float>.MinNumber(-MinNormal, 1.0f));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<float>.MinNumber(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(-float.Epsilon, NumberHelper<float>.MinNumber(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(-0.0f, NumberHelper<float>.MinNumber(-0.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MinNumber(float.NaN, 1.0f));
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.MinNumber(0.0f, 1.0f));
+            AssertBitwiseEqual(float.Epsilon, NumberHelper<float>.MinNumber(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<float>.MinNumber(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(MinNormal, NumberHelper<float>.MinNumber(MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MinNumber(1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MinNumber(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.MinNumber(float.PositiveInfinity, 1.0f));
         }
 
         [Fact]
@@ -1439,6 +1479,246 @@ namespace System.Tests
                 // AssertBitwiseEqual(2147483648.0f, NumberBaseHelper<float>.CreateTruncating<nuint>((nuint)0x80000000));
                 // AssertBitwiseEqual(4294967295.0f, NumberBaseHelper<float>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsFinite(float.NegativeInfinity));
+            Assert.True(NumberBaseHelper<float>.IsFinite(float.MinValue));
+            Assert.True(NumberBaseHelper<float>.IsFinite(-1.0f));
+            Assert.True(NumberBaseHelper<float>.IsFinite(-MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsFinite(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<float>.IsFinite(-float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsFinite(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsFinite(float.NaN));
+            Assert.True(NumberBaseHelper<float>.IsFinite(0.0f));
+            Assert.True(NumberBaseHelper<float>.IsFinite(float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsFinite(MaxSubnormal));
+            Assert.True(NumberBaseHelper<float>.IsFinite(MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsFinite(1.0f));
+            Assert.True(NumberBaseHelper<float>.IsFinite(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsFinite(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.True(NumberBaseHelper<float>.IsInfinity(float.NegativeInfinity));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(float.MinValue));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(-float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(float.NaN));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(1.0f));
+            Assert.False(NumberBaseHelper<float>.IsInfinity(float.MaxValue));
+            Assert.True(NumberBaseHelper<float>.IsInfinity(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsNaN(float.NegativeInfinity));
+            Assert.False(NumberBaseHelper<float>.IsNaN(float.MinValue));
+            Assert.False(NumberBaseHelper<float>.IsNaN(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsNaN(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsNaN(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsNaN(-float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsNaN(-0.0f));
+            Assert.True(NumberBaseHelper<float>.IsNaN(float.NaN));
+            Assert.False(NumberBaseHelper<float>.IsNaN(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsNaN(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsNaN(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsNaN(MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsNaN(1.0f));
+            Assert.False(NumberBaseHelper<float>.IsNaN(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsNaN(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.True(NumberBaseHelper<float>.IsNegative(float.NegativeInfinity));
+            Assert.True(NumberBaseHelper<float>.IsNegative(float.MinValue));
+            Assert.True(NumberBaseHelper<float>.IsNegative(-1.0f));
+            Assert.True(NumberBaseHelper<float>.IsNegative(-MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsNegative(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<float>.IsNegative(-float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsNegative(-0.0f));
+            Assert.True(NumberBaseHelper<float>.IsNegative(float.NaN));
+            Assert.False(NumberBaseHelper<float>.IsNegative(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsNegative(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsNegative(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsNegative(MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsNegative(1.0f));
+            Assert.False(NumberBaseHelper<float>.IsNegative(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsNegative(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.True(NumberBaseHelper<float>.IsNegativeInfinity(float.NegativeInfinity));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(float.MinValue));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(-float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(float.NaN));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(1.0f));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsNegativeInfinity(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsNormal(float.NegativeInfinity));
+            Assert.True(NumberBaseHelper<float>.IsNormal(float.MinValue));
+            Assert.True(NumberBaseHelper<float>.IsNormal(-1.0f));
+            Assert.True(NumberBaseHelper<float>.IsNormal(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsNormal(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsNormal(-float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsNormal(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsNormal(float.NaN));
+            Assert.False(NumberBaseHelper<float>.IsNormal(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsNormal(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsNormal(MaxSubnormal));
+            Assert.True(NumberBaseHelper<float>.IsNormal(MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsNormal(1.0f));
+            Assert.True(NumberBaseHelper<float>.IsNormal(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsNormal(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(float.NegativeInfinity));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(float.MinValue));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(-float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(float.NaN));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(1.0f));
+            Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(float.MaxValue));
+            Assert.True(NumberBaseHelper<float>.IsPositiveInfinity(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsSubnormal(float.NegativeInfinity));
+            Assert.False(NumberBaseHelper<float>.IsSubnormal(float.MinValue));
+            Assert.False(NumberBaseHelper<float>.IsSubnormal(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsSubnormal(-MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsSubnormal(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<float>.IsSubnormal(-float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsSubnormal(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsSubnormal(float.NaN));
+            Assert.False(NumberBaseHelper<float>.IsSubnormal(0.0f));
+            Assert.True(NumberBaseHelper<float>.IsSubnormal(float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsSubnormal(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsSubnormal(MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsSubnormal(1.0f));
+            Assert.False(NumberBaseHelper<float>.IsSubnormal(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsSubnormal(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, NumberBaseHelper<float>.MaxMagnitude(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(float.MinValue, NumberBaseHelper<float>.MaxMagnitude(float.MinValue, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitude(-1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitude(-MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitude(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitude(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitude(-0.0f, 1.0f));
+            AssertBitwiseEqual(float.NaN, NumberBaseHelper<float>.MaxMagnitude(float.NaN, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitude(0.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitude(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitude(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitude(MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitude(1.0f, 1.0f));
+            AssertBitwiseEqual(float.MaxValue, NumberBaseHelper<float>.MaxMagnitude(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberBaseHelper<float>.MaxMagnitude(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, NumberBaseHelper<float>.MaxMagnitudeNumber(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(float.MinValue, NumberBaseHelper<float>.MaxMagnitudeNumber(float.MinValue, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitudeNumber(-1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitudeNumber(-MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitudeNumber(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitudeNumber(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitudeNumber(-0.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitudeNumber(float.NaN, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitudeNumber(0.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitudeNumber(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitudeNumber(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitudeNumber(MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MaxMagnitudeNumber(1.0f, 1.0f));
+            AssertBitwiseEqual(float.MaxValue, NumberBaseHelper<float>.MaxMagnitudeNumber(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberBaseHelper<float>.MaxMagnitudeNumber(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MinMagnitude(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MinMagnitude(float.MinValue, 1.0f));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.MinMagnitude(-1.0f, 1.0f));
+            AssertBitwiseEqual(-MinNormal, NumberBaseHelper<float>.MinMagnitude(-MinNormal, 1.0f));
+            AssertBitwiseEqual(-MaxSubnormal, NumberBaseHelper<float>.MinMagnitude(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(-float.Epsilon, NumberBaseHelper<float>.MinMagnitude(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(-0.0f, NumberBaseHelper<float>.MinMagnitude(-0.0f, 1.0f));
+            AssertBitwiseEqual(float.NaN, NumberBaseHelper<float>.MinMagnitude(float.NaN, 1.0f));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.MinMagnitude(0.0f, 1.0f));
+            AssertBitwiseEqual(float.Epsilon, NumberBaseHelper<float>.MinMagnitude(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<float>.MinMagnitude(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<float>.MinMagnitude(MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MinMagnitude(1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MinMagnitude(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MinMagnitude(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MinMagnitudeNumber(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MinMagnitudeNumber(float.MinValue, 1.0f));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.MinMagnitudeNumber(-1.0f, 1.0f));
+            AssertBitwiseEqual(-MinNormal, NumberBaseHelper<float>.MinMagnitudeNumber(-MinNormal, 1.0f));
+            AssertBitwiseEqual(-MaxSubnormal, NumberBaseHelper<float>.MinMagnitudeNumber(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(-float.Epsilon, NumberBaseHelper<float>.MinMagnitudeNumber(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(-0.0f, NumberBaseHelper<float>.MinMagnitudeNumber(-0.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MinMagnitudeNumber(float.NaN, 1.0f));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.MinMagnitudeNumber(0.0f, 1.0f));
+            AssertBitwiseEqual(float.Epsilon, NumberBaseHelper<float>.MinMagnitudeNumber(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<float>.MinMagnitudeNumber(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<float>.MinMagnitudeNumber(MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MinMagnitudeNumber(1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MinMagnitudeNumber(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.MinMagnitudeNumber(float.PositiveInfinity, 1.0f));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
@@ -30,47 +30,9 @@ namespace System.Tests
             throw new Xunit.Sdk.EqualException(expected, actual);
         }
 
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            AssertBitwiseEqual(0.0f, AdditiveIdentityHelper<float, float>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            AssertBitwiseEqual(float.MinValue, MinMaxValueHelper<float>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            AssertBitwiseEqual(float.MaxValue, MinMaxValueHelper<float>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            AssertBitwiseEqual(1.0f, MultiplicativeIdentityHelper<float, float>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void NegativeOneTest()
-        {
-            Assert.Equal(-1.0f, SignedNumberHelper<float>.NegativeOne);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -112,6 +74,20 @@ namespace System.Tests
             AssertBitwiseEqual(float.PositiveInfinity, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(float.PositiveInfinity, 1.0f));
         }
 
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            AssertBitwiseEqual(0.0f, AdditiveIdentityHelper<float, float>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryNumber
+        //
+
         [Fact]
         public static void IsPow2Test()
         {
@@ -152,45 +128,9 @@ namespace System.Tests
             AssertBitwiseEqual(float.PositiveInfinity, BinaryNumberHelper<float>.Log2(float.PositiveInfinity));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(float.NegativeInfinity, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(float.MinValue, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-1.0f, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-MinNormal, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-MaxSubnormal, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-float.Epsilon, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-0.0f, 1.0f));
-            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(float.NaN, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(0.0f, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(float.Epsilon, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(MaxSubnormal, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(MinNormal, 1.0f));
-            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(1.0f, 1.0f));
-            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(float.MaxValue, 1.0f));
-            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(float.PositiveInfinity, 1.0f));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.NegativeInfinity, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.MinValue, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-1.0f, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-MinNormal, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-MaxSubnormal, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-float.Epsilon, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-0.0f, 1.0f));
-            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.NaN, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(0.0f, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.Epsilon, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(MaxSubnormal, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(MinNormal, 1.0f));
-            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(1.0f, 1.0f));
-            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.MaxValue, 1.0f));
-            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.PositiveInfinity, 1.0f));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -233,6 +173,50 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(float.NegativeInfinity, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(float.MinValue, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-1.0f, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-MinNormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-MaxSubnormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-float.Epsilon, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-0.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(float.NaN, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(0.0f, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(float.Epsilon, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(MaxSubnormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(MinNormal, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(1.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(float.MaxValue, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.NegativeInfinity, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.MinValue, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-1.0f, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-MinNormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-MaxSubnormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-float.Epsilon, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-0.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.NaN, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(0.0f, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.Epsilon, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(MaxSubnormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(MinNormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(1.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.MaxValue, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.PositiveInfinity, 1.0f));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             AssertBitwiseEqual(float.NegativeInfinity, DecrementOperatorsHelper<float>.op_Decrement(float.NegativeInfinity));
@@ -271,6 +255,10 @@ namespace System.Tests
             AssertBitwiseEqual(float.MaxValue, DecrementOperatorsHelper<float>.op_CheckedDecrement(float.MaxValue));
             AssertBitwiseEqual(float.PositiveInfinity, DecrementOperatorsHelper<float>.op_CheckedDecrement(float.PositiveInfinity));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -312,6 +300,10 @@ namespace System.Tests
             AssertBitwiseEqual(float.PositiveInfinity, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(float.PositiveInfinity, 2.0f));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -351,6 +343,378 @@ namespace System.Tests
             Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(float.MaxValue, 1.0f));
             Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(float.PositiveInfinity, 1.0f));
         }
+
+        //
+        // IFloatingPoint
+        //
+
+        [Fact]
+        public static void GetExponentByteCountTest()
+        {
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.NegativeInfinity));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.MinValue));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(-1.0f));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(-MinNormal));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(-MaxSubnormal));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(-float.Epsilon));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(-0.0f));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.NaN));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(0.0f));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.Epsilon));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(MaxSubnormal));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(MinNormal));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(1.0f));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.MaxValue));
+            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void GetExponentShortestBitLengthTest()
+        {
+            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(float.NegativeInfinity));
+            Assert.Equal(7, FloatingPointHelper<float>.GetExponentShortestBitLength(float.MinValue));
+            Assert.Equal(0, FloatingPointHelper<float>.GetExponentShortestBitLength(-1.0f));
+            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(-MinNormal));
+            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(-MaxSubnormal));
+            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(-float.Epsilon));
+            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(-0.0f));
+            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(float.NaN));
+            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(0.0f));
+            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(float.Epsilon));
+            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(MaxSubnormal));
+            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(MinNormal));
+            Assert.Equal(0, FloatingPointHelper<float>.GetExponentShortestBitLength(1.0f));
+            Assert.Equal(7, FloatingPointHelper<float>.GetExponentShortestBitLength(float.MaxValue));
+            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void GetSignificandByteCountTest()
+        {
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.NegativeInfinity));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.MinValue));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(-1.0f));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(-MinNormal));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(-MaxSubnormal));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(-float.Epsilon));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(-0.0f));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.NaN));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(0.0f));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.Epsilon));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(MaxSubnormal));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(MinNormal));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(1.0f));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.MaxValue));
+            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void GetSignificandBitLengthTest()
+        {
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.NegativeInfinity));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.MinValue));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(-1.0f));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(-MinNormal));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(-MaxSubnormal));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(-float.Epsilon));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(-0.0f));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.NaN));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(0.0f));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.Epsilon));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(MaxSubnormal));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(MinNormal));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(1.0f));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.MaxValue));
+            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void TryWriteExponentBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[1];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.NegativeInfinity, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.MinValue, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F }, destination.ToArray()); // +127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(-1.0f, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(-MinNormal, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x82 }, destination.ToArray()); // -126
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(-MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(-float.Epsilon, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(-0.0f, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.NaN, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(0.0f, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.Epsilon, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(MinNormal, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x82 }, destination.ToArray()); // -126
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(1.0f, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.MaxValue, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F }, destination.ToArray()); // +127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.PositiveInfinity, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
+
+            Assert.False(FloatingPointHelper<float>.TryWriteExponentBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteExponentLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[1];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.NegativeInfinity, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.MinValue, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F }, destination.ToArray()); // +127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(-1.0f, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(-MinNormal, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x82 }, destination.ToArray()); // -126
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(-MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(-float.Epsilon, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(-0.0f, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.NaN, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(0.0f, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.Epsilon, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(MinNormal, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x82 }, destination.ToArray()); // -126
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(1.0f, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.MaxValue, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F }, destination.ToArray()); // +127
+
+            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.PositiveInfinity, destination, out bytesWritten));
+            Assert.Equal(1, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
+
+            Assert.False(FloatingPointHelper<float>.TryWriteExponentLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteSignificandBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[4];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.NegativeInfinity, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.MinValue, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0xFF, 0xFF, 0xff }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(-1.0f, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(-MinNormal, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(-MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x7F, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(-float.Epsilon, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(-0.0f, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.NaN, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0xC0, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(0.0f, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.Epsilon, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x7F, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(MinNormal, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(1.0f, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.MaxValue, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.PositiveInfinity, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.False(FloatingPointHelper<float>.TryWriteSignificandBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteSignificandLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[4];
+            int bytesWritten = 0;
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.NegativeInfinity, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.MinValue, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(-1.0f, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(-MinNormal, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(-MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0x7F, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(-float.Epsilon, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(-0.0f, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.NaN, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0xC0, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(0.0f, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.Epsilon, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(MaxSubnormal, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0x7F, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(MinNormal, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(1.0f, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.MaxValue, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x00 }, destination.ToArray());
+
+            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.PositiveInfinity, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
+
+            Assert.False(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
+        }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -392,6 +756,26 @@ namespace System.Tests
             AssertBitwiseEqual(float.PositiveInfinity, IncrementOperatorsHelper<float>.op_CheckedIncrement(float.PositiveInfinity));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            AssertBitwiseEqual(float.MaxValue, MinMaxValueHelper<float>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            AssertBitwiseEqual(float.MinValue, MinMaxValueHelper<float>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -411,6 +795,20 @@ namespace System.Tests
             AssertBitwiseEqual(0.0f, ModulusOperatorsHelper<float, float, float>.op_Modulus(float.MaxValue, 2.0f));
             AssertBitwiseEqual(float.NaN, ModulusOperatorsHelper<float, float, float>.op_Modulus(float.PositiveInfinity, 2.0f));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            AssertBitwiseEqual(1.0f, MultiplicativeIdentityHelper<float, float>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -452,25 +850,9 @@ namespace System.Tests
             AssertBitwiseEqual(float.PositiveInfinity, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(float.PositiveInfinity, 2.0f));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            AssertBitwiseEqual(float.PositiveInfinity, NumberBaseHelper<float>.Abs(float.NegativeInfinity));
-            AssertBitwiseEqual(float.MaxValue, NumberBaseHelper<float>.Abs(float.MinValue));
-            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.Abs(-1.0f));
-            AssertBitwiseEqual(MinNormal, NumberBaseHelper<float>.Abs(-MinNormal));
-            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<float>.Abs(-MaxSubnormal));
-            AssertBitwiseEqual(float.Epsilon, NumberBaseHelper<float>.Abs(-float.Epsilon));
-            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.Abs(-0.0f));
-            AssertBitwiseEqual(float.NaN, NumberBaseHelper<float>.Abs(float.NaN));
-            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.Abs(0.0f));
-            AssertBitwiseEqual(float.Epsilon, NumberBaseHelper<float>.Abs(float.Epsilon));
-            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<float>.Abs(MaxSubnormal));
-            AssertBitwiseEqual(MinNormal, NumberBaseHelper<float>.Abs(MinNormal));
-            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.Abs(1.0f));
-            AssertBitwiseEqual(float.MaxValue, NumberBaseHelper<float>.Abs(float.MaxValue));
-            AssertBitwiseEqual(float.PositiveInfinity, NumberBaseHelper<float>.Abs(float.PositiveInfinity));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -490,6 +872,105 @@ namespace System.Tests
             AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(1.0f, 1.0f, 63.0f));
             AssertBitwiseEqual(63.0f, NumberHelper<float>.Clamp(float.MaxValue, 1.0f, 63.0f));
             AssertBitwiseEqual(63.0f, NumberHelper<float>.Clamp(float.PositiveInfinity, 1.0f, 63.0f));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(float.MinValue, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-0.0f, 1.0f));
+            AssertBitwiseEqual(float.NaN, NumberHelper<float>.Max(float.NaN, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(0.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(1.0f, 1.0f));
+            AssertBitwiseEqual(float.MaxValue, NumberHelper<float>.Max(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberHelper<float>.Max(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, NumberHelper<float>.Min(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(float.MinValue, NumberHelper<float>.Min(float.MinValue, 1.0f));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.Min(-1.0f, 1.0f));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<float>.Min(-MinNormal, 1.0f));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<float>.Min(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(-float.Epsilon, NumberHelper<float>.Min(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(-0.0f, NumberHelper<float>.Min(-0.0f, 1.0f));
+            AssertBitwiseEqual(float.NaN, NumberHelper<float>.Min(float.NaN, 1.0f));
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.Min(0.0f, 1.0f));
+            AssertBitwiseEqual(float.Epsilon, NumberHelper<float>.Min(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<float>.Min(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(MinNormal, NumberHelper<float>.Min(MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(-1, NumberHelper<float>.Sign(float.NegativeInfinity));
+            Assert.Equal(-1, NumberHelper<float>.Sign(float.MinValue));
+            Assert.Equal(-1, NumberHelper<float>.Sign(-1.0f));
+            Assert.Equal(-1, NumberHelper<float>.Sign(-MinNormal));
+            Assert.Equal(-1, NumberHelper<float>.Sign(-MaxSubnormal));
+            Assert.Equal(-1, NumberHelper<float>.Sign(-float.Epsilon));
+
+            Assert.Equal(0, NumberHelper<float>.Sign(-0.0f));
+            Assert.Equal(0, NumberHelper<float>.Sign(0.0f));
+
+            Assert.Equal(1, NumberHelper<float>.Sign(float.Epsilon));
+            Assert.Equal(1, NumberHelper<float>.Sign(MaxSubnormal));
+            Assert.Equal(1, NumberHelper<float>.Sign(MinNormal));
+            Assert.Equal(1, NumberHelper<float>.Sign(1.0f));
+            Assert.Equal(1, NumberHelper<float>.Sign(float.MaxValue));
+            Assert.Equal(1, NumberHelper<float>.Sign(float.PositiveInfinity));
+
+            Assert.Throws<ArithmeticException>(() => NumberHelper<float>.Sign(float.NaN));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            AssertBitwiseEqual(float.PositiveInfinity, NumberBaseHelper<float>.Abs(float.NegativeInfinity));
+            AssertBitwiseEqual(float.MaxValue, NumberBaseHelper<float>.Abs(float.MinValue));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.Abs(-1.0f));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<float>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<float>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(float.Epsilon, NumberBaseHelper<float>.Abs(-float.Epsilon));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.Abs(-0.0f));
+            AssertBitwiseEqual(float.NaN, NumberBaseHelper<float>.Abs(float.NaN));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.Abs(0.0f));
+            AssertBitwiseEqual(float.Epsilon, NumberBaseHelper<float>.Abs(float.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<float>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<float>.Abs(MinNormal));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.Abs(1.0f));
+            AssertBitwiseEqual(float.MaxValue, NumberBaseHelper<float>.Abs(float.MaxValue));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberBaseHelper<float>.Abs(float.PositiveInfinity));
         }
 
         [Fact]
@@ -961,69 +1442,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void MaxTest()
-        {
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(float.NegativeInfinity, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(float.MinValue, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-1.0f, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-MinNormal, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-MaxSubnormal, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-float.Epsilon, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-0.0f, 1.0f));
-            AssertBitwiseEqual(float.NaN, NumberHelper<float>.Max(float.NaN, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(0.0f, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(float.Epsilon, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(MaxSubnormal, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(MinNormal, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(1.0f, 1.0f));
-            AssertBitwiseEqual(float.MaxValue, NumberHelper<float>.Max(float.MaxValue, 1.0f));
-            AssertBitwiseEqual(float.PositiveInfinity, NumberHelper<float>.Max(float.PositiveInfinity, 1.0f));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            AssertBitwiseEqual(float.NegativeInfinity, NumberHelper<float>.Min(float.NegativeInfinity, 1.0f));
-            AssertBitwiseEqual(float.MinValue, NumberHelper<float>.Min(float.MinValue, 1.0f));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.Min(-1.0f, 1.0f));
-            AssertBitwiseEqual(-MinNormal, NumberHelper<float>.Min(-MinNormal, 1.0f));
-            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<float>.Min(-MaxSubnormal, 1.0f));
-            AssertBitwiseEqual(-float.Epsilon, NumberHelper<float>.Min(-float.Epsilon, 1.0f));
-            AssertBitwiseEqual(-0.0f, NumberHelper<float>.Min(-0.0f, 1.0f));
-            AssertBitwiseEqual(float.NaN, NumberHelper<float>.Min(float.NaN, 1.0f));
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.Min(0.0f, 1.0f));
-            AssertBitwiseEqual(float.Epsilon, NumberHelper<float>.Min(float.Epsilon, 1.0f));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<float>.Min(MaxSubnormal, 1.0f));
-            AssertBitwiseEqual(MinNormal, NumberHelper<float>.Min(MinNormal, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(1.0f, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(float.MaxValue, 1.0f));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(float.PositiveInfinity, 1.0f));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(-1, NumberHelper<float>.Sign(float.NegativeInfinity));
-            Assert.Equal(-1, NumberHelper<float>.Sign(float.MinValue));
-            Assert.Equal(-1, NumberHelper<float>.Sign(-1.0f));
-            Assert.Equal(-1, NumberHelper<float>.Sign(-MinNormal));
-            Assert.Equal(-1, NumberHelper<float>.Sign(-MaxSubnormal));
-            Assert.Equal(-1, NumberHelper<float>.Sign(-float.Epsilon));
-
-            Assert.Equal(0, NumberHelper<float>.Sign(-0.0f));
-            Assert.Equal(0, NumberHelper<float>.Sign(0.0f));
-
-            Assert.Equal(1, NumberHelper<float>.Sign(float.Epsilon));
-            Assert.Equal(1, NumberHelper<float>.Sign(MaxSubnormal));
-            Assert.Equal(1, NumberHelper<float>.Sign(MinNormal));
-            Assert.Equal(1, NumberHelper<float>.Sign(1.0f));
-            Assert.Equal(1, NumberHelper<float>.Sign(float.MaxValue));
-            Assert.Equal(1, NumberHelper<float>.Sign(float.PositiveInfinity));
-
-            Assert.Throws<ArithmeticException>(() => NumberHelper<float>.Sign(float.NaN));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             float result;
@@ -1338,369 +1756,19 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetExponentByteCountTest()
-        {
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.NegativeInfinity));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.MinValue));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(-1.0f));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(-MinNormal));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(-MaxSubnormal));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(-float.Epsilon));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(-0.0f));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.NaN));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(0.0f));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.Epsilon));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(MaxSubnormal));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(MinNormal));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(1.0f));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.MaxValue));
-            Assert.Equal(1, FloatingPointHelper<float>.GetExponentByteCount(float.PositiveInfinity));
-        }
+        //
+        // ISignedNumber
+        //
 
         [Fact]
-        public static void GetExponentShortestBitLengthTest()
+        public static void NegativeOneTest()
         {
-            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(float.NegativeInfinity));
-            Assert.Equal(7, FloatingPointHelper<float>.GetExponentShortestBitLength(float.MinValue));
-            Assert.Equal(0, FloatingPointHelper<float>.GetExponentShortestBitLength(-1.0f));
-            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(-MinNormal));
-            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(-MaxSubnormal));
-            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(-float.Epsilon));
-            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(-0.0f));
-            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(float.NaN));
-            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(0.0f));
-            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(float.Epsilon));
-            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(MaxSubnormal));
-            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(MinNormal));
-            Assert.Equal(0, FloatingPointHelper<float>.GetExponentShortestBitLength(1.0f));
-            Assert.Equal(7, FloatingPointHelper<float>.GetExponentShortestBitLength(float.MaxValue));
-            Assert.Equal(8, FloatingPointHelper<float>.GetExponentShortestBitLength(float.PositiveInfinity));
+            Assert.Equal(-1.0f, SignedNumberHelper<float>.NegativeOne);
         }
 
-        [Fact]
-        public static void GetSignificandByteCountTest()
-        {
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.NegativeInfinity));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.MinValue));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(-1.0f));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(-MinNormal));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(-MaxSubnormal));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(-float.Epsilon));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(-0.0f));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.NaN));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(0.0f));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.Epsilon));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(MaxSubnormal));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(MinNormal));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(1.0f));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.MaxValue));
-            Assert.Equal(4, FloatingPointHelper<float>.GetSignificandByteCount(float.PositiveInfinity));
-        }
-
-        [Fact]
-        public static void GetSignificandBitLengthTest()
-        {
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.NegativeInfinity));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.MinValue));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(-1.0f));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(-MinNormal));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(-MaxSubnormal));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(-float.Epsilon));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(-0.0f));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.NaN));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(0.0f));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.Epsilon));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(MaxSubnormal));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(MinNormal));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(1.0f));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.MaxValue));
-            Assert.Equal(24, FloatingPointHelper<float>.GetSignificandBitLength(float.PositiveInfinity));
-        }
-
-        [Fact]
-        public static void TryWriteExponentBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[1];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.NegativeInfinity, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.MinValue, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F }, destination.ToArray()); // +127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(-1.0f, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(-MinNormal, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x82 }, destination.ToArray()); // -126
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(-MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(-float.Epsilon, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(-0.0f, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.NaN, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(0.0f, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.Epsilon, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(MinNormal, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x82 }, destination.ToArray()); // -126
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(1.0f, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.MaxValue, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F }, destination.ToArray()); // +127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentBigEndian(float.PositiveInfinity, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
-
-            Assert.False(FloatingPointHelper<float>.TryWriteExponentBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteExponentLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[1];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.NegativeInfinity, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.MinValue, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F }, destination.ToArray()); // +127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(-1.0f, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(-MinNormal, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x82 }, destination.ToArray()); // -126
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(-MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(-float.Epsilon, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(-0.0f, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.NaN, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(0.0f, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.Epsilon, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(MinNormal, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x82 }, destination.ToArray()); // -126
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(1.0f, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.MaxValue, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F }, destination.ToArray()); // +127
-
-            Assert.True(FloatingPointHelper<float>.TryWriteExponentLittleEndian(float.PositiveInfinity, destination, out bytesWritten));
-            Assert.Equal(1, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
-
-            Assert.False(FloatingPointHelper<float>.TryWriteExponentLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0x80 }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteSignificandBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[4];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.NegativeInfinity, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.MinValue, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0xFF, 0xFF, 0xff }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(-1.0f, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(-MinNormal, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(-MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x7F, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(-float.Epsilon, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(-0.0f, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.NaN, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0xC0, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(0.0f, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.Epsilon, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x7F, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(MinNormal, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(1.0f, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.MaxValue, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandBigEndian(float.PositiveInfinity, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.False(FloatingPointHelper<float>.TryWriteSignificandBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteSignificandLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[4];
-            int bytesWritten = 0;
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.NegativeInfinity, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.MinValue, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(-1.0f, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(-MinNormal, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(-MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0x7F, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(-float.Epsilon, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(-0.0f, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.NaN, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0xC0, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(0.0f, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.Epsilon, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(MaxSubnormal, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0x7F, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(MinNormal, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(1.0f, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.MaxValue, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x00 }, destination.ToArray());
-
-            Assert.True(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(float.PositiveInfinity, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
-
-            Assert.False(FloatingPointHelper<float>.TryWriteSignificandLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
-        }
+        //
+        // ISubtractionOperators
+        //
 
         [Fact]
         public static void op_SubtractionTest()
@@ -1742,6 +1810,10 @@ namespace System.Tests
             AssertBitwiseEqual(float.PositiveInfinity, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(float.PositiveInfinity, 1.0f));
         }
 
+        //
+        // IUnaryNegationOperators
+        //
+
         [Fact]
         public static void op_UnaryNegationTest()
         {
@@ -1782,6 +1854,10 @@ namespace System.Tests
             AssertBitwiseEqual(float.NegativeInfinity, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(float.PositiveInfinity));
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1801,6 +1877,10 @@ namespace System.Tests
             AssertBitwiseEqual(float.MaxValue, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(float.MaxValue));
             AssertBitwiseEqual(float.PositiveInfinity, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(float.PositiveInfinity));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(SingleTests.Parse_Valid_TestData), MemberType = typeof(SingleTests))]

--- a/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
@@ -455,21 +455,21 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            AssertBitwiseEqual(float.PositiveInfinity, NumberHelper<float>.Abs(float.NegativeInfinity));
-            AssertBitwiseEqual(float.MaxValue, NumberHelper<float>.Abs(float.MinValue));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Abs(-1.0f));
-            AssertBitwiseEqual(MinNormal, NumberHelper<float>.Abs(-MinNormal));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<float>.Abs(-MaxSubnormal));
-            AssertBitwiseEqual(float.Epsilon, NumberHelper<float>.Abs(-float.Epsilon));
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.Abs(-0.0f));
-            AssertBitwiseEqual(float.NaN, NumberHelper<float>.Abs(float.NaN));
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.Abs(0.0f));
-            AssertBitwiseEqual(float.Epsilon, NumberHelper<float>.Abs(float.Epsilon));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<float>.Abs(MaxSubnormal));
-            AssertBitwiseEqual(MinNormal, NumberHelper<float>.Abs(MinNormal));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.Abs(1.0f));
-            AssertBitwiseEqual(float.MaxValue, NumberHelper<float>.Abs(float.MaxValue));
-            AssertBitwiseEqual(float.PositiveInfinity, NumberHelper<float>.Abs(float.PositiveInfinity));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberBaseHelper<float>.Abs(float.NegativeInfinity));
+            AssertBitwiseEqual(float.MaxValue, NumberBaseHelper<float>.Abs(float.MinValue));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.Abs(-1.0f));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<float>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<float>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(float.Epsilon, NumberBaseHelper<float>.Abs(-float.Epsilon));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.Abs(-0.0f));
+            AssertBitwiseEqual(float.NaN, NumberBaseHelper<float>.Abs(float.NaN));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.Abs(0.0f));
+            AssertBitwiseEqual(float.Epsilon, NumberBaseHelper<float>.Abs(float.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<float>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<float>.Abs(MinNormal));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.Abs(1.0f));
+            AssertBitwiseEqual(float.MaxValue, NumberBaseHelper<float>.Abs(float.MaxValue));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberBaseHelper<float>.Abs(float.PositiveInfinity));
         }
 
         [Fact]
@@ -495,61 +495,61 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<byte>(0x00));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<byte>(0x01));
-            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateChecked<byte>(0x7F));
-            AssertBitwiseEqual(128.0f, NumberHelper<float>.CreateChecked<byte>(0x80));
-            AssertBitwiseEqual(255.0f, NumberHelper<float>.CreateChecked<byte>(0xFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<byte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<byte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberBaseHelper<float>.CreateChecked<byte>(0x7F));
+            AssertBitwiseEqual(128.0f, NumberBaseHelper<float>.CreateChecked<byte>(0x80));
+            AssertBitwiseEqual(255.0f, NumberBaseHelper<float>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<char>((char)0x0000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<char>((char)0x0001));
-            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateChecked<char>((char)0x7FFF));
-            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateChecked<char>((char)0x8000));
-            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateChecked<char>((char)0xFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<char>((char)0x0000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0f, NumberBaseHelper<float>.CreateChecked<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberBaseHelper<float>.CreateChecked<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0f, NumberBaseHelper<float>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<short>(0x0000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<short>(0x0001));
-            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateChecked<short>(0x7FFF));
-            AssertBitwiseEqual(-32768.0f, NumberHelper<float>.CreateChecked<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<short>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<short>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberBaseHelper<float>.CreateChecked<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0f, NumberBaseHelper<float>.CreateChecked<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<int>(0x00000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<int>(0x00000001));
-            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateChecked<int>(0x7FFFFFFF));
-            AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateChecked<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<int>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateChecked<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0f, NumberBaseHelper<float>.CreateChecked<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<long>(0x0000000000000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<long>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0f, NumberBaseHelper<float>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateCheckedFromInt128Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberHelper<float>.CreateChecked<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(-170141183460469231731687303715884105728.0f, NumberHelper<float>.CreateChecked<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberBaseHelper<float>.CreateChecked<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(-170141183460469231731687303715884105728.0f, NumberBaseHelper<float>.CreateChecked<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateChecked<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -557,70 +557,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0f, NumberBaseHelper<float>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<nint>((nint)0x00000000));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<nint>((nint)0x00000001));
-                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0f, NumberBaseHelper<float>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<sbyte>(0x00));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<sbyte>(0x01));
-            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateChecked<sbyte>(0x7F));
-            AssertBitwiseEqual(-128.0f, NumberHelper<float>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<sbyte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<sbyte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberBaseHelper<float>.CreateChecked<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0f, NumberBaseHelper<float>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<ushort>(0x0000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<ushort>(0x0001));
-            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateChecked<ushort>(0x7FFF));
-            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateChecked<ushort>(0x8000));
-            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateChecked<ushort>(0xFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<ushort>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberBaseHelper<float>.CreateChecked<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberBaseHelper<float>.CreateChecked<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0f, NumberBaseHelper<float>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<uint>(0x00000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<uint>(0x00000001));
-            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateChecked<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateChecked<uint>(0x80000000));
-            AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateChecked<uint>(0xFFFFFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<uint>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateChecked<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0f, NumberBaseHelper<float>.CreateChecked<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0f, NumberBaseHelper<float>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<ulong>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateChecked<ulong>(0x8000000000000000));
-            AssertBitwiseEqual(18446744073709551615.0f, NumberHelper<float>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0f, NumberBaseHelper<float>.CreateChecked<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0f, NumberBaseHelper<float>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt128Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberHelper<float>.CreateChecked<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(170141183460469231731687303715884105728.0f, NumberHelper<float>.CreateChecked<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(float.PositiveInfinity, NumberHelper<float>.CreateChecked<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberBaseHelper<float>.CreateChecked<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(170141183460469231731687303715884105728.0f, NumberBaseHelper<float>.CreateChecked<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberBaseHelper<float>.CreateChecked<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -628,84 +628,84 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual(18446744073709551615.0f,NumberHelper<float>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual(9223372036854775808.0f, NumberBaseHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0f,NumberBaseHelper<float>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateChecked<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateChecked<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateChecked<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual(2147483648.0f, NumberBaseHelper<float>.CreateChecked<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0f, NumberBaseHelper<float>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<byte>(0x00));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<byte>(0x01));
-            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateSaturating<byte>(0x7F));
-            AssertBitwiseEqual(128.0f, NumberHelper<float>.CreateSaturating<byte>(0x80));
-            AssertBitwiseEqual(255.0f, NumberHelper<float>.CreateSaturating<byte>(0xFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<byte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<byte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberBaseHelper<float>.CreateSaturating<byte>(0x7F));
+            AssertBitwiseEqual(128.0f, NumberBaseHelper<float>.CreateSaturating<byte>(0x80));
+            AssertBitwiseEqual(255.0f, NumberBaseHelper<float>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<char>((char)0x0000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<char>((char)0x0001));
-            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateSaturating<char>((char)0x7FFF));
-            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateSaturating<char>((char)0x8000));
-            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateSaturating<char>((char)0xFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<char>((char)0x0000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0f, NumberBaseHelper<float>.CreateSaturating<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberBaseHelper<float>.CreateSaturating<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0f, NumberBaseHelper<float>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<short>(0x0000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<short>(0x0001));
-            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateSaturating<short>(0x7FFF));
-            AssertBitwiseEqual(-32768.0f, NumberHelper<float>.CreateSaturating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<short>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<short>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberBaseHelper<float>.CreateSaturating<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0f, NumberBaseHelper<float>.CreateSaturating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<int>(0x00000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<int>(0x00000001));
-            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateSaturating<int>(0x7FFFFFFF));
-            AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<int>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateSaturating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0f, NumberBaseHelper<float>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<long>(0x0000000000000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<long>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0f, NumberBaseHelper<float>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt128Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberHelper<float>.CreateSaturating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(-170141183460469231731687303715884105728.0f, NumberHelper<float>.CreateSaturating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberBaseHelper<float>.CreateSaturating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(-170141183460469231731687303715884105728.0f, NumberBaseHelper<float>.CreateSaturating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateSaturating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -713,70 +713,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0f, NumberBaseHelper<float>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<nint>((nint)0x00000001));
-                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0f, NumberBaseHelper<float>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<sbyte>(0x00));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<sbyte>(0x01));
-            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateSaturating<sbyte>(0x7F));
-            AssertBitwiseEqual(-128.0f, NumberHelper<float>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<sbyte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<sbyte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberBaseHelper<float>.CreateSaturating<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0f, NumberBaseHelper<float>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<ushort>(0x0000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<ushort>(0x0001));
-            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateSaturating<ushort>(0x7FFF));
-            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateSaturating<ushort>(0x8000));
-            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateSaturating<ushort>(0xFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<ushort>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberBaseHelper<float>.CreateSaturating<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberBaseHelper<float>.CreateSaturating<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0f, NumberBaseHelper<float>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<uint>(0x00000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<uint>(0x00000001));
-            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateSaturating<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateSaturating<uint>(0x80000000));
-            AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateSaturating<uint>(0xFFFFFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<uint>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateSaturating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0f, NumberBaseHelper<float>.CreateSaturating<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0f, NumberBaseHelper<float>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<ulong>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateSaturating<ulong>(0x8000000000000000));
-            AssertBitwiseEqual(18446744073709551615.0f, NumberHelper<float>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0f, NumberBaseHelper<float>.CreateSaturating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0f, NumberBaseHelper<float>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt128Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberHelper<float>.CreateSaturating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(170141183460469231731687303715884105728.0f, NumberHelper<float>.CreateSaturating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(float.PositiveInfinity, NumberHelper<float>.CreateSaturating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberBaseHelper<float>.CreateSaturating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(170141183460469231731687303715884105728.0f, NumberBaseHelper<float>.CreateSaturating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberBaseHelper<float>.CreateSaturating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -784,84 +784,84 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual(18446744073709551615.0f, NumberHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual(9223372036854775808.0f, NumberBaseHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0f, NumberBaseHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateSaturating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateSaturating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateSaturating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual(2147483648.0f, NumberBaseHelper<float>.CreateSaturating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0f, NumberBaseHelper<float>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<byte>(0x00));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<byte>(0x01));
-            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateTruncating<byte>(0x7F));
-            AssertBitwiseEqual(128.0f, NumberHelper<float>.CreateTruncating<byte>(0x80));
-            AssertBitwiseEqual(255.0f, NumberHelper<float>.CreateTruncating<byte>(0xFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<byte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<byte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberBaseHelper<float>.CreateTruncating<byte>(0x7F));
+            AssertBitwiseEqual(128.0f, NumberBaseHelper<float>.CreateTruncating<byte>(0x80));
+            AssertBitwiseEqual(255.0f, NumberBaseHelper<float>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<char>((char)0x0000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<char>((char)0x0001));
-            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateTruncating<char>((char)0x7FFF));
-            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateTruncating<char>((char)0x8000));
-            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateTruncating<char>((char)0xFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<char>((char)0x0000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0f, NumberBaseHelper<float>.CreateTruncating<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberBaseHelper<float>.CreateTruncating<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0f, NumberBaseHelper<float>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<short>(0x0000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<short>(0x0001));
-            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateTruncating<short>(0x7FFF));
-            AssertBitwiseEqual(-32768.0f, NumberHelper<float>.CreateTruncating<short>(unchecked((short)0x8000)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<short>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<short>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberBaseHelper<float>.CreateTruncating<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0f, NumberBaseHelper<float>.CreateTruncating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<int>(0x00000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<int>(0x00000001));
-            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateTruncating<int>(0x7FFFFFFF));
-            AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<int>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateTruncating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0f, NumberBaseHelper<float>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<long>(0x0000000000000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<long>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0f, NumberBaseHelper<float>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt128Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberHelper<float>.CreateTruncating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(-170141183460469231731687303715884105728.0f, NumberHelper<float>.CreateTruncating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberBaseHelper<float>.CreateTruncating<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(-170141183460469231731687303715884105728.0f, NumberBaseHelper<float>.CreateTruncating<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateTruncating<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -869,70 +869,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0f, NumberBaseHelper<float>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<nint>((nint)0x00000001));
-                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0f, NumberBaseHelper<float>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<sbyte>(0x00));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<sbyte>(0x01));
-            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateTruncating<sbyte>(0x7F));
-            AssertBitwiseEqual(-128.0f, NumberHelper<float>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<sbyte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<sbyte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberBaseHelper<float>.CreateTruncating<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0f, NumberBaseHelper<float>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0f, NumberBaseHelper<float>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<ushort>(0x0000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<ushort>(0x0001));
-            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateTruncating<ushort>(0x7FFF));
-            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateTruncating<ushort>(0x8000));
-            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateTruncating<ushort>(0xFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<ushort>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberBaseHelper<float>.CreateTruncating<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberBaseHelper<float>.CreateTruncating<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0f, NumberBaseHelper<float>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<uint>(0x00000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<uint>(0x00000001));
-            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateTruncating<uint>(0x7FFFFFFF));
-            AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateTruncating<uint>(0x80000000));
-            AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateTruncating<uint>(0xFFFFFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<uint>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateTruncating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0f, NumberBaseHelper<float>.CreateTruncating<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0f, NumberBaseHelper<float>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<ulong>(0x0000000000000001));
-            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateTruncating<ulong>(0x8000000000000000));
-            AssertBitwiseEqual(18446744073709551615.0f, NumberHelper<float>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0f, NumberBaseHelper<float>.CreateTruncating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0f, NumberBaseHelper<float>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt128Test()
         {
-            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
-            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberHelper<float>.CreateTruncating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
-            AssertBitwiseEqual(170141183460469231731687303715884105728.0f, NumberHelper<float>.CreateTruncating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
-            AssertBitwiseEqual(float.PositiveInfinity, NumberHelper<float>.CreateTruncating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001)));
+            AssertBitwiseEqual(170141183460469231731687303715884105727.0f, NumberBaseHelper<float>.CreateTruncating<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
+            AssertBitwiseEqual(170141183460469231731687303715884105728.0f, NumberBaseHelper<float>.CreateTruncating<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000)));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberBaseHelper<float>.CreateTruncating<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)));
         }
 
         [Fact]
@@ -940,23 +940,23 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberBaseHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                // AssertBitwiseEqual(18446744073709551615.0f, NumberHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                // AssertBitwiseEqual(9223372036854775808.0f, NumberBaseHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0f, NumberBaseHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<nuint>((nuint)0x00000001));
-                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.CreateTruncating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.CreateTruncating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberBaseHelper<float>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateTruncating<nuint>((nuint)0x80000000));
-                // AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                // AssertBitwiseEqual(2147483648.0f, NumberBaseHelper<float>.CreateTruncating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0f, NumberBaseHelper<float>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -1028,19 +1028,19 @@ namespace System.Tests
         {
             float result;
 
-            Assert.True(NumberHelper<float>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<byte>(0x00, out result));
             Assert.Equal(0.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<byte>(0x01, out result));
             Assert.Equal(1.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<byte>(0x7F, out result));
             Assert.Equal(127.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<byte>(0x80, out result));
             Assert.Equal(128.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<byte>(0xFF, out result));
             Assert.Equal(255.0f, result);
         }
 
@@ -1049,19 +1049,19 @@ namespace System.Tests
         {
             float result;
 
-            Assert.True(NumberHelper<float>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal(0.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal(1.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal(32767.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal(32768.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal(65535.0f, result);
         }
 
@@ -1070,19 +1070,19 @@ namespace System.Tests
         {
             float result;
 
-            Assert.True(NumberHelper<float>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<short>(0x0000, out result));
             Assert.Equal(0.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<short>(0x0001, out result));
             Assert.Equal(1.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal(32767.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal(-32768.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(-1.0f, result);
         }
 
@@ -1091,19 +1091,19 @@ namespace System.Tests
         {
             float result;
 
-            Assert.True(NumberHelper<float>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<int>(0x00000000, out result));
             Assert.Equal(0.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<int>(0x00000001, out result));
             Assert.Equal(1.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal(2147483647.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal(-2147483648.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(-1.0f, result);
         }
 
@@ -1112,19 +1112,19 @@ namespace System.Tests
         {
             float result;
 
-            Assert.True(NumberHelper<float>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal(0.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal(1.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(9223372036854775807.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
             Assert.Equal(-9223372036854775808.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
             Assert.Equal(-1.0f, result);
         }
 
@@ -1133,19 +1133,19 @@ namespace System.Tests
         {
             float result;
 
-            Assert.True(NumberHelper<float>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(0.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<Int128>(new Int128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
             Assert.Equal(1.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<Int128>(new Int128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(170141183460469231731687303715884105727.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<Int128>(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(-170141183460469231731687303715884105728.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<Int128>(new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(-1.0f, result);
         }
 
@@ -1156,36 +1156,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal(0.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal(1.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(9223372036854775807.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal(-9223372036854775808.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(-1.0f, result);
             }
             else
             {
-                Assert.True(NumberHelper<float>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal(0.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal(1.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal(2147483647.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal(-2147483648.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(-1.0f, result);
             }
         }
@@ -1195,19 +1195,19 @@ namespace System.Tests
         {
             float result;
 
-            Assert.True(NumberHelper<float>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal(0.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal(1.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal(127.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal(-128.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(-1.0f, result);
         }
 
@@ -1216,19 +1216,19 @@ namespace System.Tests
         {
             float result;
 
-            Assert.True(NumberHelper<float>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal(0.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal(1.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal(32767.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal(32768.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal(65535.0f, result);
         }
 
@@ -1237,19 +1237,19 @@ namespace System.Tests
         {
             float result;
 
-            Assert.True(NumberHelper<float>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal(0.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal(1.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal(2147483647.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<uint>(0x80000000, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal(2147483648.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal(4294967295.0f, result);
         }
 
@@ -1258,19 +1258,19 @@ namespace System.Tests
         {
             float result;
 
-            Assert.True(NumberHelper<float>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal(0.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal(1.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(9223372036854775807.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal(9223372036854775808.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal(18446744073709551615.0f, result);
         }
 
@@ -1279,19 +1279,19 @@ namespace System.Tests
         {
             float result;
 
-            Assert.True(NumberHelper<float>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(0.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<UInt128>(new UInt128(0x0000_0000_0000_0000, 0x0000_0000_0000_0001), out result));
             Assert.Equal(1.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<UInt128>(new UInt128(0x7FFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(170141183460469231731687303715884105727.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<UInt128>(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), out result));
             Assert.Equal(170141183460469231731687303715884105728.0f, result);
 
-            Assert.True(NumberHelper<float>.TryCreate<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
+            Assert.True(NumberBaseHelper<float>.TryCreate<UInt128>(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), out result));
             Assert.Equal(float.PositiveInfinity, result);
         }
 
@@ -1302,38 +1302,38 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal(0.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal(1.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(9223372036854775807.0f, result);
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                // Assert.True(NumberBaseHelper<float>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 // Assert.Equal(9223372036854775808.0f, result);
                 //
-                // Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                // Assert.True(NumberBaseHelper<float>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 // Assert.Equal(18446744073709551615.0f, result);
             }
             else
             {
-                Assert.True(NumberHelper<float>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal(0.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal(1.0f, result);
 
-                Assert.True(NumberHelper<float>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<float>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal(2147483647.0f, result);
 
                 // https://github.com/dotnet/roslyn/issues/60714
-                // Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                // Assert.True(NumberBaseHelper<float>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 // Assert.Equal(2147483648.0f, result);
                 //
-                // Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                // Assert.True(NumberBaseHelper<float>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 // Assert.Equal(4294967295.0f, result);
             }
         }
@@ -1813,29 +1813,29 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.True(NumberHelper<float>.TryParse(value, null, out result));
+                    Assert.True(ParsableHelper<float>.TryParse(value, null, out result));
                     Assert.Equal(expected, result);
 
-                    Assert.Equal(expected, NumberHelper<float>.Parse(value, null));
+                    Assert.Equal(expected, ParsableHelper<float>.Parse(value, null));
                 }
 
-                Assert.Equal(expected, NumberHelper<float>.Parse(value, provider));
+                Assert.Equal(expected, ParsableHelper<float>.Parse(value, provider));
             }
 
             // Use Parse(string, NumberStyles, IFormatProvider)
-            Assert.True(NumberHelper<float>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<float>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
 
-            Assert.Equal(expected, NumberHelper<float>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<float>.Parse(value, style, provider));
 
             if (isDefaultProvider)
             {
                 // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.True(NumberHelper<float>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
+                Assert.True(NumberBaseHelper<float>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
                 Assert.Equal(expected, result);
 
-                Assert.Equal(expected, NumberHelper<float>.Parse(value, style, null));
-                Assert.Equal(expected, NumberHelper<float>.Parse(value, style, NumberFormatInfo.CurrentInfo));
+                Assert.Equal(expected, NumberBaseHelper<float>.Parse(value, style, null));
+                Assert.Equal(expected, NumberBaseHelper<float>.Parse(value, style, NumberFormatInfo.CurrentInfo));
             }
         }
 
@@ -1850,29 +1850,29 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.False(NumberHelper<float>.TryParse(value, null, out result));
+                    Assert.False(ParsableHelper<float>.TryParse(value, null, out result));
                     Assert.Equal(default(float), result);
 
-                    Assert.Throws(exceptionType, () => NumberHelper<float>.Parse(value, null));
+                    Assert.Throws(exceptionType, () => ParsableHelper<float>.Parse(value, null));
                 }
 
-                Assert.Throws(exceptionType, () => NumberHelper<float>.Parse(value, provider));
+                Assert.Throws(exceptionType, () => ParsableHelper<float>.Parse(value, provider));
             }
 
             // Use Parse(string, NumberStyles, IFormatProvider)
-            Assert.False(NumberHelper<float>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<float>.TryParse(value, style, provider, out result));
             Assert.Equal(default(float), result);
 
-            Assert.Throws(exceptionType, () => NumberHelper<float>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<float>.Parse(value, style, provider));
 
             if (isDefaultProvider)
             {
                 // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
-                Assert.False(NumberHelper<float>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
+                Assert.False(NumberBaseHelper<float>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
                 Assert.Equal(default(float), result);
 
-                Assert.Throws(exceptionType, () => NumberHelper<float>.Parse(value, style, null));
-                Assert.Throws(exceptionType, () => NumberHelper<float>.Parse(value, style, NumberFormatInfo.CurrentInfo));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<float>.Parse(value, style, null));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<float>.Parse(value, style, NumberFormatInfo.CurrentInfo));
             }
         }
 
@@ -1887,18 +1887,18 @@ namespace System.Tests
                 // Use Parse(string) or Parse(string, IFormatProvider)
                 if (isDefaultProvider)
                 {
-                    Assert.True(NumberHelper<float>.TryParse(value.AsSpan(offset, count), null, out result));
+                    Assert.True(SpanParsableHelper<float>.TryParse(value.AsSpan(offset, count), null, out result));
                     Assert.Equal(expected, result);
 
-                    Assert.Equal(expected, NumberHelper<float>.Parse(value.AsSpan(offset, count), null));
+                    Assert.Equal(expected, SpanParsableHelper<float>.Parse(value.AsSpan(offset, count), null));
                 }
 
-                Assert.Equal(expected, NumberHelper<float>.Parse(value.AsSpan(offset, count), provider: provider));
+                Assert.Equal(expected, SpanParsableHelper<float>.Parse(value.AsSpan(offset, count), provider: provider));
             }
 
-            Assert.Equal(expected, NumberHelper<float>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<float>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<float>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<float>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1908,9 +1908,9 @@ namespace System.Tests
         {
             if (value != null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<float>.Parse(value.AsSpan(), style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<float>.Parse(value.AsSpan(), style, provider));
 
-                Assert.False(NumberHelper<float>.TryParse(value.AsSpan(), style, provider, out float result));
+                Assert.False(NumberBaseHelper<float>.TryParse(value.AsSpan(), style, provider, out float result));
                 Assert.Equal(0, result);
             }
         }

--- a/src/libraries/System.Runtime/tests/System/UInt128Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt128Tests.GenericMath.cs
@@ -544,6 +544,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal(One, NumberHelper<UInt128>.MaxNumber(Zero, 1U));
+            Assert.Equal(One, NumberHelper<UInt128>.MaxNumber(One, 1U));
+            Assert.Equal(Int128MaxValue, NumberHelper<UInt128>.MaxNumber(Int128MaxValue, 1U));
+            Assert.Equal(Int128MaxValuePlusOne, NumberHelper<UInt128>.MaxNumber(Int128MaxValuePlusOne, 1U));
+            Assert.Equal(MaxValue, NumberHelper<UInt128>.MaxNumber(MaxValue, 1U));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal(Zero, NumberHelper<UInt128>.Min(Zero, 1U));
@@ -551,6 +561,16 @@ namespace System.Tests
             Assert.Equal(One, NumberHelper<UInt128>.Min(Int128MaxValue, 1U));
             Assert.Equal(One, NumberHelper<UInt128>.Min(Int128MaxValuePlusOne, 1U));
             Assert.Equal(One, NumberHelper<UInt128>.Min(MaxValue, 1U));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal(Zero, NumberHelper<UInt128>.MinNumber(Zero, 1U));
+            Assert.Equal(One, NumberHelper<UInt128>.MinNumber(One, 1U));
+            Assert.Equal(One, NumberHelper<UInt128>.MinNumber(Int128MaxValue, 1U));
+            Assert.Equal(One, NumberHelper<UInt128>.MinNumber(Int128MaxValuePlusOne, 1U));
+            Assert.Equal(One, NumberHelper<UInt128>.MinNumber(MaxValue, 1U));
         }
 
         [Fact]
@@ -1208,6 +1228,126 @@ namespace System.Tests
                 Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal(UInt32MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<UInt128>.IsFinite(Zero));
+            Assert.True(NumberBaseHelper<UInt128>.IsFinite(One));
+            Assert.True(NumberBaseHelper<UInt128>.IsFinite(Int128MaxValue));
+            Assert.True(NumberBaseHelper<UInt128>.IsFinite(Int128MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<UInt128>.IsFinite(MaxValue));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<UInt128>.IsInfinity(Zero));
+            Assert.False(NumberBaseHelper<UInt128>.IsInfinity(One));
+            Assert.False(NumberBaseHelper<UInt128>.IsInfinity(Int128MaxValue));
+            Assert.False(NumberBaseHelper<UInt128>.IsInfinity(Int128MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<UInt128>.IsInfinity(MaxValue));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<UInt128>.IsNaN(Zero));
+            Assert.False(NumberBaseHelper<UInt128>.IsNaN(One));
+            Assert.False(NumberBaseHelper<UInt128>.IsNaN(Int128MaxValue));
+            Assert.False(NumberBaseHelper<UInt128>.IsNaN(Int128MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<UInt128>.IsNaN(MaxValue));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<UInt128>.IsNegative(Zero));
+            Assert.False(NumberBaseHelper<UInt128>.IsNegative(One));
+            Assert.False(NumberBaseHelper<UInt128>.IsNegative(Int128MaxValue));
+            Assert.False(NumberBaseHelper<UInt128>.IsNegative(Int128MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<UInt128>.IsNegative(MaxValue));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<UInt128>.IsNegativeInfinity(Zero));
+            Assert.False(NumberBaseHelper<UInt128>.IsNegativeInfinity(One));
+            Assert.False(NumberBaseHelper<UInt128>.IsNegativeInfinity(Int128MaxValue));
+            Assert.False(NumberBaseHelper<UInt128>.IsNegativeInfinity(Int128MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<UInt128>.IsNegativeInfinity(MaxValue));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<UInt128>.IsNormal(Zero));
+            Assert.True(NumberBaseHelper<UInt128>.IsNormal(One));
+            Assert.True(NumberBaseHelper<UInt128>.IsNormal(Int128MaxValue));
+            Assert.True(NumberBaseHelper<UInt128>.IsNormal(Int128MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<UInt128>.IsNormal(MaxValue));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<UInt128>.IsPositiveInfinity(Zero));
+            Assert.False(NumberBaseHelper<UInt128>.IsPositiveInfinity(One));
+            Assert.False(NumberBaseHelper<UInt128>.IsPositiveInfinity(Int128MaxValue));
+            Assert.False(NumberBaseHelper<UInt128>.IsPositiveInfinity(Int128MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<UInt128>.IsPositiveInfinity(MaxValue));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<UInt128>.IsSubnormal(Zero));
+            Assert.False(NumberBaseHelper<UInt128>.IsSubnormal(One));
+            Assert.False(NumberBaseHelper<UInt128>.IsSubnormal(Int128MaxValue));
+            Assert.False(NumberBaseHelper<UInt128>.IsSubnormal(Int128MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<UInt128>.IsSubnormal(MaxValue));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MaxMagnitude(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MaxMagnitude(One, 1));
+            Assert.Equal(Int128MaxValue, NumberBaseHelper<UInt128>.MaxMagnitude(Int128MaxValue, 1));
+            Assert.Equal(Int128MaxValuePlusOne, NumberBaseHelper<UInt128>.MaxMagnitude(Int128MaxValuePlusOne, 1));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.MaxMagnitude(MaxValue, 1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MaxMagnitudeNumber(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MaxMagnitudeNumber(One, 1));
+            Assert.Equal(Int128MaxValue, NumberBaseHelper<UInt128>.MaxMagnitudeNumber(Int128MaxValue, 1));
+            Assert.Equal(Int128MaxValuePlusOne, NumberBaseHelper<UInt128>.MaxMagnitudeNumber(Int128MaxValuePlusOne, 1));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.MaxMagnitudeNumber(MaxValue, 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.MinMagnitude(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MinMagnitude(One, 1));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MinMagnitude(Int128MaxValue, 1));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MinMagnitude(Int128MaxValuePlusOne, 1));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MinMagnitude(MaxValue, 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.MinMagnitudeNumber(Zero, 1));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MinMagnitudeNumber(One, 1));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MinMagnitudeNumber(Int128MaxValue, 1));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MinMagnitudeNumber(Int128MaxValuePlusOne, 1));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.MinMagnitudeNumber(MaxValue, 1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt128Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt128Tests.GenericMath.cs
@@ -582,116 +582,116 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.Abs(Zero));
-            Assert.Equal(One, NumberHelper<UInt128>.Abs(One));
-            Assert.Equal(Int128MaxValue, NumberHelper<UInt128>.Abs(Int128MaxValue));
-            Assert.Equal(Int128MaxValuePlusOne, NumberHelper<UInt128>.Abs(Int128MaxValuePlusOne));
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.Abs(MaxValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.Abs(Zero));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.Abs(One));
+            Assert.Equal(Int128MaxValue, NumberBaseHelper<UInt128>.Abs(Int128MaxValue));
+            Assert.Equal(Int128MaxValuePlusOne, NumberBaseHelper<UInt128>.Abs(Int128MaxValuePlusOne));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.Abs(MaxValue));
         }
 
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<byte>(0x00));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<byte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<UInt128>.CreateChecked<byte>(0x7F));
-            Assert.Equal(SByteMaxValuePlusOne, NumberHelper<UInt128>.CreateChecked<byte>(0x80));
-            Assert.Equal(ByteMaxValue, NumberHelper<UInt128>.CreateChecked<byte>(0xFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<byte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<byte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<UInt128>.CreateChecked<byte>(0x7F));
+            Assert.Equal(SByteMaxValuePlusOne, NumberBaseHelper<UInt128>.CreateChecked<byte>(0x80));
+            Assert.Equal(ByteMaxValue, NumberBaseHelper<UInt128>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<char>((char)0x0000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<char>((char)0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<UInt128>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<UInt128>.CreateChecked<char>((char)0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<UInt128>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<char>((char)0x0000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<char>((char)0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<UInt128>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateChecked<char>((char)0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<UInt128>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromDecimalTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<decimal>(decimal.Zero));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<decimal>(decimal.One));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<decimal>(decimal.Zero));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<decimal>(decimal.One));
 
-            Assert.Equal(new UInt128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberHelper<UInt128>.CreateChecked<decimal>(decimal.MaxValue));
+            Assert.Equal(new UInt128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberBaseHelper<UInt128>.CreateChecked<decimal>(decimal.MaxValue));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<decimal>(decimal.MinValue));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<decimal>(decimal.MinusOne));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<decimal>(decimal.MinValue));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<decimal>(decimal.MinusOne));
         }
 
         [Fact]
         public static void CreateCheckedFromDoubleTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<double>(+0.0));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<double>(-0.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<double>(+0.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<double>(-0.0));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<double>(+double.Epsilon));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<double>(+1.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<double>(+double.Epsilon));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<double>(+1.0));
 
-            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateChecked<double>(+170141183460469231731687303715884105728.0));
-            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_F800, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateChecked<double>(+340282366920938425684442744474606501888.0));
+            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateChecked<double>(+170141183460469231731687303715884105728.0));
+            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_F800, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateChecked<double>(+340282366920938425684442744474606501888.0));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<double>(-double.Epsilon));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<double>(-1.0));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<double>(-double.Epsilon));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<double>(-1.0));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<double>(+340282366920938463463374607431768211456.0));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<double>(-340282366920938425684442744474606501888.0));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<double>(+340282366920938463463374607431768211456.0));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<double>(-340282366920938425684442744474606501888.0));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<double>(double.MaxValue));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<double>(double.MinValue));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<double>(double.MaxValue));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<double>(double.MinValue));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<double>(double.PositiveInfinity));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<double>(double.NegativeInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<double>(double.PositiveInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<double>(double.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateCheckedFromHalfTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<Half>((Half)(+0.0)));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<Half>((Half)(-0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<Half>((Half)(+0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<Half>((Half)(-0.0)));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<Half>(+Half.Epsilon));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<Half>((Half)(+1.0)));
-            Assert.Equal(+65504U, NumberHelper<UInt128>.CreateChecked<Half>(Half.MaxValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<Half>(+Half.Epsilon));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<Half>((Half)(+1.0)));
+            Assert.Equal(+65504U, NumberBaseHelper<UInt128>.CreateChecked<Half>(Half.MaxValue));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<Half>(-Half.Epsilon));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<Half>((Half)(-1.0)));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<Half>(Half.MinValue));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<Half>(-Half.Epsilon));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<Half>((Half)(-1.0)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<Half>(Half.MinValue));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<Half>(Half.PositiveInfinity));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<Half>(Half.NegativeInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<Half>(Half.PositiveInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<Half>(Half.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<short>(0x0000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<short>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<UInt128>.CreateChecked<short>(0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<short>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<short>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<UInt128>.CreateChecked<short>(0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<int>(0x00000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<int>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<int>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<int>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<long>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<long>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -699,80 +699,80 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<sbyte>(0x00));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<sbyte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<UInt128>.CreateChecked<sbyte>(0x7F));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<sbyte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<sbyte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<UInt128>.CreateChecked<sbyte>(0x7F));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromSingleTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<float>(+0.0f));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<float>(-0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<float>(+0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<float>(-0.0f));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<float>(+float.Epsilon));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<float>(+1.0f));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<float>(+float.Epsilon));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<float>(+1.0f));
 
-            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateChecked<float>(+170141183460469231731687303715884105728.0f));
-            Assert.Equal(new UInt128(0xFFFF_FF00_0000_0000, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateChecked<float>(float.MaxValue));
+            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateChecked<float>(+170141183460469231731687303715884105728.0f));
+            Assert.Equal(new UInt128(0xFFFF_FF00_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateChecked<float>(float.MaxValue));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<float>(-float.Epsilon));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<float>(-1.0f));            
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<float>(float.MinValue));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<float>(-float.Epsilon));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<float>(-1.0f));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<float>(float.MinValue));
 
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<float>(float.PositiveInfinity));
-            Assert.Throws<OverflowException>(() => NumberHelper<UInt128>.CreateChecked<float>(float.NegativeInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<float>(float.PositiveInfinity));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<UInt128>.CreateChecked<float>(float.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<ushort>(0x0000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<ushort>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<UInt128>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<UInt128>.CreateChecked<ushort>(0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<UInt128>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<ushort>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<ushort>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<UInt128>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateChecked<ushort>(0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<UInt128>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<uint>(0x00000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<uint>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Equal(Int32MaxValuePlusOne, NumberHelper<UInt128>.CreateChecked<uint>(0x80000000));
-            Assert.Equal(UInt32MaxValue, NumberHelper<UInt128>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<uint>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<uint>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateChecked<uint>(0x80000000));
+            Assert.Equal(UInt32MaxValue, NumberBaseHelper<UInt128>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<UInt128>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Equal(UInt64MaxValue, NumberHelper<UInt128>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<UInt128>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -780,125 +780,125 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MaxValuePlusOne, NumberHelper<UInt128>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(UInt64MaxValue, NumberHelper<UInt128>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(UInt64MaxValue, NumberBaseHelper<UInt128>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(Int32MaxValuePlusOne, NumberHelper<UInt128>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Equal(UInt32MaxValue, NumberHelper<UInt128>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Equal(UInt32MaxValue, NumberBaseHelper<UInt128>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<byte>(0x00));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<byte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<UInt128>.CreateSaturating<byte>(0x7F));
-            Assert.Equal(SByteMaxValuePlusOne, NumberHelper<UInt128>.CreateSaturating<byte>(0x80));
-            Assert.Equal(ByteMaxValue, NumberHelper<UInt128>.CreateSaturating<byte>(0xFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<byte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<byte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<UInt128>.CreateSaturating<byte>(0x7F));
+            Assert.Equal(SByteMaxValuePlusOne, NumberBaseHelper<UInt128>.CreateSaturating<byte>(0x80));
+            Assert.Equal(ByteMaxValue, NumberBaseHelper<UInt128>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<UInt128>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<UInt128>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<UInt128>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromDecimalTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<decimal>(decimal.Zero));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<decimal>(decimal.One));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<decimal>(decimal.Zero));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<decimal>(decimal.One));
 
-            Assert.Equal(new UInt128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberHelper<UInt128>.CreateSaturating<decimal>(decimal.MaxValue));
+            Assert.Equal(new UInt128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberBaseHelper<UInt128>.CreateSaturating<decimal>(decimal.MaxValue));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<decimal>(decimal.MinValue));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<decimal>(decimal.MinusOne));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<decimal>(decimal.MinValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<decimal>(decimal.MinusOne));
         }
 
         [Fact]
         public static void CreateSaturatingFromDoubleTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<double>(+0.0));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<double>(-0.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<double>(+0.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<double>(-0.0));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<double>(+double.Epsilon));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<double>(+1.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<double>(+double.Epsilon));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<double>(+1.0));
 
-            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateSaturating<double>(+170141183460469231731687303715884105728.0));
-            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_F800, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateSaturating<double>(+340282366920938425684442744474606501888.0));
+            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateSaturating<double>(+170141183460469231731687303715884105728.0));
+            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_F800, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateSaturating<double>(+340282366920938425684442744474606501888.0));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<double>(-double.Epsilon));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<double>(-1.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<double>(-double.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<double>(-1.0));
 
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateSaturating<double>(+340282366920938463463374607431768211456.0));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<double>(-340282366920938425684442744474606501888.0));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<double>(+340282366920938463463374607431768211456.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<double>(-340282366920938425684442744474606501888.0));
 
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateSaturating<double>(double.MaxValue));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<double>(double.MinValue));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<double>(double.MaxValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<double>(double.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateSaturating<double>(double.PositiveInfinity));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<double>(double.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<double>(double.PositiveInfinity));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<double>(double.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateSaturatingFromHalfTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<Half>((Half)(+0.0)));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<Half>((Half)(-0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<Half>((Half)(+0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<Half>((Half)(-0.0)));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<Half>(+Half.Epsilon));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<Half>((Half)(+1.0)));
-            Assert.Equal(+65504U, NumberHelper<UInt128>.CreateSaturating<Half>(Half.MaxValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<Half>(+Half.Epsilon));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<Half>((Half)(+1.0)));
+            Assert.Equal(+65504U, NumberBaseHelper<UInt128>.CreateSaturating<Half>(Half.MaxValue));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<Half>(-Half.Epsilon));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<Half>((Half)(-1.0)));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<Half>(Half.MinValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<Half>(-Half.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<Half>((Half)(-1.0)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<Half>(Half.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateSaturating<Half>(Half.PositiveInfinity));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<Half>(Half.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<Half>(Half.PositiveInfinity));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<Half>(Half.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<short>(0x0000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<short>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<UInt128>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<short>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<short>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<int>(0x00000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<int>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<int>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<int>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -906,80 +906,80 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<UInt128>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<UInt128>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromSingleTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<float>(+0.0f));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<float>(-0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<float>(+0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<float>(-0.0f));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<float>(+float.Epsilon));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<float>(+1.0f));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<float>(+float.Epsilon));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<float>(+1.0f));
 
-            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateSaturating<float>(+170141183460469231731687303715884105728.0f));
-            Assert.Equal(new UInt128(0xFFFF_FF00_0000_0000, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateSaturating<float>(float.MaxValue));
+            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateSaturating<float>(+170141183460469231731687303715884105728.0f));
+            Assert.Equal(new UInt128(0xFFFF_FF00_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateSaturating<float>(float.MaxValue));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<float>(-float.Epsilon));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<float>(-1.0f));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<float>(float.MinValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<float>(-float.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<float>(-1.0f));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<float>(float.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateSaturating<float>(float.PositiveInfinity));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<float>(float.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<float>(float.PositiveInfinity));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<float>(float.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<UInt128>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<UInt128>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<UInt128>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal(Int32MaxValuePlusOne, NumberHelper<UInt128>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal(UInt32MaxValue, NumberHelper<UInt128>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal(UInt32MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<UInt128>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal(UInt64MaxValue, NumberHelper<UInt128>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -987,125 +987,125 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MaxValuePlusOne, NumberHelper<UInt128>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(UInt64MaxValue, NumberHelper<UInt128>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(UInt64MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(Int32MaxValuePlusOne, NumberHelper<UInt128>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal(UInt32MaxValue, NumberHelper<UInt128>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal(UInt32MaxValue, NumberBaseHelper<UInt128>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<byte>(0x00));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<byte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<UInt128>.CreateTruncating<byte>(0x7F));
-            Assert.Equal(SByteMaxValuePlusOne, NumberHelper<UInt128>.CreateTruncating<byte>(0x80));
-            Assert.Equal(ByteMaxValue, NumberHelper<UInt128>.CreateTruncating<byte>(0xFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<byte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<byte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<UInt128>.CreateTruncating<byte>(0x7F));
+            Assert.Equal(SByteMaxValuePlusOne, NumberBaseHelper<UInt128>.CreateTruncating<byte>(0x80));
+            Assert.Equal(ByteMaxValue, NumberBaseHelper<UInt128>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<UInt128>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<UInt128>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<UInt128>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromDecimalTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<decimal>(decimal.Zero));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<decimal>(decimal.One));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<decimal>(decimal.Zero));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<decimal>(decimal.One));
 
-            Assert.Equal(new UInt128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberHelper<UInt128>.CreateTruncating<decimal>(decimal.MaxValue));
+            Assert.Equal(new UInt128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), NumberBaseHelper<UInt128>.CreateTruncating<decimal>(decimal.MaxValue));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<decimal>(decimal.MinValue));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<decimal>(decimal.MinusOne));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<decimal>(decimal.MinValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<decimal>(decimal.MinusOne));
         }
 
         [Fact]
         public static void CreateTruncatingFromDoubleTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<double>(+0.0));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<double>(-0.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<double>(+0.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<double>(-0.0));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<double>(+double.Epsilon));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<double>(+1.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<double>(+double.Epsilon));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<double>(+1.0));
 
-            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateTruncating<double>(+170141183460469231731687303715884105728.0));
-            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_F800, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateTruncating<double>(+340282366920938425684442744474606501888.0));
+            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateTruncating<double>(+170141183460469231731687303715884105728.0));
+            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_F800, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateTruncating<double>(+340282366920938425684442744474606501888.0));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<double>(-double.Epsilon));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<double>(-1.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<double>(-double.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<double>(-1.0));
 
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateTruncating<double>(+340282366920938463463374607431768211456.0));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<double>(-340282366920938425684442744474606501888.0));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<double>(+340282366920938463463374607431768211456.0));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<double>(-340282366920938425684442744474606501888.0));
 
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateTruncating<double>(double.MaxValue));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<double>(double.MinValue));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<double>(double.MaxValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<double>(double.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateTruncating<double>(double.PositiveInfinity));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<double>(double.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<double>(double.PositiveInfinity));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<double>(double.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateTruncatingFromHalfTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<Half>((Half)(+0.0)));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<Half>((Half)(-0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<Half>((Half)(+0.0)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<Half>((Half)(-0.0)));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<Half>(+Half.Epsilon));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<Half>((Half)(+1.0)));
-            Assert.Equal(+65504U, NumberHelper<UInt128>.CreateTruncating<Half>(Half.MaxValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<Half>(+Half.Epsilon));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<Half>((Half)(+1.0)));
+            Assert.Equal(+65504U, NumberBaseHelper<UInt128>.CreateTruncating<Half>(Half.MaxValue));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<Half>(-Half.Epsilon));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<Half>((Half)(-1.0)));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<Half>(Half.MinValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<Half>(-Half.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<Half>((Half)(-1.0)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<Half>(Half.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateTruncating<Half>(Half.PositiveInfinity));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<Half>(Half.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<Half>(Half.PositiveInfinity));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<Half>(Half.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<short>(0x0000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<short>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<UInt128>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_8000), NumberHelper<UInt128>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<short>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<short>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_8000), NumberBaseHelper<UInt128>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<int>(0x00000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<int>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_8000_0000), NumberHelper<UInt128>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<int>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<int>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_8000_0000), NumberBaseHelper<UInt128>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0x8000_0000_0000_0000), NumberHelper<UInt128>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0x8000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -1113,80 +1113,80 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0x8000_0000_0000_0000), NumberHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0x8000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_8000_0000), NumberHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_8000_0000), NumberBaseHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal(SByteMaxValue, NumberHelper<UInt128>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FF80), NumberHelper<UInt128>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal(SByteMaxValue, NumberBaseHelper<UInt128>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FF80), NumberBaseHelper<UInt128>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromSingleTest()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<float>(+0.0f));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<float>(-0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<float>(+0.0f));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<float>(-0.0f));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<float>(+float.Epsilon));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<float>(+1.0f));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<float>(+float.Epsilon));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<float>(+1.0f));
 
-            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateTruncating<float>(+170141183460469231731687303715884105728.0f));
-            Assert.Equal(new UInt128(0xFFFF_FF00_0000_0000, 0x0000_0000_0000_0000), NumberHelper<UInt128>.CreateTruncating<float>(float.MaxValue));
+            Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateTruncating<float>(+170141183460469231731687303715884105728.0f));
+            Assert.Equal(new UInt128(0xFFFF_FF00_0000_0000, 0x0000_0000_0000_0000), NumberBaseHelper<UInt128>.CreateTruncating<float>(float.MaxValue));
 
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<float>(-float.Epsilon));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<float>(-1.0f));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<float>(float.MinValue));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<float>(-float.Epsilon));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<float>(-1.0f));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<float>(float.MinValue));
 
-            Assert.Equal(MaxValue, NumberHelper<UInt128>.CreateTruncating<float>(float.PositiveInfinity));
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<float>(float.NegativeInfinity));
+            Assert.Equal(MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<float>(float.PositiveInfinity));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<float>(float.NegativeInfinity));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal(Int16MaxValue, NumberHelper<UInt128>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal(Int16MaxValuePlusOne, NumberHelper<UInt128>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal(UInt16MaxValue, NumberHelper<UInt128>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal(Int16MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal(Int16MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal(UInt16MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal(Int32MaxValuePlusOne, NumberHelper<UInt128>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal(UInt32MaxValue, NumberHelper<UInt128>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal(UInt32MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(Int64MaxValuePlusOne, NumberHelper<UInt128>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal(UInt64MaxValue, NumberHelper<UInt128>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal(UInt64MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -1194,19 +1194,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(Int64MaxValue, NumberHelper<UInt128>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(Int64MaxValuePlusOne, NumberHelper<UInt128>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(UInt64MaxValue, NumberHelper<UInt128>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(Int64MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(Int64MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(UInt64MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal(Zero, NumberHelper<UInt128>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal(One, NumberHelper<UInt128>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal(Int32MaxValue, NumberHelper<UInt128>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal(Int32MaxValuePlusOne, NumberHelper<UInt128>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal(UInt32MaxValue, NumberHelper<UInt128>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal(Zero, NumberBaseHelper<UInt128>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal(One, NumberBaseHelper<UInt128>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal(Int32MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(Int32MaxValuePlusOne, NumberBaseHelper<UInt128>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal(UInt32MaxValue, NumberBaseHelper<UInt128>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -1215,19 +1215,19 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<byte>(0x00, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<byte>(0x01, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<byte>(0x7F, out result));
             Assert.Equal(SByteMaxValue, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<byte>(0x80, out result));
             Assert.Equal(SByteMaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<byte>(0xFF, out result));
             Assert.Equal(ByteMaxValue, result);
         }
 
@@ -1236,19 +1236,19 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal(Int16MaxValue, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal(Int16MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal(UInt16MaxValue, result);
         }
 
@@ -1257,19 +1257,19 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<decimal>(decimal.Zero, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<decimal>(decimal.Zero, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<decimal>(decimal.One, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<decimal>(decimal.One, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<decimal>(decimal.MaxValue, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<decimal>(decimal.MaxValue, out result));
             Assert.Equal(new UInt128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<decimal>(decimal.MinValue, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<decimal>(decimal.MinValue, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<decimal>(decimal.MinusOne, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<decimal>(decimal.MinusOne, out result));
             Assert.Equal(Zero, result);
         }
 
@@ -1278,46 +1278,46 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<double>(+0.0, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<double>(+0.0, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<double>(-0.0, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<double>(-0.0, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<double>(+double.Epsilon, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<double>(+double.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<double>(+1.0, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<double>(+1.0, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<double>(+170141183460469231731687303715884105728.0, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<double>(+170141183460469231731687303715884105728.0, out result));
             Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<double>(+340282366920938425684442744474606501888.0, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<double>(+340282366920938425684442744474606501888.0, out result));
             Assert.Equal(new UInt128(0xFFFF_FFFF_FFFF_F800, 0x0000_0000_0000_0000), result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<double>(-double.Epsilon, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<double>(-double.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<double>(-1.0, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<double>(-1.0, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<double>(+340282366920938463463374607431768211456.0, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<double>(+340282366920938463463374607431768211456.0, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<double>(-340282366920938425684442744474606501888.0, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<double>(-340282366920938425684442744474606501888.0, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<double>(double.MaxValue, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<double>(double.MaxValue, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<double>(double.MinValue, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<double>(double.MinValue, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<double>(double.PositiveInfinity, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<double>(double.PositiveInfinity, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<double>(double.NegativeInfinity, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<double>(double.NegativeInfinity, out result));
             Assert.Equal(Zero, result);
         }
 
@@ -1326,34 +1326,34 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<Half>((Half)(+0.0), out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<Half>((Half)(+0.0), out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<Half>((Half)(-0.0), out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<Half>((Half)(-0.0), out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<Half>(+Half.Epsilon, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<Half>(+Half.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<Half>((Half)(+1.0), out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<Half>((Half)(+1.0), out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<Half>(Half.MaxValue, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<Half>(Half.MaxValue, out result));
             Assert.Equal(+65504U, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<Half>(-Half.Epsilon, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<Half>(-Half.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<Half>((Half)(-1.0), out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<Half>((Half)(-1.0), out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<Half>(Half.MinValue, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<Half>(Half.MinValue, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<Half>(Half.PositiveInfinity, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<Half>(Half.PositiveInfinity, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<Half>(Half.NegativeInfinity, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<Half>(Half.NegativeInfinity, out result));
             Assert.Equal(Zero, result);
         }
 
@@ -1362,19 +1362,19 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<short>(0x0000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<short>(0x0001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal(Int16MaxValue, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal(Zero, result);
         }
 
@@ -1383,19 +1383,19 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<int>(0x00000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<int>(0x00000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal(Int32MaxValue, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(Zero, result);
         }
 
@@ -1404,19 +1404,19 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(Int64MaxValue, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
             Assert.Equal(Zero, result);
         }
 
@@ -1427,36 +1427,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<UInt128>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(Int64MaxValue, result);
 
-                Assert.False(NumberHelper<UInt128>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<UInt128>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal(Zero, result);
 
-                Assert.False(NumberHelper<UInt128>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<UInt128>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(Zero, result);
             }
             else
             {
-                Assert.True(NumberHelper<UInt128>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal(Int32MaxValue, result);
 
-                Assert.False(NumberHelper<UInt128>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<UInt128>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal(Zero, result);
 
-                Assert.False(NumberHelper<UInt128>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<UInt128>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal(Zero, result);
             }
         }
@@ -1466,19 +1466,19 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal(SByteMaxValue, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal(Zero, result);
         }
 
@@ -1487,37 +1487,37 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<float>(+0.0f, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<float>(+0.0f, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<float>(-0.0f, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<float>(-0.0f, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<float>(+float.Epsilon, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<float>(+float.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<float>(+1.0f, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<float>(+1.0f, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<float>(+170141183460469231731687303715884105728.0f, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<float>(+170141183460469231731687303715884105728.0f, out result));
             Assert.Equal(new UInt128(0x8000_0000_0000_0000, 0x0000_0000_0000_0000), result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<float>(float.MaxValue, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<float>(float.MaxValue, out result));
             Assert.Equal(new UInt128(0xFFFF_FF00_0000_0000, 0x0000_0000_0000_0000), result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<float>(-float.Epsilon, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<float>(-float.Epsilon, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<float>(-1.0f, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<float>(-1.0f, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<float>(float.MinValue, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<float>(float.MinValue, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<float>(float.PositiveInfinity, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<float>(float.PositiveInfinity, out result));
             Assert.Equal(Zero, result);
 
-            Assert.False(NumberHelper<UInt128>.TryCreate<float>(float.NegativeInfinity, out result));
+            Assert.False(NumberBaseHelper<UInt128>.TryCreate<float>(float.NegativeInfinity, out result));
             Assert.Equal(Zero, result);
         }
 
@@ -1526,19 +1526,19 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal(Int16MaxValue, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal(Int16MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal(UInt16MaxValue, result);
         }
 
@@ -1547,19 +1547,19 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal(Int32MaxValue, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<uint>(0x80000000, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal(Int32MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal(UInt32MaxValue, result);
         }
 
@@ -1568,19 +1568,19 @@ namespace System.Tests
         {
             UInt128 result;
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal(Zero, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal(One, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal(Int64MaxValue, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal(Int64MaxValuePlusOne, result);
 
-            Assert.True(NumberHelper<UInt128>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<UInt128>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal(UInt64MaxValue, result);
         }
 
@@ -1591,36 +1591,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(Int64MaxValue, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal(Int64MaxValuePlusOne, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(UInt64MaxValue, result);
             }
             else
             {
-                Assert.True(NumberHelper<UInt128>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal(Zero, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal(One, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal(Int32MaxValue, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal(Int32MaxValuePlusOne, result);
 
-                Assert.True(NumberHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<UInt128>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal(UInt32MaxValue, result);
             }
         }

--- a/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
@@ -495,6 +495,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.MaxNumber((ushort)0x0000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.MaxNumber((ushort)0x0001, (ushort)1));
+            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.MaxNumber((ushort)0x7FFF, (ushort)1));
+            Assert.Equal((ushort)0x8000, NumberHelper<ushort>.MaxNumber((ushort)0x8000, (ushort)1));
+            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.MaxNumber((ushort)0xFFFF, (ushort)1));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal((ushort)0x0000, NumberHelper<ushort>.Min((ushort)0x0000, (ushort)1));
@@ -502,6 +512,16 @@ namespace System.Tests
             Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Min((ushort)0x7FFF, (ushort)1));
             Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Min((ushort)0x8000, (ushort)1));
             Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Min((ushort)0xFFFF, (ushort)1));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.MinNumber((ushort)0x0000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.MinNumber((ushort)0x0001, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.MinNumber((ushort)0x7FFF, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.MinNumber((ushort)0x8000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.MinNumber((ushort)0xFFFF, (ushort)1));
         }
 
         [Fact]
@@ -934,6 +954,126 @@ namespace System.Tests
                 Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<ushort>.IsFinite((ushort)0x0000));
+            Assert.True(NumberBaseHelper<ushort>.IsFinite((ushort)0x0001));
+            Assert.True(NumberBaseHelper<ushort>.IsFinite((ushort)0x7FFF));
+            Assert.True(NumberBaseHelper<ushort>.IsFinite((ushort)0x8000));
+            Assert.True(NumberBaseHelper<ushort>.IsFinite((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<ushort>.IsInfinity((ushort)0x0000));
+            Assert.False(NumberBaseHelper<ushort>.IsInfinity((ushort)0x0001));
+            Assert.False(NumberBaseHelper<ushort>.IsInfinity((ushort)0x7FFF));
+            Assert.False(NumberBaseHelper<ushort>.IsInfinity((ushort)0x8000));
+            Assert.False(NumberBaseHelper<ushort>.IsInfinity((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<ushort>.IsNaN((ushort)0x0000));
+            Assert.False(NumberBaseHelper<ushort>.IsNaN((ushort)0x0001));
+            Assert.False(NumberBaseHelper<ushort>.IsNaN((ushort)0x7FFF));
+            Assert.False(NumberBaseHelper<ushort>.IsNaN((ushort)0x8000));
+            Assert.False(NumberBaseHelper<ushort>.IsNaN((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<ushort>.IsNegative((ushort)0x0000));
+            Assert.False(NumberBaseHelper<ushort>.IsNegative((ushort)0x0001));
+            Assert.False(NumberBaseHelper<ushort>.IsNegative((ushort)0x7FFF));
+            Assert.False(NumberBaseHelper<ushort>.IsNegative((ushort)0x8000));
+            Assert.False(NumberBaseHelper<ushort>.IsNegative((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<ushort>.IsNegativeInfinity((ushort)0x0000));
+            Assert.False(NumberBaseHelper<ushort>.IsNegativeInfinity((ushort)0x0001));
+            Assert.False(NumberBaseHelper<ushort>.IsNegativeInfinity((ushort)0x7FFF));
+            Assert.False(NumberBaseHelper<ushort>.IsNegativeInfinity((ushort)0x8000));
+            Assert.False(NumberBaseHelper<ushort>.IsNegativeInfinity((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<ushort>.IsNormal((ushort)0x0000));
+            Assert.True(NumberBaseHelper<ushort>.IsNormal((ushort)0x0001));
+            Assert.True(NumberBaseHelper<ushort>.IsNormal((ushort)0x7FFF));
+            Assert.True(NumberBaseHelper<ushort>.IsNormal((ushort)0x8000));
+            Assert.True(NumberBaseHelper<ushort>.IsNormal((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<ushort>.IsPositiveInfinity((ushort)0x0000));
+            Assert.False(NumberBaseHelper<ushort>.IsPositiveInfinity((ushort)0x0001));
+            Assert.False(NumberBaseHelper<ushort>.IsPositiveInfinity((ushort)0x7FFF));
+            Assert.False(NumberBaseHelper<ushort>.IsPositiveInfinity((ushort)0x8000));
+            Assert.False(NumberBaseHelper<ushort>.IsPositiveInfinity((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<ushort>.IsSubnormal((ushort)0x0000));
+            Assert.False(NumberBaseHelper<ushort>.IsSubnormal((ushort)0x0001));
+            Assert.False(NumberBaseHelper<ushort>.IsSubnormal((ushort)0x7FFF));
+            Assert.False(NumberBaseHelper<ushort>.IsSubnormal((ushort)0x8000));
+            Assert.False(NumberBaseHelper<ushort>.IsSubnormal((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MaxMagnitude((ushort)0x0000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MaxMagnitude((ushort)0x0001, (ushort)1));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.MaxMagnitude((ushort)0x7FFF, (ushort)1));
+            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.MaxMagnitude((ushort)0x8000, (ushort)1));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.MaxMagnitude((ushort)0xFFFF, (ushort)1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MaxMagnitudeNumber((ushort)0x0000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MaxMagnitudeNumber((ushort)0x0001, (ushort)1));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.MaxMagnitudeNumber((ushort)0x7FFF, (ushort)1));
+            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.MaxMagnitudeNumber((ushort)0x8000, (ushort)1));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.MaxMagnitudeNumber((ushort)0xFFFF, (ushort)1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.MinMagnitude((ushort)0x0000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MinMagnitude((ushort)0x0001, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MinMagnitude((ushort)0x7FFF, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MinMagnitude((ushort)0x8000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MinMagnitude((ushort)0xFFFF, (ushort)1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.MinMagnitudeNumber((ushort)0x0000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MinMagnitudeNumber((ushort)0x0001, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MinMagnitudeNumber((ushort)0x7FFF, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MinMagnitudeNumber((ushort)0x8000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.MinMagnitudeNumber((ushort)0xFFFF, (ushort)1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
@@ -347,11 +347,11 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.Abs((ushort)0x0000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Abs((ushort)0x0001));
-            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.Abs((ushort)0x7FFF));
-            Assert.Equal((ushort)0x8000, NumberHelper<ushort>.Abs((ushort)0x8000));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.Abs((ushort)0xFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.Abs((ushort)0x0000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.Abs((ushort)0x0001));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.Abs((ushort)0x7FFF));
+            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.Abs((ushort)0x8000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.Abs((ushort)0xFFFF));
         }
 
         [Fact]
@@ -367,51 +367,51 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<byte>(0x00));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<byte>(0x01));
-            Assert.Equal((ushort)0x007F, NumberHelper<ushort>.CreateChecked<byte>(0x7F));
-            Assert.Equal((ushort)0x0080, NumberHelper<ushort>.CreateChecked<byte>(0x80));
-            Assert.Equal((ushort)0x00FF, NumberHelper<ushort>.CreateChecked<byte>(0xFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<byte>(0x00));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<byte>(0x01));
+            Assert.Equal((ushort)0x007F, NumberBaseHelper<ushort>.CreateChecked<byte>(0x7F));
+            Assert.Equal((ushort)0x0080, NumberBaseHelper<ushort>.CreateChecked<byte>(0x80));
+            Assert.Equal((ushort)0x00FF, NumberBaseHelper<ushort>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<char>((char)0x0000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<char>((char)0x0001));
-            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal((ushort)0x8000, NumberHelper<ushort>.CreateChecked<char>((char)0x8000));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<char>((char)0x0000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<char>((char)0x0001));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.CreateChecked<char>((char)0x8000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<short>(0x0000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<short>(0x0001));
-            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.CreateChecked<short>(0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<short>(0x0000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<short>(0x0001));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.CreateChecked<short>(0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<int>(0x00000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<int>(0x00000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<int>(0x00000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<int>(0x00000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<long>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<long>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -419,60 +419,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<sbyte>(0x00));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<sbyte>(0x01));
-            Assert.Equal((ushort)0x007F, NumberHelper<ushort>.CreateChecked<sbyte>(0x7F));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<sbyte>(0x00));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<sbyte>(0x01));
+            Assert.Equal((ushort)0x007F, NumberBaseHelper<ushort>.CreateChecked<sbyte>(0x7F));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<ushort>(0x0000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<ushort>(0x0001));
-            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal((ushort)0x8000, NumberHelper<ushort>.CreateChecked<ushort>(0x8000));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<ushort>(0x0000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<ushort>(0x0001));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.CreateChecked<ushort>(0x8000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<uint>(0x00000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<uint>(0x00000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<uint>(0x80000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<uint>(0x00000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<uint>(0x00000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<uint>(0x80000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -480,70 +480,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Throws<OverflowException>(() => NumberHelper<ushort>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ushort>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<byte>(0x00));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<byte>(0x01));
-            Assert.Equal((ushort)0x007F, NumberHelper<ushort>.CreateSaturating<byte>(0x7F));
-            Assert.Equal((ushort)0x0080, NumberHelper<ushort>.CreateSaturating<byte>(0x80));
-            Assert.Equal((ushort)0x00FF, NumberHelper<ushort>.CreateSaturating<byte>(0xFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<byte>(0x00));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<byte>(0x01));
+            Assert.Equal((ushort)0x007F, NumberBaseHelper<ushort>.CreateSaturating<byte>(0x7F));
+            Assert.Equal((ushort)0x0080, NumberBaseHelper<ushort>.CreateSaturating<byte>(0x80));
+            Assert.Equal((ushort)0x00FF, NumberBaseHelper<ushort>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal((ushort)0x8000, NumberHelper<ushort>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<short>(0x0000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<short>(0x0001));
-            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<short>(0x0000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<short>(0x0001));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<int>(0x00000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<int>(0x00000001));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<int>(0x00000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<int>(0x00000001));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -551,60 +551,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal((ushort)0x007F, NumberHelper<ushort>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal((ushort)0x007F, NumberBaseHelper<ushort>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal((ushort)0x8000, NumberHelper<ushort>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -612,70 +612,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<byte>(0x00));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<byte>(0x01));
-            Assert.Equal((ushort)0x007F, NumberHelper<ushort>.CreateTruncating<byte>(0x7F));
-            Assert.Equal((ushort)0x0080, NumberHelper<ushort>.CreateTruncating<byte>(0x80));
-            Assert.Equal((ushort)0x00FF, NumberHelper<ushort>.CreateTruncating<byte>(0xFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<byte>(0x00));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<byte>(0x01));
+            Assert.Equal((ushort)0x007F, NumberBaseHelper<ushort>.CreateTruncating<byte>(0x7F));
+            Assert.Equal((ushort)0x0080, NumberBaseHelper<ushort>.CreateTruncating<byte>(0x80));
+            Assert.Equal((ushort)0x00FF, NumberBaseHelper<ushort>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal((ushort)0x8000, NumberHelper<ushort>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<short>(0x0000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<short>(0x0001));
-            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal((ushort)0x8000, NumberHelper<ushort>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<short>(0x0000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<short>(0x0001));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<int>(0x00000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<int>(0x00000001));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<int>(0x00000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<int>(0x00000001));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -683,60 +683,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal((ushort)0x007F, NumberHelper<ushort>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal((ushort)0xFF80, NumberHelper<ushort>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal((ushort)0x007F, NumberBaseHelper<ushort>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal((ushort)0xFF80, NumberBaseHelper<ushort>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal((ushort)0x8000, NumberHelper<ushort>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -744,19 +744,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal((ushort)0x0001, NumberHelper<ushort>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((ushort)0x0000, NumberHelper<ushort>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -805,19 +805,19 @@ namespace System.Tests
         {
             ushort result;
 
-            Assert.True(NumberHelper<ushort>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<byte>(0x00, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<byte>(0x01, out result));
             Assert.Equal((ushort)0x0001, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((ushort)0x007F, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<byte>(0x80, out result));
             Assert.Equal((ushort)0x0080, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((ushort)0x00FF, result);
         }
 
@@ -826,19 +826,19 @@ namespace System.Tests
         {
             ushort result;
 
-            Assert.True(NumberHelper<ushort>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal((ushort)0x0001, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((ushort)0x7FFF, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((ushort)0x8000, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((ushort)0xFFFF, result);
         }
 
@@ -847,19 +847,19 @@ namespace System.Tests
         {
             ushort result;
 
-            Assert.True(NumberHelper<ushort>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<short>(0x0000, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<short>(0x0001, out result));
             Assert.Equal((ushort)0x0001, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((ushort)0x7FFF, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal((ushort)0x0000, result);
         }
 
@@ -868,19 +868,19 @@ namespace System.Tests
         {
             ushort result;
 
-            Assert.True(NumberHelper<ushort>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<int>(0x00000000, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<int>(0x00000001, out result));
             Assert.Equal((ushort)0x0001, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal((ushort)0x0000, result);
         }
 
@@ -889,19 +889,19 @@ namespace System.Tests
         {
             ushort result;
 
-            Assert.True(NumberHelper<ushort>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal((ushort)0x0001, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
             Assert.Equal((ushort)0x0000, result);
         }
 
@@ -912,36 +912,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<ushort>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<ushort>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.True(NumberHelper<ushort>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<ushort>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal((ushort)0x0001, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((ushort)0x0000, result);
             }
             else
             {
-                Assert.True(NumberHelper<ushort>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<ushort>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.True(NumberHelper<ushort>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<ushort>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal((ushort)0x0001, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal((ushort)0x0000, result);
             }
         }
@@ -951,19 +951,19 @@ namespace System.Tests
         {
             ushort result;
 
-            Assert.True(NumberHelper<ushort>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal((ushort)0x0001, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((ushort)0x007F, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal((ushort)0x0000, result);
         }
 
@@ -972,19 +972,19 @@ namespace System.Tests
         {
             ushort result;
 
-            Assert.True(NumberHelper<ushort>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal((ushort)0x0001, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((ushort)0x7FFF, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((ushort)0x8000, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((ushort)0xFFFF, result);
         }
 
@@ -993,19 +993,19 @@ namespace System.Tests
         {
             ushort result;
 
-            Assert.True(NumberHelper<ushort>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal((ushort)0x0001, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<uint>(0x80000000, out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal((ushort)0x0000, result);
         }
 
@@ -1014,19 +1014,19 @@ namespace System.Tests
         {
             ushort result;
 
-            Assert.True(NumberHelper<ushort>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.True(NumberHelper<ushort>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal((ushort)0x0001, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal((ushort)0x0000, result);
 
-            Assert.False(NumberHelper<ushort>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<ushort>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal((ushort)0x0000, result);
         }
 
@@ -1037,36 +1037,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.True(NumberHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal((ushort)0x0001, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((ushort)0x0000, result);
             }
             else
             {
-                Assert.True(NumberHelper<ushort>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<ushort>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.True(NumberHelper<ushort>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<ushort>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal((ushort)0x0001, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal((ushort)0x0000, result);
 
-                Assert.False(NumberHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<ushort>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal((ushort)0x0000, result);
             }
         }
@@ -1242,12 +1242,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Equal(expected, NumberHelper<ushort>.Parse(value, style, provider));
+                Assert.Equal(expected, NumberBaseHelper<ushort>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.True(NumberHelper<ushort>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.True(NumberBaseHelper<ushort>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(expected, result);
-                Assert.Equal(expected, NumberHelper<ushort>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Equal(expected, NumberBaseHelper<ushort>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1257,9 +1257,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.True(NumberHelper<ushort>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
-            Assert.Equal(expected, NumberHelper<ushort>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<ushort>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1279,12 +1279,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<ushort>.Parse(value, style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<ushort>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.False(NumberHelper<ushort>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.False(NumberBaseHelper<ushort>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(default(ushort), result);
-                Assert.Throws(exceptionType, () => NumberHelper<ushort>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<ushort>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1294,9 +1294,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.False(NumberHelper<ushort>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<ushort>.TryParse(value, style, provider, out result));
             Assert.Equal(default(ushort), result);
-            Assert.Throws(exceptionType, () => NumberHelper<ushort>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<ushort>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1312,9 +1312,9 @@ namespace System.Tests
                 Assert.Equal(expected, result);
             }
 
-            Assert.Equal(expected, NumberHelper<ushort>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<ushort>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<ushort>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<ushort>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1336,9 +1336,9 @@ namespace System.Tests
                 Assert.Equal(default(ushort), result);
             }
 
-            Assert.Throws(exceptionType, () => NumberHelper<ushort>.Parse(value.AsSpan(), style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<ushort>.Parse(value.AsSpan(), style, provider));
 
-            Assert.False(NumberHelper<ushort>.TryParse(value.AsSpan(), style, provider, out result));
+            Assert.False(NumberBaseHelper<ushort>.TryParse(value.AsSpan(), style, provider, out result));
             Assert.Equal(default(ushort), result);
         }
     }

--- a/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
@@ -8,41 +8,9 @@ namespace System.Tests
 {
     public class UInt16Tests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal((ushort)0x0000, AdditiveIdentityHelper<ushort, ushort>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            Assert.Equal((ushort)0x0000, MinMaxValueHelper<ushort>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            Assert.Equal((ushort)0xFFFF, MinMaxValueHelper<ushort>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal((ushort)0x0001, MultiplicativeIdentityHelper<ushort, ushort>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -63,6 +31,30 @@ namespace System.Tests
             Assert.Equal((ushort)0x8001, AdditionOperatorsHelper<ushort, ushort, ushort>.op_CheckedAddition((ushort)0x8000, (ushort)1));
 
             Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<ushort, ushort, ushort>.op_CheckedAddition((ushort)0xFFFF, (ushort)1));
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal((ushort)0x0000, AdditiveIdentityHelper<ushort, ushort>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            Assert.Equal(((ushort)0x0000, (ushort)0x0000), BinaryIntegerHelper<ushort>.DivRem((ushort)0x0000, (ushort)2));
+            Assert.Equal(((ushort)0x0000, (ushort)0x0001), BinaryIntegerHelper<ushort>.DivRem((ushort)0x0001, (ushort)2));
+            Assert.Equal(((ushort)0x3FFF, (ushort)0x0001), BinaryIntegerHelper<ushort>.DivRem((ushort)0x7FFF, (ushort)2));
+            Assert.Equal(((ushort)0x4000, (ushort)0x0000), BinaryIntegerHelper<ushort>.DivRem((ushort)0x8000, (ushort)2));
+            Assert.Equal(((ushort)0x7FFF, (ushort)0x0001), BinaryIntegerHelper<ushort>.DivRem((ushort)0xFFFF, (ushort)2));
         }
 
         [Fact]
@@ -116,6 +108,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            Assert.Equal(2, BinaryIntegerHelper<ushort>.GetByteCount((ushort)0x0000));
+            Assert.Equal(2, BinaryIntegerHelper<ushort>.GetByteCount((ushort)0x0001));
+            Assert.Equal(2, BinaryIntegerHelper<ushort>.GetByteCount((ushort)0x7FFF));
+            Assert.Equal(2, BinaryIntegerHelper<ushort>.GetByteCount((ushort)0x8000));
+            Assert.Equal(2, BinaryIntegerHelper<ushort>.GetByteCount((ushort)0xFFFF));
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             Assert.Equal(0x00, BinaryIntegerHelper<ushort>.GetShortestBitLength((ushort)0x0000));
@@ -124,6 +126,72 @@ namespace System.Tests
             Assert.Equal(0x10, BinaryIntegerHelper<ushort>.GetShortestBitLength((ushort)0x8000));
             Assert.Equal(0x10, BinaryIntegerHelper<ushort>.GetShortestBitLength((ushort)0xFFFF));
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[2];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<ushort>.TryWriteBigEndian((ushort)0x0000, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ushort>.TryWriteBigEndian((ushort)0x0001, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x01 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ushort>.TryWriteBigEndian((ushort)0x7FFF, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F, 0xFF }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ushort>.TryWriteBigEndian((ushort)0x8000, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ushort>.TryWriteBigEndian((ushort)0xFFFF, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<ushort>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[2];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<ushort>.TryWriteLittleEndian((ushort)0x0000, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ushort>.TryWriteLittleEndian((ushort)0x0001, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ushort>.TryWriteLittleEndian((ushort)0x7FFF, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0x7F }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ushort>.TryWriteLittleEndian((ushort)0x8000, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x80 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ushort>.TryWriteLittleEndian((ushort)0xFFFF, destination, out bytesWritten));
+            Assert.Equal(2, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<ushort>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -144,6 +212,10 @@ namespace System.Tests
             Assert.Equal((ushort)0x000F, BinaryNumberHelper<ushort>.Log2((ushort)0x8000));
             Assert.Equal((ushort)0x000F, BinaryNumberHelper<ushort>.Log2((ushort)0xFFFF));
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -185,25 +257,9 @@ namespace System.Tests
             Assert.Equal((ushort)0x0000, BitwiseOperatorsHelper<ushort, ushort, ushort>.op_OnesComplement((ushort)0xFFFF));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<ushort, ushort>.op_LessThan((ushort)0x0000, (ushort)1));
-            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThan((ushort)0x0001, (ushort)1));
-            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThan((ushort)0x7FFF, (ushort)1));
-            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThan((ushort)0x8000, (ushort)1));
-            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThan((ushort)0xFFFF, (ushort)1));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<ushort, ushort>.op_LessThanOrEqual((ushort)0x0000, (ushort)1));
-            Assert.True(ComparisonOperatorsHelper<ushort, ushort>.op_LessThanOrEqual((ushort)0x0001, (ushort)1));
-            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThanOrEqual((ushort)0x7FFF, (ushort)1));
-            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThanOrEqual((ushort)0x8000, (ushort)1));
-            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThanOrEqual((ushort)0xFFFF, (ushort)1));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -226,6 +282,30 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<ushort, ushort>.op_LessThan((ushort)0x0000, (ushort)1));
+            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThan((ushort)0x0001, (ushort)1));
+            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThan((ushort)0x7FFF, (ushort)1));
+            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThan((ushort)0x8000, (ushort)1));
+            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThan((ushort)0xFFFF, (ushort)1));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<ushort, ushort>.op_LessThanOrEqual((ushort)0x0000, (ushort)1));
+            Assert.True(ComparisonOperatorsHelper<ushort, ushort>.op_LessThanOrEqual((ushort)0x0001, (ushort)1));
+            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThanOrEqual((ushort)0x7FFF, (ushort)1));
+            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThanOrEqual((ushort)0x8000, (ushort)1));
+            Assert.False(ComparisonOperatorsHelper<ushort, ushort>.op_LessThanOrEqual((ushort)0xFFFF, (ushort)1));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             Assert.Equal((ushort)0xFFFF, DecrementOperatorsHelper<ushort>.op_Decrement((ushort)0x0000));
@@ -245,6 +325,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<ushort>.op_CheckedDecrement((ushort)0x0000));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -270,6 +354,10 @@ namespace System.Tests
             Assert.Throws<DivideByZeroException>(() => DivisionOperatorsHelper<ushort, ushort, ushort>.op_CheckedDivision((ushort)0x0001, (ushort)0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -289,6 +377,10 @@ namespace System.Tests
             Assert.True(EqualityOperatorsHelper<ushort, ushort>.op_Inequality((ushort)0x8000, (ushort)1));
             Assert.True(EqualityOperatorsHelper<ushort, ushort>.op_Inequality((ushort)0xFFFF, (ushort)1));
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -311,6 +403,26 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<ushort>.op_CheckedIncrement((ushort)0xFFFF));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            Assert.Equal((ushort)0xFFFF, MinMaxValueHelper<ushort>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal((ushort)0x0000, MinMaxValueHelper<ushort>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -322,6 +434,20 @@ namespace System.Tests
 
             Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<ushort, ushort, ushort>.op_Modulus((ushort)0x0001, (ushort)0));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal((ushort)0x0001, MultiplicativeIdentityHelper<ushort, ushort>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -344,15 +470,9 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<ushort, ushort, ushort>.op_CheckedMultiply((ushort)0xFFFF, (ushort)2));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.Abs((ushort)0x0000));
-            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.Abs((ushort)0x0001));
-            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.Abs((ushort)0x7FFF));
-            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.Abs((ushort)0x8000));
-            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.Abs((ushort)0xFFFF));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -362,6 +482,62 @@ namespace System.Tests
             Assert.Equal((ushort)0x003F, NumberHelper<ushort>.Clamp((ushort)0x7FFF, (ushort)0x0001, (ushort)0x003F));
             Assert.Equal((ushort)0x003F, NumberHelper<ushort>.Clamp((ushort)0x8000, (ushort)0x0001, (ushort)0x003F));
             Assert.Equal((ushort)0x003F, NumberHelper<ushort>.Clamp((ushort)0xFFFF, (ushort)0x0001, (ushort)0x003F));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Max((ushort)0x0000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Max((ushort)0x0001, (ushort)1));
+            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.Max((ushort)0x7FFF, (ushort)1));
+            Assert.Equal((ushort)0x8000, NumberHelper<ushort>.Max((ushort)0x8000, (ushort)1));
+            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.Max((ushort)0xFFFF, (ushort)1));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.Min((ushort)0x0000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Min((ushort)0x0001, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Min((ushort)0x7FFF, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Min((ushort)0x8000, (ushort)1));
+            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Min((ushort)0xFFFF, (ushort)1));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(0, NumberHelper<ushort>.Sign((ushort)0x0000));
+            Assert.Equal(1, NumberHelper<ushort>.Sign((ushort)0x0001));
+            Assert.Equal(1, NumberHelper<ushort>.Sign((ushort)0x7FFF));
+            Assert.Equal(1, NumberHelper<ushort>.Sign((ushort)0x8000));
+            Assert.Equal(1, NumberHelper<ushort>.Sign((ushort)0xFFFF));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.Abs((ushort)0x0000));
+            Assert.Equal((ushort)0x0001, NumberBaseHelper<ushort>.Abs((ushort)0x0001));
+            Assert.Equal((ushort)0x7FFF, NumberBaseHelper<ushort>.Abs((ushort)0x7FFF));
+            Assert.Equal((ushort)0x8000, NumberBaseHelper<ushort>.Abs((ushort)0x8000));
+            Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.Abs((ushort)0xFFFF));
         }
 
         [Fact]
@@ -761,46 +937,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            Assert.Equal(((ushort)0x0000, (ushort)0x0000), BinaryIntegerHelper<ushort>.DivRem((ushort)0x0000, (ushort)2));
-            Assert.Equal(((ushort)0x0000, (ushort)0x0001), BinaryIntegerHelper<ushort>.DivRem((ushort)0x0001, (ushort)2));
-            Assert.Equal(((ushort)0x3FFF, (ushort)0x0001), BinaryIntegerHelper<ushort>.DivRem((ushort)0x7FFF, (ushort)2));
-            Assert.Equal(((ushort)0x4000, (ushort)0x0000), BinaryIntegerHelper<ushort>.DivRem((ushort)0x8000, (ushort)2));
-            Assert.Equal(((ushort)0x7FFF, (ushort)0x0001), BinaryIntegerHelper<ushort>.DivRem((ushort)0xFFFF, (ushort)2));
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Max((ushort)0x0000, (ushort)1));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Max((ushort)0x0001, (ushort)1));
-            Assert.Equal((ushort)0x7FFF, NumberHelper<ushort>.Max((ushort)0x7FFF, (ushort)1));
-            Assert.Equal((ushort)0x8000, NumberHelper<ushort>.Max((ushort)0x8000, (ushort)1));
-            Assert.Equal((ushort)0xFFFF, NumberHelper<ushort>.Max((ushort)0xFFFF, (ushort)1));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            Assert.Equal((ushort)0x0000, NumberHelper<ushort>.Min((ushort)0x0000, (ushort)1));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Min((ushort)0x0001, (ushort)1));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Min((ushort)0x7FFF, (ushort)1));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Min((ushort)0x8000, (ushort)1));
-            Assert.Equal((ushort)0x0001, NumberHelper<ushort>.Min((ushort)0xFFFF, (ushort)1));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(0, NumberHelper<ushort>.Sign((ushort)0x0000));
-            Assert.Equal(1, NumberHelper<ushort>.Sign((ushort)0x0001));
-            Assert.Equal(1, NumberHelper<ushort>.Sign((ushort)0x7FFF));
-            Assert.Equal(1, NumberHelper<ushort>.Sign((ushort)0x8000));
-            Assert.Equal(1, NumberHelper<ushort>.Sign((ushort)0xFFFF));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             ushort result;
@@ -1071,77 +1207,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            Assert.Equal(2, BinaryIntegerHelper<ushort>.GetByteCount((ushort)0x0000));
-            Assert.Equal(2, BinaryIntegerHelper<ushort>.GetByteCount((ushort)0x0001));
-            Assert.Equal(2, BinaryIntegerHelper<ushort>.GetByteCount((ushort)0x7FFF));
-            Assert.Equal(2, BinaryIntegerHelper<ushort>.GetByteCount((ushort)0x8000));
-            Assert.Equal(2, BinaryIntegerHelper<ushort>.GetByteCount((ushort)0xFFFF));
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[2];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<ushort>.TryWriteBigEndian((ushort)0x0000, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ushort>.TryWriteBigEndian((ushort)0x0001, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x01 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ushort>.TryWriteBigEndian((ushort)0x7FFF, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F, 0xFF }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ushort>.TryWriteBigEndian((ushort)0x8000, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ushort>.TryWriteBigEndian((ushort)0xFFFF, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<ushort>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[2];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<ushort>.TryWriteLittleEndian((ushort)0x0000, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ushort>.TryWriteLittleEndian((ushort)0x0001, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ushort>.TryWriteLittleEndian((ushort)0x7FFF, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0x7F }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ushort>.TryWriteLittleEndian((ushort)0x8000, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x80 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ushort>.TryWriteLittleEndian((ushort)0xFFFF, destination, out bytesWritten));
-            Assert.Equal(2, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<ushort>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF }, destination.ToArray());
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1173,6 +1241,10 @@ namespace System.Tests
             Assert.Equal((ushort)0x7FFF, ShiftOperatorsHelper<ushort, ushort>.op_UnsignedRightShift((ushort)0xFFFF, 1));
         }
 
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1193,6 +1265,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<ushort, ushort, ushort>.op_CheckedSubtraction((ushort)0x0000, (ushort)1));
         }
+
+        //
+        // IUnaryNegationOperators
+        //
 
         [Fact]
         public static void op_UnaryNegationTest()
@@ -1215,6 +1291,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => UnaryNegationOperatorsHelper<ushort, ushort>.op_CheckedUnaryNegation((ushort)0xFFFF));
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1224,6 +1304,10 @@ namespace System.Tests
             Assert.Equal((ushort)0x8000, UnaryPlusOperatorsHelper<ushort, ushort>.op_UnaryPlus((ushort)0x8000));
             Assert.Equal((ushort)0xFFFF, UnaryPlusOperatorsHelper<ushort, ushort>.op_UnaryPlus((ushort)0xFFFF));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(UInt16Tests.Parse_Valid_TestData), MemberType = typeof(UInt16Tests))]

--- a/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
@@ -8,41 +8,9 @@ namespace System.Tests
 {
     public class UInt32Tests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal((uint)0x00000000, AdditiveIdentityHelper<uint, uint>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            Assert.Equal((uint)0x00000000, MinMaxValueHelper<uint>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            Assert.Equal((uint)0xFFFFFFFF, MinMaxValueHelper<uint>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal((uint)0x00000001, MultiplicativeIdentityHelper<uint, uint>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -64,6 +32,30 @@ namespace System.Tests
 
 
             Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<uint, uint, uint>.op_CheckedAddition((uint)0xFFFFFFFF, 1));
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal((uint)0x00000000, AdditiveIdentityHelper<uint, uint>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            Assert.Equal(((uint)0x00000000, (uint)0x00000000), BinaryIntegerHelper<uint>.DivRem((uint)0x00000000, 2));
+            Assert.Equal(((uint)0x00000000, (uint)0x00000001), BinaryIntegerHelper<uint>.DivRem((uint)0x00000001, 2));
+            Assert.Equal(((uint)0x3FFFFFFF, (uint)0x00000001), BinaryIntegerHelper<uint>.DivRem((uint)0x7FFFFFFF, 2));
+            Assert.Equal(((uint)0x40000000, (uint)0x00000000), BinaryIntegerHelper<uint>.DivRem((uint)0x80000000, 2));
+            Assert.Equal(((uint)0x7FFFFFFF, (uint)0x00000001), BinaryIntegerHelper<uint>.DivRem((uint)0xFFFFFFFF, 2));
         }
 
         [Fact]
@@ -117,6 +109,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            Assert.Equal(4, BinaryIntegerHelper<uint>.GetByteCount((uint)0x00000000));
+            Assert.Equal(4, BinaryIntegerHelper<uint>.GetByteCount((uint)0x00000001));
+            Assert.Equal(4, BinaryIntegerHelper<uint>.GetByteCount((uint)0x7FFFFFFF));
+            Assert.Equal(4, BinaryIntegerHelper<uint>.GetByteCount((uint)0x80000000));
+            Assert.Equal(4, BinaryIntegerHelper<uint>.GetByteCount((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             Assert.Equal(0x00, BinaryIntegerHelper<uint>.GetShortestBitLength((uint)0x00000000));
@@ -125,6 +127,72 @@ namespace System.Tests
             Assert.Equal(0x20, BinaryIntegerHelper<uint>.GetShortestBitLength((uint)0x80000000));
             Assert.Equal(0x20, BinaryIntegerHelper<uint>.GetShortestBitLength((uint)0xFFFFFFFF));
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[4];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<uint>.TryWriteBigEndian((uint)0x00000000, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<uint>.TryWriteBigEndian((uint)0x00000001, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<uint>.TryWriteBigEndian((uint)0x7FFFFFFF, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<uint>.TryWriteBigEndian((uint)0x80000000, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<uint>.TryWriteBigEndian((uint)0xFFFFFFFF, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<uint>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[4];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<uint>.TryWriteLittleEndian((uint)0x00000000, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<uint>.TryWriteLittleEndian((uint)0x00000001, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<uint>.TryWriteLittleEndian((uint)0x7FFFFFFF, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<uint>.TryWriteLittleEndian((uint)0x80000000, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<uint>.TryWriteLittleEndian((uint)0xFFFFFFFF, destination, out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<uint>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -145,6 +213,10 @@ namespace System.Tests
             Assert.Equal((uint)0x0000001F, BinaryNumberHelper<uint>.Log2((uint)0x80000000));
             Assert.Equal((uint)0x0000001F, BinaryNumberHelper<uint>.Log2((uint)0xFFFFFFFF));
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -186,25 +258,9 @@ namespace System.Tests
             Assert.Equal((uint)0x00000000, BitwiseOperatorsHelper<uint, uint, uint>.op_OnesComplement((uint)0xFFFFFFFF));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<uint, uint>.op_LessThan((uint)0x00000000, 1));
-            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThan((uint)0x00000001, 1));
-            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThan((uint)0x7FFFFFFF, 1));
-            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThan((uint)0x80000000, 1));
-            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThan((uint)0xFFFFFFFF, 1));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<uint, uint>.op_LessThanOrEqual((uint)0x00000000, 1));
-            Assert.True(ComparisonOperatorsHelper<uint, uint>.op_LessThanOrEqual((uint)0x00000001, 1));
-            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThanOrEqual((uint)0x7FFFFFFF, 1));
-            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThanOrEqual((uint)0x80000000, 1));
-            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThanOrEqual((uint)0xFFFFFFFF, 1));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -227,6 +283,30 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<uint, uint>.op_LessThan((uint)0x00000000, 1));
+            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThan((uint)0x00000001, 1));
+            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThan((uint)0x7FFFFFFF, 1));
+            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThan((uint)0x80000000, 1));
+            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThan((uint)0xFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<uint, uint>.op_LessThanOrEqual((uint)0x00000000, 1));
+            Assert.True(ComparisonOperatorsHelper<uint, uint>.op_LessThanOrEqual((uint)0x00000001, 1));
+            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThanOrEqual((uint)0x7FFFFFFF, 1));
+            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThanOrEqual((uint)0x80000000, 1));
+            Assert.False(ComparisonOperatorsHelper<uint, uint>.op_LessThanOrEqual((uint)0xFFFFFFFF, 1));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             Assert.Equal((uint)0xFFFFFFFF, DecrementOperatorsHelper<uint>.op_Decrement((uint)0x00000000));
@@ -246,6 +326,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<uint>.op_CheckedDecrement((uint)0x00000000));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -271,6 +355,10 @@ namespace System.Tests
             Assert.Throws<DivideByZeroException>(() => DivisionOperatorsHelper<uint, uint, uint>.op_CheckedDivision((uint)0x00000001, 0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -290,6 +378,10 @@ namespace System.Tests
             Assert.True(EqualityOperatorsHelper<uint, uint>.op_Inequality((uint)0x80000000, 1));
             Assert.True(EqualityOperatorsHelper<uint, uint>.op_Inequality((uint)0xFFFFFFFF, 1));
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -312,6 +404,26 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<uint>.op_CheckedIncrement((uint)0xFFFFFFFF));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            Assert.Equal((uint)0xFFFFFFFF, MinMaxValueHelper<uint>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal((uint)0x00000000, MinMaxValueHelper<uint>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -323,6 +435,20 @@ namespace System.Tests
 
             Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<uint, uint, uint>.op_Modulus((uint)0x00000001, 0));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal((uint)0x00000001, MultiplicativeIdentityHelper<uint, uint>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -345,15 +471,9 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<uint, uint, uint>.op_CheckedMultiply((uint)0xFFFFFFFF, 2));
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.Abs((uint)0x00000000));
-            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.Abs((uint)0x00000001));
-            Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.Abs((uint)0x7FFFFFFF));
-            Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.Abs((uint)0x80000000));
-            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.Abs((uint)0xFFFFFFFF));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -363,6 +483,62 @@ namespace System.Tests
             Assert.Equal((uint)0x0000003F, NumberHelper<uint>.Clamp((uint)0x7FFFFFFF, 0x0001, 0x003F));
             Assert.Equal((uint)0x0000003F, NumberHelper<uint>.Clamp((uint)0x80000000, 0x0001, 0x003F));
             Assert.Equal((uint)0x0000003F, NumberHelper<uint>.Clamp((uint)0xFFFFFFFF, 0x0001, 0x003F));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Max((uint)0x00000000, 1));
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Max((uint)0x00000001, 1));
+            Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.Max((uint)0x7FFFFFFF, 1));
+            Assert.Equal((uint)0x80000000, NumberHelper<uint>.Max((uint)0x80000000, 1));
+            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.Max((uint)0xFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal((uint)0x00000000, NumberHelper<uint>.Min((uint)0x00000000, 1));
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Min((uint)0x00000001, 1));
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Min((uint)0x7FFFFFFF, 1));
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Min((uint)0x80000000, 1));
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Min((uint)0xFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(0, NumberHelper<uint>.Sign((uint)0x00000000));
+            Assert.Equal(1, NumberHelper<uint>.Sign((uint)0x00000001));
+            Assert.Equal(1, NumberHelper<uint>.Sign((uint)0x7FFFFFFF));
+            Assert.Equal(1, NumberHelper<uint>.Sign((uint)0x80000000));
+            Assert.Equal(1, NumberHelper<uint>.Sign((uint)0xFFFFFFFF));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.Abs((uint)0x00000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.Abs((uint)0x00000001));
+            Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.Abs((uint)0x7FFFFFFF));
+            Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.Abs((uint)0x80000000));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.Abs((uint)0xFFFFFFFF));
         }
 
         [Fact]
@@ -762,46 +938,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            Assert.Equal(((uint)0x00000000, (uint)0x00000000), BinaryIntegerHelper<uint>.DivRem((uint)0x00000000, 2));
-            Assert.Equal(((uint)0x00000000, (uint)0x00000001), BinaryIntegerHelper<uint>.DivRem((uint)0x00000001, 2));
-            Assert.Equal(((uint)0x3FFFFFFF, (uint)0x00000001), BinaryIntegerHelper<uint>.DivRem((uint)0x7FFFFFFF, 2));
-            Assert.Equal(((uint)0x40000000, (uint)0x00000000), BinaryIntegerHelper<uint>.DivRem((uint)0x80000000, 2));
-            Assert.Equal(((uint)0x7FFFFFFF, (uint)0x00000001), BinaryIntegerHelper<uint>.DivRem((uint)0xFFFFFFFF, 2));
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Max((uint)0x00000000, 1));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Max((uint)0x00000001, 1));
-            Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.Max((uint)0x7FFFFFFF, 1));
-            Assert.Equal((uint)0x80000000, NumberHelper<uint>.Max((uint)0x80000000, 1));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.Max((uint)0xFFFFFFFF, 1));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.Min((uint)0x00000000, 1));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Min((uint)0x00000001, 1));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Min((uint)0x7FFFFFFF, 1));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Min((uint)0x80000000, 1));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Min((uint)0xFFFFFFFF, 1));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(0, NumberHelper<uint>.Sign((uint)0x00000000));
-            Assert.Equal(1, NumberHelper<uint>.Sign((uint)0x00000001));
-            Assert.Equal(1, NumberHelper<uint>.Sign((uint)0x7FFFFFFF));
-            Assert.Equal(1, NumberHelper<uint>.Sign((uint)0x80000000));
-            Assert.Equal(1, NumberHelper<uint>.Sign((uint)0xFFFFFFFF));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             uint result;
@@ -1072,77 +1208,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            Assert.Equal(4, BinaryIntegerHelper<uint>.GetByteCount((uint)0x00000000));
-            Assert.Equal(4, BinaryIntegerHelper<uint>.GetByteCount((uint)0x00000001));
-            Assert.Equal(4, BinaryIntegerHelper<uint>.GetByteCount((uint)0x7FFFFFFF));
-            Assert.Equal(4, BinaryIntegerHelper<uint>.GetByteCount((uint)0x80000000));
-            Assert.Equal(4, BinaryIntegerHelper<uint>.GetByteCount((uint)0xFFFFFFFF));
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[4];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<uint>.TryWriteBigEndian((uint)0x00000000, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<uint>.TryWriteBigEndian((uint)0x00000001, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<uint>.TryWriteBigEndian((uint)0x7FFFFFFF, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<uint>.TryWriteBigEndian((uint)0x80000000, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<uint>.TryWriteBigEndian((uint)0xFFFFFFFF, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<uint>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[4];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<uint>.TryWriteLittleEndian((uint)0x00000000, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<uint>.TryWriteLittleEndian((uint)0x00000001, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<uint>.TryWriteLittleEndian((uint)0x7FFFFFFF, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<uint>.TryWriteLittleEndian((uint)0x80000000, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<uint>.TryWriteLittleEndian((uint)0xFFFFFFFF, destination, out bytesWritten));
-            Assert.Equal(4, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<uint>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1174,6 +1242,10 @@ namespace System.Tests
             Assert.Equal((uint)0x7FFFFFFF, ShiftOperatorsHelper<uint, uint>.op_UnsignedRightShift((uint)0xFFFFFFFF, 1));
         }
 
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1194,6 +1266,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<uint, uint, uint>.op_CheckedSubtraction((uint)0x00000000, 1));
         }
+
+        //
+        // IUnaryNegationOperators
+        //
 
         [Fact]
         public static void op_UnaryNegationTest()
@@ -1216,6 +1292,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => UnaryNegationOperatorsHelper<uint, uint>.op_CheckedUnaryNegation((uint)0xFFFFFFFF));
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1225,6 +1305,10 @@ namespace System.Tests
             Assert.Equal((uint)0x80000000, UnaryPlusOperatorsHelper<uint, uint>.op_UnaryPlus((uint)0x80000000));
             Assert.Equal((uint)0xFFFFFFFF, UnaryPlusOperatorsHelper<uint, uint>.op_UnaryPlus((uint)0xFFFFFFFF));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(UInt32Tests.Parse_Valid_TestData), MemberType = typeof(UInt32Tests))]

--- a/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
@@ -348,11 +348,11 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.Abs((uint)0x00000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.Abs((uint)0x00000001));
-            Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.Abs((uint)0x7FFFFFFF));
-            Assert.Equal((uint)0x80000000, NumberHelper<uint>.Abs((uint)0x80000000));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.Abs((uint)0xFFFFFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.Abs((uint)0x00000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.Abs((uint)0x00000001));
+            Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.Abs((uint)0x7FFFFFFF));
+            Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.Abs((uint)0x80000000));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.Abs((uint)0xFFFFFFFF));
         }
 
         [Fact]
@@ -368,51 +368,51 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<byte>(0x00));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<byte>(0x01));
-            Assert.Equal((uint)0x0000007F, NumberHelper<uint>.CreateChecked<byte>(0x7F));
-            Assert.Equal((uint)0x00000080, NumberHelper<uint>.CreateChecked<byte>(0x80));
-            Assert.Equal((uint)0x000000FF, NumberHelper<uint>.CreateChecked<byte>(0xFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<byte>(0x00));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<byte>(0x01));
+            Assert.Equal((uint)0x0000007F, NumberBaseHelper<uint>.CreateChecked<byte>(0x7F));
+            Assert.Equal((uint)0x00000080, NumberBaseHelper<uint>.CreateChecked<byte>(0x80));
+            Assert.Equal((uint)0x000000FF, NumberBaseHelper<uint>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<char>((char)0x0000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<char>((char)0x0001));
-            Assert.Equal((uint)0x00007FFF, NumberHelper<uint>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal((uint)0x00008000, NumberHelper<uint>.CreateChecked<char>((char)0x8000));
-            Assert.Equal((uint)0x0000FFFF, NumberHelper<uint>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<char>((char)0x0000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<char>((char)0x0001));
+            Assert.Equal((uint)0x00007FFF, NumberBaseHelper<uint>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal((uint)0x00008000, NumberBaseHelper<uint>.CreateChecked<char>((char)0x8000));
+            Assert.Equal((uint)0x0000FFFF, NumberBaseHelper<uint>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<short>(0x0000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<short>(0x0001));
-            Assert.Equal((uint)0x00007FFF, NumberHelper<uint>.CreateChecked<short>(0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<short>(0x0000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<short>(0x0001));
+            Assert.Equal((uint)0x00007FFF, NumberBaseHelper<uint>.CreateChecked<short>(0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<int>(0x00000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<int>(0x00000001));
-            Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<int>(0x00000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<int>(0x00000001));
+            Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<long>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<long>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -420,60 +420,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<sbyte>(0x00));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<sbyte>(0x01));
-            Assert.Equal((uint)0x0000007F, NumberHelper<uint>.CreateChecked<sbyte>(0x7F));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<sbyte>(0x00));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<sbyte>(0x01));
+            Assert.Equal((uint)0x0000007F, NumberBaseHelper<uint>.CreateChecked<sbyte>(0x7F));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<ushort>(0x0000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<ushort>(0x0001));
-            Assert.Equal((uint)0x00007FFF, NumberHelper<uint>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal((uint)0x00008000, NumberHelper<uint>.CreateChecked<ushort>(0x8000));
-            Assert.Equal((uint)0x0000FFFF, NumberHelper<uint>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<ushort>(0x0000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<ushort>(0x0001));
+            Assert.Equal((uint)0x00007FFF, NumberBaseHelper<uint>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal((uint)0x00008000, NumberBaseHelper<uint>.CreateChecked<ushort>(0x8000));
+            Assert.Equal((uint)0x0000FFFF, NumberBaseHelper<uint>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<uint>(0x00000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<uint>(0x00000001));
-            Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Equal((uint)0x80000000, NumberHelper<uint>.CreateChecked<uint>(0x80000000));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<uint>(0x00000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<uint>(0x00000001));
+            Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.CreateChecked<uint>(0x80000000));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -481,70 +481,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<uint>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<uint>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((uint)0x80000000, NumberHelper<uint>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<byte>(0x00));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<byte>(0x01));
-            Assert.Equal((uint)0x0000007F, NumberHelper<uint>.CreateSaturating<byte>(0x7F));
-            Assert.Equal((uint)0x00000080, NumberHelper<uint>.CreateSaturating<byte>(0x80));
-            Assert.Equal((uint)0x000000FF, NumberHelper<uint>.CreateSaturating<byte>(0xFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<byte>(0x00));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<byte>(0x01));
+            Assert.Equal((uint)0x0000007F, NumberBaseHelper<uint>.CreateSaturating<byte>(0x7F));
+            Assert.Equal((uint)0x00000080, NumberBaseHelper<uint>.CreateSaturating<byte>(0x80));
+            Assert.Equal((uint)0x000000FF, NumberBaseHelper<uint>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal((uint)0x00007FFF, NumberHelper<uint>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal((uint)0x00008000, NumberHelper<uint>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal((uint)0x0000FFFF, NumberHelper<uint>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal((uint)0x00007FFF, NumberBaseHelper<uint>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal((uint)0x00008000, NumberBaseHelper<uint>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal((uint)0x0000FFFF, NumberBaseHelper<uint>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<short>(0x0000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<short>(0x0001));
-            Assert.Equal((uint)0x00007FFF, NumberHelper<uint>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<short>(0x0000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<short>(0x0001));
+            Assert.Equal((uint)0x00007FFF, NumberBaseHelper<uint>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<int>(0x00000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<int>(0x00000001));
-            Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<int>(0x00000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<int>(0x00000001));
+            Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -552,60 +552,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal((uint)0x0000007F, NumberHelper<uint>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal((uint)0x0000007F, NumberBaseHelper<uint>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal((uint)0x00007FFF, NumberHelper<uint>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal((uint)0x00008000, NumberHelper<uint>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal((uint)0x0000FFFF, NumberHelper<uint>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal((uint)0x00007FFF, NumberBaseHelper<uint>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal((uint)0x00008000, NumberBaseHelper<uint>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal((uint)0x0000FFFF, NumberBaseHelper<uint>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal((uint)0x80000000, NumberHelper<uint>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -613,70 +613,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((uint)0x80000000, NumberHelper<uint>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<byte>(0x00));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<byte>(0x01));
-            Assert.Equal((uint)0x0000007F, NumberHelper<uint>.CreateTruncating<byte>(0x7F));
-            Assert.Equal((uint)0x00000080, NumberHelper<uint>.CreateTruncating<byte>(0x80));
-            Assert.Equal((uint)0x000000FF, NumberHelper<uint>.CreateTruncating<byte>(0xFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<byte>(0x00));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<byte>(0x01));
+            Assert.Equal((uint)0x0000007F, NumberBaseHelper<uint>.CreateTruncating<byte>(0x7F));
+            Assert.Equal((uint)0x00000080, NumberBaseHelper<uint>.CreateTruncating<byte>(0x80));
+            Assert.Equal((uint)0x000000FF, NumberBaseHelper<uint>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal((uint)0x00007FFF, NumberHelper<uint>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal((uint)0x00008000, NumberHelper<uint>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal((uint)0x0000FFFF, NumberHelper<uint>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal((uint)0x00007FFF, NumberBaseHelper<uint>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal((uint)0x00008000, NumberBaseHelper<uint>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal((uint)0x0000FFFF, NumberBaseHelper<uint>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<short>(0x0000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<short>(0x0001));
-            Assert.Equal((uint)0x00007FFF, NumberHelper<uint>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal((uint)0xFFFF8000, NumberHelper<uint>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<short>(0x0000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<short>(0x0001));
+            Assert.Equal((uint)0x00007FFF, NumberBaseHelper<uint>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal((uint)0xFFFF8000, NumberBaseHelper<uint>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<int>(0x00000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<int>(0x00000001));
-            Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal((uint)0x80000000, NumberHelper<uint>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<int>(0x00000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<int>(0x00000001));
+            Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -684,60 +684,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((uint)0x80000000, NumberHelper<uint>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal((uint)0x0000007F, NumberHelper<uint>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal((uint)0xFFFFFF80, NumberHelper<uint>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal((uint)0x0000007F, NumberBaseHelper<uint>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal((uint)0xFFFFFF80, NumberBaseHelper<uint>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal((uint)0x00007FFF, NumberHelper<uint>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal((uint)0x00008000, NumberHelper<uint>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal((uint)0x0000FFFF, NumberHelper<uint>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal((uint)0x00007FFF, NumberBaseHelper<uint>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal((uint)0x00008000, NumberBaseHelper<uint>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal((uint)0x0000FFFF, NumberBaseHelper<uint>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal((uint)0x80000000, NumberHelper<uint>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -745,19 +745,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((uint)0x00000000, NumberHelper<uint>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal((uint)0x00000001, NumberHelper<uint>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((uint)0x80000000, NumberHelper<uint>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -806,19 +806,19 @@ namespace System.Tests
         {
             uint result;
 
-            Assert.True(NumberHelper<uint>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<byte>(0x00, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<byte>(0x01, out result));
             Assert.Equal((uint)0x00000001, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((uint)0x0000007F, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<byte>(0x80, out result));
             Assert.Equal((uint)0x00000080, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((uint)0x000000FF, result);
         }
 
@@ -827,19 +827,19 @@ namespace System.Tests
         {
             uint result;
 
-            Assert.True(NumberHelper<uint>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal((uint)0x00000001, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((uint)0x00007FFF, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((uint)0x00008000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((uint)0x0000FFFF, result);
         }
 
@@ -848,19 +848,19 @@ namespace System.Tests
         {
             uint result;
 
-            Assert.True(NumberHelper<uint>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<short>(0x0000, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<short>(0x0001, out result));
             Assert.Equal((uint)0x00000001, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((uint)0x00007FFF, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal((uint)0x00000000, result);
         }
 
@@ -869,19 +869,19 @@ namespace System.Tests
         {
             uint result;
 
-            Assert.True(NumberHelper<uint>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<int>(0x00000000, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<int>(0x00000001, out result));
             Assert.Equal((uint)0x00000001, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((uint)0x7FFFFFFF, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal((uint)0x00000000, result);
         }
 
@@ -890,19 +890,19 @@ namespace System.Tests
         {
             uint result;
 
-            Assert.True(NumberHelper<uint>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal((uint)0x00000001, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
             Assert.Equal((uint)0x00000000, result);
         }
 
@@ -913,36 +913,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<uint>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal((uint)0x00000000, result);
 
-                Assert.True(NumberHelper<uint>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal((uint)0x00000001, result);
 
-                Assert.False(NumberHelper<uint>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<uint>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((uint)0x00000000, result);
 
-                Assert.False(NumberHelper<uint>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<uint>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal((uint)0x00000000, result);
 
-                Assert.False(NumberHelper<uint>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<uint>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((uint)0x00000000, result);
             }
             else
             {
-                Assert.True(NumberHelper<uint>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal((uint)0x00000000, result);
 
-                Assert.True(NumberHelper<uint>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal((uint)0x00000001, result);
 
-                Assert.True(NumberHelper<uint>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((uint)0x7FFFFFFF, result);
 
-                Assert.False(NumberHelper<uint>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<uint>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal((uint)0x00000000, result);
 
-                Assert.False(NumberHelper<uint>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<uint>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal((uint)0x00000000, result);
             }
         }
@@ -952,19 +952,19 @@ namespace System.Tests
         {
             uint result;
 
-            Assert.True(NumberHelper<uint>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal((uint)0x00000001, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((uint)0x0000007F, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal((uint)0x00000000, result);
         }
 
@@ -973,19 +973,19 @@ namespace System.Tests
         {
             uint result;
 
-            Assert.True(NumberHelper<uint>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal((uint)0x00000001, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((uint)0x00007FFF, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((uint)0x00008000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((uint)0x0000FFFF, result);
         }
 
@@ -994,19 +994,19 @@ namespace System.Tests
         {
             uint result;
 
-            Assert.True(NumberHelper<uint>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal((uint)0x00000001, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal((uint)0x7FFFFFFF, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<uint>(0x80000000, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal((uint)0x80000000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal((uint)0xFFFFFFFF, result);
         }
 
@@ -1015,19 +1015,19 @@ namespace System.Tests
         {
             uint result;
 
-            Assert.True(NumberHelper<uint>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.True(NumberHelper<uint>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<uint>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal((uint)0x00000001, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal((uint)0x00000000, result);
 
-            Assert.False(NumberHelper<uint>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.False(NumberBaseHelper<uint>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal((uint)0x00000000, result);
         }
 
@@ -1038,36 +1038,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<uint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal((uint)0x00000000, result);
 
-                Assert.True(NumberHelper<uint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal((uint)0x00000001, result);
 
-                Assert.False(NumberHelper<uint>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<uint>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((uint)0x00000000, result);
 
-                Assert.False(NumberHelper<uint>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<uint>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal((uint)0x00000000, result);
 
-                Assert.False(NumberHelper<uint>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<uint>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((uint)0x00000000, result);
             }
             else
             {
-                Assert.True(NumberHelper<uint>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal((uint)0x00000000, result);
 
-                Assert.True(NumberHelper<uint>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal((uint)0x00000001, result);
 
-                Assert.True(NumberHelper<uint>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((uint)0x7FFFFFFF, result);
 
-                Assert.True(NumberHelper<uint>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal((uint)0x80000000, result);
 
-                Assert.True(NumberHelper<uint>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<uint>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal((uint)0xFFFFFFFF, result);
             }
         }
@@ -1243,12 +1243,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Equal(expected, NumberHelper<uint>.Parse(value, style, provider));
+                Assert.Equal(expected, NumberBaseHelper<uint>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.True(NumberHelper<uint>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.True(NumberBaseHelper<uint>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(expected, result);
-                Assert.Equal(expected, NumberHelper<uint>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Equal(expected, NumberBaseHelper<uint>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1258,9 +1258,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.True(NumberHelper<uint>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<uint>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
-            Assert.Equal(expected, NumberHelper<uint>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<uint>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1280,12 +1280,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<uint>.Parse(value, style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<uint>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.False(NumberHelper<uint>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.False(NumberBaseHelper<uint>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(default(uint), result);
-                Assert.Throws(exceptionType, () => NumberHelper<uint>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<uint>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1295,9 +1295,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.False(NumberHelper<uint>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<uint>.TryParse(value, style, provider, out result));
             Assert.Equal(default(uint), result);
-            Assert.Throws(exceptionType, () => NumberHelper<uint>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<uint>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1313,9 +1313,9 @@ namespace System.Tests
                 Assert.Equal(expected, result);
             }
 
-            Assert.Equal(expected, NumberHelper<uint>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<uint>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<uint>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<uint>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1337,9 +1337,9 @@ namespace System.Tests
                 Assert.Equal(default(uint), result);
             }
 
-            Assert.Throws(exceptionType, () => NumberHelper<uint>.Parse(value.AsSpan(), style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<uint>.Parse(value.AsSpan(), style, provider));
 
-            Assert.False(NumberHelper<uint>.TryParse(value.AsSpan(), style, provider, out result));
+            Assert.False(NumberBaseHelper<uint>.TryParse(value.AsSpan(), style, provider, out result));
             Assert.Equal(default(uint), result);
         }
     }

--- a/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
@@ -496,6 +496,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.MaxNumber((uint)0x00000000, 1));
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.MaxNumber((uint)0x00000001, 1));
+            Assert.Equal((uint)0x7FFFFFFF, NumberHelper<uint>.MaxNumber((uint)0x7FFFFFFF, 1));
+            Assert.Equal((uint)0x80000000, NumberHelper<uint>.MaxNumber((uint)0x80000000, 1));
+            Assert.Equal((uint)0xFFFFFFFF, NumberHelper<uint>.MaxNumber((uint)0xFFFFFFFF, 1));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal((uint)0x00000000, NumberHelper<uint>.Min((uint)0x00000000, 1));
@@ -503,6 +513,16 @@ namespace System.Tests
             Assert.Equal((uint)0x00000001, NumberHelper<uint>.Min((uint)0x7FFFFFFF, 1));
             Assert.Equal((uint)0x00000001, NumberHelper<uint>.Min((uint)0x80000000, 1));
             Assert.Equal((uint)0x00000001, NumberHelper<uint>.Min((uint)0xFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal((uint)0x00000000, NumberHelper<uint>.MinNumber((uint)0x00000000, 1));
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.MinNumber((uint)0x00000001, 1));
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.MinNumber((uint)0x7FFFFFFF, 1));
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.MinNumber((uint)0x80000000, 1));
+            Assert.Equal((uint)0x00000001, NumberHelper<uint>.MinNumber((uint)0xFFFFFFFF, 1));
         }
 
         [Fact]
@@ -935,6 +955,126 @@ namespace System.Tests
                 Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<uint>.IsFinite((uint)0x00000000));
+            Assert.True(NumberBaseHelper<uint>.IsFinite((uint)0x00000001));
+            Assert.True(NumberBaseHelper<uint>.IsFinite((uint)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<uint>.IsFinite((uint)0x80000000));
+            Assert.True(NumberBaseHelper<uint>.IsFinite((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<uint>.IsInfinity((uint)0x00000000));
+            Assert.False(NumberBaseHelper<uint>.IsInfinity((uint)0x00000001));
+            Assert.False(NumberBaseHelper<uint>.IsInfinity((uint)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<uint>.IsInfinity((uint)0x80000000));
+            Assert.False(NumberBaseHelper<uint>.IsInfinity((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<uint>.IsNaN((uint)0x00000000));
+            Assert.False(NumberBaseHelper<uint>.IsNaN((uint)0x00000001));
+            Assert.False(NumberBaseHelper<uint>.IsNaN((uint)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<uint>.IsNaN((uint)0x80000000));
+            Assert.False(NumberBaseHelper<uint>.IsNaN((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<uint>.IsNegative((uint)0x00000000));
+            Assert.False(NumberBaseHelper<uint>.IsNegative((uint)0x00000001));
+            Assert.False(NumberBaseHelper<uint>.IsNegative((uint)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<uint>.IsNegative((uint)0x80000000));
+            Assert.False(NumberBaseHelper<uint>.IsNegative((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<uint>.IsNegativeInfinity((uint)0x00000000));
+            Assert.False(NumberBaseHelper<uint>.IsNegativeInfinity((uint)0x00000001));
+            Assert.False(NumberBaseHelper<uint>.IsNegativeInfinity((uint)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<uint>.IsNegativeInfinity((uint)0x80000000));
+            Assert.False(NumberBaseHelper<uint>.IsNegativeInfinity((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<uint>.IsNormal((uint)0x00000000));
+            Assert.True(NumberBaseHelper<uint>.IsNormal((uint)0x00000001));
+            Assert.True(NumberBaseHelper<uint>.IsNormal((uint)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<uint>.IsNormal((uint)0x80000000));
+            Assert.True(NumberBaseHelper<uint>.IsNormal((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<uint>.IsPositiveInfinity((uint)0x00000000));
+            Assert.False(NumberBaseHelper<uint>.IsPositiveInfinity((uint)0x00000001));
+            Assert.False(NumberBaseHelper<uint>.IsPositiveInfinity((uint)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<uint>.IsPositiveInfinity((uint)0x80000000));
+            Assert.False(NumberBaseHelper<uint>.IsPositiveInfinity((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<uint>.IsSubnormal((uint)0x00000000));
+            Assert.False(NumberBaseHelper<uint>.IsSubnormal((uint)0x00000001));
+            Assert.False(NumberBaseHelper<uint>.IsSubnormal((uint)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<uint>.IsSubnormal((uint)0x80000000));
+            Assert.False(NumberBaseHelper<uint>.IsSubnormal((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MaxMagnitude((uint)0x00000000, 1));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MaxMagnitude((uint)0x00000001, 1));
+            Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.MaxMagnitude((uint)0x7FFFFFFF, 1));
+            Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.MaxMagnitude((uint)0x80000000, 1));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.MaxMagnitude((uint)0xFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MaxMagnitudeNumber((uint)0x00000000, 1));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MaxMagnitudeNumber((uint)0x00000001, 1));
+            Assert.Equal((uint)0x7FFFFFFF, NumberBaseHelper<uint>.MaxMagnitudeNumber((uint)0x7FFFFFFF, 1));
+            Assert.Equal((uint)0x80000000, NumberBaseHelper<uint>.MaxMagnitudeNumber((uint)0x80000000, 1));
+            Assert.Equal((uint)0xFFFFFFFF, NumberBaseHelper<uint>.MaxMagnitudeNumber((uint)0xFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.MinMagnitude((uint)0x00000000, 1));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MinMagnitude((uint)0x00000001, 1));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MinMagnitude((uint)0x7FFFFFFF, 1));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MinMagnitude((uint)0x80000000, 1));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MinMagnitude((uint)0xFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.MinMagnitudeNumber((uint)0x00000000, 1));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MinMagnitudeNumber((uint)0x00000001, 1));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MinMagnitudeNumber((uint)0x7FFFFFFF, 1));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MinMagnitudeNumber((uint)0x80000000, 1));
+            Assert.Equal((uint)0x00000001, NumberBaseHelper<uint>.MinMagnitudeNumber((uint)0xFFFFFFFF, 1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
@@ -8,41 +8,9 @@ namespace System.Tests
 {
     public class UInt64Tests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal((ulong)0x0000000000000000, AdditiveIdentityHelper<ulong, ulong>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            Assert.Equal((ulong)0x0000000000000000, MinMaxValueHelper<ulong>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, MinMaxValueHelper<ulong>.MaxValue);
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal((ulong)0x0000000000000001, MultiplicativeIdentityHelper<ulong, ulong>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -63,6 +31,30 @@ namespace System.Tests
             Assert.Equal((ulong)0x8000000000000001, AdditionOperatorsHelper<ulong, ulong, ulong>.op_CheckedAddition((ulong)0x8000000000000000, 1));
 
             Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<ulong, ulong, ulong>.op_CheckedAddition((ulong)0xFFFFFFFFFFFFFFFF, 1));
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal((ulong)0x0000000000000000, AdditiveIdentityHelper<ulong, ulong>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            Assert.Equal(((ulong)0x0000000000000000, (ulong)0x0000000000000000), BinaryIntegerHelper<ulong>.DivRem((ulong)0x0000000000000000, 2));
+            Assert.Equal(((ulong)0x0000000000000000, (ulong)0x0000000000000001), BinaryIntegerHelper<ulong>.DivRem((ulong)0x0000000000000001, 2));
+            Assert.Equal(((ulong)0x3FFFFFFFFFFFFFFF, (ulong)0x0000000000000001), BinaryIntegerHelper<ulong>.DivRem((ulong)0x7FFFFFFFFFFFFFFF, 2));
+            Assert.Equal(((ulong)0x4000000000000000, (ulong)0x0000000000000000), BinaryIntegerHelper<ulong>.DivRem((ulong)0x8000000000000000, 2));
+            Assert.Equal(((ulong)0x7FFFFFFFFFFFFFFF, (ulong)0x0000000000000001), BinaryIntegerHelper<ulong>.DivRem((ulong)0xFFFFFFFFFFFFFFFF, 2));
         }
 
         [Fact]
@@ -116,6 +108,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            Assert.Equal(8, BinaryIntegerHelper<ulong>.GetByteCount((ulong)0x0000000000000000));
+            Assert.Equal(8, BinaryIntegerHelper<ulong>.GetByteCount((ulong)0x0000000000000001));
+            Assert.Equal(8, BinaryIntegerHelper<ulong>.GetByteCount((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(8, BinaryIntegerHelper<ulong>.GetByteCount((ulong)0x8000000000000000));
+            Assert.Equal(8, BinaryIntegerHelper<ulong>.GetByteCount((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             Assert.Equal(0x00, BinaryIntegerHelper<ulong>.GetShortestBitLength((ulong)0x0000000000000000));
@@ -124,6 +126,72 @@ namespace System.Tests
             Assert.Equal(0x40, BinaryIntegerHelper<ulong>.GetShortestBitLength((ulong)0x8000000000000000));
             Assert.Equal(0x40, BinaryIntegerHelper<ulong>.GetShortestBitLength((ulong)0xFFFFFFFFFFFFFFFF));
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[8];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<ulong>.TryWriteBigEndian((ulong)0x0000000000000000, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ulong>.TryWriteBigEndian((ulong)0x0000000000000001, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ulong>.TryWriteBigEndian((ulong)0x7FFFFFFFFFFFFFFF, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ulong>.TryWriteBigEndian((ulong)0x8000000000000000, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ulong>.TryWriteBigEndian((ulong)0xFFFFFFFFFFFFFFFF, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<ulong>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            Span<byte> destination = stackalloc byte[8];
+            int bytesWritten = 0;
+
+            Assert.True(BinaryIntegerHelper<ulong>.TryWriteLittleEndian((ulong)0x0000000000000000, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ulong>.TryWriteLittleEndian((ulong)0x0000000000000001, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ulong>.TryWriteLittleEndian((ulong)0x7FFFFFFFFFFFFFFF, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ulong>.TryWriteLittleEndian((ulong)0x8000000000000000, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
+
+            Assert.True(BinaryIntegerHelper<ulong>.TryWriteLittleEndian((ulong)0xFFFFFFFFFFFFFFFF, destination, out bytesWritten));
+            Assert.Equal(8, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+            Assert.False(BinaryIntegerHelper<ulong>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -144,6 +212,10 @@ namespace System.Tests
             Assert.Equal((ulong)0x000000000000003F, BinaryNumberHelper<ulong>.Log2((ulong)0x8000000000000000));
             Assert.Equal((ulong)0x000000000000003F, BinaryNumberHelper<ulong>.Log2((ulong)0xFFFFFFFFFFFFFFFF));
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -185,25 +257,9 @@ namespace System.Tests
             Assert.Equal((ulong)0x0000000000000000, BitwiseOperatorsHelper<ulong, ulong, ulong>.op_OnesComplement((ulong)0xFFFFFFFFFFFFFFFF));
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<ulong, ulong>.op_LessThan((ulong)0x0000000000000000, 1));
-            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThan((ulong)0x0000000000000001, 1));
-            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThan((ulong)0x7FFFFFFFFFFFFFFF, 1));
-            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThan((ulong)0x8000000000000000, 1));
-            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThan((ulong)0xFFFFFFFFFFFFFFFF, 1));
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            Assert.True(ComparisonOperatorsHelper<ulong, ulong>.op_LessThanOrEqual((ulong)0x0000000000000000, 1));
-            Assert.True(ComparisonOperatorsHelper<ulong, ulong>.op_LessThanOrEqual((ulong)0x0000000000000001, 1));
-            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThanOrEqual((ulong)0x7FFFFFFFFFFFFFFF, 1));
-            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThanOrEqual((ulong)0x8000000000000000, 1));
-            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThanOrEqual((ulong)0xFFFFFFFFFFFFFFFF, 1));
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -226,6 +282,30 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<ulong, ulong>.op_LessThan((ulong)0x0000000000000000, 1));
+            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThan((ulong)0x0000000000000001, 1));
+            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThan((ulong)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThan((ulong)0x8000000000000000, 1));
+            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThan((ulong)0xFFFFFFFFFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<ulong, ulong>.op_LessThanOrEqual((ulong)0x0000000000000000, 1));
+            Assert.True(ComparisonOperatorsHelper<ulong, ulong>.op_LessThanOrEqual((ulong)0x0000000000000001, 1));
+            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThanOrEqual((ulong)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThanOrEqual((ulong)0x8000000000000000, 1));
+            Assert.False(ComparisonOperatorsHelper<ulong, ulong>.op_LessThanOrEqual((ulong)0xFFFFFFFFFFFFFFFF, 1));
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, DecrementOperatorsHelper<ulong>.op_Decrement((ulong)0x0000000000000000));
@@ -245,6 +325,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<ulong>.op_CheckedDecrement((ulong)0x0000000000000000));
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -270,6 +354,10 @@ namespace System.Tests
             Assert.Throws<DivideByZeroException>(() => DivisionOperatorsHelper<ulong, ulong, ulong>.op_CheckedDivision((ulong)0x0000000000000001, 0));
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -289,6 +377,10 @@ namespace System.Tests
             Assert.True(EqualityOperatorsHelper<ulong, ulong>.op_Inequality((ulong)0x8000000000000000, 1));
             Assert.True(EqualityOperatorsHelper<ulong, ulong>.op_Inequality((ulong)0xFFFFFFFFFFFFFFFF, 1));
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -311,6 +403,26 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<ulong>.op_CheckedIncrement((ulong)0xFFFFFFFFFFFFFFFF));
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, MinMaxValueHelper<ulong>.MaxValue);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal((ulong)0x0000000000000000, MinMaxValueHelper<ulong>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -322,6 +434,20 @@ namespace System.Tests
 
             Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<ulong, ulong, ulong>.op_Modulus((ulong)0x0000000000000001, 0));
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal((ulong)0x0000000000000001, MultiplicativeIdentityHelper<ulong, ulong>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -343,16 +469,9 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<ulong, ulong, ulong>.op_CheckedMultiply((ulong)0xFFFFFFFFFFFFFFFF, 2));
         }
 
-
-        [Fact]
-        public static void AbsTest()
-        {
-            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.Abs((ulong)0x0000000000000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.Abs((ulong)0x0000000000000001));
-            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.Abs((ulong)0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.Abs((ulong)0x8000000000000000));
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.Abs((ulong)0xFFFFFFFFFFFFFFFF));
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -362,6 +481,62 @@ namespace System.Tests
             Assert.Equal((ulong)0x000000000000003F, NumberHelper<ulong>.Clamp((ulong)0x7FFFFFFFFFFFFFFF, 0x0001, 0x003F));
             Assert.Equal((ulong)0x000000000000003F, NumberHelper<ulong>.Clamp((ulong)0x8000000000000000, 0x0001, 0x003F));
             Assert.Equal((ulong)0x000000000000003F, NumberHelper<ulong>.Clamp((ulong)0xFFFFFFFFFFFFFFFF, 0x0001, 0x003F));
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Max((ulong)0x0000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Max((ulong)0x0000000000000001, 1));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.Max((ulong)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.Max((ulong)0x8000000000000000, 1));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.Max((ulong)0xFFFFFFFFFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.Min((ulong)0x0000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Min((ulong)0x0000000000000001, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Min((ulong)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Min((ulong)0x8000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Min((ulong)0xFFFFFFFFFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(0, NumberHelper<ulong>.Sign((ulong)0x0000000000000000));
+            Assert.Equal(1, NumberHelper<ulong>.Sign((ulong)0x0000000000000001));
+            Assert.Equal(1, NumberHelper<ulong>.Sign((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(1, NumberHelper<ulong>.Sign((ulong)0x8000000000000000));
+            Assert.Equal(1, NumberHelper<ulong>.Sign((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.Abs((ulong)0x0000000000000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.Abs((ulong)0x0000000000000001));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.Abs((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.Abs((ulong)0x8000000000000000));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.Abs((ulong)0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -761,46 +936,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            Assert.Equal(((ulong)0x0000000000000000, (ulong)0x0000000000000000), BinaryIntegerHelper<ulong>.DivRem((ulong)0x0000000000000000, 2));
-            Assert.Equal(((ulong)0x0000000000000000, (ulong)0x0000000000000001), BinaryIntegerHelper<ulong>.DivRem((ulong)0x0000000000000001, 2));
-            Assert.Equal(((ulong)0x3FFFFFFFFFFFFFFF, (ulong)0x0000000000000001), BinaryIntegerHelper<ulong>.DivRem((ulong)0x7FFFFFFFFFFFFFFF, 2));
-            Assert.Equal(((ulong)0x4000000000000000, (ulong)0x0000000000000000), BinaryIntegerHelper<ulong>.DivRem((ulong)0x8000000000000000, 2));
-            Assert.Equal(((ulong)0x7FFFFFFFFFFFFFFF, (ulong)0x0000000000000001), BinaryIntegerHelper<ulong>.DivRem((ulong)0xFFFFFFFFFFFFFFFF, 2));
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Max((ulong)0x0000000000000000, 1));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Max((ulong)0x0000000000000001, 1));
-            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.Max((ulong)0x7FFFFFFFFFFFFFFF, 1));
-            Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.Max((ulong)0x8000000000000000, 1));
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.Max((ulong)0xFFFFFFFFFFFFFFFF, 1));
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.Min((ulong)0x0000000000000000, 1));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Min((ulong)0x0000000000000001, 1));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Min((ulong)0x7FFFFFFFFFFFFFFF, 1));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Min((ulong)0x8000000000000000, 1));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Min((ulong)0xFFFFFFFFFFFFFFFF, 1));
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            Assert.Equal(0, NumberHelper<ulong>.Sign((ulong)0x0000000000000000));
-            Assert.Equal(1, NumberHelper<ulong>.Sign((ulong)0x0000000000000001));
-            Assert.Equal(1, NumberHelper<ulong>.Sign((ulong)0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(1, NumberHelper<ulong>.Sign((ulong)0x8000000000000000));
-            Assert.Equal(1, NumberHelper<ulong>.Sign((ulong)0xFFFFFFFFFFFFFFFF));
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             ulong result;
@@ -1071,77 +1206,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            Assert.Equal(8, BinaryIntegerHelper<ulong>.GetByteCount((ulong)0x0000000000000000));
-            Assert.Equal(8, BinaryIntegerHelper<ulong>.GetByteCount((ulong)0x0000000000000001));
-            Assert.Equal(8, BinaryIntegerHelper<ulong>.GetByteCount((ulong)0x7FFFFFFFFFFFFFFF));
-            Assert.Equal(8, BinaryIntegerHelper<ulong>.GetByteCount((ulong)0x8000000000000000));
-            Assert.Equal(8, BinaryIntegerHelper<ulong>.GetByteCount((ulong)0xFFFFFFFFFFFFFFFF));
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[8];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<ulong>.TryWriteBigEndian((ulong)0x0000000000000000, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ulong>.TryWriteBigEndian((ulong)0x0000000000000001, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ulong>.TryWriteBigEndian((ulong)0x7FFFFFFFFFFFFFFF, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ulong>.TryWriteBigEndian((ulong)0x8000000000000000, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ulong>.TryWriteBigEndian((ulong)0xFFFFFFFFFFFFFFFF, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<ulong>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            Span<byte> destination = stackalloc byte[8];
-            int bytesWritten = 0;
-
-            Assert.True(BinaryIntegerHelper<ulong>.TryWriteLittleEndian((ulong)0x0000000000000000, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ulong>.TryWriteLittleEndian((ulong)0x0000000000000001, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ulong>.TryWriteLittleEndian((ulong)0x7FFFFFFFFFFFFFFF, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ulong>.TryWriteLittleEndian((ulong)0x8000000000000000, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
-
-            Assert.True(BinaryIntegerHelper<ulong>.TryWriteLittleEndian((ulong)0xFFFFFFFFFFFFFFFF, destination, out bytesWritten));
-            Assert.Equal(8, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-            Assert.False(BinaryIntegerHelper<ulong>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-            Assert.Equal(0, bytesWritten);
-            Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1173,6 +1240,10 @@ namespace System.Tests
             Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, ShiftOperatorsHelper<ulong, ulong>.op_UnsignedRightShift((ulong)0xFFFFFFFFFFFFFFFF, 1));
         }
 
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1193,6 +1264,10 @@ namespace System.Tests
 
             Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<ulong, ulong, ulong>.op_CheckedSubtraction((ulong)0x0000000000000000, 1));
         }
+
+        //
+        // IUnaryNegationOperators
+        //
 
         [Fact]
         public static void op_UnaryNegationTest()
@@ -1215,6 +1290,10 @@ namespace System.Tests
             Assert.Throws<OverflowException>(() => UnaryNegationOperatorsHelper<ulong, ulong>.op_CheckedUnaryNegation((ulong)0xFFFFFFFFFFFFFFFF));
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1224,6 +1303,10 @@ namespace System.Tests
             Assert.Equal((ulong)0x8000000000000000, UnaryPlusOperatorsHelper<ulong, ulong>.op_UnaryPlus((ulong)0x8000000000000000));
             Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, UnaryPlusOperatorsHelper<ulong, ulong>.op_UnaryPlus((ulong)0xFFFFFFFFFFFFFFFF));
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(UInt64Tests.Parse_Valid_TestData), MemberType = typeof(UInt64Tests))]

--- a/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
@@ -494,6 +494,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.MaxNumber((ulong)0x0000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.MaxNumber((ulong)0x0000000000000001, 1));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.MaxNumber((ulong)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.MaxNumber((ulong)0x8000000000000000, 1));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.MaxNumber((ulong)0xFFFFFFFFFFFFFFFF, 1));
+        }
+
+        [Fact]
         public static void MinTest()
         {
             Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.Min((ulong)0x0000000000000000, 1));
@@ -501,6 +511,16 @@ namespace System.Tests
             Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Min((ulong)0x7FFFFFFFFFFFFFFF, 1));
             Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Min((ulong)0x8000000000000000, 1));
             Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Min((ulong)0xFFFFFFFFFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.MinNumber((ulong)0x0000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.MinNumber((ulong)0x0000000000000001, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.MinNumber((ulong)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.MinNumber((ulong)0x8000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.MinNumber((ulong)0xFFFFFFFFFFFFFFFF, 1));
         }
 
         [Fact]
@@ -933,6 +953,126 @@ namespace System.Tests
                 Assert.Equal((ulong)0x0000000080000000, NumberBaseHelper<ulong>.CreateTruncating<nuint>((nuint)0x80000000));
                 Assert.Equal((ulong)0x00000000FFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.True(NumberBaseHelper<ulong>.IsFinite((ulong)0x0000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsFinite((ulong)0x0000000000000001));
+            Assert.True(NumberBaseHelper<ulong>.IsFinite((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<ulong>.IsFinite((ulong)0x8000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsFinite((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<ulong>.IsInfinity((ulong)0x0000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsInfinity((ulong)0x0000000000000001));
+            Assert.False(NumberBaseHelper<ulong>.IsInfinity((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<ulong>.IsInfinity((ulong)0x8000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsInfinity((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<ulong>.IsNaN((ulong)0x0000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsNaN((ulong)0x0000000000000001));
+            Assert.False(NumberBaseHelper<ulong>.IsNaN((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<ulong>.IsNaN((ulong)0x8000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsNaN((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.False(NumberBaseHelper<ulong>.IsNegative((ulong)0x0000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsNegative((ulong)0x0000000000000001));
+            Assert.False(NumberBaseHelper<ulong>.IsNegative((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<ulong>.IsNegative((ulong)0x8000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsNegative((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<ulong>.IsNegativeInfinity((ulong)0x0000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsNegativeInfinity((ulong)0x0000000000000001));
+            Assert.False(NumberBaseHelper<ulong>.IsNegativeInfinity((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<ulong>.IsNegativeInfinity((ulong)0x8000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsNegativeInfinity((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<ulong>.IsNormal((ulong)0x0000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsNormal((ulong)0x0000000000000001));
+            Assert.True(NumberBaseHelper<ulong>.IsNormal((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<ulong>.IsNormal((ulong)0x8000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsNormal((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<ulong>.IsPositiveInfinity((ulong)0x0000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsPositiveInfinity((ulong)0x0000000000000001));
+            Assert.False(NumberBaseHelper<ulong>.IsPositiveInfinity((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<ulong>.IsPositiveInfinity((ulong)0x8000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsPositiveInfinity((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<ulong>.IsSubnormal((ulong)0x0000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsSubnormal((ulong)0x0000000000000001));
+            Assert.False(NumberBaseHelper<ulong>.IsSubnormal((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<ulong>.IsSubnormal((ulong)0x8000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsSubnormal((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MaxMagnitude((ulong)0x0000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MaxMagnitude((ulong)0x0000000000000001, 1));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.MaxMagnitude((ulong)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.MaxMagnitude((ulong)0x8000000000000000, 1));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.MaxMagnitude((ulong)0xFFFFFFFFFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MaxMagnitudeNumber((ulong)0x0000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MaxMagnitudeNumber((ulong)0x0000000000000001, 1));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.MaxMagnitudeNumber((ulong)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.MaxMagnitudeNumber((ulong)0x8000000000000000, 1));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.MaxMagnitudeNumber((ulong)0xFFFFFFFFFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.MinMagnitude((ulong)0x0000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MinMagnitude((ulong)0x0000000000000001, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MinMagnitude((ulong)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MinMagnitude((ulong)0x8000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MinMagnitude((ulong)0xFFFFFFFFFFFFFFFF, 1));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.MinMagnitudeNumber((ulong)0x0000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MinMagnitudeNumber((ulong)0x0000000000000001, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MinMagnitudeNumber((ulong)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MinMagnitudeNumber((ulong)0x8000000000000000, 1));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.MinMagnitudeNumber((ulong)0xFFFFFFFFFFFFFFFF, 1));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
@@ -347,11 +347,11 @@ namespace System.Tests
         [Fact]
         public static void AbsTest()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.Abs((ulong)0x0000000000000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.Abs((ulong)0x0000000000000001));
-            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.Abs((ulong)0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.Abs((ulong)0x8000000000000000));
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.Abs((ulong)0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.Abs((ulong)0x0000000000000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.Abs((ulong)0x0000000000000001));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.Abs((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.Abs((ulong)0x8000000000000000));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.Abs((ulong)0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -367,51 +367,51 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<byte>(0x00));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<byte>(0x01));
-            Assert.Equal((ulong)0x000000000000007F, NumberHelper<ulong>.CreateChecked<byte>(0x7F));
-            Assert.Equal((ulong)0x0000000000000080, NumberHelper<ulong>.CreateChecked<byte>(0x80));
-            Assert.Equal((ulong)0x00000000000000FF, NumberHelper<ulong>.CreateChecked<byte>(0xFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<byte>(0x00));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<byte>(0x01));
+            Assert.Equal((ulong)0x000000000000007F, NumberBaseHelper<ulong>.CreateChecked<byte>(0x7F));
+            Assert.Equal((ulong)0x0000000000000080, NumberBaseHelper<ulong>.CreateChecked<byte>(0x80));
+            Assert.Equal((ulong)0x00000000000000FF, NumberBaseHelper<ulong>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<char>((char)0x0000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<char>((char)0x0001));
-            Assert.Equal((ulong)0x0000000000007FFF, NumberHelper<ulong>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal((ulong)0x0000000000008000, NumberHelper<ulong>.CreateChecked<char>((char)0x8000));
-            Assert.Equal((ulong)0x000000000000FFFF, NumberHelper<ulong>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<char>((char)0x0000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<char>((char)0x0001));
+            Assert.Equal((ulong)0x0000000000007FFF, NumberBaseHelper<ulong>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal((ulong)0x0000000000008000, NumberBaseHelper<ulong>.CreateChecked<char>((char)0x8000));
+            Assert.Equal((ulong)0x000000000000FFFF, NumberBaseHelper<ulong>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<short>(0x0000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<short>(0x0001));
-            Assert.Equal((ulong)0x0000000000007FFF, NumberHelper<ulong>.CreateChecked<short>(0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<short>(0x0000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<short>(0x0001));
+            Assert.Equal((ulong)0x0000000000007FFF, NumberBaseHelper<ulong>.CreateChecked<short>(0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<int>(0x00000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<int>(0x00000001));
-            Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<int>(0x00000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<int>(0x00000001));
+            Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<long>(0x0000000000000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<long>(0x0000000000000001));
-            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<long>(0x0000000000000001));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -419,60 +419,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<sbyte>(0x00));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<sbyte>(0x01));
-            Assert.Equal((ulong)0x000000000000007F, NumberHelper<ulong>.CreateChecked<sbyte>(0x7F));
-            Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Throws<OverflowException>(() => NumberHelper<ulong>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<sbyte>(0x00));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<sbyte>(0x01));
+            Assert.Equal((ulong)0x000000000000007F, NumberBaseHelper<ulong>.CreateChecked<sbyte>(0x7F));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<ulong>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<ushort>(0x0000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<ushort>(0x0001));
-            Assert.Equal((ulong)0x0000000000007FFF, NumberHelper<ulong>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal((ulong)0x0000000000008000, NumberHelper<ulong>.CreateChecked<ushort>(0x8000));
-            Assert.Equal((ulong)0x000000000000FFFF, NumberHelper<ulong>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<ushort>(0x0000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<ushort>(0x0001));
+            Assert.Equal((ulong)0x0000000000007FFF, NumberBaseHelper<ulong>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal((ulong)0x0000000000008000, NumberBaseHelper<ulong>.CreateChecked<ushort>(0x8000));
+            Assert.Equal((ulong)0x000000000000FFFF, NumberBaseHelper<ulong>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<uint>(0x00000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<uint>(0x00000001));
-            Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Equal((ulong)0x0000000080000000, NumberHelper<ulong>.CreateChecked<uint>(0x80000000));
-            Assert.Equal((ulong)0x00000000FFFFFFFF, NumberHelper<ulong>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<uint>(0x00000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<uint>(0x00000001));
+            Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Equal((ulong)0x0000000080000000, NumberBaseHelper<ulong>.CreateChecked<uint>(0x80000000));
+            Assert.Equal((ulong)0x00000000FFFFFFFF, NumberBaseHelper<ulong>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<ulong>(0x0000000000000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<ulong>(0x0000000000000001));
-            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.CreateChecked<ulong>(0x8000000000000000));
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -480,70 +480,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((ulong)0x0000000080000000, NumberHelper<ulong>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Equal((ulong)0x00000000FFFFFFFF, NumberHelper<ulong>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((ulong)0x0000000080000000, NumberBaseHelper<ulong>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Equal((ulong)0x00000000FFFFFFFF, NumberBaseHelper<ulong>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<byte>(0x00));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<byte>(0x01));
-            Assert.Equal((ulong)0x000000000000007F, NumberHelper<ulong>.CreateSaturating<byte>(0x7F));
-            Assert.Equal((ulong)0x0000000000000080, NumberHelper<ulong>.CreateSaturating<byte>(0x80));
-            Assert.Equal((ulong)0x00000000000000FF, NumberHelper<ulong>.CreateSaturating<byte>(0xFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<byte>(0x00));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<byte>(0x01));
+            Assert.Equal((ulong)0x000000000000007F, NumberBaseHelper<ulong>.CreateSaturating<byte>(0x7F));
+            Assert.Equal((ulong)0x0000000000000080, NumberBaseHelper<ulong>.CreateSaturating<byte>(0x80));
+            Assert.Equal((ulong)0x00000000000000FF, NumberBaseHelper<ulong>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal((ulong)0x0000000000007FFF, NumberHelper<ulong>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal((ulong)0x0000000000008000, NumberHelper<ulong>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal((ulong)0x000000000000FFFF, NumberHelper<ulong>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal((ulong)0x0000000000007FFF, NumberBaseHelper<ulong>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal((ulong)0x0000000000008000, NumberBaseHelper<ulong>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal((ulong)0x000000000000FFFF, NumberBaseHelper<ulong>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<short>(0x0000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<short>(0x0001));
-            Assert.Equal((ulong)0x0000000000007FFF, NumberHelper<ulong>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<short>(0x0000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<short>(0x0001));
+            Assert.Equal((ulong)0x0000000000007FFF, NumberBaseHelper<ulong>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<int>(0x00000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<int>(0x00000001));
-            Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<int>(0x00000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<int>(0x00000001));
+            Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<long>(0x0000000000000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<long>(0x0000000000000001));
-            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -551,60 +551,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal((ulong)0x000000000000007F, NumberHelper<ulong>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal((ulong)0x000000000000007F, NumberBaseHelper<ulong>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal((ulong)0x0000000000007FFF, NumberHelper<ulong>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal((ulong)0x0000000000008000, NumberHelper<ulong>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal((ulong)0x000000000000FFFF, NumberHelper<ulong>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal((ulong)0x0000000000007FFF, NumberBaseHelper<ulong>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal((ulong)0x0000000000008000, NumberBaseHelper<ulong>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal((ulong)0x000000000000FFFF, NumberBaseHelper<ulong>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal((ulong)0x0000000080000000, NumberHelper<ulong>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal((ulong)0x00000000FFFFFFFF, NumberHelper<ulong>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal((ulong)0x0000000080000000, NumberBaseHelper<ulong>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal((ulong)0x00000000FFFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<ulong>(0x0000000000000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<ulong>(0x0000000000000001));
-            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.CreateSaturating<ulong>(0x8000000000000000));
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -612,70 +612,70 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((ulong)0x0000000080000000, NumberHelper<ulong>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal((ulong)0x00000000FFFFFFFF, NumberHelper<ulong>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((ulong)0x0000000080000000, NumberBaseHelper<ulong>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal((ulong)0x00000000FFFFFFFF, NumberBaseHelper<ulong>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<byte>(0x00));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<byte>(0x01));
-            Assert.Equal((ulong)0x000000000000007F, NumberHelper<ulong>.CreateTruncating<byte>(0x7F));
-            Assert.Equal((ulong)0x0000000000000080, NumberHelper<ulong>.CreateTruncating<byte>(0x80));
-            Assert.Equal((ulong)0x00000000000000FF, NumberHelper<ulong>.CreateTruncating<byte>(0xFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<byte>(0x00));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<byte>(0x01));
+            Assert.Equal((ulong)0x000000000000007F, NumberBaseHelper<ulong>.CreateTruncating<byte>(0x7F));
+            Assert.Equal((ulong)0x0000000000000080, NumberBaseHelper<ulong>.CreateTruncating<byte>(0x80));
+            Assert.Equal((ulong)0x00000000000000FF, NumberBaseHelper<ulong>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal((ulong)0x0000000000007FFF, NumberHelper<ulong>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal((ulong)0x0000000000008000, NumberHelper<ulong>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal((ulong)0x000000000000FFFF, NumberHelper<ulong>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal((ulong)0x0000000000007FFF, NumberBaseHelper<ulong>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal((ulong)0x0000000000008000, NumberBaseHelper<ulong>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal((ulong)0x000000000000FFFF, NumberBaseHelper<ulong>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<short>(0x0000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<short>(0x0001));
-            Assert.Equal((ulong)0x0000000000007FFF, NumberHelper<ulong>.CreateTruncating<short>(0x7FFF));
-            Assert.Equal((ulong)0xFFFFFFFFFFFF8000, NumberHelper<ulong>.CreateTruncating<short>(unchecked((short)0x8000)));
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<short>(0x0000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<short>(0x0001));
+            Assert.Equal((ulong)0x0000000000007FFF, NumberBaseHelper<ulong>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal((ulong)0xFFFFFFFFFFFF8000, NumberBaseHelper<ulong>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<int>(0x00000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<int>(0x00000001));
-            Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateTruncating<int>(0x7FFFFFFF));
-            Assert.Equal((ulong)0xFFFFFFFF80000000, NumberHelper<ulong>.CreateTruncating<int>(unchecked((int)0x80000000)));
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<int>(0x00000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<int>(0x00000001));
+            Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal((ulong)0xFFFFFFFF80000000, NumberBaseHelper<ulong>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<long>(0x0000000000000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<long>(0x0000000000000001));
-            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -683,60 +683,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((ulong)0xFFFFFFFF80000000, NumberHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((ulong)0xFFFFFFFF80000000, NumberBaseHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<sbyte>(0x00));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<sbyte>(0x01));
-            Assert.Equal((ulong)0x000000000000007F, NumberHelper<ulong>.CreateTruncating<sbyte>(0x7F));
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFF80, NumberHelper<ulong>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal((ulong)0x000000000000007F, NumberBaseHelper<ulong>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFF80, NumberBaseHelper<ulong>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal((ulong)0x0000000000007FFF, NumberHelper<ulong>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal((ulong)0x0000000000008000, NumberHelper<ulong>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal((ulong)0x000000000000FFFF, NumberHelper<ulong>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal((ulong)0x0000000000007FFF, NumberBaseHelper<ulong>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal((ulong)0x0000000000008000, NumberBaseHelper<ulong>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal((ulong)0x000000000000FFFF, NumberBaseHelper<ulong>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal((ulong)0x0000000080000000, NumberHelper<ulong>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal((ulong)0x00000000FFFFFFFF, NumberHelper<ulong>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal((ulong)0x0000000080000000, NumberBaseHelper<ulong>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal((ulong)0x00000000FFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<ulong>(0x0000000000000000));
-            Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<ulong>(0x0000000000000001));
-            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-            Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.CreateTruncating<ulong>(0x8000000000000000));
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+            Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -744,19 +744,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal((ulong)0x8000000000000000, NumberHelper<ulong>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberHelper<ulong>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal((ulong)0x8000000000000000, NumberBaseHelper<ulong>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((ulong)0x0000000000000000, NumberHelper<ulong>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal((ulong)0x0000000000000001, NumberHelper<ulong>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal((ulong)0x000000007FFFFFFF, NumberHelper<ulong>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((ulong)0x0000000080000000, NumberHelper<ulong>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal((ulong)0x00000000FFFFFFFF, NumberHelper<ulong>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal((ulong)0x0000000000000001, NumberBaseHelper<ulong>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal((ulong)0x000000007FFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((ulong)0x0000000080000000, NumberBaseHelper<ulong>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal((ulong)0x00000000FFFFFFFF, NumberBaseHelper<ulong>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -805,19 +805,19 @@ namespace System.Tests
         {
             ulong result;
 
-            Assert.True(NumberHelper<ulong>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<byte>(0x00, out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<byte>(0x01, out result));
             Assert.Equal((ulong)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((ulong)0x000000000000007F, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<byte>(0x80, out result));
             Assert.Equal((ulong)0x0000000000000080, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((ulong)0x00000000000000FF, result);
         }
 
@@ -826,19 +826,19 @@ namespace System.Tests
         {
             ulong result;
 
-            Assert.True(NumberHelper<ulong>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal((ulong)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((ulong)0x0000000000007FFF, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((ulong)0x0000000000008000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((ulong)0x000000000000FFFF, result);
         }
 
@@ -847,19 +847,19 @@ namespace System.Tests
         {
             ulong result;
 
-            Assert.True(NumberHelper<ulong>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<short>(0x0000, out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<short>(0x0001, out result));
             Assert.Equal((ulong)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((ulong)0x0000000000007FFF, result);
 
-            Assert.False(NumberHelper<ulong>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.False(NumberBaseHelper<ulong>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.False(NumberHelper<ulong>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.False(NumberBaseHelper<ulong>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal((ulong)0x0000000000000000, result);
         }
 
@@ -868,19 +868,19 @@ namespace System.Tests
         {
             ulong result;
 
-            Assert.True(NumberHelper<ulong>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<int>(0x00000000, out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<int>(0x00000001, out result));
             Assert.Equal((ulong)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((ulong)0x000000007FFFFFFF, result);
 
-            Assert.False(NumberHelper<ulong>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.False(NumberBaseHelper<ulong>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.False(NumberHelper<ulong>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<ulong>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal((ulong)0x0000000000000000, result);
         }
 
@@ -889,19 +889,19 @@ namespace System.Tests
         {
             ulong result;
 
-            Assert.True(NumberHelper<ulong>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<long>(0x0000000000000000, out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<long>(0x0000000000000001, out result));
             Assert.Equal((ulong)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, result);
 
-            Assert.False(NumberHelper<ulong>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+            Assert.False(NumberBaseHelper<ulong>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.False(NumberHelper<ulong>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<ulong>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
             Assert.Equal((ulong)0x0000000000000000, result);
         }
 
@@ -912,36 +912,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<ulong>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal((ulong)0x0000000000000000, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal((ulong)0x0000000000000001, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, result);
 
-                Assert.False(NumberHelper<ulong>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<ulong>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal((ulong)0x0000000000000000, result);
 
-                Assert.False(NumberHelper<ulong>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<ulong>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((ulong)0x0000000000000000, result);
             }
             else
             {
-                Assert.True(NumberHelper<ulong>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal((ulong)0x0000000000000000, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal((ulong)0x0000000000000001, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((ulong)0x000000007FFFFFFF, result);
 
-                Assert.False(NumberHelper<ulong>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<ulong>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal((ulong)0x0000000000000000, result);
 
-                Assert.False(NumberHelper<ulong>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<ulong>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal((ulong)0x0000000000000000, result);
             }
         }
@@ -951,19 +951,19 @@ namespace System.Tests
         {
             ulong result;
 
-            Assert.True(NumberHelper<ulong>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal((ulong)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((ulong)0x000000000000007F, result);
 
-            Assert.False(NumberHelper<ulong>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.False(NumberBaseHelper<ulong>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.False(NumberHelper<ulong>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.False(NumberBaseHelper<ulong>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal((ulong)0x0000000000000000, result);
         }
 
@@ -972,19 +972,19 @@ namespace System.Tests
         {
             ulong result;
 
-            Assert.True(NumberHelper<ulong>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal((ulong)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((ulong)0x0000000000007FFF, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((ulong)0x0000000000008000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((ulong)0x000000000000FFFF, result);
         }
 
@@ -993,19 +993,19 @@ namespace System.Tests
         {
             ulong result;
 
-            Assert.True(NumberHelper<ulong>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal((ulong)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal((ulong)0x000000007FFFFFFF, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<uint>(0x80000000, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal((ulong)0x0000000080000000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal((ulong)0x00000000FFFFFFFF, result);
         }
 
@@ -1014,19 +1014,19 @@ namespace System.Tests
         {
             ulong result;
 
-            Assert.True(NumberHelper<ulong>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<ulong>(0x0000000000000000, out result));
             Assert.Equal((ulong)0x0000000000000000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<ulong>(0x0000000000000001, out result));
             Assert.Equal((ulong)0x0000000000000001, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
             Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<ulong>(0x8000000000000000, out result));
             Assert.Equal((ulong)0x8000000000000000, result);
 
-            Assert.True(NumberHelper<ulong>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
             Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, result);
         }
 
@@ -1037,36 +1037,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal((ulong)0x0000000000000000, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal((ulong)0x0000000000000001, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((ulong)0x7FFFFFFFFFFFFFFF, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal((ulong)0x8000000000000000, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, result);
             }
             else
             {
-                Assert.True(NumberHelper<ulong>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal((ulong)0x0000000000000000, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal((ulong)0x0000000000000001, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((ulong)0x000000007FFFFFFF, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal((ulong)0x0000000080000000, result);
 
-                Assert.True(NumberHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<ulong>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal((ulong)0x00000000FFFFFFFF, result);
             }
         }
@@ -1242,12 +1242,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Equal(expected, NumberHelper<ulong>.Parse(value, style, provider));
+                Assert.Equal(expected, NumberBaseHelper<ulong>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.True(NumberHelper<ulong>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.True(NumberBaseHelper<ulong>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(expected, result);
-                Assert.Equal(expected, NumberHelper<ulong>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Equal(expected, NumberBaseHelper<ulong>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1257,9 +1257,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.True(NumberHelper<ulong>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
-            Assert.Equal(expected, NumberHelper<ulong>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<ulong>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1279,12 +1279,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<ulong>.Parse(value, style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<ulong>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.False(NumberHelper<ulong>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.False(NumberBaseHelper<ulong>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(default(ulong), result);
-                Assert.Throws(exceptionType, () => NumberHelper<ulong>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<ulong>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1294,9 +1294,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.False(NumberHelper<ulong>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<ulong>.TryParse(value, style, provider, out result));
             Assert.Equal(default(ulong), result);
-            Assert.Throws(exceptionType, () => NumberHelper<ulong>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<ulong>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1312,9 +1312,9 @@ namespace System.Tests
                 Assert.Equal(expected, result);
             }
 
-            Assert.Equal(expected, NumberHelper<ulong>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<ulong>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<ulong>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<ulong>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -1336,9 +1336,9 @@ namespace System.Tests
                 Assert.Equal(default(ulong), result);
             }
 
-            Assert.Throws(exceptionType, () => NumberHelper<ulong>.Parse(value.AsSpan(), style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<ulong>.Parse(value.AsSpan(), style, provider));
 
-            Assert.False(NumberHelper<ulong>.TryParse(value.AsSpan(), style, provider, out result));
+            Assert.False(NumberBaseHelper<ulong>.TryParse(value.AsSpan(), style, provider, out result));
             Assert.Equal(default(ulong), result);
         }
     }

--- a/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
@@ -685,19 +685,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.Abs(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Abs(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.Abs(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.Abs(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.Abs(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.Abs((nuint)0x00000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Abs((nuint)0x00000001));
-                Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.Abs((nuint)0x7FFFFFFF));
-                Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.Abs((nuint)0x80000000));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.Abs((nuint)0xFFFFFFFF));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.Abs((nuint)0x00000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.Abs((nuint)0x00000001));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.Abs((nuint)0x7FFFFFFF));
+                Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.Abs((nuint)0x80000000));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.Abs((nuint)0xFFFFFFFF));
             }
         }
 
@@ -725,41 +725,41 @@ namespace System.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateChecked<byte>(0x00));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateChecked<byte>(0x01));
-            Assert.Equal((nuint)0x0000007F, NumberHelper<nuint>.CreateChecked<byte>(0x7F));
-            Assert.Equal((nuint)0x00000080, NumberHelper<nuint>.CreateChecked<byte>(0x80));
-            Assert.Equal((nuint)0x000000FF, NumberHelper<nuint>.CreateChecked<byte>(0xFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<byte>(0x00));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<byte>(0x01));
+            Assert.Equal((nuint)0x0000007F, NumberBaseHelper<nuint>.CreateChecked<byte>(0x7F));
+            Assert.Equal((nuint)0x00000080, NumberBaseHelper<nuint>.CreateChecked<byte>(0x80));
+            Assert.Equal((nuint)0x000000FF, NumberBaseHelper<nuint>.CreateChecked<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateChecked<char>((char)0x0000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateChecked<char>((char)0x0001));
-            Assert.Equal((nuint)0x00007FFF, NumberHelper<nuint>.CreateChecked<char>((char)0x7FFF));
-            Assert.Equal((nuint)0x00008000, NumberHelper<nuint>.CreateChecked<char>((char)0x8000));
-            Assert.Equal((nuint)0x0000FFFF, NumberHelper<nuint>.CreateChecked<char>((char)0xFFFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<char>((char)0x0000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<char>((char)0x0001));
+            Assert.Equal((nuint)0x00007FFF, NumberBaseHelper<nuint>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal((nuint)0x00008000, NumberBaseHelper<nuint>.CreateChecked<char>((char)0x8000));
+            Assert.Equal((nuint)0x0000FFFF, NumberBaseHelper<nuint>.CreateChecked<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateChecked<short>(0x0000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateChecked<short>(0x0001));
-            Assert.Equal((nuint)0x00007FFF, NumberHelper<nuint>.CreateChecked<short>(0x7FFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<short>(unchecked((short)0x8000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<short>(0x0000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<short>(0x0001));
+            Assert.Equal((nuint)0x00007FFF, NumberBaseHelper<nuint>.CreateChecked<short>(0x7FFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateChecked<int>(0x00000000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateChecked<int>(0x00000001));
-            Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateChecked<int>(0x7FFFFFFF));
-            Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<int>(unchecked((int)0x80000000)));
-            Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<int>(0x00000000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<int>(0x00000001));
+            Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
@@ -767,19 +767,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateChecked<long>(0x0000000000000000));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateChecked<long>(0x0000000000000001));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateChecked<long>(0x0000000000000000));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateChecked<long>(0x0000000000000001));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateChecked<long>(0x0000000000000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateChecked<long>(0x0000000000000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<long>(0x0000000000000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<long>(0x0000000000000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<long>(unchecked((long)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
         }
 
@@ -788,50 +788,50 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateChecked<nint>((nint)0x00000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateChecked<nint>((nint)0x00000001));
-                Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateChecked<nint>((nint)0x7FFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<nint>(unchecked((nint)0x80000000)));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateChecked<sbyte>(0x00));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateChecked<sbyte>(0x01));
-            Assert.Equal((nuint)0x0000007F, NumberHelper<nuint>.CreateChecked<sbyte>(0x7F));
-            Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<sbyte>(0x00));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<sbyte>(0x01));
+            Assert.Equal((nuint)0x0000007F, NumberBaseHelper<nuint>.CreateChecked<sbyte>(0x7F));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateChecked<ushort>(0x0000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateChecked<ushort>(0x0001));
-            Assert.Equal((nuint)0x00007FFF, NumberHelper<nuint>.CreateChecked<ushort>(0x7FFF));
-            Assert.Equal((nuint)0x00008000, NumberHelper<nuint>.CreateChecked<ushort>(0x8000));
-            Assert.Equal((nuint)0x0000FFFF, NumberHelper<nuint>.CreateChecked<ushort>(0xFFFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<ushort>(0x0000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<ushort>(0x0001));
+            Assert.Equal((nuint)0x00007FFF, NumberBaseHelper<nuint>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal((nuint)0x00008000, NumberBaseHelper<nuint>.CreateChecked<ushort>(0x8000));
+            Assert.Equal((nuint)0x0000FFFF, NumberBaseHelper<nuint>.CreateChecked<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateChecked<uint>(0x00000000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateChecked<uint>(0x00000001));
-            Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateChecked<uint>(0x7FFFFFFF));
-            Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.CreateChecked<uint>(0x80000000));
-            Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateChecked<uint>(0xFFFFFFFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<uint>(0x00000000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<uint>(0x00000001));
+            Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.CreateChecked<uint>(0x80000000));
+            Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateChecked<uint>(0xFFFFFFFF));
         }
 
         [Fact]
@@ -839,19 +839,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateChecked<ulong>(0x0000000000000000));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateChecked<ulong>(0x0000000000000001));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.CreateChecked<ulong>(0x8000000000000000));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateChecked<ulong>(0x0000000000000000));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateChecked<ulong>(0x0000000000000001));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.CreateChecked<ulong>(0x8000000000000000));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateChecked<ulong>(0x0000000000000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateChecked<ulong>(0x0000000000000001));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<ulong>(0x8000000000000000));
-                Assert.Throws<OverflowException>(() => NumberHelper<nuint>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<ulong>(0x0000000000000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<ulong>(0x0000000000000001));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<ulong>(0x8000000000000000));
+                Assert.Throws<OverflowException>(() => NumberBaseHelper<nuint>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
             }
         }
 
@@ -860,60 +860,60 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateChecked<nuint>((nuint)0x00000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateChecked<nuint>((nuint)0x00000001));
-                Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.CreateChecked<nuint>((nuint)0x80000000));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<byte>(0x00));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateSaturating<byte>(0x01));
-            Assert.Equal((nuint)0x0000007F, NumberHelper<nuint>.CreateSaturating<byte>(0x7F));
-            Assert.Equal((nuint)0x00000080, NumberHelper<nuint>.CreateSaturating<byte>(0x80));
-            Assert.Equal((nuint)0x000000FF, NumberHelper<nuint>.CreateSaturating<byte>(0xFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<byte>(0x00));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<byte>(0x01));
+            Assert.Equal((nuint)0x0000007F, NumberBaseHelper<nuint>.CreateSaturating<byte>(0x7F));
+            Assert.Equal((nuint)0x00000080, NumberBaseHelper<nuint>.CreateSaturating<byte>(0x80));
+            Assert.Equal((nuint)0x000000FF, NumberBaseHelper<nuint>.CreateSaturating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<char>((char)0x0000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateSaturating<char>((char)0x0001));
-            Assert.Equal((nuint)0x00007FFF, NumberHelper<nuint>.CreateSaturating<char>((char)0x7FFF));
-            Assert.Equal((nuint)0x00008000, NumberHelper<nuint>.CreateSaturating<char>((char)0x8000));
-            Assert.Equal((nuint)0x0000FFFF, NumberHelper<nuint>.CreateSaturating<char>((char)0xFFFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal((nuint)0x00007FFF, NumberBaseHelper<nuint>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal((nuint)0x00008000, NumberBaseHelper<nuint>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal((nuint)0x0000FFFF, NumberBaseHelper<nuint>.CreateSaturating<char>((char)0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<short>(0x0000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateSaturating<short>(0x0001));
-            Assert.Equal((nuint)0x00007FFF, NumberHelper<nuint>.CreateSaturating<short>(0x7FFF));
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<short>(unchecked((short)0x8000)));
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<short>(0x0000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<short>(0x0001));
+            Assert.Equal((nuint)0x00007FFF, NumberBaseHelper<nuint>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<short>(unchecked((short)0xFFFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<int>(0x00000000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateSaturating<int>(0x00000001));
-            Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateSaturating<int>(0x7FFFFFFF));
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<int>(unchecked((int)0x80000000)));
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<int>(0x00000000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<int>(0x00000001));
+            Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
@@ -921,19 +921,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateSaturating<long>(0x0000000000000000));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateSaturating<long>(0x0000000000000001));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateSaturating<long>(0x0000000000000000));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateSaturating<long>(0x0000000000000001));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<long>(0x0000000000000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateSaturating<long>(0x0000000000000001));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<long>(0x0000000000000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<long>(0x0000000000000001));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<long>(unchecked((long)0x8000000000000000)));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
         }
 
@@ -942,50 +942,50 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<nint>((nint)0x00000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateSaturating<nint>((nint)0x00000001));
-                Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateSaturating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<sbyte>(0x00));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateSaturating<sbyte>(0x01));
-            Assert.Equal((nuint)0x0000007F, NumberHelper<nuint>.CreateSaturating<sbyte>(0x7F));
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal((nuint)0x0000007F, NumberBaseHelper<nuint>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<ushort>(0x0000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateSaturating<ushort>(0x0001));
-            Assert.Equal((nuint)0x00007FFF, NumberHelper<nuint>.CreateSaturating<ushort>(0x7FFF));
-            Assert.Equal((nuint)0x00008000, NumberHelper<nuint>.CreateSaturating<ushort>(0x8000));
-            Assert.Equal((nuint)0x0000FFFF, NumberHelper<nuint>.CreateSaturating<ushort>(0xFFFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal((nuint)0x00007FFF, NumberBaseHelper<nuint>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal((nuint)0x00008000, NumberBaseHelper<nuint>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal((nuint)0x0000FFFF, NumberBaseHelper<nuint>.CreateSaturating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<uint>(0x00000000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateSaturating<uint>(0x00000001));
-            Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateSaturating<uint>(0x7FFFFFFF));
-            Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.CreateSaturating<uint>(0x80000000));
-            Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateSaturating<uint>(0xFFFFFFFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateSaturating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
@@ -993,19 +993,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateSaturating<ulong>(0x0000000000000000));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateSaturating<ulong>(0x0000000000000001));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.CreateSaturating<ulong>(0x8000000000000000));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateSaturating<ulong>(0x0000000000000000));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateSaturating<ulong>(0x0000000000000001));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.CreateSaturating<ulong>(0x8000000000000000));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<ulong>(0x0000000000000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateSaturating<ulong>(0x0000000000000001));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateSaturating<ulong>(0x8000000000000000));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<ulong>(0x0000000000000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<ulong>(0x0000000000000001));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateSaturating<ulong>(0x8000000000000000));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
         }
 
@@ -1014,40 +1014,40 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateSaturating<nuint>((nuint)0x00000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateSaturating<nuint>((nuint)0x00000001));
-                Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.CreateSaturating<nuint>((nuint)0x80000000));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<byte>(0x00));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateTruncating<byte>(0x01));
-            Assert.Equal((nuint)0x0000007F, NumberHelper<nuint>.CreateTruncating<byte>(0x7F));
-            Assert.Equal((nuint)0x00000080, NumberHelper<nuint>.CreateTruncating<byte>(0x80));
-            Assert.Equal((nuint)0x000000FF, NumberHelper<nuint>.CreateTruncating<byte>(0xFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<byte>(0x00));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateTruncating<byte>(0x01));
+            Assert.Equal((nuint)0x0000007F, NumberBaseHelper<nuint>.CreateTruncating<byte>(0x7F));
+            Assert.Equal((nuint)0x00000080, NumberBaseHelper<nuint>.CreateTruncating<byte>(0x80));
+            Assert.Equal((nuint)0x000000FF, NumberBaseHelper<nuint>.CreateTruncating<byte>(0xFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<char>((char)0x0000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateTruncating<char>((char)0x0001));
-            Assert.Equal((nuint)0x00007FFF, NumberHelper<nuint>.CreateTruncating<char>((char)0x7FFF));
-            Assert.Equal((nuint)0x00008000, NumberHelper<nuint>.CreateTruncating<char>((char)0x8000));
-            Assert.Equal((nuint)0x0000FFFF, NumberHelper<nuint>.CreateTruncating<char>((char)0xFFFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal((nuint)0x00007FFF, NumberBaseHelper<nuint>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal((nuint)0x00008000, NumberBaseHelper<nuint>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal((nuint)0x0000FFFF, NumberBaseHelper<nuint>.CreateTruncating<char>((char)0xFFFF));
         }
 
         [Fact]
@@ -1055,19 +1055,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateTruncating<short>(0x0000));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateTruncating<short>(0x0001));
-                Assert.Equal(unchecked((nuint)0x0000000000007FFF), NumberHelper<nuint>.CreateTruncating<short>(0x7FFF));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFF8000), NumberHelper<nuint>.CreateTruncating<short>(unchecked((short)0x8000)));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateTruncating<short>(0x0000));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateTruncating<short>(0x0001));
+                Assert.Equal(unchecked((nuint)0x0000000000007FFF), NumberBaseHelper<nuint>.CreateTruncating<short>(0x7FFF));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFF8000), NumberBaseHelper<nuint>.CreateTruncating<short>(unchecked((short)0x8000)));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<short>(unchecked((short)0xFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<short>(0x0000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateTruncating<short>(0x0001));
-                Assert.Equal((nuint)0x00007FFF, NumberHelper<nuint>.CreateTruncating<short>(0x7FFF));
-                Assert.Equal((nuint)0xFFFF8000, NumberHelper<nuint>.CreateTruncating<short>(unchecked((short)0x8000)));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<short>(0x0000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateTruncating<short>(0x0001));
+                Assert.Equal((nuint)0x00007FFF, NumberBaseHelper<nuint>.CreateTruncating<short>(0x7FFF));
+                Assert.Equal((nuint)0xFFFF8000, NumberBaseHelper<nuint>.CreateTruncating<short>(unchecked((short)0x8000)));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<short>(unchecked((short)0xFFFF)));
             }
         }
 
@@ -1076,19 +1076,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateTruncating<int>(0x00000000));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateTruncating<int>(0x00000001));
-                Assert.Equal(unchecked((nuint)0x000000007FFFFFFF), NumberHelper<nuint>.CreateTruncating<int>(0x7FFFFFFF));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFF80000000), NumberHelper<nuint>.CreateTruncating<int>(unchecked((int)0x80000000)));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateTruncating<int>(0x00000000));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateTruncating<int>(0x00000001));
+                Assert.Equal(unchecked((nuint)0x000000007FFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<int>(0x7FFFFFFF));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFF80000000), NumberBaseHelper<nuint>.CreateTruncating<int>(unchecked((int)0x80000000)));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<int>(0x00000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateTruncating<int>(0x00000001));
-                Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateTruncating<int>(0x7FFFFFFF));
-                Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.CreateTruncating<int>(unchecked((int)0x80000000)));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<int>(0x00000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateTruncating<int>(0x00000001));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<int>(0x7FFFFFFF));
+                Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.CreateTruncating<int>(unchecked((int)0x80000000)));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
             }
         }
 
@@ -1097,19 +1097,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateTruncating<long>(0x0000000000000000));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateTruncating<long>(0x0000000000000001));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateTruncating<long>(0x0000000000000000));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateTruncating<long>(0x0000000000000001));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<long>(0x0000000000000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateTruncating<long>(0x0000000000000001));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<long>(0x0000000000000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateTruncating<long>(0x0000000000000001));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<long>(unchecked((long)0x8000000000000000)));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<long>(unchecked((long)0xFFFFFFFFFFFFFFFF)));
             }
         }
 
@@ -1118,19 +1118,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<nint>((nint)0x00000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateTruncating<nint>((nint)0x00000001));
-                Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateTruncating<nint>((nint)0x7FFFFFFF));
-                Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
@@ -1139,40 +1139,40 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateTruncating<sbyte>(0x00));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateTruncating<sbyte>(0x01));
-                Assert.Equal(unchecked((nuint)0x000000000000007F), NumberHelper<nuint>.CreateTruncating<sbyte>(0x7F));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFF80), NumberHelper<nuint>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateTruncating<sbyte>(0x00));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateTruncating<sbyte>(0x01));
+                Assert.Equal(unchecked((nuint)0x000000000000007F), NumberBaseHelper<nuint>.CreateTruncating<sbyte>(0x7F));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFF80), NumberBaseHelper<nuint>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<sbyte>(0x00));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateTruncating<sbyte>(0x01));
-                Assert.Equal((nuint)0x0000007F, NumberHelper<nuint>.CreateTruncating<sbyte>(0x7F));
-                Assert.Equal((nuint)0xFFFFFF80, NumberHelper<nuint>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<sbyte>(0x00));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateTruncating<sbyte>(0x01));
+                Assert.Equal((nuint)0x0000007F, NumberBaseHelper<nuint>.CreateTruncating<sbyte>(0x7F));
+                Assert.Equal((nuint)0xFFFFFF80, NumberBaseHelper<nuint>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
             }
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<ushort>(0x0000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateTruncating<ushort>(0x0001));
-            Assert.Equal((nuint)0x00007FFF, NumberHelper<nuint>.CreateTruncating<ushort>(0x7FFF));
-            Assert.Equal((nuint)0x00008000, NumberHelper<nuint>.CreateTruncating<ushort>(0x8000));
-            Assert.Equal((nuint)0x0000FFFF, NumberHelper<nuint>.CreateTruncating<ushort>(0xFFFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal((nuint)0x00007FFF, NumberBaseHelper<nuint>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal((nuint)0x00008000, NumberBaseHelper<nuint>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal((nuint)0x0000FFFF, NumberBaseHelper<nuint>.CreateTruncating<ushort>(0xFFFF));
         }
 
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<uint>(0x00000000));
-            Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateTruncating<uint>(0x00000001));
-            Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateTruncating<uint>(0x7FFFFFFF));
-            Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.CreateTruncating<uint>(0x80000000));
-            Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateTruncating<uint>(0xFFFFFFFF));
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<uint>(0xFFFFFFFF));
         }
 
         [Fact]
@@ -1180,19 +1180,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateTruncating<ulong>(0x0000000000000000));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateTruncating<ulong>(0x0000000000000001));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.CreateTruncating<ulong>(0x8000000000000000));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateTruncating<ulong>(0x0000000000000000));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateTruncating<ulong>(0x0000000000000001));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.CreateTruncating<ulong>(0x8000000000000000));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<ulong>(0x0000000000000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateTruncating<ulong>(0x0000000000000001));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<ulong>(0x8000000000000000));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<ulong>(0x0000000000000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateTruncating<ulong>(0x0000000000000001));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<ulong>(0x8000000000000000));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
             }
         }
 
@@ -1201,19 +1201,19 @@ namespace System.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.CreateTruncating<nuint>((nuint)0x00000000));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.CreateTruncating<nuint>((nuint)0x00000001));
-                Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
-                Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.CreateTruncating<nuint>((nuint)0x80000000));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
             }
         }
 
@@ -1306,19 +1306,19 @@ namespace System.Tests
         {
             nuint result;
 
-            Assert.True(NumberHelper<nuint>.TryCreate<byte>(0x00, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<byte>(0x00, out result));
             Assert.Equal((nuint)0x00000000, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<byte>(0x01, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<byte>(0x01, out result));
             Assert.Equal((nuint)0x00000001, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<byte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((nuint)0x0000007F, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<byte>(0x80, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<byte>(0x80, out result));
             Assert.Equal((nuint)0x00000080, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<byte>(0xFF, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<byte>(0xFF, out result));
             Assert.Equal((nuint)0x000000FF, result);
         }
 
@@ -1327,19 +1327,19 @@ namespace System.Tests
         {
             nuint result;
 
-            Assert.True(NumberHelper<nuint>.TryCreate<char>((char)0x0000, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<char>((char)0x0000, out result));
             Assert.Equal((nuint)0x00000000, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<char>((char)0x0001, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<char>((char)0x0001, out result));
             Assert.Equal((nuint)0x00000001, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((nuint)0x00007FFF, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<char>((char)0x8000, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<char>((char)0x8000, out result));
             Assert.Equal((nuint)0x00008000, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<char>((char)0xFFFF, out result));
             Assert.Equal((nuint)0x0000FFFF, result);
         }
 
@@ -1348,19 +1348,19 @@ namespace System.Tests
         {
             nuint result;
 
-            Assert.True(NumberHelper<nuint>.TryCreate<short>(0x0000, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<short>(0x0000, out result));
             Assert.Equal((nuint)0x00000000, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<short>(0x0001, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<short>(0x0001, out result));
             Assert.Equal((nuint)0x00000001, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<short>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((nuint)0x00007FFF, result);
 
-            Assert.False(NumberHelper<nuint>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.False(NumberBaseHelper<nuint>.TryCreate<short>(unchecked((short)0x8000), out result));
             Assert.Equal((nuint)0x00000000, result);
 
-            Assert.False(NumberHelper<nuint>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.False(NumberBaseHelper<nuint>.TryCreate<short>(unchecked((short)0xFFFF), out result));
             Assert.Equal((nuint)0x00000000, result);
         }
 
@@ -1369,19 +1369,19 @@ namespace System.Tests
         {
             nuint result;
 
-            Assert.True(NumberHelper<nuint>.TryCreate<int>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<int>(0x00000000, out result));
             Assert.Equal((nuint)0x00000000, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<int>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<int>(0x00000001, out result));
             Assert.Equal((nuint)0x00000001, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<int>(0x7FFFFFFF, out result));
             Assert.Equal((nuint)0x7FFFFFFF, result);
 
-            Assert.False(NumberHelper<nuint>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.False(NumberBaseHelper<nuint>.TryCreate<int>(unchecked((int)0x80000000), out result));
             Assert.Equal((nuint)0x00000000, result);
 
-            Assert.False(NumberHelper<nuint>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.False(NumberBaseHelper<nuint>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal((nuint)0x00000000, result);
         }
 
@@ -1392,36 +1392,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<nuint>.TryCreate<long>(0x0000000000000000, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<long>(0x0000000000000000, out result));
                 Assert.Equal(unchecked((nuint)0x0000000000000000), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<long>(0x0000000000000001, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<long>(0x0000000000000001, out result));
                 Assert.Equal(unchecked((nuint)0x0000000000000001), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
                 Assert.Equal(unchecked((nuint)0x0000000000000000), result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((nuint)0x0000000000000000), result);
             }
             else
             {
-                Assert.True(NumberHelper<nuint>.TryCreate<long>(0x0000000000000000, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<long>(0x0000000000000000, out result));
                 Assert.Equal((nuint)0x00000000, result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<long>(0x0000000000000001, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<long>(0x0000000000000001, out result));
                 Assert.Equal((nuint)0x00000001, result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal((nuint)0x00000000, result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<long>(unchecked((long)0x8000000000000000), out result));
                 Assert.Equal((nuint)0x00000000, result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<long>(unchecked((long)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal((nuint)0x00000000, result);
             }
         }
@@ -1433,36 +1433,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<nuint>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
                 Assert.Equal(unchecked((nuint)0x0000000000000000), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
                 Assert.Equal(unchecked((nuint)0x0000000000000001), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
                 Assert.Equal(unchecked((nuint)0x0000000000000000), result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((nuint)0x0000000000000000), result);
             }
             else
             {
-                Assert.True(NumberHelper<nuint>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nint>((nint)0x00000000, out result));
                 Assert.Equal((nuint)0x00000000, result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nint>((nint)0x00000001, out result));
                 Assert.Equal((nuint)0x00000001, result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((nuint)0x7FFFFFFF, result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
                 Assert.Equal((nuint)0x00000000, result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
                 Assert.Equal((nuint)0x00000000, result);
             }
         }
@@ -1472,19 +1472,19 @@ namespace System.Tests
         {
             nuint result;
 
-            Assert.True(NumberHelper<nuint>.TryCreate<sbyte>(0x00, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<sbyte>(0x00, out result));
             Assert.Equal((nuint)0x00000000, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<sbyte>(0x01, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<sbyte>(0x01, out result));
             Assert.Equal((nuint)0x00000001, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<sbyte>(0x7F, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((nuint)0x0000007F, result);
 
-            Assert.False(NumberHelper<nuint>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.False(NumberBaseHelper<nuint>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
             Assert.Equal((nuint)0x00000000, result);
 
-            Assert.False(NumberHelper<nuint>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.False(NumberBaseHelper<nuint>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
             Assert.Equal((nuint)0x00000000, result);
         }
 
@@ -1493,19 +1493,19 @@ namespace System.Tests
         {
             nuint result;
 
-            Assert.True(NumberHelper<nuint>.TryCreate<ushort>(0x0000, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<ushort>(0x0000, out result));
             Assert.Equal((nuint)0x00000000, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<ushort>(0x0001, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<ushort>(0x0001, out result));
             Assert.Equal((nuint)0x00000001, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((nuint)0x00007FFF, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<ushort>(0x8000, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<ushort>(0x8000, out result));
             Assert.Equal((nuint)0x00008000, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<ushort>(0xFFFF, out result));
             Assert.Equal((nuint)0x0000FFFF, result);
         }
 
@@ -1514,19 +1514,19 @@ namespace System.Tests
         {
             nuint result;
 
-            Assert.True(NumberHelper<nuint>.TryCreate<uint>(0x00000000, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<uint>(0x00000000, out result));
             Assert.Equal((nuint)0x00000000, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<uint>(0x00000001, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<uint>(0x00000001, out result));
             Assert.Equal((nuint)0x00000001, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<uint>(0x7FFFFFFF, out result));
             Assert.Equal((nuint)0x7FFFFFFF, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<uint>(0x80000000, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<uint>(0x80000000, out result));
             Assert.Equal((nuint)0x80000000, result);
 
-            Assert.True(NumberHelper<nuint>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryCreate<uint>(0xFFFFFFFF, out result));
             Assert.Equal((nuint)0xFFFFFFFF, result);
         }
 
@@ -1537,36 +1537,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<nuint>.TryCreate<ulong>(0x0000000000000000, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<ulong>(0x0000000000000000, out result));
                 Assert.Equal(unchecked((nuint)0x0000000000000000), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<ulong>(0x0000000000000001, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<ulong>(0x0000000000000001, out result));
                 Assert.Equal(unchecked((nuint)0x00000000000000001), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<ulong>(0x8000000000000000, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<ulong>(0x8000000000000000, out result));
                 Assert.Equal(unchecked((nuint)0x8000000000000000), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
                 Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), result);
             }
             else
             {
-                Assert.True(NumberHelper<nuint>.TryCreate<ulong>(0x0000000000000000, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<ulong>(0x0000000000000000, out result));
                 Assert.Equal((nuint)0x00000000, result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<ulong>(0x0000000000000001, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<ulong>(0x0000000000000001, out result));
                 Assert.Equal((nuint)0x00000001, result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
                 Assert.Equal((nuint)0x00000000, result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<ulong>(0x8000000000000000, out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<ulong>(0x8000000000000000, out result));
                 Assert.Equal((nuint)0x00000000, result);
 
-                Assert.False(NumberHelper<nuint>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+                Assert.False(NumberBaseHelper<nuint>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
                 Assert.Equal((nuint)0x00000000, result);
             }
         }
@@ -1578,36 +1578,36 @@ namespace System.Tests
 
             if (Environment.Is64BitProcess)
             {
-                Assert.True(NumberHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
                 Assert.Equal(unchecked((nuint)0x0000000000000000), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
                 Assert.Equal(unchecked((nuint)0x0000000000000001), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
                 Assert.Equal(unchecked((nuint)0x8000000000000000), result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
                 Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), result);
             }
             else
             {
-                Assert.True(NumberHelper<nuint>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nuint>((nuint)0x00000000, out result));
                 Assert.Equal((nuint)0x00000000, result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nuint>((nuint)0x00000001, out result));
                 Assert.Equal((nuint)0x00000001, result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((nuint)0x7FFFFFFF, result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
                 Assert.Equal((nuint)0x80000000, result);
 
-                Assert.True(NumberHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.True(NumberBaseHelper<nuint>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
                 Assert.Equal((nuint)0xFFFFFFFF, result);
             }
         }
@@ -1948,12 +1948,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Equal(expected, NumberHelper<nuint>.Parse(value, style, provider));
+                Assert.Equal(expected, NumberBaseHelper<nuint>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.True(NumberHelper<nuint>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.True(NumberBaseHelper<nuint>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(expected, result);
-                Assert.Equal(expected, NumberHelper<nuint>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Equal(expected, NumberBaseHelper<nuint>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -1963,9 +1963,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.True(NumberHelper<nuint>.TryParse(value, style, provider, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryParse(value, style, provider, out result));
             Assert.Equal(expected, result);
-            Assert.Equal(expected, NumberHelper<nuint>.Parse(value, style, provider));
+            Assert.Equal(expected, NumberBaseHelper<nuint>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -1985,12 +1985,12 @@ namespace System.Tests
             // Default provider
             if (provider is null)
             {
-                Assert.Throws(exceptionType, () => NumberHelper<nuint>.Parse(value, style, provider));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<nuint>.Parse(value, style, provider));
 
                 // Substitute default NumberFormatInfo
-                Assert.False(NumberHelper<nuint>.TryParse(value, style, new NumberFormatInfo(), out result));
+                Assert.False(NumberBaseHelper<nuint>.TryParse(value, style, new NumberFormatInfo(), out result));
                 Assert.Equal(default(nuint), result);
-                Assert.Throws(exceptionType, () => NumberHelper<nuint>.Parse(value, style, new NumberFormatInfo()));
+                Assert.Throws(exceptionType, () => NumberBaseHelper<nuint>.Parse(value, style, new NumberFormatInfo()));
             }
 
             // Default style
@@ -2000,9 +2000,9 @@ namespace System.Tests
             }
 
             // Full overloads
-            Assert.False(NumberHelper<nuint>.TryParse(value, style, provider, out result));
+            Assert.False(NumberBaseHelper<nuint>.TryParse(value, style, provider, out result));
             Assert.Equal(default(nuint), result);
-            Assert.Throws(exceptionType, () => NumberHelper<nuint>.Parse(value, style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<nuint>.Parse(value, style, provider));
         }
 
         [Theory]
@@ -2018,9 +2018,9 @@ namespace System.Tests
                 Assert.Equal(expected, result);
             }
 
-            Assert.Equal(expected, NumberHelper<nuint>.Parse(value.AsSpan(offset, count), style, provider));
+            Assert.Equal(expected, NumberBaseHelper<nuint>.Parse(value.AsSpan(offset, count), style, provider));
 
-            Assert.True(NumberHelper<nuint>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.True(NumberBaseHelper<nuint>.TryParse(value.AsSpan(offset, count), style, provider, out result));
             Assert.Equal(expected, result);
         }
 
@@ -2042,9 +2042,9 @@ namespace System.Tests
                 Assert.Equal(default(nuint), result);
             }
 
-            Assert.Throws(exceptionType, () => NumberHelper<nuint>.Parse(value.AsSpan(), style, provider));
+            Assert.Throws(exceptionType, () => NumberBaseHelper<nuint>.Parse(value.AsSpan(), style, provider));
 
-            Assert.False(NumberHelper<nuint>.TryParse(value.AsSpan(), style, provider, out result));
+            Assert.False(NumberBaseHelper<nuint>.TryParse(value.AsSpan(), style, provider, out result));
             Assert.Equal(default(nuint), result);
         }
     }

--- a/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
@@ -939,6 +939,27 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void MaxNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.MaxNumber(unchecked((nuint)0x0000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.MaxNumber(unchecked((nuint)0x0000000000000001), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.MaxNumber(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.MaxNumber(unchecked((nuint)0x8000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.MaxNumber(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
+            }
+            else
+            {
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.MaxNumber((nuint)0x00000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.MaxNumber((nuint)0x00000001, (nuint)1));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.MaxNumber((nuint)0x7FFFFFFF, (nuint)1));
+                Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.MaxNumber((nuint)0x80000000, (nuint)1));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.MaxNumber((nuint)0xFFFFFFFF, (nuint)1));
+            }
+        }
+
+        [Fact]
         public static void MinTest()
         {
             if (Environment.Is64BitProcess)
@@ -956,6 +977,27 @@ namespace System.Tests
                 Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Min((nuint)0x7FFFFFFF, (nuint)1));
                 Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Min((nuint)0x80000000, (nuint)1));
                 Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Min((nuint)0xFFFFFFFF, (nuint)1));
+            }
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.MinNumber(unchecked((nuint)0x0000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.MinNumber(unchecked((nuint)0x0000000000000001), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.MinNumber(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.MinNumber(unchecked((nuint)0x8000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.MinNumber(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
+            }
+            else
+            {
+                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.MinNumber((nuint)0x00000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.MinNumber((nuint)0x00000001, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.MinNumber((nuint)0x7FFFFFFF, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.MinNumber((nuint)0x80000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.MinNumber((nuint)0xFFFFFFFF, (nuint)1));
             }
         }
 
@@ -1038,7 +1080,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateCheckedFromInt16Test()
+        public static void CreateCheckedFroMinMagnitudet16Test()
         {
             Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<short>(0x0000));
             Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<short>(0x0001));
@@ -1048,7 +1090,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateCheckedFromInt32Test()
+        public static void CreateCheckedFroMinMagnitudet32Test()
         {
             Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateChecked<int>(0x00000000));
             Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateChecked<int>(0x00000001));
@@ -1058,7 +1100,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateCheckedFromInt64Test()
+        public static void CreateCheckedFroMinMagnitudet64Test()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1079,7 +1121,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateCheckedFromIntPtrTest()
+        public static void CreateCheckedFroMinMagnitudetPtrTest()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1192,7 +1234,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateSaturatingFromInt16Test()
+        public static void CreateSaturatingFroMinMagnitudet16Test()
         {
             Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<short>(0x0000));
             Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<short>(0x0001));
@@ -1202,7 +1244,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateSaturatingFromInt32Test()
+        public static void CreateSaturatingFroMinMagnitudet32Test()
         {
             Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.CreateSaturating<int>(0x00000000));
             Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.CreateSaturating<int>(0x00000001));
@@ -1212,7 +1254,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateSaturatingFromInt64Test()
+        public static void CreateSaturatingFroMinMagnitudet64Test()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1233,7 +1275,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateSaturatingFromIntPtrTest()
+        public static void CreateSaturatingFroMinMagnitudetPtrTest()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1346,7 +1388,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateTruncatingFromInt16Test()
+        public static void CreateTruncatingFroMinMagnitudet16Test()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1367,7 +1409,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateTruncatingFromInt32Test()
+        public static void CreateTruncatingFroMinMagnitudet32Test()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1388,7 +1430,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateTruncatingFromInt64Test()
+        public static void CreateTruncatingFroMinMagnitudet64Test()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1409,7 +1451,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CreateTruncatingFromIntPtrTest()
+        public static void CreateTruncatingFroMinMagnitudetPtrTest()
         {
             if (Environment.Is64BitProcess)
             {
@@ -1513,6 +1555,258 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsFiniteTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsFinite(unchecked((nuint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsFinite(unchecked((nuint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nuint>.IsFinite(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nuint>.IsFinite(unchecked((nuint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsFinite(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsFinite((nuint)0x00000000));
+                Assert.True(NumberBaseHelper<nuint>.IsFinite((nuint)0x00000001));
+                Assert.True(NumberBaseHelper<nuint>.IsFinite((nuint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nuint>.IsFinite((nuint)0x80000000));
+                Assert.True(NumberBaseHelper<nuint>.IsFinite((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsInfinity(unchecked((nuint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsInfinity(unchecked((nuint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nuint>.IsInfinity(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nuint>.IsInfinity(unchecked((nuint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsInfinity(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsInfinity((nuint)0x00000000));
+                Assert.False(NumberBaseHelper<nuint>.IsInfinity((nuint)0x00000001));
+                Assert.False(NumberBaseHelper<nuint>.IsInfinity((nuint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nuint>.IsInfinity((nuint)0x80000000));
+                Assert.False(NumberBaseHelper<nuint>.IsInfinity((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsNaN(unchecked((nuint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsNaN(unchecked((nuint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nuint>.IsNaN(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nuint>.IsNaN(unchecked((nuint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsNaN(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsNaN((nuint)0x00000000));
+                Assert.False(NumberBaseHelper<nuint>.IsNaN((nuint)0x00000001));
+                Assert.False(NumberBaseHelper<nuint>.IsNaN((nuint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nuint>.IsNaN((nuint)0x80000000));
+                Assert.False(NumberBaseHelper<nuint>.IsNaN((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsNegative(unchecked((nuint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsNegative(unchecked((nuint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nuint>.IsNegative(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nuint>.IsNegative(unchecked((nuint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsNegative(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsNegative((nuint)0x00000000));
+                Assert.False(NumberBaseHelper<nuint>.IsNegative((nuint)0x00000001));
+                Assert.False(NumberBaseHelper<nuint>.IsNegative((nuint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nuint>.IsNegative((nuint)0x80000000));
+                Assert.False(NumberBaseHelper<nuint>.IsNegative((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsNegativeInfinity(unchecked((nuint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsNegativeInfinity(unchecked((nuint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nuint>.IsNegativeInfinity(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nuint>.IsNegativeInfinity(unchecked((nuint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsNegativeInfinity(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsNegativeInfinity((nuint)0x00000000));
+                Assert.False(NumberBaseHelper<nuint>.IsNegativeInfinity((nuint)0x00000001));
+                Assert.False(NumberBaseHelper<nuint>.IsNegativeInfinity((nuint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nuint>.IsNegativeInfinity((nuint)0x80000000));
+                Assert.False(NumberBaseHelper<nuint>.IsNegativeInfinity((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsNormal(unchecked((nuint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsNormal(unchecked((nuint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nuint>.IsNormal(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nuint>.IsNormal(unchecked((nuint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsNormal(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsNormal((nuint)0x00000000));
+                Assert.True(NumberBaseHelper<nuint>.IsNormal((nuint)0x00000001));
+                Assert.True(NumberBaseHelper<nuint>.IsNormal((nuint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nuint>.IsNormal((nuint)0x80000000));
+                Assert.True(NumberBaseHelper<nuint>.IsNormal((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsPositiveInfinity(unchecked((nuint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsPositiveInfinity(unchecked((nuint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nuint>.IsPositiveInfinity(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nuint>.IsPositiveInfinity(unchecked((nuint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsPositiveInfinity(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsPositiveInfinity((nuint)0x00000000));
+                Assert.False(NumberBaseHelper<nuint>.IsPositiveInfinity((nuint)0x00000001));
+                Assert.False(NumberBaseHelper<nuint>.IsPositiveInfinity((nuint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nuint>.IsPositiveInfinity((nuint)0x80000000));
+                Assert.False(NumberBaseHelper<nuint>.IsPositiveInfinity((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsSubnormal(unchecked((nuint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsSubnormal(unchecked((nuint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nuint>.IsSubnormal(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nuint>.IsSubnormal(unchecked((nuint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsSubnormal(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsSubnormal((nuint)0x00000000));
+                Assert.False(NumberBaseHelper<nuint>.IsSubnormal((nuint)0x00000001));
+                Assert.False(NumberBaseHelper<nuint>.IsSubnormal((nuint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nuint>.IsSubnormal((nuint)0x80000000));
+                Assert.False(NumberBaseHelper<nuint>.IsSubnormal((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MaxMagnitude(unchecked((nuint)0x0000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MaxMagnitude(unchecked((nuint)0x0000000000000001), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.MaxMagnitude(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.MaxMagnitude(unchecked((nuint)0x8000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.MaxMagnitude(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
+            }
+            else
+            {
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MaxMagnitude((nuint)0x00000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MaxMagnitude((nuint)0x00000001, (nuint)1));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.MaxMagnitude((nuint)0x7FFFFFFF, (nuint)1));
+                Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.MaxMagnitude((nuint)0x80000000, (nuint)1));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.MaxMagnitude((nuint)0xFFFFFFFF, (nuint)1));
+            }
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MaxMagnitudeNumber(unchecked((nuint)0x0000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MaxMagnitudeNumber(unchecked((nuint)0x0000000000000001), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.MaxMagnitudeNumber(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.MaxMagnitudeNumber(unchecked((nuint)0x8000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.MaxMagnitudeNumber(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
+            }
+            else
+            {
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MaxMagnitudeNumber((nuint)0x00000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MaxMagnitudeNumber((nuint)0x00000001, (nuint)1));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.MaxMagnitudeNumber((nuint)0x7FFFFFFF, (nuint)1));
+                Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.MaxMagnitudeNumber((nuint)0x80000000, (nuint)1));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.MaxMagnitudeNumber((nuint)0xFFFFFFFF, (nuint)1));
+            }
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.MinMagnitude(unchecked((nuint)0x0000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MinMagnitude(unchecked((nuint)0x0000000000000001), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MinMagnitude(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MinMagnitude(unchecked((nuint)0x8000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MinMagnitude(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
+            }
+            else
+            {
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.MinMagnitude((nuint)0x00000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MinMagnitude((nuint)0x00000001, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MinMagnitude((nuint)0x7FFFFFFF, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MinMagnitude((nuint)0x80000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MinMagnitude((nuint)0xFFFFFFFF, (nuint)1));
+            }
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.MinMagnitudeNumber(unchecked((nuint)0x0000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MinMagnitudeNumber(unchecked((nuint)0x0000000000000001), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MinMagnitudeNumber(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MinMagnitudeNumber(unchecked((nuint)0x8000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.MinMagnitudeNumber(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
+            }
+            else
+            {
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.MinMagnitudeNumber((nuint)0x00000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MinMagnitudeNumber((nuint)0x00000001, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MinMagnitudeNumber((nuint)0x7FFFFFFF, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MinMagnitudeNumber((nuint)0x80000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.MinMagnitudeNumber((nuint)0xFFFFFFFF, (nuint)1));
+            }
+        }
+
+        [Fact]
         public static void TryCreateFromByteTest()
         {
             nuint result;
@@ -1555,7 +1849,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void TryCreateFromInt16Test()
+        public static void TryCreateFroMinMagnitudet16Test()
         {
             nuint result;
 
@@ -1576,7 +1870,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void TryCreateFromInt32Test()
+        public static void TryCreateFroMinMagnitudet32Test()
         {
             nuint result;
 
@@ -1597,7 +1891,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void TryCreateFromInt64Test()
+        public static void TryCreateFroMinMagnitudet64Test()
         {
             nuint result;
 
@@ -1638,7 +1932,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void TryCreateFromIntPtrTest()
+        public static void TryCreateFroMinMagnitudetPtrTest()
         {
             nuint result;
 

--- a/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
@@ -8,48 +8,9 @@ namespace System.Tests
 {
     public class UIntPtrTests_GenericMath
     {
-        [Fact]
-        public static void AdditiveIdentityTest()
-        {
-            Assert.Equal((nuint)0x00000000, AdditiveIdentityHelper<nuint, nuint>.AdditiveIdentity);
-        }
-
-        [Fact]
-        public static void MinValueTest()
-        {
-            Assert.Equal((nuint)0x00000000, MinMaxValueHelper<nuint>.MinValue);
-        }
-
-        [Fact]
-        public static void MaxValueTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), MinMaxValueHelper<nuint>.MaxValue);
-            }
-            else
-            {
-                Assert.Equal((nuint)0xFFFFFFFF, MinMaxValueHelper<nuint>.MaxValue);
-            }
-        }
-
-        [Fact]
-        public static void MultiplicativeIdentityTest()
-        {
-            Assert.Equal((nuint)0x00000001, MultiplicativeIdentityHelper<nuint, nuint>.MultiplicativeIdentity);
-        }
-
-        [Fact]
-        public static void OneTest()
-        {
-            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.One);
-        }
-
-        [Fact]
-        public static void ZeroTest()
-        {
-            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.Zero);
-        }
+        //
+        // IAdditionOperators
+        //
 
         [Fact]
         public static void op_AdditionTest()
@@ -92,6 +53,41 @@ namespace System.Tests
                 Assert.Equal((nuint)0x80000001, AdditionOperatorsHelper<nuint, nuint, nuint>.op_CheckedAddition((nuint)0x80000000, (nuint)1));
 
                 Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<nuint, nuint, nuint>.op_CheckedAddition((nuint)0xFFFFFFFF, (nuint)1));
+            }
+        }
+
+        //
+        // IAdditiveIdentity
+        //
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal((nuint)0x00000000, AdditiveIdentityHelper<nuint, nuint>.AdditiveIdentity);
+        }
+
+        //
+        // IBinaryInteger
+        //
+
+        [Fact]
+        public static void DivRemTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal((unchecked((nuint)0x0000000000000000), unchecked((nuint)0x0000000000000000)), BinaryIntegerHelper<nuint>.DivRem(unchecked((nuint)0x0000000000000000), (nuint)2));
+                Assert.Equal((unchecked((nuint)0x0000000000000000), unchecked((nuint)0x0000000000000001)), BinaryIntegerHelper<nuint>.DivRem(unchecked((nuint)0x0000000000000001), (nuint)2));
+                Assert.Equal((unchecked((nuint)0x3FFFFFFFFFFFFFFF), unchecked((nuint)0x0000000000000001)), BinaryIntegerHelper<nuint>.DivRem(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)2));
+                Assert.Equal((unchecked((nuint)0x4000000000000000), unchecked((nuint)0x0000000000000000)), BinaryIntegerHelper<nuint>.DivRem(unchecked((nuint)0x8000000000000000), (nuint)2));
+                Assert.Equal((unchecked((nuint)0x7FFFFFFFFFFFFFFF), unchecked((nuint)0x0000000000000001)), BinaryIntegerHelper<nuint>.DivRem(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)2));
+            }
+            else
+            {
+                Assert.Equal(((nuint)0x00000000, (nuint)0x00000000), BinaryIntegerHelper<nuint>.DivRem((nuint)0x00000000, (nuint)2));
+                Assert.Equal(((nuint)0x00000000, (nuint)0x00000001), BinaryIntegerHelper<nuint>.DivRem((nuint)0x00000001, (nuint)2));
+                Assert.Equal(((nuint)0x3FFFFFFF, (nuint)0x00000001), BinaryIntegerHelper<nuint>.DivRem((nuint)0x7FFFFFFF, (nuint)2));
+                Assert.Equal(((nuint)0x40000000, (nuint)0x00000000), BinaryIntegerHelper<nuint>.DivRem((nuint)0x80000000, (nuint)2));
+                Assert.Equal(((nuint)0x7FFFFFFF, (nuint)0x00000001), BinaryIntegerHelper<nuint>.DivRem((nuint)0xFFFFFFFF, (nuint)2));
             }
         }
 
@@ -201,6 +197,27 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void GetByteCountTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(8, BinaryIntegerHelper<nuint>.GetByteCount(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(8, BinaryIntegerHelper<nuint>.GetByteCount(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(8, BinaryIntegerHelper<nuint>.GetByteCount(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(8, BinaryIntegerHelper<nuint>.GetByteCount(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(8, BinaryIntegerHelper<nuint>.GetByteCount(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal(4, BinaryIntegerHelper<nuint>.GetByteCount((nuint)0x00000000));
+                Assert.Equal(4, BinaryIntegerHelper<nuint>.GetByteCount((nuint)0x00000001));
+                Assert.Equal(4, BinaryIntegerHelper<nuint>.GetByteCount((nuint)0x7FFFFFFF));
+                Assert.Equal(4, BinaryIntegerHelper<nuint>.GetByteCount((nuint)0x80000000));
+                Assert.Equal(4, BinaryIntegerHelper<nuint>.GetByteCount((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
         public static void GetShortestBitLengthTest()
         {
             if (Environment.Is64BitProcess)
@@ -220,6 +237,136 @@ namespace System.Tests
                 Assert.Equal(0x20, BinaryIntegerHelper<nuint>.GetShortestBitLength((nuint)0xFFFFFFFF));
             }
         }
+
+        [Fact]
+        public static void TryWriteBigEndianTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Span<byte> destination = stackalloc byte[8];
+                int bytesWritten = 0;
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian(unchecked((nuint)0x0000000000000000), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian(unchecked((nuint)0x0000000000000001), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian(unchecked((nuint)0x7FFFFFFFFFFFFFFF), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian(unchecked((nuint)0x8000000000000000), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian(unchecked((nuint)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.False(BinaryIntegerHelper<nuint>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+            }
+            else
+            {
+                Span<byte> destination = stackalloc byte[4];
+                int bytesWritten = 0;
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian((nuint)0x00000000, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian((nuint)0x00000001, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian((nuint)0x7FFFFFFF, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian((nuint)0x80000000, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian((nuint)0xFFFFFFFF, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.False(BinaryIntegerHelper<nuint>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+            }
+        }
+
+        [Fact]
+        public static void TryWriteLittleEndianTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Span<byte> destination = stackalloc byte[8];
+                int bytesWritten = 0;
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(unchecked((nuint)0x0000000000000000), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(unchecked((nuint)0x0000000000000001), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(unchecked((nuint)0x7FFFFFFFFFFFFFFF), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(unchecked((nuint)0x8000000000000000), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(unchecked((nuint)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
+                Assert.Equal(8, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.False(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+            }
+            else
+            {
+                Span<byte> destination = stackalloc byte[4];
+                int bytesWritten = 0;
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian((nuint)0x00000000, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian((nuint)0x00000001, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian((nuint)0x7FFFFFFF, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian((nuint)0x80000000, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
+
+                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian((nuint)0xFFFFFFFF, destination, out bytesWritten));
+                Assert.Equal(4, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+
+                Assert.False(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
+                Assert.Equal(0, bytesWritten);
+                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
+            }
+        }
+
+        //
+        // IBinaryNumber
+        //
 
         [Fact]
         public static void IsPow2Test()
@@ -262,6 +409,10 @@ namespace System.Tests
                 Assert.Equal((nuint)0x0000001F, BinaryNumberHelper<nuint>.Log2((nuint)0xFFFFFFFF));
             }
         }
+
+        //
+        // IBitwiseOperators
+        //
 
         [Fact]
         public static void op_BitwiseAndTest()
@@ -347,47 +498,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void op_LessThanTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan(unchecked((nuint)0x0000000000000000), (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan(unchecked((nuint)0x0000000000000001), (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan(unchecked((nuint)0x8000000000000000), (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
-            }
-            else
-            {
-                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan((nuint)0x00000000, (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan((nuint)0x00000001, (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan((nuint)0x7FFFFFFF, (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan((nuint)0x80000000, (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan((nuint)0xFFFFFFFF, (nuint)1));
-            }
-        }
-
-        [Fact]
-        public static void op_LessThanOrEqualTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual(unchecked((nuint)0x0000000000000000), (nuint)1));
-                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual(unchecked((nuint)0x0000000000000001), (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual(unchecked((nuint)0x8000000000000000), (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
-            }
-            else
-            {
-                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual((nuint)0x00000000, (nuint)1));
-                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual((nuint)0x00000001, (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual((nuint)0x7FFFFFFF, (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual((nuint)0x80000000, (nuint)1));
-                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual((nuint)0xFFFFFFFF, (nuint)1));
-            }
-        }
+        //
+        // IComparisonOperators
+        //
 
         [Fact]
         public static void op_GreaterThanTest()
@@ -432,6 +545,52 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void op_LessThanTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan(unchecked((nuint)0x0000000000000000), (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan(unchecked((nuint)0x0000000000000001), (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan(unchecked((nuint)0x8000000000000000), (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
+            }
+            else
+            {
+                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan((nuint)0x00000000, (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan((nuint)0x00000001, (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan((nuint)0x7FFFFFFF, (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan((nuint)0x80000000, (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThan((nuint)0xFFFFFFFF, (nuint)1));
+            }
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual(unchecked((nuint)0x0000000000000000), (nuint)1));
+                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual(unchecked((nuint)0x0000000000000001), (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual(unchecked((nuint)0x8000000000000000), (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
+            }
+            else
+            {
+                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual((nuint)0x00000000, (nuint)1));
+                Assert.True(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual((nuint)0x00000001, (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual((nuint)0x7FFFFFFF, (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual((nuint)0x80000000, (nuint)1));
+                Assert.False(ComparisonOperatorsHelper<nuint, nuint>.op_LessThanOrEqual((nuint)0xFFFFFFFF, (nuint)1));
+            }
+        }
+
+        //
+        // IDecrementOperators
+        //
+
+        [Fact]
         public static void op_DecrementTest()
         {
             if (Environment.Is64BitProcess)
@@ -474,6 +633,10 @@ namespace System.Tests
                 Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<nuint>.op_CheckedDecrement((nuint)0x00000000));
             }
         }
+
+        //
+        // IDivisionOperators
+        //
 
         [Fact]
         public static void op_DivisionTest()
@@ -525,6 +688,10 @@ namespace System.Tests
             }
         }
 
+        //
+        // IEqualityOperators
+        //
+
         [Fact]
         public static void op_EqualityTest()
         {
@@ -566,6 +733,10 @@ namespace System.Tests
                 Assert.True(EqualityOperatorsHelper<nuint, nuint>.op_Inequality((nuint)0xFFFFFFFF, (nuint)1));
             }
         }
+
+        //
+        // IIncrementOperators
+        //
 
         [Fact]
         public static void op_IncrementTest()
@@ -611,6 +782,33 @@ namespace System.Tests
             }
         }
 
+        //
+        // IMinMaxValue
+        //
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), MinMaxValueHelper<nuint>.MaxValue);
+            }
+            else
+            {
+                Assert.Equal((nuint)0xFFFFFFFF, MinMaxValueHelper<nuint>.MaxValue);
+            }
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal((nuint)0x00000000, MinMaxValueHelper<nuint>.MinValue);
+        }
+
+        //
+        // IModulusOperators
+        //
+
         [Fact]
         public static void op_ModulusTest()
         {
@@ -635,6 +833,20 @@ namespace System.Tests
                 Assert.Throws<DivideByZeroException>(() => ModulusOperatorsHelper<nuint, nuint, nuint>.op_Modulus((nuint)0x00000001, (nuint)0));
             }
         }
+
+        //
+        // IMultiplicativeIdentity
+        //
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal((nuint)0x00000001, MultiplicativeIdentityHelper<nuint, nuint>.MultiplicativeIdentity);
+        }
+
+        //
+        // IMultiplyOperators
+        //
 
         [Fact]
         public static void op_MultiplyTest()
@@ -680,26 +892,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void AbsTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.Abs((nuint)0x00000000));
-                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.Abs((nuint)0x00000001));
-                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.Abs((nuint)0x7FFFFFFF));
-                Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.Abs((nuint)0x80000000));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.Abs((nuint)0xFFFFFFFF));
-            }
-        }
+        //
+        // INumber
+        //
 
         [Fact]
         public static void ClampTest()
@@ -719,6 +914,106 @@ namespace System.Tests
                 Assert.Equal((nuint)0x0000003F, NumberHelper<nuint>.Clamp((nuint)0x7FFFFFFF, (nuint)0x00000001, (nuint)0x0000003F));
                 Assert.Equal((nuint)0x0000003F, NumberHelper<nuint>.Clamp((nuint)0x80000000, (nuint)0x00000001, (nuint)0x0000003F));
                 Assert.Equal((nuint)0x0000003F, NumberHelper<nuint>.Clamp((nuint)0xFFFFFFFF, (nuint)0x00000001, (nuint)0x0000003F));
+            }
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Max(unchecked((nuint)0x0000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Max(unchecked((nuint)0x0000000000000001), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.Max(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.Max(unchecked((nuint)0x8000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.Max(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
+            }
+            else
+            {
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Max((nuint)0x00000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Max((nuint)0x00000001, (nuint)1));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.Max((nuint)0x7FFFFFFF, (nuint)1));
+                Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.Max((nuint)0x80000000, (nuint)1));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.Max((nuint)0xFFFFFFFF, (nuint)1));
+            }
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.Min(unchecked((nuint)0x0000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Min(unchecked((nuint)0x0000000000000001), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Min(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Min(unchecked((nuint)0x8000000000000000), (nuint)1));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Min(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
+            }
+            else
+            {
+                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.Min((nuint)0x00000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Min((nuint)0x00000001, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Min((nuint)0x7FFFFFFF, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Min((nuint)0x80000000, (nuint)1));
+                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Min((nuint)0xFFFFFFFF, (nuint)1));
+            }
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(0, NumberHelper<nuint>.Sign(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(1, NumberHelper<nuint>.Sign(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(1, NumberHelper<nuint>.Sign(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(1, NumberHelper<nuint>.Sign(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(1, NumberHelper<nuint>.Sign(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal(0, NumberHelper<nuint>.Sign((nuint)0x00000000));
+                Assert.Equal(1, NumberHelper<nuint>.Sign((nuint)0x00000001));
+                Assert.Equal(1, NumberHelper<nuint>.Sign((nuint)0x7FFFFFFF));
+                Assert.Equal(1, NumberHelper<nuint>.Sign((nuint)0x80000000));
+                Assert.Equal(1, NumberHelper<nuint>.Sign((nuint)0xFFFFFFFF));
+            }
+        }
+
+        //
+        // INumberBase
+        //
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.Zero);
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberBaseHelper<nuint>.Abs(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.Abs((nuint)0x00000000));
+                Assert.Equal((nuint)0x00000001, NumberBaseHelper<nuint>.Abs((nuint)0x00000001));
+                Assert.Equal((nuint)0x7FFFFFFF, NumberBaseHelper<nuint>.Abs((nuint)0x7FFFFFFF));
+                Assert.Equal((nuint)0x80000000, NumberBaseHelper<nuint>.Abs((nuint)0x80000000));
+                Assert.Equal((nuint)0xFFFFFFFF, NumberBaseHelper<nuint>.Abs((nuint)0xFFFFFFFF));
             }
         }
 
@@ -1218,90 +1513,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void DivRemTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal((unchecked((nuint)0x0000000000000000), unchecked((nuint)0x0000000000000000)), BinaryIntegerHelper<nuint>.DivRem(unchecked((nuint)0x0000000000000000), (nuint)2));
-                Assert.Equal((unchecked((nuint)0x0000000000000000), unchecked((nuint)0x0000000000000001)), BinaryIntegerHelper<nuint>.DivRem(unchecked((nuint)0x0000000000000001), (nuint)2));
-                Assert.Equal((unchecked((nuint)0x3FFFFFFFFFFFFFFF), unchecked((nuint)0x0000000000000001)), BinaryIntegerHelper<nuint>.DivRem(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)2));
-                Assert.Equal((unchecked((nuint)0x4000000000000000), unchecked((nuint)0x0000000000000000)), BinaryIntegerHelper<nuint>.DivRem(unchecked((nuint)0x8000000000000000), (nuint)2));
-                Assert.Equal((unchecked((nuint)0x7FFFFFFFFFFFFFFF), unchecked((nuint)0x0000000000000001)), BinaryIntegerHelper<nuint>.DivRem(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)2));
-            }
-            else
-            {
-                Assert.Equal(((nuint)0x00000000, (nuint)0x00000000), BinaryIntegerHelper<nuint>.DivRem((nuint)0x00000000, (nuint)2));
-                Assert.Equal(((nuint)0x00000000, (nuint)0x00000001), BinaryIntegerHelper<nuint>.DivRem((nuint)0x00000001, (nuint)2));
-                Assert.Equal(((nuint)0x3FFFFFFF, (nuint)0x00000001), BinaryIntegerHelper<nuint>.DivRem((nuint)0x7FFFFFFF, (nuint)2));
-                Assert.Equal(((nuint)0x40000000, (nuint)0x00000000), BinaryIntegerHelper<nuint>.DivRem((nuint)0x80000000, (nuint)2));
-                Assert.Equal(((nuint)0x7FFFFFFF, (nuint)0x00000001), BinaryIntegerHelper<nuint>.DivRem((nuint)0xFFFFFFFF, (nuint)2));
-            }
-        }
-
-        [Fact]
-        public static void MaxTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Max(unchecked((nuint)0x0000000000000000), (nuint)1));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Max(unchecked((nuint)0x0000000000000001), (nuint)1));
-                Assert.Equal(unchecked((nuint)0x7FFFFFFFFFFFFFFF), NumberHelper<nuint>.Max(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
-                Assert.Equal(unchecked((nuint)0x8000000000000000), NumberHelper<nuint>.Max(unchecked((nuint)0x8000000000000000), (nuint)1));
-                Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFF), NumberHelper<nuint>.Max(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
-            }
-            else
-            {
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Max((nuint)0x00000000, (nuint)1));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Max((nuint)0x00000001, (nuint)1));
-                Assert.Equal((nuint)0x7FFFFFFF, NumberHelper<nuint>.Max((nuint)0x7FFFFFFF, (nuint)1));
-                Assert.Equal((nuint)0x80000000, NumberHelper<nuint>.Max((nuint)0x80000000, (nuint)1));
-                Assert.Equal((nuint)0xFFFFFFFF, NumberHelper<nuint>.Max((nuint)0xFFFFFFFF, (nuint)1));
-            }
-        }
-
-        [Fact]
-        public static void MinTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(unchecked((nuint)0x0000000000000000), NumberHelper<nuint>.Min(unchecked((nuint)0x0000000000000000), (nuint)1));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Min(unchecked((nuint)0x0000000000000001), (nuint)1));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Min(unchecked((nuint)0x7FFFFFFFFFFFFFFF), (nuint)1));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Min(unchecked((nuint)0x8000000000000000), (nuint)1));
-                Assert.Equal(unchecked((nuint)0x0000000000000001), NumberHelper<nuint>.Min(unchecked((nuint)0xFFFFFFFFFFFFFFFF), (nuint)1));
-            }
-            else
-            {
-                Assert.Equal((nuint)0x00000000, NumberHelper<nuint>.Min((nuint)0x00000000, (nuint)1));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Min((nuint)0x00000001, (nuint)1));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Min((nuint)0x7FFFFFFF, (nuint)1));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Min((nuint)0x80000000, (nuint)1));
-                Assert.Equal((nuint)0x00000001, NumberHelper<nuint>.Min((nuint)0xFFFFFFFF, (nuint)1));
-            }
-        }
-
-        [Fact]
-        public static void SignTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(0, NumberHelper<nuint>.Sign(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(1, NumberHelper<nuint>.Sign(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(1, NumberHelper<nuint>.Sign(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(1, NumberHelper<nuint>.Sign(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(1, NumberHelper<nuint>.Sign(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                Assert.Equal(0, NumberHelper<nuint>.Sign((nuint)0x00000000));
-                Assert.Equal(1, NumberHelper<nuint>.Sign((nuint)0x00000001));
-                Assert.Equal(1, NumberHelper<nuint>.Sign((nuint)0x7FFFFFFF));
-                Assert.Equal(1, NumberHelper<nuint>.Sign((nuint)0x80000000));
-                Assert.Equal(1, NumberHelper<nuint>.Sign((nuint)0xFFFFFFFF));
-            }
-        }
-
-        [Fact]
         public static void TryCreateFromByteTest()
         {
             nuint result;
@@ -1612,152 +1823,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        public static void GetByteCountTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(8, BinaryIntegerHelper<nuint>.GetByteCount(unchecked((nuint)0x0000000000000000)));
-                Assert.Equal(8, BinaryIntegerHelper<nuint>.GetByteCount(unchecked((nuint)0x0000000000000001)));
-                Assert.Equal(8, BinaryIntegerHelper<nuint>.GetByteCount(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
-                Assert.Equal(8, BinaryIntegerHelper<nuint>.GetByteCount(unchecked((nuint)0x8000000000000000)));
-                Assert.Equal(8, BinaryIntegerHelper<nuint>.GetByteCount(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
-            }
-            else
-            {
-                Assert.Equal(4, BinaryIntegerHelper<nuint>.GetByteCount((nuint)0x00000000));
-                Assert.Equal(4, BinaryIntegerHelper<nuint>.GetByteCount((nuint)0x00000001));
-                Assert.Equal(4, BinaryIntegerHelper<nuint>.GetByteCount((nuint)0x7FFFFFFF));
-                Assert.Equal(4, BinaryIntegerHelper<nuint>.GetByteCount((nuint)0x80000000));
-                Assert.Equal(4, BinaryIntegerHelper<nuint>.GetByteCount((nuint)0xFFFFFFFF));
-            }
-        }
-
-        [Fact]
-        public static void TryWriteBigEndianTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Span<byte> destination = stackalloc byte[8];
-                int bytesWritten = 0;
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian(unchecked((nuint)0x0000000000000000), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian(unchecked((nuint)0x0000000000000001), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian(unchecked((nuint)0x7FFFFFFFFFFFFFFF), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian(unchecked((nuint)0x8000000000000000), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian(unchecked((nuint)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.False(BinaryIntegerHelper<nuint>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-                Assert.Equal(0, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-            }
-            else
-            {
-                Span<byte> destination = stackalloc byte[4];
-                int bytesWritten = 0;
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian((nuint)0x00000000, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian((nuint)0x00000001, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x01 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian((nuint)0x7FFFFFFF, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian((nuint)0x80000000, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteBigEndian((nuint)0xFFFFFFFF, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.False(BinaryIntegerHelper<nuint>.TryWriteBigEndian(default, Span<byte>.Empty, out bytesWritten));
-                Assert.Equal(0, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-            }
-        }
-
-        [Fact]
-        public static void TryWriteLittleEndianTest()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                Span<byte> destination = stackalloc byte[8];
-                int bytesWritten = 0;
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(unchecked((nuint)0x0000000000000000), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(unchecked((nuint)0x0000000000000001), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(unchecked((nuint)0x7FFFFFFFFFFFFFFF), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(unchecked((nuint)0x8000000000000000), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(unchecked((nuint)0xFFFFFFFFFFFFFFFF), destination, out bytesWritten));
-                Assert.Equal(8, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.False(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-                Assert.Equal(0, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-            }
-            else
-            {
-                Span<byte> destination = stackalloc byte[4];
-                int bytesWritten = 0;
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian((nuint)0x00000000, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian((nuint)0x00000001, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian((nuint)0x7FFFFFFF, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0x7F }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian((nuint)0x80000000, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x80 }, destination.ToArray());
-
-                Assert.True(BinaryIntegerHelper<nuint>.TryWriteLittleEndian((nuint)0xFFFFFFFF, destination, out bytesWritten));
-                Assert.Equal(4, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-
-                Assert.False(BinaryIntegerHelper<nuint>.TryWriteLittleEndian(default, Span<byte>.Empty, out bytesWritten));
-                Assert.Equal(0, bytesWritten);
-                Assert.Equal(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, destination.ToArray());
-            }
-        }
+        //
+        // IShiftOperators
+        //
 
         [Fact]
         public static void op_LeftShiftTest()
@@ -1822,6 +1890,10 @@ namespace System.Tests
             }
         }
 
+        //
+        // ISubtractionOperators
+        //
+
         [Fact]
         public static void op_SubtractionTest()
         {
@@ -1865,6 +1937,10 @@ namespace System.Tests
                 Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<nuint, nuint, nuint>.op_CheckedSubtraction((nuint)0x00000000, (nuint)1));
             }
         }
+
+        //
+        // IUnaryNegationOperators
+        //
 
         [Fact]
         public static void op_UnaryNegationTest()
@@ -1910,6 +1986,10 @@ namespace System.Tests
             }
         }
 
+        //
+        // IUnaryPlusOperators
+        //
+
         [Fact]
         public static void op_UnaryPlusTest()
         {
@@ -1930,6 +2010,10 @@ namespace System.Tests
                 Assert.Equal((nuint)0xFFFFFFFF, UnaryPlusOperatorsHelper<nuint, nuint>.op_UnaryPlus((nuint)0xFFFFFFFF));
             }
         }
+
+        //
+        // IParsable and ISpanParsable
+        //
 
         [Theory]
         [MemberData(nameof(UIntPtrTests.Parse_Valid_TestData), MemberType = typeof(UIntPtrTests))]

--- a/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
@@ -1672,7 +1672,7 @@ namespace System.Tests
             }
             else
             {
-                Assert.True(NumberBaseHelper<nuint>.IsNormal((nuint)0x00000000));
+                Assert.False(NumberBaseHelper<nuint>.IsNormal((nuint)0x00000000));
                 Assert.True(NumberBaseHelper<nuint>.IsNormal((nuint)0x00000001));
                 Assert.True(NumberBaseHelper<nuint>.IsNormal((nuint)0x7FFFFFFF));
                 Assert.True(NumberBaseHelper<nuint>.IsNormal((nuint)0x80000000));


### PR DESCRIPTION
This is broken into a few commits and it may be easiest to review this per commit rather than altogether.
* The first is largely a refactoring that moves the existing interface methods down to `INumberBase` as per API review. This includes fixing up the tests to use the right helper type.
  * Moving the interfaces required exposing new explicitly implemented APIs on most types that return constant true or false.
* The second is purely a refactoring of the test declaration ordering to be consistent so we can actually easily see the coverage that already exists
* The third is purely additional and adds test coverage for the new APIs added by the first commit
* The final is likewise purely additional and adds the same coverage for `System.Numerics.Complex`
  * This one is standalone because it is larger, since `Complex` only implements `INumberBase<T>` and so needed more tests overall