### PR TITLE
Use a better endpoint for backport workflows runs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,12 +22,16 @@ jobs:
     steps:
     - name: Delete old workflow runs
       run: |
-        _UrlPath="/repos/$GITHUB_REPOSITORY/actions/runs"
+        _UrlPath="/repos/$GITHUB_REPOSITORY/actions/workflows"
+
+        _CurrentWorkflowID="$(gh api -X GET "$_UrlPath" | jq '.workflows[] | select(.name == '\""$GITHUB_WORKFLOW"\"') | .id')"
+
+        _UrlPath="$_UrlPath/$_CurrentWorkflowID/runs"
 
         # delete workitems which are 'completed'. (other candidate values of status field are: 'queued' and 'in_progress')
 
         gh api -X GET "$_UrlPath" --paginate \
-          | jq '.workflow_runs[] | select(.name == '\""$GITHUB_WORKFLOW"\"' and .status == "completed") | .id' \
+          | jq '.workflow_runs[] | select(.status == "completed") | .id' \
           | xargs -I{} gh api -X DELETE "$_UrlPath"/{}
 
   backport:


### PR DESCRIPTION
By switching to [this](https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs) endpoint, we can skip fetching undesired records in first place; currently we skip them in piped filter.