### PR TITLE
Remove destructors

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43719,7 +43719,7 @@ HRESULT GCHeap::StaticShutdown()
 
     for (int i = 0; i < gc_heap::n_heaps; i ++)
     {
-        delete gc_heap::g_heaps[i]->vm_heap;
+        // delete gc_heap::g_heaps[i]->vm_heap;
         //destroy pure GC stuff
         gc_heap::destroy_gc_heap (gc_heap::g_heaps[i]);
     }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43719,7 +43719,6 @@ HRESULT GCHeap::StaticShutdown()
 
     for (int i = 0; i < gc_heap::n_heaps; i ++)
     {
-        // delete gc_heap::g_heaps[i]->vm_heap;
         //destroy pure GC stuff
         gc_heap::destroy_gc_heap (gc_heap::g_heaps[i]);
     }

--- a/src/coreclr/gc/gc.h
+++ b/src/coreclr/gc/gc.h
@@ -252,10 +252,6 @@ struct alloc_context : gc_alloc_context
 
 class IGCHeapInternal : public IGCHeap {
 public:
-
-    virtual ~IGCHeapInternal() {}
-
-public:
     virtual int GetNumberOfHeaps () = 0;
     virtual int GetHomeHeapNumber () = 0;
     virtual size_t GetPromotedBytes(int heap_index) = 0;

--- a/src/coreclr/gc/gcimpl.h
+++ b/src/coreclr/gc/gcimpl.h
@@ -66,7 +66,6 @@ public:
 
 public:
     GCHeap(){};
-    ~GCHeap(){};
 
     /* BaseGCHeap Methods*/
     PER_HEAP_ISOLATED   HRESULT StaticShutdown ();

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -921,11 +921,16 @@ public:
     // Enables or disables the given keyword or level on the private event provider.
     virtual void ControlPrivateEvents(GCEventKeyword keyword, GCEventLevel level) = 0;
 
+    // Get the segment/region associated with an address together with its generation for the profiler.
     virtual unsigned int GetGenerationWithRange(Object* object, uint8_t** ppStart, uint8_t** ppAllocated, uint8_t** ppReserved) = 0;
 
     IGCHeap() {}
 
-    // Get the total paused duration
+    // The virtual destructors for the IGCHeap class hierarchy is intentionally omitted.
+    // This is to ensure we have a stable virtual function table for this interface for
+    // version resilience purposes.
+
+    // Get the total paused duration.
     virtual int64_t GetTotalPauseDuration() = 0;
 };
 

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -924,7 +924,6 @@ public:
     virtual unsigned int GetGenerationWithRange(Object* object, uint8_t** ppStart, uint8_t** ppAllocated, uint8_t** ppReserved) = 0;
 
     IGCHeap() {}
-    virtual ~IGCHeap() {}
 
     // Get the total paused duration
     virtual int64_t GetTotalPauseDuration() = 0;


### PR DESCRIPTION
The goal of this change is to eliminate the virtual destructor from the virtual function table of `IGCHeap`. 

The existence of the virtual destructor can potentially impact the virtual function table layout and therefore our version resiliency plan. (e.g. clang++-9 seems to generate two entries for it while MSVC generates only 1)

The commented call to `delete gc_heap::g_heaps[i]->vm_heap` is in `GCHeap::StaticShutdown()`, it is not called at all, so commenting that out has no impact. If it were left there, clang would complain about the missed virtual destructor so I have to comment it out.