### PR TITLE
Dispose of processes launched in host tests

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
+++ b/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             sharedTestState.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining($"The application to execute does not exist: '{assemblyName}'");
         }
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             sharedTestState.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining($"The application to execute does not exist: '{assemblyName}'");
         }
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             sharedTestState.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining($"dotnet exec needs a managed .dll or .exe extension. The application specified was '{assemblyName}'");
         }
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             sharedTestState.BuiltDotNet.Exec("--fx-version")
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining($"Failed to parse supported options or their values:");
         }
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .WorkingDirectory(sharedTestState.BaseDirectory)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining($"The application '{fileName}' does not exist")
                 .And.FindAnySdk(false);

--- a/src/installer/tests/HostActivation.Tests/DotnetTestXunit.cs
+++ b/src/installer/tests/HostActivation.Tests/DotnetTestXunit.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
                     appDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute(fExpectedToFail:true)
+                .Execute(expectedToFail:true)
                 .Should().Fail()
                 .And.HaveStdOutContaining("Total: 2")
                 .And.HaveStdOutContaining("Failed: 1");

--- a/src/installer/tests/HostActivation.Tests/LightupAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/LightupAppActivation.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             }
         }
 
-        // Attempt to run the app with lightup deps.json specified but lightup library missing in the expected 
+        // Attempt to run the app with lightup deps.json specified but lightup library missing in the expected
         // probe locations.
         [Fact]
         public void Muxer_activation_of_LightupApp_NoLightupLib_Fails()
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             dotnet.Exec("exec", "--additional-deps", libDepsJson, appDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(
                     "Error:" + Environment.NewLine +
@@ -196,9 +196,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             //                  8889.0.0
             // Expected: 8888.0.4
             dotnet.Exec("exec", "--additional-deps", baseDir, appDll)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdErr()
-                .CaptureStdOut()
+                .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello LightupClient")
@@ -256,9 +254,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             //                  8888.0.5
             // Expected: 8888.0.4
             dotnet.Exec("exec", "--additional-deps", baseDir, appDll)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdErr()
-                .CaptureStdOut()
+                .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello LightupClient")
@@ -308,15 +304,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             //                  8889.0.0
             // Expected: fail since we only roll backward on patch, not minor
             dotnet.Exec("exec", "--additional-deps", baseDir, appDll)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute(fExpectedToFail: true)
+                .EnableTracingAndCaptureOutputs()
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining($"No additional deps directory less than or equal to [8888.0.1] found with same major and minor version.");
         }
 
-        // Attempt to run the app without lightup deps.json specified but lightup library present in the expected 
+        // Attempt to run the app without lightup deps.json specified but lightup library present in the expected
         // probe location (of being app-local).
         [Fact]
         public void Muxer_activation_of_LightupApp_WithLightupLib_NoLightupDepsJson_Fails()
@@ -339,7 +333,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             dotnet.Exec("exec", appDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdOutContaining("Exception: Failed to load the lightup assembly!");
         }
@@ -375,10 +369,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             // Expected: a parsing error since the json file is bad.
             dotnet.Exec("exec", "--additional-deps", additionalDepsRootPath, appDll)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdOut()
-                .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .EnableTracingAndCaptureOutputs()
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining($"Error initializing the dependency resolver: An error occurred while parsing: {additionalDepsPath}");
         }
@@ -426,9 +418,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Expected: the uber framework's version of System.Collections.Immutable is used instead of the additional-deps
             string uberAssembly = Path.Combine(_uberFxBaseDir, "7777.0.0", "System.Collections.Immutable.dll");
             dotnet.Exec("exec", "--additional-deps", additionalDepsPath, appDll)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdOut()
-                .CaptureStdErr()
+                .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdErrContaining($"Using specified additional deps.json: '{additionalDepsPath}'")
@@ -485,9 +475,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Expected: the additional dep's version of System.Collections.Immutable is used instead of the uber's assembly
             string uberAssembly = Path.Combine(_uberFxBaseDir, "7777.0.0", "System.Collections.Immutable.dll");
             dotnet.Exec("exec", "--additional-deps", additionalDepsPath, appDll)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdOut()
-                .CaptureStdErr()
+                .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdErrContaining($"Using specified additional deps.json: '{additionalDepsPath}'")

--- a/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         private readonly string _regSdkBaseDir;
         private readonly string _exeSelectedMessage;
         private readonly string _regSelectedMessage;
-        private readonly string _multilevelDir;
+        private readonly TestArtifact _multilevelDir;
 
         private const string _dotnetSdkDllMessageTerminator = "dotnet.dll]";
 
@@ -36,15 +36,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // The dotnetMultilevelSDKLookup dir will contain some folders and files that will be
             // necessary to perform the tests
             string baseMultilevelDir = Path.Combine(TestArtifact.TestArtifactsPath, "dotnetMultilevelSDKLookup");
-            _multilevelDir = SharedFramework.CalculateUniqueTestDirectory(baseMultilevelDir);
+            _multilevelDir = new TestArtifact(SharedFramework.CalculateUniqueTestDirectory(baseMultilevelDir));
 
             // The tested locations will be the cwd, exe dir, and registered directory. cwd is no longer supported.
             //     All dirs will be placed inside the multilevel folder
-            _currentWorkingDir = Path.Combine(_multilevelDir, "cwd");
-            _exeDir = Path.Combine(_multilevelDir, "exe");
-            _regDir = Path.Combine(_multilevelDir, "reg");
+            _currentWorkingDir = Path.Combine(_multilevelDir.Location, "cwd");
+            _exeDir = Path.Combine(_multilevelDir.Location, "exe");
+            _regDir = Path.Combine(_multilevelDir.Location, "reg");
 
-            DotNet = new DotNetBuilder(_multilevelDir, Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish"), "exe")
+            DotNet = new DotNetBuilder(_multilevelDir.Location, Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish"), "exe")
                 .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("9999.0.0")
                 .Build();
 
@@ -70,11 +70,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void Dispose()
         {
             _testOnlyProductBehaviorMarker?.Dispose();
-
-            if (!TestArtifact.PreserveTestRuns())
-            {
-                Directory.Delete(_multilevelDir, true);
-            }
+            _multilevelDir.Dispose();
         }
 
         [Fact]

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             dotnet.Exec(appDll)
                 .EnvironmentVariable("CORE_BREADCRUMBS", sharedTestState.BreadcrumbLocation)
                 .EnableTracingAndCaptureOutputs()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining("Unhandled exception.")
                 .And.HaveStdErrContaining("System.Exception: Goodbye World")

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             };
 
             sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.InitializeContextForApp(project.AppDll)
                 .And.ExecuteApplicationWithException(sharedState.NativeHostPath, project.AppDll);

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
@@ -204,7 +204,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             };
 
             sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.InitializeContextForApp(appProject.AppDll)
                 .And.ExecuteFunctionPointerWithException(entryPoint, 1);

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
@@ -223,7 +223,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             };
 
             sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.InitializeContextForConfig(componentProject.RuntimeConfigJson)
                 .And.ExecuteComponentEntryPointWithException(entryPoint, 1);

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             dotnet.Exec("exec", appExe)
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining("has already been found but with a different file extension");
         }
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             dotnet.Exec("exec", "--runtimeconfig", runtimeConfig, appDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail();
         }
 
@@ -242,7 +242,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             dotnet.Exec("exec", "--depsfile", depsJson, appDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail();
         }
 
@@ -479,14 +479,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}";
                 }
 
-                Command command = Command.Create(appExe)
+                CommandResult result = Command.Create(appExe)
                     .EnableTracingAndCaptureOutputs()
                     .DotNetRoot(invalidDotNet)
                     .MultilevelLookup(false)
-                    .Start();
+                    .Execute(expectedToFail: true);
 
-                var result = command.WaitForExit(true);
-                    result.Should().Fail()
+                result.Should().Fail()
                     .And.HaveStdErrContaining($"https://aka.ms/dotnet-core-applaunch?{expectedUrlQuery}")
                     .And.HaveStdErrContaining(expectedStdErr);
 

--- a/src/installer/tests/HostActivation.Tests/RuntimeProperties.cs
+++ b/src/installer/tests/HostActivation.Tests/RuntimeProperties.cs
@@ -127,14 +127,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             public string FrameworkTestPropertyValue => "VALUE_FROM_FRAMEWORK";
             public string HostFxrPathPropertyName => "HOSTFXR_PATH";
 
-            private readonly string copiedDotnet;
+            private readonly TestArtifact copiedDotnet;
 
             public SharedTestState()
             {
-                copiedDotnet = Path.Combine(TestArtifact.TestArtifactsPath, "runtimeProperties");
-                SharedFramework.CopyDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish"), copiedDotnet);
+                copiedDotnet = new TestArtifact(Path.Combine(TestArtifact.TestArtifactsPath, "runtimeProperties"));
+                SharedFramework.CopyDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish"), copiedDotnet.Location);
 
-                MockSDK = new DotNetBuilder(copiedDotnet, Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish"), "exe")
+                MockSDK = new DotNetBuilder(copiedDotnet.Location, Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish"), "exe")
                     .AddMicrosoftNETCoreAppFrameworkMockCoreClr("9999.0.0")
                     .AddMockSDK("9999.0.0-dev", "9999.0.0")
                     .Build();
@@ -147,7 +147,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
     }
 }");
 
-                RepoDirectories = new RepoDirectoriesProvider(builtDotnet: copiedDotnet);
+                RepoDirectories = new RepoDirectoriesProvider(builtDotnet: copiedDotnet.Location);
 
                 RuntimePropertiesFixture = new TestProjectFixture("RuntimeProperties", RepoDirectories)
                     .EnsureRestored()
@@ -165,10 +165,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             public void Dispose()
             {
                 RuntimePropertiesFixture.Dispose();
-                if (!TestArtifact.PreserveTestRuns() && Directory.Exists(copiedDotnet))
-                {
-                    Directory.Delete(copiedDotnet, true);
-                }
+                copiedDotnet.Dispose();
             }
         }
     }

--- a/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
@@ -92,7 +92,7 @@ namespace HostActivation.Tests
             int exitCode = Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .ExitCode;
 
             if (OperatingSystem.IsWindows())
@@ -121,7 +121,7 @@ namespace HostActivation.Tests
             int exitCode = Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .ExitCode;
 
             if (OperatingSystem.IsWindows())
@@ -222,7 +222,7 @@ namespace HostActivation.Tests
             Command.Create(appExe)
                 .EnableTracingAndCaptureOutputs()
                 .DotNetRoot(newOutDir)
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveUsedDotNetRootInstallLocation(Path.GetFullPath(newOutDir), fixture.CurrentRid)
                 .And.HaveStdErrContaining($"The required library {RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostfxr")} could not be found.");

--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -56,10 +56,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             // Ensure startup hook tracing works
             dotnet.Exec(appDll)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
                 .EnvironmentVariable(startupHookVarName, startupHookDll)
-                .CaptureStdOut()
-                .CaptureStdErr()
+                .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdErrContaining("Property STARTUP_HOOKS = " + startupHookDll)
@@ -198,7 +196,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookDll)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining("System.IO.FileNotFoundException: Could not load file or assembly 'Newtonsoft.Json");
         }
@@ -223,7 +221,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello from startup hook!")
                 .And.HaveStdOutContaining("Hello from startup hook with dependency!")
@@ -235,7 +233,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining("System.ArgumentException: The startup hook simple assembly name ' ' is invalid.");
 
@@ -245,7 +243,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello from startup hook!")
                 .And.HaveStdOutContaining("Hello World");
@@ -256,7 +254,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello from startup hook!")
                 .And.HaveStdOutContaining("Hello from startup hook with dependency!")
@@ -283,7 +281,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookVar))
                 .And.NotHaveStdErrContaining("--->");
@@ -294,7 +292,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookVar))
                 .And.NotHaveStdErrContaining("--->");
@@ -305,7 +303,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookVar))
                 .And.NotHaveStdErrContaining("--->");
@@ -316,7 +314,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookVar))
                 .And.NotHaveStdErrContaining("--->");
@@ -327,7 +325,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookVar))
                 .And.NotHaveStdErrContaining("--->");
@@ -338,7 +336,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookVar))
                 .And.HaveStdErrContaining("---> System.IO.FileLoadException: The given assembly name was invalid.");
@@ -349,7 +347,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, relativeAssemblyPath))
                 .And.NotHaveStdOutContaining("Hello from startup hook!");
@@ -373,7 +371,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookVar))
                 .And.HaveStdErrContaining($"---> System.IO.FileNotFoundException: Could not load file or assembly '{startupHookVar}'. The system cannot find the file specified.");
@@ -384,7 +382,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookVar))
                 .And.HaveStdErrContaining($"---> System.IO.FileNotFoundException: Could not load file or assembly '{startupHookVar}");
@@ -436,7 +434,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, Path.GetFullPath(startupHookMissingDll)));
 
@@ -446,7 +444,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdOutContaining("Hello from startup hook!")
                 .And.HaveStdErrContaining(string.Format(expectedError, Path.GetFullPath((startupHookMissingDll))));
@@ -473,7 +471,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookInvalidAssemblyDll)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(expectedError);
 
@@ -483,7 +481,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(expectedError);
         }
@@ -507,7 +505,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookMissingTypeDll)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining("System.TypeLoadException: Could not load type 'StartupHook' from assembly 'StartupHook");
 
@@ -517,7 +515,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdOutContaining("Hello from startup hook!")
                 .And.HaveStdErrContaining("System.TypeLoadException: Could not load type 'StartupHook' from assembly 'StartupHookWithoutStartupHookType");
@@ -545,7 +543,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookMissingMethodDll)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(expectedError);
 
@@ -555,7 +553,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdOutContaining("Hello from startup hook!")
                 .And.HaveStdErrContaining(expectedError);
@@ -581,7 +579,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookWithInstanceMethodDll)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookWithInstanceMethodDll));
 
@@ -592,7 +590,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookWithParameterDll)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookWithParameterDll));
 
@@ -603,7 +601,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookWithReturnTypeDll)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookWithReturnTypeDll));
 
@@ -614,7 +612,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookWithMultipleIncorrectSignaturesDll)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookWithMultipleIncorrectSignaturesDll));
 
@@ -624,7 +622,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdOutContaining("Hello from startup hook!")
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookWithMultipleIncorrectSignaturesDll));
@@ -685,7 +683,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             dotnet.Exec(appDll)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining("FileNotFoundException: Could not load file or assembly 'SharedLibrary");
 
@@ -694,7 +692,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable(startupHookVarName, startupHookDll)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(fExpectedToFail: true)
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.ExitWith(2);
         }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleRename.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleRename.cs
@@ -41,9 +41,9 @@ namespace AppHost.Bundle.Tests
                 .CaptureStdOut()
                 .Start();
 
-            const int twoMitutes = 120000 /*milliseconds*/;
+            const int twoMinutes = 120000 /*milliseconds*/;
             int waitTime = 0;
-            while (!File.Exists(waitFile) && !singleExe.Process.HasExited && waitTime < twoMitutes)
+            while (!File.Exists(waitFile) && !singleExe.Process.HasExited && waitTime < twoMinutes)
             {
                 Thread.Sleep(100);
                 waitTime += 100;
@@ -54,13 +54,9 @@ namespace AppHost.Bundle.Tests
             File.Move(singleFile, renameFile);
             File.Create(resumeFile).Close();
 
-            var result = singleExe.WaitForExit(fExpectedToFail: false, twoMitutes);
-
-            result
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello World!");
+            singleExe.WaitForExit(expectedToFail: false, twoMinutes)
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World!");
         }
 
         public class SharedTestState : SharedTestStateBase, IDisposable


### PR DESCRIPTION
There have been intermittent failures where the host tests fail to clean up with `UnauthorizedAccessException` for an executable we launch. Examples:
- https://dnceng.visualstudio.com/public/_build/results?buildId=1781597&view=ms.vss-test-web.build-test-results-tab&runId=47749186&resultId=100084&paneView=debug
- https://dnceng.visualstudio.com/public/_build/results?buildId=1781253&view=ms.vss-test-web.build-test-results-tab&runId=47741596&resultId=100143&paneView=debug
- https://dnceng.visualstudio.com/public/_build/results?buildId=1780001&view=ms.vss-test-web.build-test-results-tab&runId=47722460&paneView=debug&resultId=100078

It seems the host test don't dispose any of the processes they launch. This change makes the `Command.WaitForExit` helper dispose of the underlying process. All the tests should go through this. We could also make `Command` disposable, but that makes the usage in all the tests more awkward with the current pattern of chained invokes/assertions.

This also switches some of the tests to use the `TestArtifact` helper class for cleaning up a test directory.