### PR TITLE
Style improvements for generated p/invokes

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Interop
         /// </summary>
         public StubCodeContext? ParentContext { get; protected init; }
 
-        public const string GeneratedNativeIdentifierSuffix = "_gen_native";
+        public const string GeneratedNativeIdentifierSuffix = "_native";
 
         /// <summary>
         /// Get managed and native instance identifiers for the <paramref name="info"/>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SyntaxExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SyntaxExtensions.cs
@@ -19,16 +19,31 @@ namespace Microsoft.Interop
             {
                 return fixedStatement.WithStatement(childStatement);
             }
+
+            BlockSyntax block;
             if (fixedStatement.Statement.IsKind(SyntaxKind.Block))
             {
-                var block = (BlockSyntax)fixedStatement.Statement;
+                block = (BlockSyntax)fixedStatement.Statement;
                 if (block.Statements.Count == 0)
                 {
                     return fixedStatement.WithStatement(childStatement);
                 }
-                return fixedStatement.WithStatement(block.AddStatements(childStatement));
             }
-            return fixedStatement.WithStatement(SyntaxFactory.Block(fixedStatement.Statement, childStatement));
+            else
+            {
+                block = SyntaxFactory.Block(fixedStatement.Statement);
+            }
+
+            if (childStatement.IsKind(SyntaxKind.Block))
+            {
+                block = block.WithStatements(block.Statements.AddRange(((BlockSyntax)childStatement).Statements));
+            }
+            else
+            {
+                block = block.AddStatements(childStatement);
+            }
+
+            return fixedStatement.WithStatement(block);
         }
 
         public static StatementSyntax NestFixedStatements(this ImmutableArray<FixedStatementSyntax> fixedStatements, StatementSyntax innerStatement)


### PR DESCRIPTION
- Remove '_gen` part of suffix
- Remove unnecessary braces in fixed block

Contributes to https://github.com/dotnet/runtime/issues/69608: Style items (3) and (5)