### PR TITLE
optimize BlockingCollection<T>.GetConsumingEnumerable iterator

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -694,7 +694,8 @@ namespace System.Collections.Concurrent
         /// <exception cref="System.ObjectDisposedException">If the collection has been disposed.</exception>
         private bool TryTakeWithNoTimeValidation([MaybeNullWhen(false)] out T item, int millisecondsTimeout, CancellationToken cancellationToken, CancellationTokenSource? combinedTokenSource)
         {
-            CheckDisposed();
+            Debug.Assert(!_isDisposed);
+            Debug.Assert(!IsCompleted);
             item = default(T)!;
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -603,6 +603,14 @@ namespace System.Collections.Concurrent
         public bool TryTake([MaybeNullWhen(false)] out T item, TimeSpan timeout)
         {
             ValidateTimeout(timeout);
+
+            //If the collection is completed then there is no need remove an item.
+            if (IsCompleted)
+            {
+                item = default(T);
+                return false;
+            }
+
             return TryTakeWithNoTimeValidation(out item, (int)timeout.TotalMilliseconds, CancellationToken.None, null);
         }
 
@@ -624,6 +632,14 @@ namespace System.Collections.Concurrent
         public bool TryTake([MaybeNullWhen(false)] out T item, int millisecondsTimeout)
         {
             ValidateMillisecondsTimeout(millisecondsTimeout);
+
+            //If the collection is completed then there is no need remove an item.
+            if (IsCompleted)
+            {
+                item = default(T);
+                return false;
+            }
+
             return TryTakeWithNoTimeValidation(out item, millisecondsTimeout, CancellationToken.None, null);
         }
 
@@ -649,6 +665,14 @@ namespace System.Collections.Concurrent
         public bool TryTake([MaybeNullWhen(false)] out T item, int millisecondsTimeout, CancellationToken cancellationToken)
         {
             ValidateMillisecondsTimeout(millisecondsTimeout);
+
+            //If the collection is completed then there is no need remove an item.
+            if (IsCompleted)
+            {
+                item = default(T);
+                return false;
+            }
+
             return TryTakeWithNoTimeValidation(out item, millisecondsTimeout, cancellationToken, null);
         }
 
@@ -675,11 +699,6 @@ namespace System.Collections.Concurrent
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            //If the collection is completed then there is no need to wait.
-            if (IsCompleted)
-            {
-                return false;
-            }
             bool waitForSemaphoreWasSuccessful = false;
 
             // set the combined token source to the combinedToken parameter if it is not null (came from GetConsumingEnumerable)

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -695,7 +695,6 @@ namespace System.Collections.Concurrent
         private bool TryTakeWithNoTimeValidation([MaybeNullWhen(false)] out T item, int millisecondsTimeout, CancellationToken cancellationToken, CancellationTokenSource? combinedTokenSource)
         {
             Debug.Assert(!_isDisposed);
-            Debug.Assert(!IsCompleted);
             item = default(T)!;
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -604,7 +604,7 @@ namespace System.Collections.Concurrent
         {
             ValidateTimeout(timeout);
 
-            //If the collection is completed then there is no need remove an item.
+            // If the collection is completed then there is no need remove an item.
             if (IsCompleted)
             {
                 item = default(T);
@@ -633,7 +633,7 @@ namespace System.Collections.Concurrent
         {
             ValidateMillisecondsTimeout(millisecondsTimeout);
 
-            //If the collection is completed then there is no need remove an item.
+            // If the collection is completed then there is no need remove an item.
             if (IsCompleted)
             {
                 item = default(T);
@@ -666,7 +666,8 @@ namespace System.Collections.Concurrent
         {
             ValidateMillisecondsTimeout(millisecondsTimeout);
 
-            //If the collection is completed then there is no need remove an item.
+            cancellationToken.ThrowIfCancellationRequested();
+            // If the collection is completed then there is no need remove an item.
             if (IsCompleted)
             {
                 item = default(T);
@@ -696,8 +697,6 @@ namespace System.Collections.Concurrent
         {
             Debug.Assert(!_isDisposed);
             item = default(T)!;
-
-            cancellationToken.ThrowIfCancellationRequested();
 
             bool waitForSemaphoreWasSuccessful = false;
 
@@ -1664,6 +1663,7 @@ namespace System.Collections.Concurrent
         /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken"/> is canceled.</exception>
         public IEnumerable<T> GetConsumingEnumerable(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             CancellationTokenSource? linkedTokenSource = null;
             try
             {


### PR DESCRIPTION
Fixes #69320

I tried to search why this double-check had been done. It exists since the first RC of .NETCore 1.0. Could not find what version of .NET Framework introduced this change (just found that it exists in .NET 4.8)