### PR TITLE
Use ClassLayout::AreCompatible in fgMorphCanUseLclFldForCopy

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -868,10 +868,7 @@ void Compiler::impPopCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call)
             // the parameter type but exact types in the signature type.
             //
             // TODO-ARGS: Remove this quirk; we should be able to use the
-            // signature type that is different in the rare case above. It will
-            // cause positive diffs, but that is probably an indication that we
-            // have downstream phases that should be using
-            // `ClassLayout::AreCompatible` instead.
+            // signature type that is different in the rare case above.
             //
             classHnd = ti.GetClassHandleForValueClass();
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9652,11 +9652,7 @@ GenTree* Compiler::fgMorphBlockOperand(GenTree* tree, var_types asgType, unsigne
 //    lclNum2 - the local variable on the other side of ASG, can be BAD_VAR_NUM.
 //
 // Return Value:
-//    True if the second local is valid and has the same struct handle as the first,
-//    false otherwise.
-//
-// Notes:
-//   TODO-PhysicalVN: with the physical VN scheme, this method is no longer needed.
+//    True if the second local is valid and has a layout compatible with the first local.
 //
 bool Compiler::fgMorphCanUseLclFldForCopy(unsigned lclNum1, unsigned lclNum2)
 {
@@ -9672,15 +9668,7 @@ bool Compiler::fgMorphCanUseLclFldForCopy(unsigned lclNum1, unsigned lclNum2)
     {
         return false;
     }
-    CORINFO_CLASS_HANDLE struct1 = varDsc1->GetStructHnd();
-    CORINFO_CLASS_HANDLE struct2 = varDsc2->GetStructHnd();
-    assert(struct1 != NO_CLASS_HANDLE);
-    assert(struct2 != NO_CLASS_HANDLE);
-    if (struct1 != struct2)
-    {
-        return false;
-    }
-    return true;
+    return ClassLayout::AreCompatible(varDsc1->GetLayout(), varDsc2->GetLayout());
 }
 
 // insert conversions and normalize to make tree amenable to register


### PR DESCRIPTION
I was looking at removing the quirk in `impPopCallArgs` and tracked the positive diffs down to this.

All credit goes to @SingleAccretion for being able to make this change.