### PR TITLE
Fix IsSupported guard check for use of Ssse3.Shuffle in Span.Reverse

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -2374,7 +2374,7 @@ namespace System
                 buf = ref Unsafe.Add(ref buf, numIters * numElements);
                 length -= numIters * numElements * 2;
             }
-            else if (Sse2.IsSupported && (nuint)Vector128<byte>.Count * 2 <= length)
+            else if (Ssse3.IsSupported && (nuint)Vector128<byte>.Count * 2 <= length)
             {
                 Vector128<byte> reverseMask = Vector128.Create((byte)15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
                 nuint numElements = (nuint)Vector128<byte>.Count;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -2061,7 +2061,7 @@ namespace System
                 bufByte = ref Unsafe.Add(ref bufByte, numIters * numElements);
                 length -= numIters * (nuint)Vector256<short>.Count * 2;
             }
-            else if (Sse2.IsSupported && (nuint)Vector128<short>.Count * 2 <= length)
+            else if (Ssse3.IsSupported && (nuint)Vector128<short>.Count * 2 <= length)
             {
                 Vector128<byte> reverseMask = Vector128.Create((byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
                 nuint numElements = (nuint)Vector128<byte>.Count;


### PR DESCRIPTION
We were checking for SSE2 support and then using SSSE3 instructions.

Fixes #68880.