### PR TITLE
Use CanCreateSymbolicLinks instead of IsSymLinkSupported

### DIFF
--- a/src/libraries/Common/tests/System/IO/ReparsePointUtilities.cs
+++ b/src/libraries/Common/tests/System/IO/ReparsePointUtilities.cs
@@ -10,14 +10,10 @@ This is meant to contain useful utilities for IO related work in ReparsePoints
 #define DEBUG
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
-using Xunit;
 
 public static partial class MountHelper
 {
@@ -35,77 +31,7 @@ public static partial class MountHelper
     // Helper for ConditionalClass attributes
     internal static bool IsSubstAvailable => PlatformDetection.IsSubstAvailable;
 
-    /// <summary>
-    /// In some cases (such as when running without elevated privileges),
-    /// the symbolic link may fail to create. Only run this test if it creates
-    /// links successfully.
-    /// </summary>
-    internal static bool CanCreateSymbolicLinks => s_canCreateSymbolicLinks.Value;
 
-    private static readonly Lazy<bool> s_canCreateSymbolicLinks = new Lazy<bool>(() =>
-    {
-        bool success = true;
-
-        // Verify file symlink creation
-        string path = Path.GetTempFileName();
-        string linkPath = path + ".link";
-        success = CreateSymbolicLink(linkPath: linkPath, targetPath: path, isDirectory: false);
-        try { File.Delete(path); } catch { }
-        try { File.Delete(linkPath); } catch { }
-
-        // Verify directory symlink creation
-        path = Path.GetTempFileName();
-        linkPath = path + ".link";
-        success = success && CreateSymbolicLink(linkPath: linkPath, targetPath: path, isDirectory: true);
-        try { Directory.Delete(path); } catch { }
-        try { Directory.Delete(linkPath); } catch { }
-
-        // Reduce the risk we accidentally stop running these altogether
-        // on Windows, due to a bug in CreateSymbolicLink
-        if (!success && PlatformDetection.IsWindows)
-            Assert.True(!PlatformDetection.IsWindowsAndElevated);
-
-        return success;
-    });
-
-    /// <summary>Creates a symbolic link using command line tools.</summary>
-    public static bool CreateSymbolicLink(string linkPath, string targetPath, bool isDirectory)
-    {
-        // It's easy to get the parameters backwards.
-        Assert.EndsWith(".link", linkPath);
-        if (linkPath != targetPath) // testing loop
-            Assert.False(targetPath.EndsWith(".link"), $"{targetPath} should not end with .link");
-
-#if NETFRAMEWORK
-        bool isWindows = true;
-#else
-        if (OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsBrowser()) // OSes that don't support Process.Start()
-        {
-            return false;
-        }
-
-        bool isWindows = OperatingSystem.IsWindows();
-#endif
-        Process symLinkProcess = new Process();
-        if (isWindows)
-        {
-            symLinkProcess.StartInfo.FileName = "cmd";
-            symLinkProcess.StartInfo.Arguments = string.Format("/c mklink{0} \"{1}\" \"{2}\"", isDirectory ? " /D" : "", linkPath, targetPath);
-        }
-        else
-        {
-            symLinkProcess.StartInfo.FileName = "/bin/ln";
-            symLinkProcess.StartInfo.Arguments = string.Format("-s \"{0}\" \"{1}\"", targetPath, linkPath);
-        }
-        symLinkProcess.StartInfo.UseShellExecute = false;
-        symLinkProcess.StartInfo.RedirectStandardOutput = true;
-
-        symLinkProcess.Start();
-
-        symLinkProcess.WaitForExit();
-
-        return (symLinkProcess.ExitCode == 0);
-    }
 
     /// <summary>On Windows, creates a junction using command line tools.</summary>
     public static bool CreateJunction(string junctionPath, string targetPath)

--- a/src/libraries/Common/tests/System/IO/SymbolicLinkHelper.cs
+++ b/src/libraries/Common/tests/System/IO/SymbolicLinkHelper.cs
@@ -69,7 +69,7 @@ public static class SymbolicLinkHelper
         Process symLinkProcess = new Process();
 
         symLinkProcess.StartInfo.FileName = "cmd";
-        symLinkProcess.StartInfo.Arguments = string.Format("/c mklink{0} \"{1}\" \"{2}\"", isDirectory ? " /D" : "", linkPath, targetPath);
+        symLinkProcess.StartInfo.Arguments = $"/c mklink{(isDirectory ? " /D" : "")} \"{linkPath}\" \"{targetPath}\"";
         symLinkProcess.StartInfo.UseShellExecute = false;
         symLinkProcess.StartInfo.RedirectStandardOutput = true;
 

--- a/src/libraries/Common/tests/System/IO/SymbolicLinkHelper.cs
+++ b/src/libraries/Common/tests/System/IO/SymbolicLinkHelper.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+public static class SymbolicLinkHelper
+{
+    /// <summary>
+    /// In some cases (such as when running without elevated privileges),
+    /// the symbolic link may fail to create. Only run this test if it creates
+    /// links successfully.
+    /// </summary>
+    internal static bool CanCreateSymbolicLinks => s_canCreateSymbolicLinks.Value;
+
+    private static readonly Lazy<bool> s_canCreateSymbolicLinks = new Lazy<bool>(() =>
+    {
+        bool success = true;
+
+        // Verify file symlink creation
+        string path = Path.GetTempFileName();
+        string linkPath = path + ".link";
+        success = CreateSymbolicLink(linkPath: linkPath, targetPath: path, isDirectory: false);
+        try { File.Delete(path); } catch { }
+        try { File.Delete(linkPath); } catch { }
+
+        // Verify directory symlink creation
+        path = Path.GetTempFileName();
+        linkPath = path + ".link";
+        success = success && CreateSymbolicLink(linkPath: linkPath, targetPath: path, isDirectory: true);
+        try { Directory.Delete(path); } catch { }
+        try { Directory.Delete(linkPath); } catch { }
+
+        // Reduce the risk we accidentally stop running these altogether
+        // on Windows, due to a bug in CreateSymbolicLink
+        if (!success && PlatformDetection.IsWindows)
+            Assert.True(!PlatformDetection.IsWindowsAndElevated);
+
+        return success;
+    });
+
+    /// <summary>Creates a symbolic link using command line tools.</summary>
+    public static bool CreateSymbolicLink(string linkPath, string targetPath, bool isDirectory)
+    {
+        // It's easy to get the parameters backwards.
+        Assert.EndsWith(".link", linkPath);
+        if (linkPath != targetPath) // testing loop
+            Assert.False(targetPath.EndsWith(".link"), $"{targetPath} should not end with .link");
+
+        if (PlatformDetection.IsiOS || PlatformDetection.IstvOS || PlatformDetection.IsMacCatalyst || PlatformDetection.IsBrowser)
+        {
+            return false;
+        }
+
+#if !NETFRAMEWORK
+        try
+        {
+            FileSystemInfo linkInfo = isDirectory ?
+                Directory.CreateSymbolicLink(linkPath, targetPath) : File.CreateSymbolicLink(linkPath, targetPath);
+
+            // Detect silent failures.
+            Assert.True(linkInfo.Exists);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+#else
+        Process symLinkProcess = new Process();
+
+        symLinkProcess.StartInfo.FileName = "cmd";
+        symLinkProcess.StartInfo.Arguments = string.Format("/c mklink{0} \"{1}\" \"{2}\"", isDirectory ? " /D" : "", linkPath, targetPath);
+        symLinkProcess.StartInfo.UseShellExecute = false;
+        symLinkProcess.StartInfo.RedirectStandardOutput = true;
+
+        symLinkProcess.Start();
+
+        symLinkProcess.WaitForExit();
+
+        return (symLinkProcess.ExitCode == 0);
+#endif
+    }
+}

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -89,7 +89,6 @@ namespace System
 
         public static bool IsThreadingSupported => !IsBrowser;
         public static bool IsBinaryFormatterSupported => IsNotMobile && !IsNativeAot;
-        public static bool IsSymLinkSupported => !IsiOS && !IstvOS;
 
         public static bool IsSpeedOptimized => !IsSizeOptimized;
         public static bool IsSizeOptimized => IsBrowser || IsAndroid || IsAppleMobile;
@@ -326,6 +325,8 @@ namespace System
                 return false;
             }
         }
+
+        public static bool CanCreateSymbolicLinks => SymbolicLinkHelper.CanCreateSymbolicLinks;
 
         private static Version GetICUVersion()
         {

--- a/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
+++ b/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- For some reason, xunit.core.props isn't excluded in VS and sets this to true. -->
@@ -39,6 +39,8 @@
 
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
              Link="Common\System\Text\ValueStringBuilder.cs" />
+    <Compile Include="$(CommonTestPath)System\IO\SymbolicLinkHelper.cs"
+             Link="Common\System\IO\SymbolicLinkHelper.cs" />
     <!--
       Interop.Library is not designed to support runtime checks therefore we are picking the Windows
       variant from the Common folder and adding the missing members manually.

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.netcoreapp.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.netcoreapp.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.FileProviders
 {
     public partial class PhysicalFileProviderTests : FileCleanupTestBase
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsSymLinkSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task UsePollingFileWatcher_UseActivePolling_HasChanged_SymbolicLink(bool useWildcard)
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.FileProviders
                 $"Change event was not raised - current time: {DateTime.UtcNow:O}, file LastWriteTimeUtc: {File.GetLastWriteTimeUtc(filePath):O}.");
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsSymLinkSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         [OuterLoop]
         [InlineData(false)]
         [InlineData(true)]
@@ -70,7 +70,7 @@ namespace Microsoft.Extensions.FileProviders
             await Assert.ThrowsAsync<TaskCanceledException>(() => tcs.Task);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsSymLinkSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         [InlineData(false, false)]
         [InlineData(false, true)]
         [InlineData(true, false)]
@@ -119,7 +119,7 @@ namespace Microsoft.Extensions.FileProviders
             catch (UnauthorizedAccessException) { }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsSymLinkSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task UsePollingFileWatcher_UseActivePolling_HasChanged_SymbolicLink_TargetDeleted(bool useWildcard)

--- a/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.Unix.cs
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.Unix.cs
@@ -20,7 +20,7 @@ namespace System.Diagnostics.Tests
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSymLinkSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void Symlink_ValidFile_Succeeds()
         {
             string filePath = Path.Combine(Directory.GetCurrentDirectory(), TestAssemblyFileName);
@@ -63,7 +63,7 @@ namespace System.Diagnostics.Tests
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSymLinkSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void Symlink_InvalidFile_Throws()
         {
             string sourcePath = Path.Combine(Directory.GetCurrentDirectory(), TestAssemblyFileName);

--- a/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
+++ b/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
@@ -33,7 +33,6 @@
     <Compile Include="TarWriter\TarWriter.WriteEntry.Entry.V7.Tests.cs" />
     <Compile Include="WrappedStream.cs" Link="WrappedStream.cs" />
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs" Link="Common\DisableRuntimeMarshalling.cs" />
-    <Compile Include="$(CommonTestPath)System\IO\ReparsePointUtilities.cs" Link="Common\System\IO\ReparsePointUtilities.cs" />
   </ItemGroup>
   <!-- Windows specific files -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -94,7 +94,7 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(0, Directory.GetFileSystemEntries(root.Path).Count());
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void Extract_SymbolicLinkEntry_TargetInsideDirectory() => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.SymbolicLink);
 
         [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
@@ -160,7 +160,7 @@ namespace System.Formats.Tar.Tests
             }
         }
 
-        [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         [InlineData(TarFormat.V7, false)]
         [InlineData(TarFormat.V7, true)]
         [InlineData(TarFormat.Ustar, false)]

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
@@ -57,7 +57,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void FileSystemWatcher_Directory_Changed_SymLink()
         {
             string dir = Path.Combine(TestDirectory, "dir");
@@ -68,7 +68,7 @@ namespace System.IO.Tests
                 // Setup the watcher
                 watcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.Size;
                 watcher.IncludeSubdirectories = true;
-                Assert.True(MountHelper.CreateSymbolicLink(Path.Combine(dir, GetRandomLinkName()), tempDir, true));
+                Assert.True(SymbolicLinkHelper.CreateSymbolicLink(Path.Combine(dir, GetRandomLinkName()), tempDir, true));
 
                 Action action = () => File.AppendAllText(file, "longtext");
                 Action cleanup = () => File.AppendAllText(file, "short");

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Create.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Create.cs
@@ -81,7 +81,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void FileSystemWatcher_Directory_Create_SymLink()
         {
             string dir = CreateTestDirectory(TestDirectory, "dir");
@@ -90,7 +90,7 @@ namespace System.IO.Tests
             {
                 // Make the symlink in our path (to the temp folder) and make sure an event is raised
                 string symLinkPath = Path.Combine(dir, GetRandomLinkName());
-                Action action = () => Assert.True(MountHelper.CreateSymbolicLink(symLinkPath, temp, true));
+                Action action = () => Assert.True(SymbolicLinkHelper.CreateSymbolicLink(symLinkPath, temp, true));
                 Action cleanup = () => Directory.Delete(symLinkPath);
 
                 ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup, symLinkPath);

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Delete.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Delete.cs
@@ -63,7 +63,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void FileSystemWatcher_Directory_Delete_SymLink()
         {
             string dir = CreateTestDirectory(TestDirectory, "dir");
@@ -73,7 +73,7 @@ namespace System.IO.Tests
                 // Make the symlink in our path (to the temp folder) and make sure an event is raised
                 string symLinkPath = Path.Combine(dir, GetRandomLinkName());
                 Action action = () => Directory.Delete(symLinkPath);
-                Action cleanup = () => Assert.True(MountHelper.CreateSymbolicLink(symLinkPath, tempDir, true));
+                Action cleanup = () => Assert.True(SymbolicLinkHelper.CreateSymbolicLink(symLinkPath, tempDir, true));
                 cleanup();
 
                 ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup, expectedPath: symLinkPath);

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Changed.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Changed.cs
@@ -59,7 +59,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void FileSystemWatcher_File_Changed_SymLink()
         {
             string dir = CreateTestDirectory(TestDirectory, "dir");
@@ -67,7 +67,7 @@ namespace System.IO.Tests
             using (var watcher = new FileSystemWatcher(dir, "*"))
             {
                 watcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.Size;
-                Assert.True(MountHelper.CreateSymbolicLink(Path.Combine(dir, GetRandomLinkName()), file, false));
+                Assert.True(SymbolicLinkHelper.CreateSymbolicLink(Path.Combine(dir, GetRandomLinkName()), file, false));
 
                 Action action = () => File.AppendAllText(file, "longtext");
                 Action cleanup = () => File.AppendAllText(file, "short");

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
@@ -120,7 +120,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void FileSystemWatcher_File_Create_SymLink()
         {
             string dir = CreateTestDirectory(TestDirectory, "dir");
@@ -129,7 +129,7 @@ namespace System.IO.Tests
             {
                 // Make the symlink in our path (to the temp file) and make sure an event is raised
                 string symLinkPath = Path.Combine(dir, GetRandomLinkName());
-                Action action = () => Assert.True(MountHelper.CreateSymbolicLink(symLinkPath, temp, false));
+                Action action = () => Assert.True(SymbolicLinkHelper.CreateSymbolicLink(symLinkPath, temp, false));
                 Action cleanup = () => File.Delete(symLinkPath);
 
                 ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup, symLinkPath);

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
@@ -84,7 +84,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void FileSystemWatcher_File_Delete_SymLink()
         {
             FileSystemWatcherTest.Execute(() =>
@@ -96,7 +96,7 @@ namespace System.IO.Tests
                     // Make the symlink in our path (to the temp file) and make sure an event is raised
                     string symLinkPath = Path.Combine(dir, GetRandomLinkName());
                     Action action = () => File.Delete(symLinkPath);
-                    Action cleanup = () => Assert.True(MountHelper.CreateSymbolicLink(symLinkPath, temp, false));
+                    Action cleanup = () => Assert.True(SymbolicLinkHelper.CreateSymbolicLink(symLinkPath, temp, false));
                     cleanup();
 
                     ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup, symLinkPath);

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.SymbolicLink.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.SymbolicLink.cs
@@ -7,13 +7,13 @@ using Xunit.Sdk;
 
 namespace System.IO.Tests
 {
-    [ConditionalClass(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
     public class SymbolicLink_Changed_Tests : FileSystemWatcherTest
     {
         private string CreateSymbolicLinkToTarget(string targetPath, bool isDirectory, string linkPath = null)
         {
             linkPath ??= GetRandomLinkPath();
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, targetPath, isDirectory));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, targetPath, isDirectory));
 
             return linkPath;
         }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -37,8 +37,6 @@
              Link="Common\System\IO\TempFile.cs" />
     <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs"
              Link="Common\System\IO\TempDirectory.cs" />
-    <Compile Include="$(CommonTestPath)System\IO\ReparsePointUtilities.cs"
-             Link="Common\System\IO\ReparsePointUtilities.cs" />
     <Compile Include="$(CommonTestPath)System\Threading\ThreadTestHelpers.cs"
              Link="Common\System\Threading\ThreadTestHelpers.cs" />
     <Compile Include="$(CommonTestPath)TestUtilities\System\DisableParallelization.cs"

--- a/src/libraries/System.IO.FileSystem/tests/Base/AllGetSetAttributes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/AllGetSetAttributes.cs
@@ -35,25 +35,25 @@ namespace System.IO.Tests
         }
 
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void SymLinksAreReparsePoints()
         {
             string path = CreateItem();
             string linkPath = GetRandomLinkPath();
 
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: IsDirectory));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: IsDirectory));
 
             Assert.NotEqual(FileAttributes.ReparsePoint, FileAttributes.ReparsePoint & GetAttributes(path));
             Assert.Equal(FileAttributes.ReparsePoint, FileAttributes.ReparsePoint & GetAttributes(linkPath));
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void SymLinksReflectSymLinkAttributes()
         {
             string path = CreateItem();
             string linkPath = GetRandomLinkPath();
 
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: IsDirectory));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: IsDirectory));
 
             SetAttributes(path, FileAttributes.ReadOnly);
             try

--- a/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -98,7 +98,7 @@ namespace System.IO.Tests
             SettingUpdatesPropertiesCore(item);
         }
 
-        [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         [PlatformSpecific(~TestPlatforms.Browser)] // Browser is excluded as it doesn't support symlinks
         [InlineData(false)]
         [InlineData(true)]

--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.cs
@@ -12,14 +12,14 @@ namespace System.IO.Tests
     {
         public BaseSymbolicLinks()
         {
-            Assert.True(MountHelper.CanCreateSymbolicLinks);
+            Assert.True(PlatformDetection.CanCreateSymbolicLinks);
         }
 
         protected DirectoryInfo CreateDirectoryContainingSelfReferencingSymbolicLink()
         {
             DirectoryInfo testDirectory = Directory.CreateDirectory(GetRandomDirPath());
             string pathToLink = Path.Join(testDirectory.FullName, GetRandomDirName() + ".link");
-            Assert.True(MountHelper.CreateSymbolicLink(pathToLink, pathToLink, isDirectory: true)); // Create a symlink cycle
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(pathToLink, pathToLink, isDirectory: true)); // Create a symlink cycle
             return testDirectory;
         }
 

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -100,14 +100,14 @@ namespace System.IO.Tests
             Assert.Throws<IOException>(() => Delete(Directory.GetCurrentDirectory()));
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void DeletingSymLinkDoesntDeleteTarget()
         {
             var path = GetTestFilePath();
             var linkPath = GetRandomLinkPath();
 
             Directory.CreateDirectory(path);
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
 
             // Both the symlink and the target exist
             Assert.True(Directory.Exists(path), "path should exist");
@@ -294,7 +294,7 @@ namespace System.IO.Tests
             Assert.True(testDir.Exists);
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void RecursiveDeletingDoesntFollowLinks()
         {
             var target = GetTestFilePath();

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -95,14 +95,14 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void SymLinksMayExistIndependentlyOfTarget()
         {
             var path = GetTestFilePath();
             var linkPath = GetRandomLinkPath();
 
             Directory.CreateDirectory(path);
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
 
             // Both the symlink and the target exist
             Assert.True(Directory.Exists(path), "path should exist");
@@ -142,14 +142,14 @@ namespace System.IO.Tests
             Assert.False(File.Exists(linkPath), "linkPath should no longer exist as a file");
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void SymlinkToNewDirectory()
         {
             string path = GetTestFilePath();
             Directory.CreateDirectory(path);
 
             string linkPath = GetRandomLinkPath();
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
 
             Assert.True(Directory.Exists(path));
             Assert.True(Directory.Exists(linkPath));

--- a/src/libraries/System.IO.FileSystem/tests/Directory/GetDirectories.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/GetDirectories.cs
@@ -16,7 +16,7 @@ namespace System.IO.Tests
             return Directory.GetDirectories(path);
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void EnumerateWithSymLinkToDirectory()
         {
             DirectoryInfo containingFolder = Directory.CreateDirectory(GetTestFilePath());
@@ -26,7 +26,7 @@ namespace System.IO.Tests
             {
                 // Create a symlink to a folder that exists
                 string linkPath = Path.Combine(containingFolder.FullName, GetRandomLinkName());
-                Assert.True(MountHelper.CreateSymbolicLink(linkPath, targetDir.FullName, isDirectory: true));
+                Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, targetDir.FullName, isDirectory: true));
 
                 Assert.True(Directory.Exists(linkPath));
                 Assert.Equal(1, GetEntries(containingFolder.FullName).Count());

--- a/src/libraries/System.IO.FileSystem/tests/Directory/GetFiles.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/GetFiles.cs
@@ -16,7 +16,7 @@ namespace System.IO.Tests
             return Directory.GetFiles(path);
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void EnumerateWithSymLinkToFile()
         {
             DirectoryInfo containingFolder = Directory.CreateDirectory(GetTestFilePath());
@@ -26,7 +26,7 @@ namespace System.IO.Tests
             targetFile.Create().Dispose();
 
             string linkPath = Path.Combine(containingFolder.FullName, GetRandomLinkName());
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, targetFile.FullName, isDirectory: false));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, targetFile.FullName, isDirectory: false));
 
             Assert.True(File.Exists(linkPath));
             Assert.Equal(1, GetEntries(containingFolder.FullName).Count());

--- a/src/libraries/System.IO.FileSystem/tests/Directory/SetCurrentDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/SetCurrentDirectory.cs
@@ -47,7 +47,7 @@ namespace System.IO.Tests
 
         public sealed class Directory_SetCurrentDirectory_SymLink : FileSystemTest
         {
-            private static bool CanCreateSymbolicLinksAndRemoteExecutorSupported => MountHelper.CanCreateSymbolicLinks && RemoteExecutor.IsSupported;
+            private static bool CanCreateSymbolicLinksAndRemoteExecutorSupported => PlatformDetection.CanCreateSymbolicLinks && RemoteExecutor.IsSupported;
 
             [ConditionalFact(nameof(CanCreateSymbolicLinksAndRemoteExecutorSupported))]
             public void SetToPathContainingSymLink()
@@ -58,7 +58,7 @@ namespace System.IO.Tests
                     var linkPath = GetRandomLinkPath();
 
                     Directory.CreateDirectory(path);
-                    Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
+                    Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
 
                     // Both the symlink and the target exist
                     Assert.True(Directory.Exists(path), "path should exist");

--- a/src/libraries/System.IO.FileSystem/tests/Directory/SymbolicLinks.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/SymbolicLinks.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    [ConditionalClass(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
     public class Directory_SymbolicLinks : BaseSymbolicLinks_FileSystem
     {
         protected override bool IsDirectoryTest => true;

--- a/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -118,20 +118,20 @@ namespace System.IO.Tests
             Assert.False(di.Exists);
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void SymlinkToNewDirectoryInfo()
         {
             string path = GetTestFilePath();
             new DirectoryInfo(path).Create();
 
             string linkPath = GetRandomLinkPath();
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
 
             Assert.True(new DirectoryInfo(path).Exists);
             Assert.True(new DirectoryInfo(linkPath).Exists);
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void SymLinksMayExistIndependentlyOfTarget()
         {
             var path = GetTestFilePath();
@@ -141,7 +141,7 @@ namespace System.IO.Tests
             var linkPathFI = new DirectoryInfo(linkPath);
 
             pathFI.Create();
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: true));
 
             // Both the symlink and the target exist
             pathFI.Refresh();

--- a/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/SymbolicLinks.cs
+++ b/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/SymbolicLinks.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    [ConditionalClass(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
     public class DirectoryInfo_SymbolicLinks : BaseSymbolicLinks_FileSystemInfo
     {
         protected override bool IsDirectoryTest => true;

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -64,7 +64,7 @@ namespace System.IO.Tests.Enumeration
                 yield return new object[] { "dir1", "file2" };
                 yield return new object[] { "file1", "file2" };
 
-                if (MountHelper.CanCreateSymbolicLinks)
+                if (PlatformDetection.CanCreateSymbolicLinks)
                 {
                     yield return new object[] { "dir1", "link2" };
                     yield return new object[] { "file1", "link2" };

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/SymbolicLinksTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/SymbolicLinksTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.IO.Tests.Enumeration
 {
-    [ConditionalClass(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
     public class Enumeration_SymbolicLinksTests : BaseSymbolicLinks
     {
         [Fact]

--- a/src/libraries/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Delete.cs
@@ -83,14 +83,14 @@ namespace System.IO.Tests
             Assert.Throws<UnauthorizedAccessException>(() => Delete(TestDirectory));
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void DeletingSymLinkDoesntDeleteTarget()
         {
             var path = GetTestFilePath();
             var linkPath = GetRandomLinkPath();
 
             File.Create(path).Dispose();
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
 
             // Both the symlink and the target exist
             Assert.True(File.Exists(path), "path should exist");

--- a/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
@@ -115,14 +115,14 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void SymLinksMayExistIndependentlyOfTarget()
         {
             var path = GetTestFilePath();
             var linkPath = GetRandomLinkPath();
 
             File.Create(path).Dispose();
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
 
             // Both the symlink and the target exist
             Assert.True(File.Exists(path), "path should exist");

--- a/src/libraries/System.IO.FileSystem/tests/File/SymbolicLinks.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/SymbolicLinks.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    [ConditionalClass(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
     public class File_SymbolicLinks : BaseSymbolicLinks_FileSystem
     {
         protected override bool IsDirectoryTest => false;

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/Exists.cs
@@ -99,7 +99,7 @@ namespace System.IO.Tests
             Assert.True(fi.Exists);
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void SymLinksMayExistIndependentlyOfTarget()
         {
             var path = GetTestFilePath();
@@ -109,7 +109,7 @@ namespace System.IO.Tests
             var linkPathFI = new FileInfo(linkPath);
 
             pathFI.Create().Dispose();
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
+            Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
 
             // Both the symlink and the target exist
             pathFI.Refresh();

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/Length.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/Length.cs
@@ -63,7 +63,7 @@ namespace System.IO.Tests
             Assert.Throws<FileNotFoundException>(() => info.Length);
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
         public void SymLinkLength()
         {
             string path = GetTestFilePath();
@@ -72,7 +72,7 @@ namespace System.IO.Tests
             const int FileSize = 2000;
             using (var tempFile = new TempFile(path, FileSize))
             {
-                Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
+                Assert.True(SymbolicLinkHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
 
                 var info = new FileInfo(path);
                 Assert.Equal(FileSize, info.Length);

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/SymbolicLinks.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/SymbolicLinks.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.Tests
 {
-    [ConditionalClass(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
     public class FileInfo_SymbolicLinks : BaseSymbolicLinks_FileSystemInfo
     {
         protected override bool IsDirectoryTest => false;

--- a/src/libraries/System.IO.FileSystem/tests/Junctions.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Junctions.Windows.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace System.IO.Tests
 {
     [PlatformSpecific(TestPlatforms.Windows)]
-    [ConditionalClass(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks))]
     public class Junctions : BaseSymbolicLinks
     {
         private DirectoryInfo CreateJunction(string junctionPath, string targetPath)

--- a/src/libraries/System.IO.FileSystem/tests/VirtualDriveSymbolicLinks.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/VirtualDriveSymbolicLinks.Windows.cs
@@ -8,7 +8,7 @@ namespace System.IO.Tests
     // Need to reuse the same virtual drive for all the test methods.
     // Creating and disposing one virtual drive per class achieves this.
     [PlatformSpecific(TestPlatforms.Windows)]
-    [ConditionalClass(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks), nameof(MountHelper.IsSubstAvailable))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.CanCreateSymbolicLinks), nameof(PlatformDetection.IsSubstAvailable))]
     public class VirtualDrive_SymbolicLinks : BaseSymbolicLinks
     {
         private VirtualDriveHelper VirtualDrive { get; } = new VirtualDriveHelper();


### PR DESCRIPTION
* Remove redundant PlatformDetection.IsSymLinkSupported.
* Move CanCreateSymbolicLinks to PlatformDetection (from MountHelper).
* Change logic of CreateSymbolicLink to use our APIs for creation, when possible. 

Fixes https://github.com/dotnet/runtime/issues/69470.