### PR TITLE
Reimplement I52/U52 in C, clean up and optimize range checks

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
@@ -104,7 +104,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 actionDelegate(3.14,40);
             "));
 
-            Assert.Contains("Value is not integer but float", ex.Message);
+            Assert.Contains("Value is not an integer: 3.14 (number)", ex.Message);
             Assert.Equal(0, HelperMarshal._actionResultValue);
         }
 
@@ -289,7 +289,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             var value = await promise;
 
             Assert.Equal("foo", (string)value);
-            
+
         }
 
         [Fact]

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -458,7 +458,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int ();
             "));
-            Assert.Contains("Value is not integer but undefined", ex.Message);
+            Assert.Contains("Value is not an integer: undefined (undefined)", ex.Message);
             Assert.Equal(1, HelperMarshal._intValue);
         }
 
@@ -495,7 +495,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (3.14);
             "));
-            Assert.Contains("Value is not integer but float", ex.Message);
+            Assert.Contains("Value is not an integer: 3.14 (number)", ex.Message);
             Assert.Equal(0, HelperMarshal._intValue);
         }
 
@@ -508,7 +508,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (""200"");
             "));
-            Assert.Contains("Value is not integer but string", ex.Message);
+            Assert.Contains("Value is not an integer: 200 (string)", ex.Message);
             Assert.Equal(0, HelperMarshal._intValue);
         }
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MemoryTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MemoryTests.cs
@@ -19,7 +19,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [InlineData(42L)]
         [InlineData(int.MaxValue)]
         [InlineData(0xF_FFFF_FFFFL)]
-        [InlineData(9007199254740991L)]//MAX_SAFE_INTEGER 
+        [InlineData(9007199254740991L)]//MAX_SAFE_INTEGER
         public static unsafe void Int52TestOK(long value)
         {
             long expected = value;
@@ -46,7 +46,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [InlineData(42UL)]
         [InlineData(uint.MaxValue)]
         [InlineData(0xF_FFFF_FFFFUL)]
-        [InlineData(9007199254740991UL)]//MAX_SAFE_INTEGER 
+        [InlineData(9007199254740991UL)]//MAX_SAFE_INTEGER
         public static unsafe void UInt52TestOK(ulong value)
         {
             ulong expected = value;
@@ -101,14 +101,14 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             var bagFn = new Function("ptr", "value", @"
                 globalThis.App.MONO.setI52(ptr, value);");
             var ex=Assert.Throws<JSException>(() => bagFn.Call(null, ptr, value));
-            Assert.Contains("Overflow: value out of Number.isSafeInteger range", ex.Message);
+            Assert.Contains("Value is not a safe integer", ex.Message);
 
             double expectedD = value;
             uint ptrD = (uint)Unsafe.AsPointer(ref expectedD);
             var bagFnD = new Function("ptr", "value", @"
                 globalThis.App.MONO.getI52(ptr);");
             var exD = Assert.Throws<JSException>(() => bagFn.Call(null, ptr, value));
-            Assert.Contains("Overflow: value out of Number.isSafeInteger range", ex.Message);
+            Assert.Contains("Value is not a safe integer", ex.Message);
         }
 
         [Theory]
@@ -138,7 +138,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             var bagFn = new Function("ptr", "value", @"
                 globalThis.App.MONO.setI52(ptr, value);");
             var ex=Assert.Throws<JSException>(() => bagFn.Call(null, ptr, double.NaN));
-            Assert.Contains("Can't convert Number.Nan into Int64", ex.Message);
+            Assert.Contains("Value is not a safe integer: NaN (number)", ex.Message);
         }
     }
 }

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -81,6 +81,10 @@ const fn_signatures: [ident: string, returnType: string | null, argTypes?: strin
     ["mono_wasm_exec_regression", "number", ["number", "string"]],
     ["mono_wasm_write_managed_pointer_unsafe", "void", ["number", "number"]],
     ["mono_wasm_copy_managed_pointer", "void", ["number", "number"]],
+    ["mono_wasm_i52_to_f64", "number", ["number", "number"]],
+    ["mono_wasm_u52_to_f64", "number", ["number", "number"]],
+    ["mono_wasm_f64_to_i52", "number", ["number", "number"]],
+    ["mono_wasm_f64_to_u52", "number", ["number", "number"]],
 ];
 
 export interface t_Cwraps {
@@ -180,6 +184,10 @@ export interface t_Cwraps {
     mono_wasm_exec_regression(verbose_level: number, image: string): number;
     mono_wasm_write_managed_pointer_unsafe(destination: VoidPtr | MonoObjectRef, pointer: ManagedPointer): void;
     mono_wasm_copy_managed_pointer(destination: VoidPtr | MonoObjectRef, source: VoidPtr | MonoObjectRef): void;
+    mono_wasm_i52_to_f64 (source: VoidPtr, error: Int32Ptr) : number;
+    mono_wasm_u52_to_f64 (source: VoidPtr, error: Int32Ptr) : number;
+    mono_wasm_f64_to_i52 (destination: VoidPtr, value: number) : I52Error;
+    mono_wasm_f64_to_u52 (destination: VoidPtr, value: number) : I52Error;
 }
 
 const wrapped_c_functions: t_Cwraps = <any>{};
@@ -201,4 +209,11 @@ export function wrap_c_function(name: string): Function {
     const fce = Module.cwrap(sig[0], sig[1], sig[2], sig[3]);
     wf[sig[0]] = fce;
     return fce;
+}
+
+// see src/mono/wasm/driver.c I52_ERROR_xxx
+export const enum I52Error {
+    NONE = 0,
+    NON_INTEGRAL = 1,
+    OUT_OF_RANGE = 2,
 }

--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -329,11 +329,11 @@ declare function getI8(offset: _MemOffset): number;
 declare function getI16(offset: _MemOffset): number;
 declare function getI32(offset: _MemOffset): number;
 /**
- * Throws for  Number.MIN_SAFE_INTEGER > value > Number.MAX_SAFE_INTEGER
+ * Throws for Number.MIN_SAFE_INTEGER > value > Number.MAX_SAFE_INTEGER
  */
 declare function getI52(offset: _MemOffset): number;
 /**
- * Throws for  Number.MIN_SAFE_INTEGER > value > Number.MAX_SAFE_INTEGER
+ * Throws for 0 > value > Number.MAX_SAFE_INTEGER
  */
 declare function getU52(offset: _MemOffset): number;
 declare function getI64Big(offset: _MemOffset): bigint;

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <assert.h>
+#include <math.h>
 #include <dlfcn.h>
 #include <sys/stat.h>
 
@@ -1002,6 +1003,7 @@ static int
 _mono_wasm_try_unbox_primitive_and_get_type_ref_impl (PVOLATILE(MonoObject) obj, void *result, int result_capacity) {
 	void **resultP = result;
 	int *resultI = result;
+	uint32_t *resultU = result;
 	int64_t *resultL = result;
 	float *resultF = result;
 	double *resultD = result;
@@ -1045,22 +1047,21 @@ _mono_wasm_try_unbox_primitive_and_get_type_ref_impl (PVOLATILE(MonoObject) obj,
 			*resultI = *(signed char*)mono_object_unbox (obj);
 			break;
 		case MONO_TYPE_U1:
-			*resultI = *(unsigned char*)mono_object_unbox (obj);
+			*resultU = *(unsigned char*)mono_object_unbox (obj);
 			break;
 		case MONO_TYPE_I2:
 		case MONO_TYPE_CHAR:
 			*resultI = *(short*)mono_object_unbox (obj);
 			break;
 		case MONO_TYPE_U2:
-			*resultI = *(unsigned short*)mono_object_unbox (obj);
+			*resultU = *(unsigned short*)mono_object_unbox (obj);
 			break;
 		case MONO_TYPE_I4:
 		case MONO_TYPE_I:
 			*resultI = *(int*)mono_object_unbox (obj);
 			break;
 		case MONO_TYPE_U4:
-			// FIXME: Will this behave the way we want for large unsigned values?
-			*resultI = *(int*)mono_object_unbox (obj);
+			*resultU = *(uint32_t*)mono_object_unbox (obj);
 			break;
 		case MONO_TYPE_R4:
 			*resultF = *(float*)mono_object_unbox (obj);
@@ -1069,7 +1070,7 @@ _mono_wasm_try_unbox_primitive_and_get_type_ref_impl (PVOLATILE(MonoObject) obj,
 			*resultD = *(double*)mono_object_unbox (obj);
 			break;
 		case MONO_TYPE_PTR:
-			*resultL = (int64_t)(*(void**)mono_object_unbox (obj));
+			*resultU = (uint32_t)(*(void**)mono_object_unbox (obj));
 			break;
 		case MONO_TYPE_I8:
 		case MONO_TYPE_U8:
@@ -1346,4 +1347,56 @@ mono_wasm_init_finalizer_thread (void)
 #if 0
 	mono_gc_init_finalizer_thread ();
 #endif
+}
+
+#define I52_ERROR_NONE 0
+#define I52_ERROR_NON_INTEGRAL 1
+#define I52_ERROR_OUT_OF_RANGE 2
+
+#define U52_MAX_VALUE ((1ULL << 53) - 1)
+#define I52_MAX_VALUE ((1LL << 53) - 1)
+#define I52_MIN_VALUE -I52_MAX_VALUE
+
+EMSCRIPTEN_KEEPALIVE double mono_wasm_i52_to_f64 (int64_t *source, int *error) {
+	int64_t value = *source;
+
+	if ((value < I52_MIN_VALUE) || (value > I52_MAX_VALUE)) {
+		*error = I52_ERROR_OUT_OF_RANGE;
+		return NAN;
+	}
+
+	*error = I52_ERROR_NONE;
+	return (double)value;
+}
+
+EMSCRIPTEN_KEEPALIVE double mono_wasm_u52_to_f64 (uint64_t *source, int *error) {
+	uint64_t value = *source;
+
+	if (value > U52_MAX_VALUE) {
+		*error = I52_ERROR_OUT_OF_RANGE;
+		return NAN;
+	}
+
+	*error = I52_ERROR_NONE;
+	return (double)value;
+}
+
+EMSCRIPTEN_KEEPALIVE int mono_wasm_f64_to_u52 (uint64_t *destination, double value) {
+	if ((value < 0) || (value > U52_MAX_VALUE))
+		return I52_ERROR_OUT_OF_RANGE;
+	if (floor(value) != value)
+		return I52_ERROR_NON_INTEGRAL;
+
+	*destination = (uint64_t)value;
+	return I52_ERROR_NONE;
+}
+
+EMSCRIPTEN_KEEPALIVE int mono_wasm_f64_to_i52 (int64_t *destination, double value) {
+	if ((value < I52_MIN_VALUE) || (value > I52_MAX_VALUE))
+		return I52_ERROR_OUT_OF_RANGE;
+	if (floor(value) != value)
+		return I52_ERROR_NON_INTEGRAL;
+
+	*destination = (int64_t)value;
+	return I52_ERROR_NONE;
 }

--- a/src/mono/wasm/runtime/gc-handles.ts
+++ b/src/mono/wasm/runtime/gc-handles.ts
@@ -3,7 +3,7 @@
 
 import corebindings from "./corebindings";
 import { GCHandle, JSHandle, JSHandleDisposed, JSHandleNull, MonoObjectRef } from "./types";
-import { setU32 } from "./memory";
+import { setI32_unchecked } from "./memory";
 import { create_weak_ref } from "./weak-ref";
 
 export const _use_finalization_registry = typeof globalThis.FinalizationRegistry === "function";
@@ -27,7 +27,7 @@ export const cs_owned_js_handle_symbol = Symbol.for("wasm cs_owned_js_handle");
 
 export function get_js_owned_object_by_gc_handle_ref(gc_handle: GCHandle, result: MonoObjectRef): void {
     if (!gc_handle) {
-        setU32(result, 0);
+        setI32_unchecked(result, 0);
         return;
     }
     // this is always strong gc_handle
@@ -44,7 +44,7 @@ export function mono_wasm_get_jsobj_from_js_handle(js_handle: JSHandle): any {
 // its InFlight gc_handle would be freed when the instance arrives to managed side via Interop.Runtime.ReleaseInFlight
 export function get_cs_owned_object_by_js_handle_ref(js_handle: JSHandle, should_add_in_flight: boolean, result: MonoObjectRef): void {
     if (js_handle === JSHandleNull || js_handle === JSHandleDisposed) {
-        setU32(result, 0);
+        setI32_unchecked(result, 0);
         return;
     }
     corebindings._get_cs_owned_object_by_js_handle_ref(js_handle, should_add_in_flight ? 1 : 0, result);

--- a/src/mono/wasm/runtime/js-to-cs.ts
+++ b/src/mono/wasm/runtime/js-to-cs.ts
@@ -16,7 +16,7 @@ import { js_string_to_mono_string_root, js_string_to_mono_string_interned_root }
 import { isThenable } from "./cancelable-promise";
 import { has_backing_array_buffer } from "./buffers";
 import { JSHandle, MonoArray, MonoMethod, MonoObject, MonoObjectNull, wasm_type_symbol, MonoClass, MonoObjectRef, is_nullish } from "./types";
-import { setI32, setU32, setF64 } from "./memory";
+import { setF64, setI32_unchecked, setU32_unchecked, setB32 } from "./memory";
 import { Int32Ptr, TypedArray } from "./types/emscripten";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -78,10 +78,10 @@ export function js_to_mono_obj_root(js_obj: any, result: WasmRoot<MonoObject>, s
         case typeof js_obj === "number": {
             let box_class : MonoClass;
             if ((js_obj | 0) === js_obj) {
-                setI32(runtimeHelpers._box_buffer, js_obj);
+                setI32_unchecked(runtimeHelpers._box_buffer, js_obj);
                 box_class = runtimeHelpers._class_int32;
             } else if ((js_obj >>> 0) === js_obj) {
-                setU32(runtimeHelpers._box_buffer, js_obj);
+                setU32_unchecked(runtimeHelpers._box_buffer, js_obj);
                 box_class = runtimeHelpers._class_uint32;
             } else {
                 setF64(runtimeHelpers._box_buffer, js_obj);
@@ -98,7 +98,7 @@ export function js_to_mono_obj_root(js_obj: any, result: WasmRoot<MonoObject>, s
             js_string_to_mono_string_interned_root(js_obj, <any>result);
             return;
         case typeof js_obj === "boolean":
-            setI32(runtimeHelpers._box_buffer, js_obj ? 1 : 0);
+            setB32(runtimeHelpers._box_buffer, js_obj);
             cwraps.mono_wasm_box_primitive_ref(runtimeHelpers._class_boolean, runtimeHelpers._box_buffer, 4, result.address);
             return;
         case isThenable(js_obj) === true: {

--- a/src/mono/wasm/runtime/memory.ts
+++ b/src/mono/wasm/runtime/memory.ts
@@ -1,7 +1,8 @@
 import { Module } from "./imports";
 import { mono_assert } from "./types";
-import { VoidPtr, NativePointer, ManagedPointer } from "./types/emscripten";
+import { VoidPtr, NativePointer, ManagedPointer, Int32Ptr } from "./types/emscripten";
 import * as cuint64 from "./cuint64";
+import cwraps, { I52Error } from "./cwraps";
 
 const alloca_stack: Array<VoidPtr> = [];
 const alloca_buffer_size = 32 * 1024;
@@ -16,7 +17,7 @@ function _ensure_allocated(): void {
     alloca_limit = <VoidPtr>(<any>alloca_base + alloca_buffer_size);
 }
 
-const is_bingint_supported = typeof BigInt !== "undefined" && typeof BigInt64Array !== "undefined";
+const is_bigint_supported = typeof BigInt !== "undefined" && typeof BigInt64Array !== "undefined";
 
 export function temp_malloc(size: number): VoidPtr {
     _ensure_allocated();
@@ -45,90 +46,98 @@ export function _release_temp_frame(): void {
 type _MemOffset = number | VoidPtr | NativePointer | ManagedPointer;
 type _NumberOrPointer = number | VoidPtr | NativePointer | ManagedPointer;
 
-function is_int_in_range(value: Number, min: Number, max: Number) {
-    mono_assert(typeof value === "number", () => `Value is not integer but ${typeof value}`);
-    mono_assert(Number.isInteger(value), "Value is not integer but float");
+function assert_int_in_range(value: Number, min: Number, max: Number) {
+    mono_assert(Number.isSafeInteger(value), () => `Value is not an integer: ${value} (${typeof (value)})`);
     mono_assert(value >= min && value <= max, () => `Overflow: value ${value} is out of ${min} ${max} range`);
 }
 
+export function _zero_region(byteOffset: VoidPtr, sizeBytes: number): void {
+    if (((<any>byteOffset % 4) === 0) && ((sizeBytes % 4) === 0))
+        Module.HEAP32.fill(0, <any>byteOffset >>> 2, sizeBytes >>> 2);
+    else
+        Module.HEAP8.fill(0, <any>byteOffset, sizeBytes);
+}
+
 export function setB32(offset: _MemOffset, value: number | boolean): void {
-    mono_assert(typeof value === "boolean", () => `Value is not boolean but ${typeof value}`);
-    Module.HEAP32[<any>offset >>> 2] = <any>!!value;
+    const boolValue = !!value;
+    if (typeof (value) === "number")
+        assert_int_in_range(value, 0, 1);
+    Module.HEAP32[<any>offset >>> 2] = boolValue ? 1 : 0;
 }
 
 export function setU8(offset: _MemOffset, value: number): void {
-    is_int_in_range(value, 0, 0xFF);
+    assert_int_in_range(value, 0, 0xFF);
     Module.HEAPU8[<any>offset] = value;
 }
 
 export function setU16(offset: _MemOffset, value: number): void {
-    is_int_in_range(value, 0, 0xFFFF);
+    assert_int_in_range(value, 0, 0xFFFF);
     Module.HEAPU16[<any>offset >>> 1] = value;
 }
 
+export function setU32_unchecked(offset: _MemOffset, value: _NumberOrPointer): void {
+    Module.HEAPU32[<any>offset >>> 2] = <number><any>value;
+}
+
 export function setU32(offset: _MemOffset, value: _NumberOrPointer): void {
-    is_int_in_range(<any>value, 0, 0xFFFF_FFFF);
+    assert_int_in_range(<any>value, 0, 0xFFFF_FFFF);
     Module.HEAPU32[<any>offset >>> 2] = <number><any>value;
 }
 
 export function setI8(offset: _MemOffset, value: number): void {
-    is_int_in_range(value, -0x80, 0x7F);
+    assert_int_in_range(value, -0x80, 0x7F);
     Module.HEAP8[<any>offset] = value;
 }
 
 export function setI16(offset: _MemOffset, value: number): void {
-    is_int_in_range(value, -0x8000, 0x7FFF);
+    assert_int_in_range(value, -0x8000, 0x7FFF);
     Module.HEAP16[<any>offset >>> 1] = value;
 }
 
-export function setI32(offset: _MemOffset, value: number): void {
-    is_int_in_range(<any>value, -0x8000_0000, 0x7FFF_FFFF);
+export function setI32_unchecked(offset: _MemOffset, value: number): void {
     Module.HEAP32[<any>offset >>> 2] = value;
+}
+
+export function setI32(offset: _MemOffset, value: number): void {
+    assert_int_in_range(<any>value, -0x8000_0000, 0x7FFF_FFFF);
+    Module.HEAP32[<any>offset >>> 2] = value;
+}
+
+function autoThrowI52 (error: I52Error) {
+    if (error === I52Error.NONE)
+        return;
+
+    switch (error) {
+        case I52Error.NON_INTEGRAL:
+            throw new Error("value was not an integer");
+        case I52Error.OUT_OF_RANGE:
+            throw new Error("value out of range");
+        default:
+            throw new Error("unknown internal error");
+    }
 }
 
 /**
  * Throws for values which are not 52 bit integer. See Number.isSafeInteger()
  */
 export function setI52(offset: _MemOffset, value: number): void {
-    // 52 bits = 0x1F_FFFF_FFFF_FFFF
-    // see also https://en.wikipedia.org/wiki/Double-precision_floating-point_format
-    mono_assert(!Number.isNaN(value), "Can't convert Number.Nan into Int64");
-    mono_assert(Number.isSafeInteger(value), "Overflow: value out of Number.isSafeInteger range");
-    let hi: number;
-    let lo: number;
-    if (value < 0) {
-        const nvalue = -1 - value;
-        // take hi dword (on double because >>>32 doesn't work) and negate it
-        hi = ((nvalue / 0x1_0000_0000) ^ 0xFFFF_FFFF) >>> 0;
-
-        // mask lo dword and negate it
-        lo = ((nvalue >>> 0) ^ 0xFFFF_FFFF) >>> 0;
-    }
-    else {
-        hi = (value / 0x1_0000_0000) >>> 0;
-        lo = value >>> 0;
-    }
-    Module.HEAPU32[1 + (<any>offset >>> 2)] = hi;
-    Module.HEAPU32[<any>offset >>> 2] = lo;
+    mono_assert(Number.isSafeInteger(value), () => `Value is not a safe integer: ${value} (${typeof (value)})`);
+    const error = cwraps.mono_wasm_f64_to_i52(<any>offset, value);
+    autoThrowI52(error);
 }
 
 /**
  * Throws for values which are not 52 bit integer or are negative. See Number.isSafeInteger().
  */
 export function setU52(offset: _MemOffset, value: number): void {
-    // 52 bits = 0x1F_FFFF_FFFF_FFFF
-    mono_assert(!Number.isNaN(value), "Can't convert Number.Nan into UInt64");
-    mono_assert(Number.isSafeInteger(value), "Overflow: value out of Number.isSafeInteger range");
+    mono_assert(Number.isSafeInteger(value), () => `Value is not a safe integer: ${value} (${typeof (value)})`);
     mono_assert(value >= 0, "Can't convert negative Number into UInt64");
-    // take hi dword (on double because >>>32 doesn't work)
-    const hi = (value / 0x1_0000_0000) >>> 0;
-    const lo = value >>> 0;
-    Module.HEAPU32[1 + (<any>offset >>> 2)] = hi;
-    Module.HEAPU32[<any>offset >>> 2] = lo;
+    const error = cwraps.mono_wasm_f64_to_u52(<any>offset, value);
+    autoThrowI52(error);
 }
 
 export function setI64Big(offset: _MemOffset, value: bigint): void {
-    mono_assert(is_bingint_supported, "BigInt is not supported.");
+    mono_assert(is_bigint_supported, "BigInt is not supported.");
     HEAPI64[<any>offset >>> 3] = value;
 }
 
@@ -169,46 +178,36 @@ export function getI32(offset: _MemOffset): number {
     return Module.HEAP32[<any>offset >>> 2];
 }
 
+let i52_error_scratch_buffer : Int32Ptr = <any>0;
+
 /**
- * Throws for  Number.MIN_SAFE_INTEGER > value > Number.MAX_SAFE_INTEGER
+ * Throws for Number.MIN_SAFE_INTEGER > value > Number.MAX_SAFE_INTEGER
  */
 export function getI52(offset: _MemOffset): number {
-    // 52 bits = 0x1F_FFFF_FFFF_FFFF
-    // see also https://en.wikipedia.org/wiki/Double-precision_floating-point_format
-    const hi = Module.HEAPU32[1 + (<any>offset >>> 2)];
-    const lo = Module.HEAPU32[<any>offset >>> 2];
-    const sign = hi & 0x8000_0000;
-    const exp = hi & 0x7FE0_0000;
-    if (sign) {
-        // for negative numbers, the integer would have all bits of exponent set to 1
-        mono_assert(exp === 0x7FE0_0000, "Overflow: value out of Number.isSafeInteger range");
-        // mask and negate integer bits of hi dword
-        const nhi = (hi & 0x001F_FFFF) ^ 0x001F_FFFF;
-        // all lo dword bits are for integer, negate them and force JS to treat it as int32
-        const nlo = (lo ^ 0xFFFF_FFFF) >>> 0;
-        // shift hi dword and add lo, then make it negative again
-        return -1 - ((nhi * 0x1_0000_0000) + nlo);
-    }
-    else {
-        mono_assert(exp === 0, "Overflow: value out of Number.isSafeInteger range");
-        return (hi * 0x1_0000_0000) + lo;
-    }
+    if (!i52_error_scratch_buffer)
+        i52_error_scratch_buffer = <any>Module._malloc(4);
+
+    const result = cwraps.mono_wasm_i52_to_f64(<any>offset, i52_error_scratch_buffer);
+    const error = getI32(i52_error_scratch_buffer);
+    autoThrowI52(error);
+    return result;
 }
 
 /**
- * Throws for  Number.MIN_SAFE_INTEGER > value > Number.MAX_SAFE_INTEGER
+ * Throws for 0 > value > Number.MAX_SAFE_INTEGER
  */
 export function getU52(offset: _MemOffset): number {
-    // 52 bits = 0x1F_FFFF_FFFF_FFFF
-    const hi = Module.HEAPU32[1 + (<any>offset >>> 2)];
-    const lo = Module.HEAPU32[<any>offset >>> 2];
-    const exp_sign = hi & 0xFFE0_0000;
-    mono_assert(exp_sign === 0, "Overflow: value out of Number.isSafeInteger range");
-    return (hi * 0x1_0000_0000) + lo;
+    if (!i52_error_scratch_buffer)
+        i52_error_scratch_buffer = <any>Module._malloc(4);
+
+    const result = cwraps.mono_wasm_u52_to_f64(<any>offset, i52_error_scratch_buffer);
+    const error = getI32(i52_error_scratch_buffer);
+    autoThrowI52(error);
+    return result;
 }
 
 export function getI64Big(offset: _MemOffset): bigint {
-    mono_assert(is_bingint_supported, "BigInt is not supported.");
+    mono_assert(is_bigint_supported, "BigInt is not supported.");
     return HEAPI64[<any>offset >>> 3];
 }
 
@@ -221,7 +220,7 @@ export function getF64(offset: _MemOffset): number {
 }
 
 export function afterUpdateGlobalBufferAndViews(buffer: Buffer): void {
-    if (is_bingint_supported) {
+    if (is_bigint_supported) {
         HEAPI64 = new BigInt64Array(buffer);
     }
 }
@@ -234,8 +233,8 @@ export function getCU64(offset: _MemOffset): cuint64.CUInt64 {
 
 export function setCU64(offset: _MemOffset, value: cuint64.CUInt64): void {
     const [lo, hi] = cuint64.unpack32(value);
-    setU32(offset, lo);
-    setU32(<any>offset + 4, hi);
+    setU32_unchecked(offset, lo);
+    setU32_unchecked(<any>offset + 4, hi);
 }
 
 /// Allocates a new buffer of the given size on the Emscripten stack and passes a pointer to it to the callback.

--- a/src/mono/wasm/runtime/memory.ts
+++ b/src/mono/wasm/runtime/memory.ts
@@ -1,6 +1,6 @@
-import { Module } from "./imports";
+import { Module, runtimeHelpers } from "./imports";
 import { mono_assert } from "./types";
-import { VoidPtr, NativePointer, ManagedPointer, Int32Ptr } from "./types/emscripten";
+import { VoidPtr, NativePointer, ManagedPointer } from "./types/emscripten";
 import * as cuint64 from "./cuint64";
 import cwraps, { I52Error } from "./cwraps";
 
@@ -178,17 +178,12 @@ export function getI32(offset: _MemOffset): number {
     return Module.HEAP32[<any>offset >>> 2];
 }
 
-let i52_error_scratch_buffer : Int32Ptr = <any>0;
-
 /**
  * Throws for Number.MIN_SAFE_INTEGER > value > Number.MAX_SAFE_INTEGER
  */
 export function getI52(offset: _MemOffset): number {
-    if (!i52_error_scratch_buffer)
-        i52_error_scratch_buffer = <any>Module._malloc(4);
-
-    const result = cwraps.mono_wasm_i52_to_f64(<any>offset, i52_error_scratch_buffer);
-    const error = getI32(i52_error_scratch_buffer);
+    const result = cwraps.mono_wasm_i52_to_f64(<any>offset, runtimeHelpers._i52_error_scratch_buffer);
+    const error = getI32(runtimeHelpers._i52_error_scratch_buffer);
     autoThrowI52(error);
     return result;
 }
@@ -197,11 +192,8 @@ export function getI52(offset: _MemOffset): number {
  * Throws for 0 > value > Number.MAX_SAFE_INTEGER
  */
 export function getU52(offset: _MemOffset): number {
-    if (!i52_error_scratch_buffer)
-        i52_error_scratch_buffer = <any>Module._malloc(4);
-
-    const result = cwraps.mono_wasm_u52_to_f64(<any>offset, i52_error_scratch_buffer);
-    const error = getI32(i52_error_scratch_buffer);
+    const result = cwraps.mono_wasm_u52_to_f64(<any>offset, runtimeHelpers._i52_error_scratch_buffer);
+    const error = getI32(runtimeHelpers._i52_error_scratch_buffer);
     autoThrowI52(error);
     return result;
 }

--- a/src/mono/wasm/runtime/roots.ts
+++ b/src/mono/wasm/runtime/roots.ts
@@ -5,6 +5,7 @@ import cwraps from "./cwraps";
 import { Module } from "./imports";
 import { VoidPtr, ManagedPointer, NativePointer } from "./types/emscripten";
 import { MonoObjectRef, MonoObjectRefNull, MonoObject, is_nullish } from "./types";
+import { _zero_region } from "./memory";
 
 const maxScratchRoots = 8192;
 let _scratch_root_buffer: WasmRootBuffer | null = null;
@@ -143,13 +144,6 @@ export function mono_wasm_release_roots(...args: WasmRoot<any>[]): void {
 
         args[i].release();
     }
-}
-
-function _zero_region(byteOffset: VoidPtr, sizeBytes: number) {
-    if (((<any>byteOffset % 4) === 0) && ((sizeBytes % 4) === 0))
-        Module.HEAP32.fill(0, <any>byteOffset >>> 2, sizeBytes >>> 2);
-    else
-        Module.HEAP8.fill(0, <any>byteOffset, sizeBytes);
 }
 
 function _mono_wasm_release_scratch_index(index: number) {

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -406,6 +406,7 @@ export function bindings_lazy_init(): void {
     runtimeHelpers._unbox_buffer_size = 65536;
     runtimeHelpers._box_buffer = Module._malloc(runtimeHelpers._box_buffer_size);
     runtimeHelpers._unbox_buffer = Module._malloc(runtimeHelpers._unbox_buffer_size);
+    runtimeHelpers._i52_error_scratch_buffer = <any>Module._malloc(4);
     runtimeHelpers._class_int32 = find_corlib_class("System", "Int32");
     runtimeHelpers._class_uint32 = find_corlib_class("System", "UInt32");
     runtimeHelpers._class_double = find_corlib_class("System", "Double");

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { bind_runtime_method } from "./method-binding";
-import { CharPtr, EmscriptenModule, ManagedPointer, NativePointer, VoidPtr } from "./types/emscripten";
+import { CharPtr, EmscriptenModule, ManagedPointer, NativePointer, VoidPtr, Int32Ptr } from "./types/emscripten";
 
 export type GCHandle = {
     __brand: "GCHandle"
@@ -144,6 +144,7 @@ export type RuntimeHelpers = {
 
     _box_buffer: VoidPtr;
     _unbox_buffer: VoidPtr;
+    _i52_error_scratch_buffer: Int32Ptr;
     _box_root: any;
     // A WasmRoot that is guaranteed to contain 0
     _null_root: any;
@@ -220,7 +221,7 @@ export type DotnetModuleConfigImports = {
     url?: any;
 }
 
-// see src\mono\wasm\runtime\rollup.config.js 
+// see src\mono\wasm\runtime\rollup.config.js
 // inline this, because the lambda could allocate closure on hot path otherwise
 export function mono_assert(condition: unknown, messageFactory: string | (() => string)): asserts condition {
     if (!condition) {


### PR DESCRIPTION
This PR reimplements the I52/U52 memory accessors in C since the JS got really complicated and we kept finding bugs. It also simplifies some of the range checks in the other accessors so they will have less overhead, and uses some unchecked accessors in a few hot paths.