### PR TITLE
Update NoTargets SDK and clean-up code

### DIFF
--- a/eng/NoTargetsSdk.BeforeTargets.targets
+++ b/eng/NoTargetsSdk.BeforeTargets.targets
@@ -1,11 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <!-- NoTargets SDK projects don't produce symbols. Set here as Arcade and Directory.Build.props overwrite the SDKs setting. -->
-    <!-- TODO: Remove when https://github.com/microsoft/MSBuildSdks/pull/360 is merged and consumed. -->
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
-
     <!-- NoTargets SDK needs a TFM set. Set a default if the project doesn't multi target. -->
     <TargetFramework Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -11,7 +11,7 @@
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22255.2",
     "Microsoft.DotNet.Helix.Sdk": "7.0.0-beta.22255.2",
     "Microsoft.DotNet.SharedFramework.Sdk": "7.0.0-beta.22255.2",
-    "Microsoft.Build.NoTargets": "3.4.0",
+    "Microsoft.Build.NoTargets": "3.5.0",
     "Microsoft.Build.Traversal": "3.1.6",
     "Microsoft.NET.Sdk.IL": "7.0.0-preview.5.22258.4"
   }


### PR DESCRIPTION
https://github.com/microsoft/MSBuildSdks/commit/9af7ea2c0d302af50ec2cc2566c7f4e32325ec3f is merged so we can now clean-up the symbol properties that were set to disable the pdb feature.