### PR TITLE
Fix native sourcelink support

### DIFF
--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -178,10 +178,18 @@
   </Target>
 
   <Target Name="GenerateNativeSourcelinkFile"
-          DependsOnTargets="GenerateSourceLinkFile"
           Condition="'$(DisableSourceLink)' != 'true'"
+          DependsOnTargets="_CopyGeneratedSourcelinkFile;_VerifyNativeSourceLinkFileExists" />
+
+  <Target Name="_CopyGeneratedSourcelinkFile"
+          DependsOnTargets="GenerateSourceLinkFile"
           Inputs="$(SourceLink)" Outputs="$(NativeSourceLinkFile)">
     <Error Condition="'$(NativeSourceLinkFile)' == ''" Text="Please set NativeSourceLinkFile to forward appropriate information for sourcelink."/>
     <Copy SourceFiles="$(SourceLink)" DestinationFiles="$(NativeSourceLinkFile)" />
+  </Target>
+
+  <Target Name="_VerifyNativeSourceLinkFileExists"
+          Condition="'$(VerifySourceLinkFileExists)' == true">
+    <Error Condition="!Exists('$(NativeSourceLinkFile)')" Text="Native SourceLink file could not be made available to the native build. Ensure that $(MSBuildProjectName) ran the sourcelink targets."/>
   </Target>
 </Project>

--- a/src/coreclr/runtime-prereqs.proj
+++ b/src/coreclr/runtime-prereqs.proj
@@ -14,7 +14,7 @@
   <Import Project="$(RepositoryEngineeringDir)nativepgo.targets" />
 
   <Target Name="BuildPrereqs" BeforeTargets="Build" DependsOnTargets="GenerateRuntimeVersionFile;GenerateNativeSourcelinkFile;OutputPgoPathForCI" />
-  <Import Project="Sdk.Targets" Sdk="Microsoft.Build.NoTargets" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" />
   <!--
     This is relatively ugly. The NoTargets SDK sets DebugType=None, but that makes it such that the sourcelink targets
     don't run, and we wouldn't generate the sourcelink file for native compilation. It would be better if we could call

--- a/src/coreclr/runtime-prereqs.proj
+++ b/src/coreclr/runtime-prereqs.proj
@@ -1,9 +1,12 @@
-<Project Sdk="Microsoft.Build.NoTargets">
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" />
   <PropertyGroup>
     <NativeVersionFile Condition="$([MSBuild]::IsOsPlatform(Windows))">$(ArtifactsObjDir)_version.h</NativeVersionFile>
     <NativeVersionFile Condition="!$([MSBuild]::IsOsPlatform(Windows))">$(ArtifactsObjDir)_version.c</NativeVersionFile>
     <RuntimeVersionFile>$(ArtifactsObjDir)runtime_version.h</RuntimeVersionFile>
     <NativeSourceLinkFile>$(ArtifactsObjDir)native.sourcelink.json</NativeSourceLinkFile>
+    <VerifySourceLinkFileExists>false</VerifySourceLinkFileExists>
+    <VerifySourceLinkFileExists Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</VerifySourceLinkFileExists>
     <AssemblyName>.NET Runtime</AssemblyName>
   </PropertyGroup>
 
@@ -11,4 +14,13 @@
   <Import Project="$(RepositoryEngineeringDir)nativepgo.targets" />
 
   <Target Name="BuildPrereqs" BeforeTargets="Build" DependsOnTargets="GenerateRuntimeVersionFile;GenerateNativeSourcelinkFile;OutputPgoPathForCI" />
+  <Import Project="Sdk.Targets" Sdk="Microsoft.Build.NoTargets" />
+  <!--
+    This is relatively ugly. The NoTargets SDK sets DebugType=None, but that makes it such that the sourcelink targets
+    don't run, and we wouldn't generate the sourcelink file for native compilation. It would be better if we could call
+    the target directly and have it generate the file, but it's guarded by this property anyway...
+  -->
+  <PropertyGroup>
+    <DebugType>Portable</DebugType>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
microsoft/MSBuildSdks#360 sets DebugType=none in a non-overrideable manner. The problem is 
that property gates the sourcelink targets from running. While this is not very clean, the other
alternatives are not all that much better

- Modify sourcelink to allow to generate this always.
- Modify this to run in empty.csproj instead of runtime-prereqs.proj and add a p2p ref. That be invoked separately if any other part of the repo wants native sourcelink.
- Revert to the old NoTargets behavior, but I don't think this is right...

Opening this PR to discuss if there's a better fix and have one that at least solves the issue.