### PR TITLE
Exposing `Radix` and the remaining `Is*` generic-math APIs

### DIFF
--- a/src/libraries/Common/tests/System/GenericMathHelpers.cs
+++ b/src/libraries/Common/tests/System/GenericMathHelpers.cs
@@ -297,6 +297,8 @@ namespace System
     {
         public static TSelf One => TSelf.One;
 
+        public static int Radix => TSelf.Radix;
+
         public static TSelf Zero => TSelf.Zero;
 
         public static TSelf Abs(TSelf value) => TSelf.Abs(value);
@@ -310,9 +312,19 @@ namespace System
         public static TSelf CreateTruncating<TOther>(TOther value)
             where TOther : INumberBase<TOther> => TSelf.CreateTruncating(value);
 
+        public static bool IsCanonical(TSelf value) => TSelf.IsCanonical(value);
+
+        public static bool IsComplexNumber(TSelf value) => TSelf.IsComplexNumber(value);
+
+        public static bool IsEvenInteger(TSelf value) => TSelf.IsEvenInteger(value);
+
         public static bool IsFinite(TSelf value) => TSelf.IsFinite(value);
 
+        public static bool IsImaginaryNumber(TSelf value) => TSelf.IsImaginaryNumber(value);
+
         public static bool IsInfinity(TSelf value) => TSelf.IsInfinity(value);
+
+        public static bool IsInteger(TSelf value) => TSelf.IsInteger(value);
 
         public static bool IsNaN(TSelf value) => TSelf.IsNaN(value);
 
@@ -322,9 +334,17 @@ namespace System
 
         public static bool IsNormal(TSelf value) => TSelf.IsNormal(value);
 
+        public static bool IsOddInteger(TSelf value) => TSelf.IsOddInteger(value);
+
+        public static bool IsPositive(TSelf value) => TSelf.IsPositive(value);
+
         public static bool IsPositiveInfinity(TSelf value) => TSelf.IsPositiveInfinity(value);
 
+        public static bool IsRealNumber(TSelf value) => TSelf.IsRealNumber(value);
+
         public static bool IsSubnormal(TSelf value) => TSelf.IsSubnormal(value);
+
+        public static bool IsZero(TSelf value) => TSelf.IsZero(value);
 
         public static TSelf MaxMagnitude(TSelf x, TSelf y) => TSelf.MaxMagnitude(x, y);
 

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -840,10 +840,7 @@ namespace System
         /// <param name="value">The number to convert.</param>
         /// <returns>A 16-bit signed integer whose bits are identical to <paramref name="value"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe short HalfToInt16Bits(Half value)
-        {
-            return *((short*)&value);
-        }
+        public static unsafe short HalfToInt16Bits(Half value) => (short)HalfToUInt16Bits(value);
 
         /// <summary>
         /// Converts the specified 16-bit signed integer to a half-precision floating point number.
@@ -851,10 +848,7 @@ namespace System
         /// <param name="value">The number to convert.</param>
         /// <returns>A half-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe Half Int16BitsToHalf(short value)
-        {
-            return *(Half*)&value;
-        }
+        public static unsafe Half Int16BitsToHalf(short value) => UInt16BitsToHalf((ushort)(value));
 
         /// <summary>
         /// Converts the specified double-precision floating point number to a 64-bit unsigned integer.
@@ -899,7 +893,7 @@ namespace System
         /// <returns>A 16-bit unsigned integer whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ushort HalfToUInt16Bits(Half value) => (ushort)HalfToInt16Bits(value);
+        public static unsafe ushort HalfToUInt16Bits(Half value) => value._value;
 
         /// <summary>
         /// Converts the specified 16-bit unsigned integer to a half-precision floating point number.
@@ -908,6 +902,6 @@ namespace System
         /// <returns>A half-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe Half UInt16BitsToHalf(ushort value) => Int16BitsToHalf((short)value);
+        public static unsafe Half UInt16BitsToHalf(ushort value) => new Half(value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -522,6 +522,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static byte INumberBase<byte>.One => One;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<byte>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static byte INumberBase<byte>.Zero => Zero;
 
@@ -752,11 +755,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<byte>.IsCanonical(byte value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<byte>.IsComplexNumber(byte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(byte value) => (value & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<byte>.IsFinite(byte value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<byte>.IsImaginaryNumber(byte value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<byte>.IsInfinity(byte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<byte>.IsInteger(byte value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<byte>.IsNaN(byte value) => false;
@@ -770,11 +788,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<byte>.IsNormal(byte value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(byte value) => (value & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        static bool INumberBase<byte>.IsPositive(byte value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<byte>.IsPositiveInfinity(byte value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<byte>.IsRealNumber(byte value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<byte>.IsSubnormal(byte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<byte>.IsZero(byte value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         static byte INumberBase<byte>.MaxMagnitude(byte x, byte y) => Max(x, y);

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -1373,6 +1373,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static char INumberBase<char>.One => (char)1;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<char>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static char INumberBase<char>.Zero => (char)0;
 
@@ -1597,11 +1600,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<char>.IsCanonical(char value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<char>.IsComplexNumber(char value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        static bool INumberBase<char>.IsEvenInteger(char value) => (value & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<char>.IsFinite(char value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<char>.IsImaginaryNumber(char value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<char>.IsInfinity(char value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<char>.IsInteger(char value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<char>.IsNaN(char value) => false;
@@ -1615,11 +1633,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<char>.IsNormal(char value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        static bool INumberBase<char>.IsOddInteger(char value) => (value & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        static bool INumberBase<char>.IsPositive(char value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<char>.IsPositiveInfinity(char value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<char>.IsRealNumber(char value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<char>.IsSubnormal(char value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<char>.IsZero(char value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         static char INumberBase<char>.MaxMagnitude(char x, char y) => (char)Math.Max(x, y);

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
@@ -1332,6 +1332,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static decimal INumberBase<decimal>.One => One;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<decimal>.Radix => 10;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static decimal INumberBase<decimal>.Zero => Zero;
 
@@ -1585,11 +1588,50 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        public static bool IsCanonical(decimal value)
+        {
+            uint scale = (byte)(value._flags >> ScaleShift);
+
+            if (scale == 0)
+            {
+                // We have an exact integer represented with no trailing zero
+                return true;
+            }
+
+            // We have some value where some fractional part is specified. So,
+            // if the least significant digit is 0, then we are not canonical
+
+            if (value._hi32 == 0)
+            {
+                return (value._lo64 % 10) != 0;
+            }
+
+            var significand = new UInt128(value._hi32, value._lo64);
+            return (significand % 10U) != 0U;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<decimal>.IsComplexNumber(decimal value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(decimal value)
+        {
+            decimal truncatedValue = Truncate(value);
+            return (value == truncatedValue) && ((truncatedValue._lo64 & 1) == 0);
+        }
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<decimal>.IsFinite(decimal value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<decimal>.IsImaginaryNumber(decimal value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<decimal>.IsInfinity(decimal value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        public static bool IsInteger(decimal value) => value == Truncate(value);
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<decimal>.IsNaN(decimal value) => false;
@@ -1603,11 +1645,27 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<decimal>.IsNormal(decimal value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(decimal value)
+        {
+            decimal truncatedValue = Truncate(value);
+            return (value == truncatedValue) && ((truncatedValue._lo64 & 1) != 0);
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(decimal value) => value._flags >= 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<decimal>.IsPositiveInfinity(decimal value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<decimal>.IsRealNumber(decimal value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<decimal>.IsSubnormal(decimal value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<decimal>.IsZero(decimal value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static decimal MaxMagnitude(decimal x, decimal y)

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -994,6 +994,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static double INumberBase<double>.One => One;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<double>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static double INumberBase<double>.Zero => Zero;
 
@@ -1091,6 +1094,41 @@ namespace System
         {
             return CreateSaturating(value);
         }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<double>.IsCanonical(double value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<double>.IsComplexNumber(double value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(double value) => IsInteger(value) && (Abs(value % 2) == 0);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<double>.IsImaginaryNumber(double value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        public static bool IsInteger(double value) => IsFinite(value) && (value == Truncate(value));
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(double value) => IsInteger(value) && (Abs(value % 2) == 1);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(double value) => BitConverter.DoubleToInt64Bits(value) >= 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        public static bool IsRealNumber(double value)
+        {
+            // A NaN will never equal itself so this is an
+            // easy and efficient way to check for a real number.
+
+#pragma warning disable CS1718
+            return value == value;
+#pragma warning restore CS1718
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<double>.IsZero(double value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static double MaxMagnitude(double x, double y) => Math.MaxMagnitude(x, y);

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -92,7 +92,7 @@ namespace System
         /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         public static Half MaxValue => new Half(MaxValueBits);                      //  65504
 
-        private readonly ushort _value;
+        internal readonly ushort _value;
 
         internal Half(ushort value)
         {
@@ -1186,6 +1186,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         public static Half One => new Half(PositiveOneBits);
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<Half>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         public static Half Zero => new Half(PositiveZeroBits);
 
@@ -1283,6 +1286,41 @@ namespace System
         {
             return CreateSaturating(value);
         }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<Half>.IsCanonical(Half value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<Half>.IsComplexNumber(Half value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(Half value) => float.IsEvenInteger((float)value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<Half>.IsImaginaryNumber(Half value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        public static bool IsInteger(Half value) => float.IsInteger((float)value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(Half value) => float.IsOddInteger((float)value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(Half value) => (short)(value._value) >= 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        public static bool IsRealNumber(Half value)
+        {
+            // A NaN will never equal itself so this is an
+            // easy and efficient way to check for a real number.
+
+#pragma warning disable CS1718
+            return value == value;
+#pragma warning restore CS1718
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<Half>.IsZero(Half value) => (value == Zero);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static Half MaxMagnitude(Half x, Half y) => (Half)MathF.MaxMagnitude((float)x, (float)y);

--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -1265,6 +1265,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         public static Int128 One => new Int128(0, 1);
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<Int128>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         public static Int128 Zero => default;
 
@@ -1499,11 +1502,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<Int128>.IsCanonical(Int128 value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<Int128>.IsComplexNumber(Int128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(Int128 value) => (value._lower & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<Int128>.IsFinite(Int128 value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<Int128>.IsImaginaryNumber(Int128 value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<Int128>.IsInfinity(Int128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<Int128>.IsInteger(Int128 value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<Int128>.IsNaN(Int128 value) => false;
@@ -1517,13 +1535,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<Int128>.IsNormal(Int128 value) => value != 0;
 
-        internal static bool IsPositive(Int128 value) => (long)value._upper >= 0;
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(Int128 value) => (value._lower & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(Int128 value) => (long)value._upper >= 0;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<Int128>.IsPositiveInfinity(Int128 value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<Int128>.IsRealNumber(Int128 value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<Int128>.IsSubnormal(Int128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<Int128>.IsZero(Int128 value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static Int128 MaxMagnitude(Int128 x, Int128 y)

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -568,6 +568,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static short INumberBase<short>.One => One;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<short>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static short INumberBase<short>.Zero => Zero;
 
@@ -795,11 +798,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<short>.IsCanonical(short value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<short>.IsComplexNumber(short value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(short value) => (value & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<short>.IsFinite(short value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<short>.IsImaginaryNumber(short value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<short>.IsInfinity(short value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<short>.IsInteger(short value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<short>.IsNaN(short value) => false;
@@ -813,11 +831,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<short>.IsNormal(short value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(short value) => (value & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(short value) => value >= 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<short>.IsPositiveInfinity(short value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<short>.IsRealNumber(short value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<short>.IsSubnormal(short value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<short>.IsZero(short value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static short MaxMagnitude(short x, short y)

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -560,6 +560,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static int INumberBase<int>.One => One;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<int>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static int INumberBase<int>.Zero => Zero;
 
@@ -783,11 +786,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<int>.IsCanonical(int value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<int>.IsComplexNumber(int value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(int value) => (value & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<int>.IsFinite(int value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<int>.IsImaginaryNumber(int value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<int>.IsInfinity(int value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<int>.IsInteger(int value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<int>.IsNaN(int value) => false;
@@ -801,11 +819,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<int>.IsNormal(int value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(int value) => (value & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(int value) => value >= 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<int>.IsPositiveInfinity(int value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<int>.IsRealNumber(int value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<int>.IsSubnormal(int value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<int>.IsZero(int value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static int MaxMagnitude(int x, int y)

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -547,6 +547,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static long INumberBase<long>.One => One;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<long>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static long INumberBase<long>.Zero => Zero;
 
@@ -765,11 +768,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<long>.IsCanonical(long value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<long>.IsComplexNumber(long value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(long value) => (value & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<long>.IsFinite(long value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<long>.IsImaginaryNumber(long value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<long>.IsInfinity(long value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<long>.IsInteger(long value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<long>.IsNaN(long value) => false;
@@ -783,11 +801,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<long>.IsNormal(long value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(long value) => (value & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(long value) => value >= 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<long>.IsPositiveInfinity(long value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<long>.IsRealNumber(long value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<long>.IsSubnormal(long value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<long>.IsZero(long value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static long MaxMagnitude(long x, long y)

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -520,6 +520,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static nint INumberBase<nint>.One => 1;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<nint>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static nint INumberBase<nint>.Zero => 0;
 
@@ -741,11 +744,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<nint>.IsCanonical(nint value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<nint>.IsComplexNumber(nint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(nint value) => (value & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<nint>.IsFinite(nint value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<nint>.IsImaginaryNumber(nint value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<nint>.IsInfinity(nint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<nint>.IsInteger(nint value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<nint>.IsNaN(nint value) => false;
@@ -759,11 +777,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<nint>.IsNormal(nint value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(nint value) => (value & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(nint value) => value >= 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<nint>.IsPositiveInfinity(nint value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<nint>.IsRealNumber(nint value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<nint>.IsSubnormal(nint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<nint>.IsZero(nint value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static nint MaxMagnitude(nint x, nint y)

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
@@ -27,6 +27,9 @@ namespace System.Numerics
         /// <summary>Gets the value <c>1</c> for the type.</summary>
         static abstract TSelf One { get; }
 
+        /// <summary>Gets the radix, or base, for the type.</summary>
+        static abstract int Radix { get; }
+
         /// <summary>Gets the value <c>0</c> for the type.</summary>
         static abstract TSelf Zero { get; }
 
@@ -61,15 +64,49 @@ namespace System.Numerics
         static abstract TSelf CreateTruncating<TOther>(TOther value)
             where TOther : INumberBase<TOther>;
 
+        /// <summary>Determines if a value is in its canonical representation.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is in its canonical representation; otherwise, <c>false</c>.</returns>
+        static abstract bool IsCanonical(TSelf value);
+
+        /// <summary>Determines if a value represents a complex value.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is a complex number; otherwise, <c>false</c>.</returns>
+        /// <remarks>This function returns <c>false</c> for a complex number <c>a + bi</c> where <c>b</c> is zero.</remarks>
+        static abstract bool IsComplexNumber(TSelf value);
+
+        /// <summary>Determines if a value represents an even integral value.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is an even integer; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        ///     <para>This correctly handles floating-point values and so <c>2.0</c> will return <c>true</c> while <c>2.2</c> will return <c>false</c>.</para>
+        ///     <para>This functioning returning <c>false</c> does not imply that <see cref="IsOddInteger(TSelf)" /> will return <c>true</c>. A number with a fractional portion, <c>3.3</c>, is not even nor odd.</para>
+        /// </remarks>
+        static abstract bool IsEvenInteger(TSelf value);
+
         /// <summary>Determines if a value is finite.</summary>
         /// <param name="value">The value to be checked.</param>
         /// <returns><c>true</c> if <paramref name="value" /> is finite; otherwise, <c>false</c>.</returns>
+        /// <remarks>This function returning <c>false</c> does not imply that <see cref="IsInfinity(TSelf)" /> will return <c>true</c>. <c>NaN</c> is not finite nor infinite.</remarks>
         static abstract bool IsFinite(TSelf value);
+
+        /// <summary>Determines if a value represents an imaginary value.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is an imaginary number; otherwise, <c>false</c>.</returns>
+        /// <remarks>This function returns <c>false</c> for a complex number <c>a + bi</c> where <c>a</c> is non-zero.</remarks>
+        static abstract bool IsImaginaryNumber(TSelf value);
 
         /// <summary>Determines if a value is infinite.</summary>
         /// <param name="value">The value to be checked.</param>
         /// <returns><c>true</c> if <paramref name="value" /> is infinite; otherwise, <c>false</c>.</returns>
+        /// <remarks>This function returning <c>false</c> does not imply that <see cref="IsFinite(TSelf)" /> will return <c>true</c>. <c>NaN</c> is not finite nor infinite.</remarks>
         static abstract bool IsInfinity(TSelf value);
+
+        /// <summary>Determines if a value represents an integral value.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is an integer; otherwise, <c>false</c>.</returns>
+        /// <remarks>This correctly handles floating-point values and so <c>2.0</c> and <c>3.0</c> will return <c>true</c> while <c>2.2</c> and <c>3.3</c> will return <c>false</c>.</remarks>
+        static abstract bool IsInteger(TSelf value);
 
         /// <summary>Determines if a value is NaN.</summary>
         /// <param name="value">The value to be checked.</param>
@@ -79,6 +116,7 @@ namespace System.Numerics
         /// <summary>Determines if a value is negative.</summary>
         /// <param name="value">The value to be checked.</param>
         /// <returns><c>true</c> if <paramref name="value" /> is negative; otherwise, <c>false</c>.</returns>
+        /// <remarks>This function returning <c>false</c> does not imply that <see cref="IsPositive(TSelf)" /> will return <c>true</c>. A complex number, <c>a + bi</c> for non-zero <c>b</c>, is not positive nor negative</remarks>
         static abstract bool IsNegative(TSelf value);
 
         /// <summary>Determines if a value is negative infinity.</summary>
@@ -91,15 +129,42 @@ namespace System.Numerics
         /// <returns><c>true</c> if <paramref name="value" /> is normal; otherwise, <c>false</c>.</returns>
         static abstract bool IsNormal(TSelf value);
 
+        /// <summary>Determines if a value represents an odd integral value.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is an odd integer; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        ///     <para>This correctly handles floating-point values and so <c>3.0</c> will return <c>true</c> while <c>3.3</c> will return <c>false</c>.</para>
+        ///     <para>This functioning returning <c>false</c> does not imply that <see cref="IsOddInteger(TSelf)" /> will return <c>true</c>. A number with a fractional portion, <c>3.3</c>, is neither even nor odd.</para>
+        /// </remarks>
+        static abstract bool IsOddInteger(TSelf value);
+
+        /// <summary>Determines if a value is positive.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is positive; otherwise, <c>false</c>.</returns>
+        /// <remarks>This function returning <c>false</c> does not imply that <see cref="IsNegative(TSelf)" /> will return <c>true</c>. A complex number, <c>a + bi</c> for non-zero <c>b</c>, is not positive nor negative</remarks>
+        static abstract bool IsPositive(TSelf value);
+
         /// <summary>Determines if a value is positive infinity.</summary>
         /// <param name="value">The value to be checked.</param>
         /// <returns><c>true</c> if <paramref name="value" /> is positive infinity; otherwise, <c>false</c>.</returns>
         static abstract bool IsPositiveInfinity(TSelf value);
 
+        /// <summary>Determines if a value represents a real value.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is a real number; otherwise, <c>false</c>.</returns>
+        /// <remarks>This function returns <c>true</c> for a complex number <c>a + bi</c> where <c>b</c> is zero.</remarks>
+        static abstract bool IsRealNumber(TSelf value);
+
         /// <summary>Determines if a value is subnormal.</summary>
         /// <param name="value">The value to be checked.</param>
         /// <returns><c>true</c> if <paramref name="value" /> is subnormal; otherwise, <c>false</c>.</returns>
         static abstract bool IsSubnormal(TSelf value);
+
+        /// <summary>Determines if a value is zero.</summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if <paramref name="value" /> is zero; otherwise, <c>false</c>.</returns>
+        /// <remarks>This function treats both positive and negative zero as zero and so will return <c>true</c> for <c>+0.0</c> and <c>-0.0</c>.</remarks>
+        static abstract bool IsZero(TSelf value);
 
         /// <summary>Compares two values to compute which is greater.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
@@ -1128,6 +1128,9 @@ namespace System.Runtime.InteropServices
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static NFloat INumberBase<NFloat>.One => new NFloat(NativeType.One);
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<NFloat>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static NFloat INumberBase<NFloat>.Zero => new NFloat(NativeType.Zero);
 
@@ -1221,6 +1224,33 @@ namespace System.Runtime.InteropServices
         {
             return CreateChecked(value);
         }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<NFloat>.IsCanonical(NFloat value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<NFloat>.IsComplexNumber(NFloat value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(NFloat value) => NativeType.IsEvenInteger(value._value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<NFloat>.IsImaginaryNumber(NFloat value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        public static bool IsInteger(NFloat value) => NativeType.IsInteger(value._value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(NFloat value) => NativeType.IsOddInteger(value._value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(NFloat value) => NativeType.IsPositive(value._value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        public static bool IsRealNumber(NFloat value) => NativeType.IsRealNumber(value._value);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<NFloat>.IsZero(NFloat value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static NFloat MaxMagnitude(NFloat x, NFloat y) => new NFloat(NativeType.MaxMagnitude(x._value, y._value));

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -575,6 +575,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static sbyte INumberBase<sbyte>.One => One;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<sbyte>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static sbyte INumberBase<sbyte>.Zero => Zero;
 
@@ -805,14 +808,29 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<sbyte>.IsCanonical(sbyte value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<sbyte>.IsComplexNumber(sbyte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(sbyte value) => (value & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<sbyte>.IsFinite(sbyte value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<sbyte>.IsImaginaryNumber(sbyte value) => false;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<sbyte>.IsInfinity(sbyte value) => false;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<sbyte>.IsNaN(sbyte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<sbyte>.IsInteger(sbyte value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
         public static bool IsNegative(sbyte value) => value < 0;
@@ -823,11 +841,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<sbyte>.IsNormal(sbyte value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(sbyte value) => (value & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(sbyte value) => value >= 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<sbyte>.IsPositiveInfinity(sbyte value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<sbyte>.IsRealNumber(sbyte value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<sbyte>.IsSubnormal(sbyte value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<sbyte>.IsZero(sbyte value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static sbyte MaxMagnitude(sbyte x, sbyte y)

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -977,6 +977,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static float INumberBase<float>.One => One;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<float>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static float INumberBase<float>.Zero => Zero;
 
@@ -1074,6 +1077,41 @@ namespace System
         {
             return CreateSaturating(value);
         }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<float>.IsCanonical(float value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<float>.IsComplexNumber(float value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(float value) => IsInteger(value) && (Abs(value % 2) == 0);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<float>.IsImaginaryNumber(float value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        public static bool IsInteger(float value) => IsFinite(value) && (value == Truncate(value));
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(float value) => IsInteger(value) && (Abs((value) % 2) == 1);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(float value) => BitConverter.SingleToInt32Bits(value) >= 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        public static bool IsRealNumber(float value)
+        {
+            // A NaN will never equal itself so this is an
+            // easy and efficient way to check for a real number.
+
+#pragma warning disable CS1718
+            return value == value;
+#pragma warning restore CS1718
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<float>.IsZero(float value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static float MaxMagnitude(float x, float y) => MathF.MaxMagnitude(x, y);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
@@ -1335,6 +1335,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         public static UInt128 One => new UInt128(0, 1);
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<UInt128>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         public static UInt128 Zero => default;
 
@@ -1564,11 +1567,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<UInt128>.IsCanonical(UInt128 value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<UInt128>.IsComplexNumber(UInt128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(UInt128 value) => (value._lower & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<UInt128>.IsFinite(UInt128 value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<UInt128>.IsImaginaryNumber(UInt128 value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<UInt128>.IsInfinity(UInt128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<UInt128>.IsInteger(UInt128 value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<UInt128>.IsNaN(UInt128 value) => false;
@@ -1582,11 +1600,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<UInt128>.IsNormal(UInt128 value) => value != 0U;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(UInt128 value) => (value._lower & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        static bool INumberBase<UInt128>.IsPositive(UInt128 value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<UInt128>.IsPositiveInfinity(UInt128 value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<UInt128>.IsRealNumber(UInt128 value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<UInt128>.IsSubnormal(UInt128 value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<UInt128>.IsZero(UInt128 value) => (value == 0U);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         static UInt128 INumberBase<UInt128>.MaxMagnitude(UInt128 x, UInt128 y) => Max(x, y);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -517,6 +517,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static ushort INumberBase<ushort>.One => One;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<ushort>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static ushort INumberBase<ushort>.Zero => Zero;
 
@@ -744,11 +747,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<ushort>.IsCanonical(ushort value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<ushort>.IsComplexNumber(ushort value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(ushort value) => (value & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<ushort>.IsFinite(ushort value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<ushort>.IsImaginaryNumber(ushort value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<ushort>.IsInfinity(ushort value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<ushort>.IsInteger(ushort value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<ushort>.IsNaN(ushort value) => false;
@@ -762,11 +780,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<ushort>.IsNormal(ushort value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(ushort value) => (value & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        static bool INumberBase<ushort>.IsPositive(ushort value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<ushort>.IsPositiveInfinity(ushort value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<ushort>.IsRealNumber(ushort value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<ushort>.IsSubnormal(ushort value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<ushort>.IsZero(ushort value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         static ushort INumberBase<ushort>.MaxMagnitude(ushort x, ushort y) => Max(x, y);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -503,6 +503,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static uint INumberBase<uint>.One => One;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<uint>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static uint INumberBase<uint>.Zero => Zero;
 
@@ -728,11 +731,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<uint>.IsCanonical(uint value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<uint>.IsComplexNumber(uint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(uint value) => (value & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<uint>.IsFinite(uint value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<uint>.IsImaginaryNumber(uint value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<uint>.IsInfinity(uint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<uint>.IsInteger(uint value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<uint>.IsNaN(uint value) => false;
@@ -746,11 +764,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<uint>.IsNormal(uint value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(uint value) => (value & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        static bool INumberBase<uint>.IsPositive(uint value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<uint>.IsPositiveInfinity(uint value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<uint>.IsRealNumber(uint value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<uint>.IsSubnormal(uint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<uint>.IsZero(uint value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         static uint INumberBase<uint>.MaxMagnitude(uint x, uint y) => Max(x, y);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -502,6 +502,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static ulong INumberBase<ulong>.One => One;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<ulong>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static ulong INumberBase<ulong>.Zero => Zero;
 
@@ -723,11 +726,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<ulong>.IsCanonical(ulong value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<ulong>.IsComplexNumber(ulong value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(ulong value) => (value & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<ulong>.IsFinite(ulong value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<ulong>.IsImaginaryNumber(ulong value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<ulong>.IsInfinity(ulong value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<ulong>.IsInteger(ulong value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<ulong>.IsNaN(ulong value) => false;
@@ -741,11 +759,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<ulong>.IsNormal(ulong value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(ulong value) => (value & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        static bool INumberBase<ulong>.IsPositive(ulong value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<ulong>.IsPositiveInfinity(ulong value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<ulong>.IsRealNumber(ulong value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<ulong>.IsSubnormal(ulong value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<ulong>.IsZero(ulong value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         static ulong INumberBase<ulong>.MaxMagnitude(ulong x, ulong y) => Max(x, y);

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -478,6 +478,9 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static nuint INumberBase<nuint>.One => 1;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<nuint>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static nuint INumberBase<nuint>.Zero => 0;
 
@@ -702,11 +705,26 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<nuint>.IsCanonical(nuint value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<nuint>.IsComplexNumber(nuint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(nuint value) => (value & 1) == 0;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<nuint>.IsFinite(nuint value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<nuint>.IsImaginaryNumber(nuint value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<nuint>.IsInfinity(nuint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<nuint>.IsInteger(nuint value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<nuint>.IsNaN(nuint value) => false;
@@ -720,11 +738,23 @@ namespace System
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<nuint>.IsNormal(nuint value) => value != 0;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(nuint value) => (value & 1) != 0;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        static bool INumberBase<nuint>.IsPositive(nuint value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<nuint>.IsPositiveInfinity(nuint value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<nuint>.IsRealNumber(nuint value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<nuint>.IsSubnormal(nuint value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<nuint>.IsZero(nuint value) => (value == 0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         static nuint INumberBase<nuint>.MaxMagnitude(nuint x, nuint y) => Max(x, y);

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -830,6 +830,7 @@ namespace System.Runtime.InteropServices
         static System.Runtime.InteropServices.NFloat System.Numerics.IAdditiveIdentity<System.Runtime.InteropServices.NFloat,System.Runtime.InteropServices.NFloat>.AdditiveIdentity { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.IMultiplicativeIdentity<System.Runtime.InteropServices.NFloat,System.Runtime.InteropServices.NFloat>.MultiplicativeIdentity { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>.Radix { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>.Zero { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.ISignedNumber<System.Runtime.InteropServices.NFloat>.NegativeOne { get { throw null; } }
         public static System.Runtime.InteropServices.NFloat Tau { get { throw null; } }
@@ -868,14 +869,19 @@ namespace System.Runtime.InteropServices
         public override int GetHashCode() { throw null; }
         public static System.Runtime.InteropServices.NFloat Ieee754Remainder(System.Runtime.InteropServices.NFloat left, System.Runtime.InteropServices.NFloat right) { throw null; }
         public static int ILogB(System.Runtime.InteropServices.NFloat x) { throw null; }
+        public static bool IsEvenInteger(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static bool IsFinite(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static bool IsInfinity(System.Runtime.InteropServices.NFloat value) { throw null; }
+        public static bool IsInteger(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static bool IsNaN(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static bool IsNegative(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static bool IsNegativeInfinity(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static bool IsNormal(System.Runtime.InteropServices.NFloat value) { throw null; }
+        public static bool IsOddInteger(System.Runtime.InteropServices.NFloat value) { throw null; }
+        public static bool IsPositive(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static bool IsPositiveInfinity(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static bool IsPow2(System.Runtime.InteropServices.NFloat value) { throw null; }
+        public static bool IsRealNumber(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static bool IsSubnormal(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static System.Runtime.InteropServices.NFloat Log(System.Runtime.InteropServices.NFloat x) { throw null; }
         public static System.Runtime.InteropServices.NFloat Log(System.Runtime.InteropServices.NFloat x, System.Runtime.InteropServices.NFloat newBase) { throw null; }
@@ -981,6 +987,10 @@ namespace System.Runtime.InteropServices
         bool System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         static System.Runtime.InteropServices.NFloat System.Numerics.IIncrementOperators<System.Runtime.InteropServices.NFloat>.operator checked ++(System.Runtime.InteropServices.NFloat value) { throw null; }
         static System.Runtime.InteropServices.NFloat System.Numerics.IMultiplyOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>.operator checked *(System.Runtime.InteropServices.NFloat left, System.Runtime.InteropServices.NFloat right) { throw null; }
+        static bool System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>.IsCanonical(System.Runtime.InteropServices.NFloat value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>.IsComplexNumber(System.Runtime.InteropServices.NFloat value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>.IsImaginaryNumber(System.Runtime.InteropServices.NFloat value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>.IsZero(System.Runtime.InteropServices.NFloat value) { throw null; }
         static System.Runtime.InteropServices.NFloat System.Numerics.ISubtractionOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>.operator checked -(System.Runtime.InteropServices.NFloat left, System.Runtime.InteropServices.NFloat right) { throw null; }
         static System.Runtime.InteropServices.NFloat System.Numerics.IUnaryNegationOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>.operator checked -(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static System.Runtime.InteropServices.NFloat Tan(System.Runtime.InteropServices.NFloat x) { throw null; }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
@@ -82,7 +82,7 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
-        private static NFloat PositiveOne
+        private static NFloat One
         {
             get
             {
@@ -97,7 +97,7 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
-        private static NFloat PositiveTwo
+        private static NFloat Two
         {
             get
             {
@@ -112,7 +112,7 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
-        private static NFloat PositiveZero
+        private static NFloat Zero
         {
             get
             {
@@ -165,41 +165,41 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void op_AdditionTest()
         {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(NFloat.MinValue, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.MinValue, PositiveOne));
-            AssertBitwiseEqual(PositiveZero, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(-NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(NFloat.NaN, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.NaN, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveTwo, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(NFloat.MaxValue, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.MaxValue, PositiveOne));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.PositiveInfinity, PositiveOne));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(NFloat.MinValue, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.MinValue, One));
+            AssertBitwiseEqual(Zero, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NegativeOne, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(-MinNormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NegativeZero, One));
+            AssertBitwiseEqual(NFloat.NaN, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.NaN, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(Zero, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(MaxSubnormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(MinNormal, One));
+            AssertBitwiseEqual(Two, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(One, One));
+            AssertBitwiseEqual(NFloat.MaxValue, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.MaxValue, One));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_Addition(NFloat.PositiveInfinity, One));
         }
 
         [Fact]
         public static void op_CheckedAdditionTest()
         {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(NFloat.MinValue, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.MinValue, PositiveOne));
-            AssertBitwiseEqual(PositiveZero, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(-NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(NFloat.NaN, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.NaN, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveTwo, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(NFloat.MaxValue, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.MaxValue, PositiveOne));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.PositiveInfinity, PositiveOne));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(NFloat.MinValue, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.MinValue, One));
+            AssertBitwiseEqual(Zero, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NegativeOne, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(-MinNormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NegativeZero, One));
+            AssertBitwiseEqual(NFloat.NaN, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.NaN, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(Zero, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(MaxSubnormal, One));
+            AssertBitwiseEqual(One, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(MinNormal, One));
+            AssertBitwiseEqual(Two, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(One, One));
+            AssertBitwiseEqual(NFloat.MaxValue, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.MaxValue, One));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, AdditionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedAddition(NFloat.PositiveInfinity, One));
         }
 
         //
@@ -209,7 +209,7 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void AdditiveIdentityTest()
         {
-            AssertBitwiseEqual(PositiveZero, AdditiveIdentityHelper<NFloat, NFloat>.AdditiveIdentity);
+            AssertBitwiseEqual(Zero, AdditiveIdentityHelper<NFloat, NFloat>.AdditiveIdentity);
         }
 
         //
@@ -227,11 +227,11 @@ namespace System.Runtime.InteropServices.Tests
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(-NFloat.Epsilon));
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(NegativeZero));
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(NFloat.NaN));
-            Assert.False(BinaryNumberHelper<NFloat>.IsPow2(PositiveZero));
+            Assert.False(BinaryNumberHelper<NFloat>.IsPow2(Zero));
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(NFloat.Epsilon));
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(MaxSubnormal));
             Assert.True(BinaryNumberHelper<NFloat>.IsPow2(MinNormal));
-            Assert.True(BinaryNumberHelper<NFloat>.IsPow2(PositiveOne));
+            Assert.True(BinaryNumberHelper<NFloat>.IsPow2(One));
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(NFloat.MaxValue));
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(NFloat.PositiveInfinity));
         }
@@ -247,8 +247,8 @@ namespace System.Runtime.InteropServices.Tests
             AssertBitwiseEqual(NFloat.NaN, BinaryNumberHelper<NFloat>.Log2(-NFloat.Epsilon));
             AssertBitwiseEqual(NFloat.NegativeInfinity, BinaryNumberHelper<NFloat>.Log2(NegativeZero));
             AssertBitwiseEqual(NFloat.NaN, BinaryNumberHelper<NFloat>.Log2(NFloat.NaN));
-            AssertBitwiseEqual(NFloat.NegativeInfinity, BinaryNumberHelper<NFloat>.Log2(PositiveZero));
-            AssertBitwiseEqual(PositiveZero, BinaryNumberHelper<NFloat>.Log2(PositiveOne));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, BinaryNumberHelper<NFloat>.Log2(Zero));
+            AssertBitwiseEqual(Zero, BinaryNumberHelper<NFloat>.Log2(One));
             AssertBitwiseEqual(NFloat.PositiveInfinity, BinaryNumberHelper<NFloat>.Log2(NFloat.PositiveInfinity));
 
             if (Environment.Is64BitProcess)
@@ -274,81 +274,81 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void op_GreaterThanTest()
         {
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.NegativeInfinity, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.MinValue, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NegativeOne, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(-MinNormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(-MaxSubnormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(-NFloat.Epsilon, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NegativeZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.NaN, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(PositiveZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.Epsilon, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(MaxSubnormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(MinNormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(PositiveOne, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.MaxValue, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.PositiveInfinity, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.NegativeInfinity, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.MinValue, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NegativeOne, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(-MinNormal, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(-MaxSubnormal, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(-NFloat.Epsilon, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NegativeZero, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.NaN, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(Zero, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.Epsilon, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(MaxSubnormal, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(MinNormal, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(One, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.MaxValue, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThan(NFloat.PositiveInfinity, One));
         }
 
         [Fact]
         public static void op_GreaterThanOrEqualTest()
         {
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.NegativeInfinity, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.MinValue, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NegativeOne, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(-MinNormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(-MaxSubnormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(-NFloat.Epsilon, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NegativeZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.NaN, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(PositiveZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.Epsilon, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(MaxSubnormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(MinNormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(PositiveOne, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.MaxValue, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.PositiveInfinity, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.NegativeInfinity, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.MinValue, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NegativeOne, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(-MinNormal, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(-MaxSubnormal, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(-NFloat.Epsilon, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NegativeZero, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.NaN, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(Zero, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.Epsilon, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(MaxSubnormal, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(MinNormal, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(One, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.MaxValue, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_GreaterThanOrEqual(NFloat.PositiveInfinity, One));
         }
 
         [Fact]
         public static void op_LessThanTest()
         {
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.NegativeInfinity, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.MinValue, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NegativeOne, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-MinNormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-NFloat.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NegativeZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.NaN, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(PositiveZero, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(MinNormal, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(PositiveOne, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.MaxValue, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.PositiveInfinity, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.NegativeInfinity, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.MinValue, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NegativeOne, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-MinNormal, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-MaxSubnormal, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(-NFloat.Epsilon, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NegativeZero, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.NaN, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(Zero, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.Epsilon, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(MaxSubnormal, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(MinNormal, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(One, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.MaxValue, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThan(NFloat.PositiveInfinity, One));
         }
 
         [Fact]
         public static void op_LessThanOrEqualTest()
         {
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.NegativeInfinity, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.MinValue, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NegativeOne, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-MinNormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-NFloat.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NegativeZero, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.NaN, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(PositiveZero, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.Epsilon, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(MaxSubnormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(MinNormal, PositiveOne));
-            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(PositiveOne, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.MaxValue, PositiveOne));
-            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.PositiveInfinity, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.NegativeInfinity, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.MinValue, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NegativeOne, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-MinNormal, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-MaxSubnormal, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(-NFloat.Epsilon, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NegativeZero, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.NaN, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(Zero, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.Epsilon, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(MaxSubnormal, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(MinNormal, One));
+            Assert.True(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(One, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.MaxValue, One));
+            Assert.False(ComparisonOperatorsHelper<NFloat, NFloat>.op_LessThanOrEqual(NFloat.PositiveInfinity, One));
         }
 
         //
@@ -366,11 +366,11 @@ namespace System.Runtime.InteropServices.Tests
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_Decrement(-NFloat.Epsilon));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_Decrement(NegativeZero));
             AssertBitwiseEqual(NFloat.NaN, DecrementOperatorsHelper<NFloat>.op_Decrement(NFloat.NaN));
-            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_Decrement(PositiveZero));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_Decrement(Zero));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_Decrement(NFloat.Epsilon));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_Decrement(MaxSubnormal));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_Decrement(MinNormal));
-            AssertBitwiseEqual(PositiveZero, DecrementOperatorsHelper<NFloat>.op_Decrement(PositiveOne));
+            AssertBitwiseEqual(Zero, DecrementOperatorsHelper<NFloat>.op_Decrement(One));
             AssertBitwiseEqual(NFloat.MaxValue, DecrementOperatorsHelper<NFloat>.op_Decrement(NFloat.MaxValue));
             AssertBitwiseEqual(NFloat.PositiveInfinity, DecrementOperatorsHelper<NFloat>.op_Decrement(NFloat.PositiveInfinity));
         }
@@ -386,11 +386,11 @@ namespace System.Runtime.InteropServices.Tests
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(-NFloat.Epsilon));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(NegativeZero));
             AssertBitwiseEqual(NFloat.NaN, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(NFloat.NaN));
-            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(PositiveZero));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(Zero));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(NFloat.Epsilon));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(MaxSubnormal));
             AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(MinNormal));
-            AssertBitwiseEqual(PositiveZero, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(PositiveOne));
+            AssertBitwiseEqual(Zero, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(One));
             AssertBitwiseEqual(NFloat.MaxValue, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(NFloat.MaxValue));
             AssertBitwiseEqual(NFloat.PositiveInfinity, DecrementOperatorsHelper<NFloat>.op_CheckedDecrement(NFloat.PositiveInfinity));
         }
@@ -402,66 +402,66 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void op_DivisionTest()
         {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual((NFloat)(-0.5f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(-NFloat.Epsilon, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NaN, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.Epsilon, PositiveTwo));
-            AssertBitwiseEqual((NFloat)0.5f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.PositiveInfinity, PositiveTwo));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.NegativeInfinity, Two));
+            AssertBitwiseEqual((NFloat)(-0.5f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NegativeOne, Two));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(-NFloat.Epsilon, Two));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NegativeZero, Two));
+            AssertBitwiseEqual(NFloat.NaN, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.NaN, Two));
+            AssertBitwiseEqual(Zero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(Zero, Two));
+            AssertBitwiseEqual(Zero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.Epsilon, Two));
+            AssertBitwiseEqual((NFloat)0.5f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(One, Two));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.PositiveInfinity, Two));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)(-8.9884656743115785E+307), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.MinValue, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-1.1125369292536007E-308), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-1.1125369292536007E-308), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)1.1125369292536007E-308, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)1.1125369292536007E-308, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)8.9884656743115785E+307, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.MaxValue, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-8.9884656743115785E+307), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.MinValue, Two));
+                AssertBitwiseEqual((NFloat)(-1.1125369292536007E-308), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(-MinNormal, Two));
+                AssertBitwiseEqual((NFloat)(-1.1125369292536007E-308), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(-MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)1.1125369292536007E-308, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)1.1125369292536007E-308, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(MinNormal, Two));
+                AssertBitwiseEqual((NFloat)8.9884656743115785E+307, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.MaxValue, Two));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)(-1.70141173E+38f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.MinValue, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-5.87747175E-39f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-5.87747175E-39f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)5.87747175E-39f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)5.87747175E-39f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)1.70141173E+38f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.MaxValue, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-1.70141173E+38f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.MinValue, Two));
+                AssertBitwiseEqual((NFloat)(-5.87747175E-39f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(-MinNormal, Two));
+                AssertBitwiseEqual((NFloat)(-5.87747175E-39f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(-MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)5.87747175E-39f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)5.87747175E-39f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(MinNormal, Two));
+                AssertBitwiseEqual((NFloat)1.70141173E+38f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_Division(NFloat.MaxValue, Two));
             }
         }
 
         [Fact]
         public static void op_CheckedDivisionTest()
         {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual((NFloat)(-0.5f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(-NFloat.Epsilon, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NaN, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.Epsilon, PositiveTwo));
-            AssertBitwiseEqual((NFloat)0.5f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.PositiveInfinity, PositiveTwo));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.NegativeInfinity, Two));
+            AssertBitwiseEqual((NFloat)(-0.5f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NegativeOne, Two));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(-NFloat.Epsilon, Two));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NegativeZero, Two));
+            AssertBitwiseEqual(NFloat.NaN, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.NaN, Two));
+            AssertBitwiseEqual(Zero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(Zero, Two));
+            AssertBitwiseEqual(Zero, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.Epsilon, Two));
+            AssertBitwiseEqual((NFloat)0.5f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(One, Two));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.PositiveInfinity, Two));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)(-8.9884656743115785E+307), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.MinValue, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-1.1125369292536007E-308), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-1.1125369292536007E-308), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)1.1125369292536007E-308, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)1.1125369292536007E-308, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)8.9884656743115785E+307, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.MaxValue, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-8.9884656743115785E+307), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.MinValue, Two));
+                AssertBitwiseEqual((NFloat)(-1.1125369292536007E-308), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(-MinNormal, Two));
+                AssertBitwiseEqual((NFloat)(-1.1125369292536007E-308), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(-MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)1.1125369292536007E-308, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)1.1125369292536007E-308, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(MinNormal, Two));
+                AssertBitwiseEqual((NFloat)8.9884656743115785E+307, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.MaxValue, Two));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)(-1.70141173E+38f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.MinValue, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-5.87747175E-39f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-5.87747175E-39f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)5.87747175E-39f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)5.87747175E-39f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)1.70141173E+38f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.MaxValue, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-1.70141173E+38f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.MinValue, Two));
+                AssertBitwiseEqual((NFloat)(-5.87747175E-39f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(-MinNormal, Two));
+                AssertBitwiseEqual((NFloat)(-5.87747175E-39f), DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(-MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)5.87747175E-39f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)5.87747175E-39f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(MinNormal, Two));
+                AssertBitwiseEqual((NFloat)1.70141173E+38f, DivisionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedDivision(NFloat.MaxValue, Two));
             }
         }
 
@@ -472,41 +472,41 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void op_EqualityTest()
         {
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.NegativeInfinity, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.MinValue, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NegativeOne, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(-MinNormal, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(-MaxSubnormal, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(-NFloat.Epsilon, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NegativeZero, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.NaN, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(PositiveZero, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.Epsilon, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(MaxSubnormal, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(MinNormal, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(PositiveOne, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.MaxValue, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.PositiveInfinity, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.NegativeInfinity, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.MinValue, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NegativeOne, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(-MinNormal, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(-MaxSubnormal, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(-NFloat.Epsilon, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NegativeZero, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.NaN, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(Zero, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.Epsilon, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(MaxSubnormal, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(MinNormal, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(One, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.MaxValue, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Equality(NFloat.PositiveInfinity, One));
         }
 
         [Fact]
         public static void op_InequalityTest()
         {
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.NegativeInfinity, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.MinValue, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NegativeOne, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(-MinNormal, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(-MaxSubnormal, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(-NFloat.Epsilon, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NegativeZero, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.NaN, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(PositiveZero, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.Epsilon, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(MaxSubnormal, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(MinNormal, PositiveOne));
-            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(PositiveOne, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.MaxValue, PositiveOne));
-            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.PositiveInfinity, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.NegativeInfinity, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.MinValue, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NegativeOne, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(-MinNormal, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(-MaxSubnormal, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(-NFloat.Epsilon, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NegativeZero, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.NaN, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(Zero, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.Epsilon, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(MaxSubnormal, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(MinNormal, One));
+            Assert.False(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(One, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.MaxValue, One));
+            Assert.True(EqualityOperatorsHelper<NFloat, NFloat>.op_Inequality(NFloat.PositiveInfinity, One));
         }
 
         //
@@ -526,11 +526,11 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(-NFloat.Epsilon));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(NegativeZero));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(NFloat.NaN));
-            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(PositiveZero));
+            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(Zero));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(NFloat.Epsilon));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(MaxSubnormal));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(MinNormal));
-            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(PositiveOne));
+            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(One));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(NFloat.MaxValue));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentByteCount(NFloat.PositiveInfinity));
         }
@@ -546,7 +546,7 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentShortestBitLength(-NFloat.Epsilon));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentShortestBitLength(NegativeZero));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentShortestBitLength(NFloat.NaN));
-            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentShortestBitLength(PositiveZero));
+            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentShortestBitLength(Zero));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentShortestBitLength(NFloat.Epsilon));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentShortestBitLength(MaxSubnormal));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentShortestBitLength(MinNormal));
@@ -560,7 +560,7 @@ namespace System.Runtime.InteropServices.Tests
             expected = 0;
 
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentShortestBitLength(NegativeOne));
-            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentShortestBitLength(PositiveOne));
+            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetExponentShortestBitLength(One));
         }
 
         [Fact]
@@ -576,11 +576,11 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(-NFloat.Epsilon));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(NegativeZero));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(NFloat.NaN));
-            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(PositiveZero));
+            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(Zero));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(NFloat.Epsilon));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(MaxSubnormal));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(MinNormal));
-            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(PositiveOne));
+            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(One));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(NFloat.MaxValue));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandByteCount(NFloat.PositiveInfinity));
         }
@@ -598,11 +598,11 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(-NFloat.Epsilon));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(NegativeZero));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(NFloat.NaN));
-            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(PositiveZero));
+            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(Zero));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(NFloat.Epsilon));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(MaxSubnormal));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(MinNormal));
-            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(PositiveOne));
+            Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(One));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(NFloat.MaxValue));
             Assert.Equal(expected, FloatingPointHelper<NFloat>.GetSignificandBitLength(NFloat.PositiveInfinity));
         }
@@ -647,7 +647,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(2, bytesWritten);
                 Assert.Equal(new byte[] { 0x04, 0x00 }, destination.ToArray()); // +1024
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentBigEndian(PositiveZero, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentBigEndian(Zero, destination, out bytesWritten));
                 Assert.Equal(2, bytesWritten);
                 Assert.Equal(new byte[] { 0xFC, 0x01 }, destination.ToArray()); // -1023
 
@@ -663,7 +663,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(2, bytesWritten);
                 Assert.Equal(new byte[] { 0xFC, 0x02 }, destination.ToArray()); // -1022
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentBigEndian(PositiveOne, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentBigEndian(One, destination, out bytesWritten));
                 Assert.Equal(2, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray()); // +0
 
@@ -716,7 +716,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(1, bytesWritten);
                 Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentBigEndian(PositiveZero, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentBigEndian(Zero, destination, out bytesWritten));
                 Assert.Equal(1, bytesWritten);
                 Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
 
@@ -732,7 +732,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(1, bytesWritten);
                 Assert.Equal(new byte[] { 0x82 }, destination.ToArray()); // -126
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentBigEndian(PositiveOne, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentBigEndian(One, destination, out bytesWritten));
                 Assert.Equal(1, bytesWritten);
                 Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
 
@@ -790,7 +790,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(2, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x04 }, destination.ToArray()); // +1024
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentLittleEndian(PositiveZero, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentLittleEndian(Zero, destination, out bytesWritten));
                 Assert.Equal(2, bytesWritten);
                 Assert.Equal(new byte[] { 0x01, 0xFC }, destination.ToArray()); // -1023
 
@@ -806,7 +806,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(2, bytesWritten);
                 Assert.Equal(new byte[] { 0x02, 0xFC }, destination.ToArray()); // -1022
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentLittleEndian(PositiveOne, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentLittleEndian(One, destination, out bytesWritten));
                 Assert.Equal(2, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00 }, destination.ToArray()); // +0
 
@@ -859,7 +859,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(1, bytesWritten);
                 Assert.Equal(new byte[] { 0x80 }, destination.ToArray()); // -128
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentLittleEndian(PositiveZero, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentLittleEndian(Zero, destination, out bytesWritten));
                 Assert.Equal(1, bytesWritten);
                 Assert.Equal(new byte[] { 0x81 }, destination.ToArray()); // -127
 
@@ -875,7 +875,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(1, bytesWritten);
                 Assert.Equal(new byte[] { 0x82 }, destination.ToArray()); // -126
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentLittleEndian(PositiveOne, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteExponentLittleEndian(One, destination, out bytesWritten));
                 Assert.Equal(1, bytesWritten);
                 Assert.Equal(new byte[] { 0x00 }, destination.ToArray()); // +0
 
@@ -933,7 +933,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(8, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandBigEndian(PositiveZero, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandBigEndian(Zero, destination, out bytesWritten));
                 Assert.Equal(8, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
 
@@ -949,7 +949,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(8, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandBigEndian(PositiveOne, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandBigEndian(One, destination, out bytesWritten));
                 Assert.Equal(8, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
 
@@ -1002,7 +1002,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(4, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0xC0, 0x00, 0x00 }, destination.ToArray());
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandBigEndian(PositiveZero, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandBigEndian(Zero, destination, out bytesWritten));
                 Assert.Equal(4, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
 
@@ -1018,7 +1018,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(4, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandBigEndian(PositiveOne, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandBigEndian(One, destination, out bytesWritten));
                 Assert.Equal(4, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x80, 0x00, 0x00 }, destination.ToArray());
 
@@ -1076,7 +1076,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(8, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00 }, destination.ToArray());
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandLittleEndian(PositiveZero, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandLittleEndian(Zero, destination, out bytesWritten));
                 Assert.Equal(8, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
 
@@ -1092,7 +1092,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(8, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandLittleEndian(PositiveOne, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandLittleEndian(One, destination, out bytesWritten));
                 Assert.Equal(8, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00 }, destination.ToArray());
 
@@ -1145,7 +1145,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(4, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00, 0xC0, 0x00 }, destination.ToArray());
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandLittleEndian(PositiveZero, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandLittleEndian(Zero, destination, out bytesWritten));
                 Assert.Equal(4, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00 }, destination.ToArray());
 
@@ -1161,7 +1161,7 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.Equal(4, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
 
-                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandLittleEndian(PositiveOne, destination, out bytesWritten));
+                Assert.True(FloatingPointHelper<NFloat>.TryWriteSignificandLittleEndian(One, destination, out bytesWritten));
                 Assert.Equal(4, bytesWritten);
                 Assert.Equal(new byte[] { 0x00, 0x00, 0x80, 0x00 }, destination.ToArray());
 
@@ -1188,17 +1188,17 @@ namespace System.Runtime.InteropServices.Tests
         {
             AssertBitwiseEqual(NFloat.NegativeInfinity, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.NegativeInfinity));
             AssertBitwiseEqual(NFloat.MinValue, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.MinValue));
-            AssertBitwiseEqual(PositiveZero, IncrementOperatorsHelper<NFloat>.op_Increment(NegativeOne));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(-MinNormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(-MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(-NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(NegativeZero));
+            AssertBitwiseEqual(Zero, IncrementOperatorsHelper<NFloat>.op_Increment(NegativeOne));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_Increment(-MinNormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_Increment(-MaxSubnormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_Increment(-NFloat.Epsilon));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_Increment(NegativeZero));
             AssertBitwiseEqual(NFloat.NaN, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.NaN));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(PositiveZero));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_Increment(MinNormal));
-            AssertBitwiseEqual(PositiveTwo, IncrementOperatorsHelper<NFloat>.op_Increment(PositiveOne));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_Increment(Zero));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.Epsilon));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_Increment(MaxSubnormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_Increment(MinNormal));
+            AssertBitwiseEqual(Two, IncrementOperatorsHelper<NFloat>.op_Increment(One));
             AssertBitwiseEqual(NFloat.MaxValue, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.MaxValue));
             AssertBitwiseEqual(NFloat.PositiveInfinity, IncrementOperatorsHelper<NFloat>.op_Increment(NFloat.PositiveInfinity));
         }
@@ -1208,17 +1208,17 @@ namespace System.Runtime.InteropServices.Tests
         {
             AssertBitwiseEqual(NFloat.NegativeInfinity, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.NegativeInfinity));
             AssertBitwiseEqual(NFloat.MinValue, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.MinValue));
-            AssertBitwiseEqual(PositiveZero, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NegativeOne));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-MinNormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NegativeZero));
+            AssertBitwiseEqual(Zero, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NegativeOne));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-MinNormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-MaxSubnormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(-NFloat.Epsilon));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NegativeZero));
             AssertBitwiseEqual(NFloat.NaN, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.NaN));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(PositiveZero));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(MaxSubnormal));
-            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(MinNormal));
-            AssertBitwiseEqual(PositiveTwo, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(PositiveOne));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(Zero));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.Epsilon));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(MaxSubnormal));
+            AssertBitwiseEqual(One, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(MinNormal));
+            AssertBitwiseEqual(Two, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(One));
             AssertBitwiseEqual(NFloat.MaxValue, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.MaxValue));
             AssertBitwiseEqual(NFloat.PositiveInfinity, IncrementOperatorsHelper<NFloat>.op_CheckedIncrement(NFloat.PositiveInfinity));
         }
@@ -1246,21 +1246,21 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void op_ModulusTest()
         {
-            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.MinValue, PositiveTwo));
-            AssertBitwiseEqual(NegativeOne, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-MinNormal, PositiveTwo));
-            AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual(-NFloat.Epsilon, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-NFloat.Epsilon, PositiveTwo)); ;
-            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual(NFloat.Epsilon, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.Epsilon, PositiveTwo));
-            AssertBitwiseEqual(MaxSubnormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(MaxSubnormal, PositiveTwo));
-            AssertBitwiseEqual(MinNormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(MinNormal, PositiveTwo));
-            AssertBitwiseEqual(PositiveOne, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.MaxValue, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.PositiveInfinity, PositiveTwo));
+            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.NegativeInfinity, Two));
+            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.MinValue, Two));
+            AssertBitwiseEqual(NegativeOne, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NegativeOne, Two));
+            AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-MinNormal, Two));
+            AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-MaxSubnormal, Two));
+            AssertBitwiseEqual(-NFloat.Epsilon, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(-NFloat.Epsilon, Two)); ;
+            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NegativeZero, Two));
+            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.NaN, Two));
+            AssertBitwiseEqual(Zero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(Zero, Two));
+            AssertBitwiseEqual(NFloat.Epsilon, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.Epsilon, Two));
+            AssertBitwiseEqual(MaxSubnormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(MaxSubnormal, Two));
+            AssertBitwiseEqual(MinNormal, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(MinNormal, Two));
+            AssertBitwiseEqual(One, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(One, Two));
+            AssertBitwiseEqual(Zero, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.MaxValue, Two));
+            AssertBitwiseEqual(NFloat.NaN, ModulusOperatorsHelper<NFloat, NFloat, NFloat>.op_Modulus(NFloat.PositiveInfinity, Two));
         }
 
         //
@@ -1270,7 +1270,7 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void MultiplicativeIdentityTest()
         {
-            AssertBitwiseEqual(PositiveOne, MultiplicativeIdentityHelper<NFloat, NFloat>.MultiplicativeIdentity);
+            AssertBitwiseEqual(One, MultiplicativeIdentityHelper<NFloat, NFloat>.MultiplicativeIdentity);
         }
 
         //
@@ -1280,66 +1280,66 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void op_MultiplyTest()
         {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.MinValue, PositiveTwo));
-            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NaN, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual(PositiveTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.MaxValue, PositiveTwo));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.PositiveInfinity, PositiveTwo));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.NegativeInfinity, Two));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.MinValue, Two));
+            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NegativeOne, Two));
+            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NegativeZero, Two));
+            AssertBitwiseEqual(NFloat.NaN, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.NaN, Two));
+            AssertBitwiseEqual(Zero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(Zero, Two));
+            AssertBitwiseEqual(Two, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(One, Two));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.MaxValue, Two));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.PositiveInfinity, Two));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)(-4.4501477170144028E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-4.4501477170144018E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-9.8813129168249309E-324), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)9.8813129168249309E-324, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)4.4501477170144018E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)4.4501477170144028E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MinNormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-4.4501477170144028E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MinNormal, Two));
+                AssertBitwiseEqual((NFloat)(-4.4501477170144018E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)(-9.8813129168249309E-324), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-NFloat.Epsilon, Two));
+                AssertBitwiseEqual((NFloat)9.8813129168249309E-324, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.Epsilon, Two));
+                AssertBitwiseEqual((NFloat)4.4501477170144018E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)4.4501477170144028E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MinNormal, Two));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)(-2.3509887E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-2.35098842E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-2.80259693E-45f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.80259693E-45f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.35098842E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.3509887E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MinNormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-2.3509887E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MinNormal, Two));
+                AssertBitwiseEqual((NFloat)(-2.35098842E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)(-2.80259693E-45f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(-NFloat.Epsilon, Two));
+                AssertBitwiseEqual((NFloat)2.80259693E-45f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(NFloat.Epsilon, Two));
+                AssertBitwiseEqual((NFloat)2.35098842E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)2.3509887E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_Multiply(MinNormal, Two));
             }
         }
 
         [Fact]
         public static void op_CheckedMultiplyTest()
         {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.MinValue, PositiveTwo));
-            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NegativeOne, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NegativeZero, PositiveTwo));
-            AssertBitwiseEqual(NFloat.NaN, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.NaN, PositiveTwo));
-            AssertBitwiseEqual(PositiveZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(PositiveZero, PositiveTwo));
-            AssertBitwiseEqual(PositiveTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(PositiveOne, PositiveTwo));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.MaxValue, PositiveTwo));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.PositiveInfinity, PositiveTwo));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.NegativeInfinity, Two));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.MinValue, Two));
+            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NegativeOne, Two));
+            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NegativeZero, Two));
+            AssertBitwiseEqual(NFloat.NaN, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.NaN, Two));
+            AssertBitwiseEqual(Zero, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(Zero, Two));
+            AssertBitwiseEqual(Two, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(One, Two));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.MaxValue, Two));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.PositiveInfinity, Two));
 
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual((NFloat)(-4.4501477170144028E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-4.4501477170144018E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-9.8813129168249309E-324), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)9.8813129168249309E-324, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)4.4501477170144018E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)4.4501477170144028E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MinNormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-4.4501477170144028E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MinNormal, Two));
+                AssertBitwiseEqual((NFloat)(-4.4501477170144018E-308), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)(-9.8813129168249309E-324), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-NFloat.Epsilon, Two));
+                AssertBitwiseEqual((NFloat)9.8813129168249309E-324, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.Epsilon, Two));
+                AssertBitwiseEqual((NFloat)4.4501477170144018E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)4.4501477170144028E-308, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MinNormal, Two));
             }
             else
             {
-                AssertBitwiseEqual((NFloat)(-2.3509887E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MinNormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-2.35098842E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)(-2.80259693E-45f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.80259693E-45f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.Epsilon, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.35098842E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MaxSubnormal, PositiveTwo));
-                AssertBitwiseEqual((NFloat)2.3509887E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MinNormal, PositiveTwo));
+                AssertBitwiseEqual((NFloat)(-2.3509887E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MinNormal, Two));
+                AssertBitwiseEqual((NFloat)(-2.35098842E-38f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)(-2.80259693E-45f), MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(-NFloat.Epsilon, Two));
+                AssertBitwiseEqual((NFloat)2.80259693E-45f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(NFloat.Epsilon, Two));
+                AssertBitwiseEqual((NFloat)2.35098842E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MaxSubnormal, Two));
+                AssertBitwiseEqual((NFloat)2.3509887E-38f, MultiplyOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedMultiply(MinNormal, Two));
             }
         }
 
@@ -1350,61 +1350,101 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void ClampTest()
         {
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NFloat.NegativeInfinity, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NFloat.MinValue, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NegativeOne, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(-MinNormal, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(-MaxSubnormal, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(-NFloat.Epsilon, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NegativeZero, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Clamp(NFloat.NaN, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(PositiveZero, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(NFloat.Epsilon, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(MaxSubnormal, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(MinNormal, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Clamp(PositiveOne, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual((NFloat)63.0f, NumberHelper<NFloat>.Clamp(NFloat.MaxValue, PositiveOne, (NFloat)63.0f));
-            AssertBitwiseEqual((NFloat)63.0f, NumberHelper<NFloat>.Clamp(NFloat.PositiveInfinity, PositiveOne, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(NFloat.NegativeInfinity, One, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(NFloat.MinValue, One, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(NegativeOne, One, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(-MinNormal, One, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(-MaxSubnormal, One, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(-NFloat.Epsilon, One, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(NegativeZero, One, (NFloat)63.0f));
+            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Clamp(NFloat.NaN, One, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(Zero, One, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(NFloat.Epsilon, One, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(MaxSubnormal, One, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(MinNormal, One, (NFloat)63.0f));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Clamp(One, One, (NFloat)63.0f));
+            AssertBitwiseEqual((NFloat)63.0f, NumberHelper<NFloat>.Clamp(NFloat.MaxValue, One, (NFloat)63.0f));
+            AssertBitwiseEqual((NFloat)63.0f, NumberHelper<NFloat>.Clamp(NFloat.PositiveInfinity, One, (NFloat)63.0f));
         }
 
         [Fact]
         public static void MaxTest()
         {
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NFloat.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NFloat.MinValue, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(-NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Max(NFloat.NaN, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Max(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(NFloat.MaxValue, NumberHelper<NFloat>.Max(NFloat.MaxValue, PositiveOne));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberHelper<NFloat>.Max(NFloat.PositiveInfinity, PositiveOne));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(NFloat.MinValue, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(NegativeOne, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(-MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(NegativeZero, One));
+            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Max(NFloat.NaN, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(Zero, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Max(One, One));
+            AssertBitwiseEqual(NFloat.MaxValue, NumberHelper<NFloat>.Max(NFloat.MaxValue, One));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberHelper<NFloat>.Max(NFloat.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void MaxNumberTest()
+        {
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(NFloat.MinValue, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(NegativeOne, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(-MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(NegativeZero, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(NFloat.NaN, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(Zero, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MaxNumber(One, One));
+            AssertBitwiseEqual(NFloat.MaxValue, NumberHelper<NFloat>.MaxNumber(NFloat.MaxValue, One));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberHelper<NFloat>.MaxNumber(NFloat.PositiveInfinity, One));
         }
 
         [Fact]
         public static void MinTest()
         {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, NumberHelper<NFloat>.Min(NFloat.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(NFloat.MinValue, NumberHelper<NFloat>.Min(NFloat.MinValue, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.Min(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(-MinNormal, NumberHelper<NFloat>.Min(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<NFloat>.Min(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(-NFloat.Epsilon, NumberHelper<NFloat>.Min(-NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(NegativeZero, NumberHelper<NFloat>.Min(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Min(NFloat.NaN, PositiveOne));
-            AssertBitwiseEqual(PositiveZero, NumberHelper<NFloat>.Min(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(NFloat.Epsilon, NumberHelper<NFloat>.Min(NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(MaxSubnormal, NumberHelper<NFloat>.Min(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(MinNormal, NumberHelper<NFloat>.Min(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Min(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Min(NFloat.MaxValue, PositiveOne));
-            AssertBitwiseEqual(PositiveOne, NumberHelper<NFloat>.Min(NFloat.PositiveInfinity, PositiveOne));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, NumberHelper<NFloat>.Min(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(NFloat.MinValue, NumberHelper<NFloat>.Min(NFloat.MinValue, One));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.Min(NegativeOne, One));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<NFloat>.Min(-MinNormal, One));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<NFloat>.Min(-MaxSubnormal, One));
+            AssertBitwiseEqual(-NFloat.Epsilon, NumberHelper<NFloat>.Min(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(NegativeZero, NumberHelper<NFloat>.Min(NegativeZero, One));
+            AssertBitwiseEqual(NFloat.NaN, NumberHelper<NFloat>.Min(NFloat.NaN, One));
+            AssertBitwiseEqual(Zero, NumberHelper<NFloat>.Min(Zero, One));
+            AssertBitwiseEqual(NFloat.Epsilon, NumberHelper<NFloat>.Min(NFloat.Epsilon, One));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<NFloat>.Min(MaxSubnormal, One));
+            AssertBitwiseEqual(MinNormal, NumberHelper<NFloat>.Min(MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Min(One, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Min(NFloat.MaxValue, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.Min(NFloat.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void MinNumberTest()
+        {
+            AssertBitwiseEqual(NFloat.NegativeInfinity, NumberHelper<NFloat>.MinNumber(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(NFloat.MinValue, NumberHelper<NFloat>.MinNumber(NFloat.MinValue, One));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<NFloat>.MinNumber(NegativeOne, One));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<NFloat>.MinNumber(-MinNormal, One));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<NFloat>.MinNumber(-MaxSubnormal, One));
+            AssertBitwiseEqual(-NFloat.Epsilon, NumberHelper<NFloat>.MinNumber(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(NegativeZero, NumberHelper<NFloat>.MinNumber(NegativeZero, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MinNumber(NFloat.NaN, One));
+            AssertBitwiseEqual(Zero, NumberHelper<NFloat>.MinNumber(Zero, One));
+            AssertBitwiseEqual(NFloat.Epsilon, NumberHelper<NFloat>.MinNumber(NFloat.Epsilon, One));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<NFloat>.MinNumber(MaxSubnormal, One));
+            AssertBitwiseEqual(MinNormal, NumberHelper<NFloat>.MinNumber(MinNormal, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MinNumber(One, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MinNumber(NFloat.MaxValue, One));
+            AssertBitwiseEqual(One, NumberHelper<NFloat>.MinNumber(NFloat.PositiveInfinity, One));
         }
 
         [Fact]
@@ -1418,12 +1458,12 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(-1, NumberHelper<NFloat>.Sign(-NFloat.Epsilon));
 
             Assert.Equal(0, NumberHelper<NFloat>.Sign(NegativeZero));
-            Assert.Equal(0, NumberHelper<NFloat>.Sign(PositiveZero));
+            Assert.Equal(0, NumberHelper<NFloat>.Sign(Zero));
 
             Assert.Equal(1, NumberHelper<NFloat>.Sign(NFloat.Epsilon));
             Assert.Equal(1, NumberHelper<NFloat>.Sign(MaxSubnormal));
             Assert.Equal(1, NumberHelper<NFloat>.Sign(MinNormal));
-            Assert.Equal(1, NumberHelper<NFloat>.Sign(PositiveOne));
+            Assert.Equal(1, NumberHelper<NFloat>.Sign(One));
             Assert.Equal(1, NumberHelper<NFloat>.Sign(NFloat.MaxValue));
             Assert.Equal(1, NumberHelper<NFloat>.Sign(NFloat.PositiveInfinity));
 
@@ -1437,13 +1477,19 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void OneTest()
         {
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.One);
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.One);
+        }
+
+        [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<NFloat>.Radix);
         }
 
         [Fact]
         public static void ZeroTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.Zero);
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.Zero);
         }
 
         [Fact]
@@ -1451,17 +1497,17 @@ namespace System.Runtime.InteropServices.Tests
         {
             AssertBitwiseEqual(NFloat.PositiveInfinity, NumberBaseHelper<NFloat>.Abs(NFloat.NegativeInfinity));
             AssertBitwiseEqual(NFloat.MaxValue, NumberBaseHelper<NFloat>.Abs(NFloat.MinValue));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.Abs(NegativeOne));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.Abs(NegativeOne));
             AssertBitwiseEqual(MinNormal, NumberBaseHelper<NFloat>.Abs(-MinNormal));
             AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<NFloat>.Abs(-MaxSubnormal));
             AssertBitwiseEqual(NFloat.Epsilon, NumberBaseHelper<NFloat>.Abs(-NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.Abs(NegativeZero));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.Abs(NegativeZero));
             AssertBitwiseEqual(NFloat.NaN, NumberBaseHelper<NFloat>.Abs(NFloat.NaN));
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.Abs(PositiveZero));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.Abs(Zero));
             AssertBitwiseEqual(NFloat.Epsilon, NumberBaseHelper<NFloat>.Abs(NFloat.Epsilon));
             AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<NFloat>.Abs(MaxSubnormal));
             AssertBitwiseEqual(MinNormal, NumberBaseHelper<NFloat>.Abs(MinNormal));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.Abs(PositiveOne));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.Abs(One));
             AssertBitwiseEqual(NFloat.MaxValue, NumberBaseHelper<NFloat>.Abs(NFloat.MaxValue));
             AssertBitwiseEqual(NFloat.PositiveInfinity, NumberBaseHelper<NFloat>.Abs(NFloat.PositiveInfinity));
         }
@@ -1469,8 +1515,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateCheckedFromByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x01));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x01));
             AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x7F));
             AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0x80));
             AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateChecked<byte>(0xFF));
@@ -1479,8 +1525,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateCheckedFromCharTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x0001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x0001));
             AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x7FFF));
             AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0x8000));
             AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateChecked<char>((char)0xFFFF));
@@ -1489,8 +1535,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateCheckedFromInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<short>(0x0001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<short>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<short>(0x0001));
             AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<short>(0x7FFF));
             AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateChecked<short>(unchecked((short)0x8000)));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<short>(unchecked((short)0xFFFF)));
@@ -1499,8 +1545,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateCheckedFromInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<int>(0x00000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<int>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<int>(0x00000001));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
 
             if (Environment.Is64BitProcess)
@@ -1518,8 +1564,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateCheckedFromInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<long>(0x0000000000000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<long>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<long>(0x0000000000000001));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
 
             if (Environment.Is64BitProcess)
@@ -1539,16 +1585,16 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
                 AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
                 AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
                 AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x00000001));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x00000001));
                 AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<nint>((nint)0x7FFFFFFF));
                 AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0x80000000)));
                 AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
@@ -1558,8 +1604,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateCheckedFromSByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x01));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x01));
             AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(0x7F));
             AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
@@ -1568,8 +1614,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateCheckedFromUInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x0001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x0001));
             AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x7FFF));
             AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0x8000));
             AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateChecked<ushort>(0xFFFF));
@@ -1578,8 +1624,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateCheckedFromUInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x00000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<uint>(0x00000001));
 
             if (Environment.Is64BitProcess)
             {
@@ -1598,8 +1644,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateCheckedFromUInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<ulong>(0x0000000000000001));
 
             if (Environment.Is64BitProcess)
             {
@@ -1620,8 +1666,8 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
                 AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
@@ -1630,8 +1676,8 @@ namespace System.Runtime.InteropServices.Tests
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x00000001));
                 AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
@@ -1643,8 +1689,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateSaturatingFromByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x01));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x01));
             AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x7F));
             AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0x80));
             AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateSaturating<byte>(0xFF));
@@ -1653,8 +1699,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateSaturatingFromCharTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x0001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x0001));
             AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x7FFF));
             AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0x8000));
             AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateSaturating<char>((char)0xFFFF));
@@ -1663,8 +1709,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateSaturatingFromInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x0001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x0001));
             AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<short>(0x7FFF));
             AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateSaturating<short>(unchecked((short)0x8000)));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<short>(unchecked((short)0xFFFF)));
@@ -1673,8 +1719,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateSaturatingFromInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x00000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<int>(0x00000001));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
 
             if (Environment.Is64BitProcess)
@@ -1692,8 +1738,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateSaturatingFromInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x0000000000000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<long>(0x0000000000000001));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
 
             if (Environment.Is64BitProcess)
@@ -1713,16 +1759,16 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
                 AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
                 AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
                 AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x00000001));
                 AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<nint>((nint)0x7FFFFFFF));
                 AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
                 AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
@@ -1732,8 +1778,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateSaturatingFromSByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x01));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x01));
             AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(0x7F));
             AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
@@ -1742,8 +1788,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateSaturatingFromUInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x0001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x0001));
             AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x7FFF));
             AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0x8000));
             AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateSaturating<ushort>(0xFFFF));
@@ -1752,8 +1798,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateSaturatingFromUInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x00000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<uint>(0x00000001));
 
             if (Environment.Is64BitProcess)
             {
@@ -1772,8 +1818,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateSaturatingFromUInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<ulong>(0x0000000000000001));
 
             if (Environment.Is64BitProcess)
             {
@@ -1794,8 +1840,8 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
                 AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
@@ -1804,8 +1850,8 @@ namespace System.Runtime.InteropServices.Tests
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x00000001));
                 AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
@@ -1817,8 +1863,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateTruncatingFromByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x01));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x01));
             AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x7F));
             AssertBitwiseEqual((NFloat)128.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0x80));
             AssertBitwiseEqual((NFloat)255.0f, NumberBaseHelper<NFloat>.CreateTruncating<byte>(0xFF));
@@ -1827,8 +1873,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateTruncatingFromCharTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x0001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x0001));
             AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x7FFF));
             AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0x8000));
             AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateTruncating<char>((char)0xFFFF));
@@ -1837,8 +1883,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateTruncatingFromInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x0001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x0001));
             AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<short>(0x7FFF));
             AssertBitwiseEqual((NFloat)(-32768.0f), NumberBaseHelper<NFloat>.CreateTruncating<short>(unchecked((short)0x8000)));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<short>(unchecked((short)0xFFFF)));
@@ -1847,8 +1893,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateTruncatingFromInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x00000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<int>(0x00000001));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
 
             if (Environment.Is64BitProcess)
@@ -1866,8 +1912,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateTruncatingFromInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x0000000000000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<long>(0x0000000000000001));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
 
             if (Environment.Is64BitProcess)
@@ -1887,16 +1933,16 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
                 AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
                 AssertBitwiseEqual((NFloat)(-9223372036854775808.0), NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
                 AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x00000001));
                 AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<nint>((nint)0x7FFFFFFF));
                 AssertBitwiseEqual((NFloat)(-2147483648.0f), NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
                 AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
@@ -1906,8 +1952,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateTruncatingFromSByteTest()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x00));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x01));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x00));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x01));
             AssertBitwiseEqual((NFloat)127.0f, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(0x7F));
             AssertBitwiseEqual((NFloat)(-128.0f), NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
             AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
@@ -1916,8 +1962,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateTruncatingFromUInt16Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x0000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x0001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x0000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x0001));
             AssertBitwiseEqual((NFloat)32767.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x7FFF));
             AssertBitwiseEqual((NFloat)32768.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0x8000));
             AssertBitwiseEqual((NFloat)65535.0f, NumberBaseHelper<NFloat>.CreateTruncating<ushort>(0xFFFF));
@@ -1926,8 +1972,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateTruncatingFromUInt32Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x00000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x00000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x00000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<uint>(0x00000001));
 
             if (Environment.Is64BitProcess)
             {
@@ -1946,8 +1992,8 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void CreateTruncatingFromUInt64Test()
         {
-            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000000));
-            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<ulong>(0x0000000000000001));
 
             if (Environment.Is64BitProcess)
             {
@@ -1968,8 +2014,8 @@ namespace System.Runtime.InteropServices.Tests
         {
             if (Environment.Is64BitProcess)
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
                 AssertBitwiseEqual((NFloat)9223372036854775807.0, NumberBaseHelper<NFloat>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
 
                 // https://github.com/dotnet/roslyn/issues/60714
@@ -1978,8 +2024,8 @@ namespace System.Runtime.InteropServices.Tests
             }
             else
             {
-                AssertBitwiseEqual(PositiveZero, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000000));
-                AssertBitwiseEqual(PositiveOne, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x00000001));
                 AssertBitwiseEqual((NFloat)2147483647.0f, NumberBaseHelper<NFloat>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
 
                 // https://github.com/dotnet/roslyn/issues/60714
@@ -1989,15 +2035,435 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(NFloat.NegativeInfinity));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(NFloat.MinValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(NegativeOne));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(-MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(-NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(NegativeZero));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(NFloat.NaN));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(Zero));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(MaxSubnormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(One));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(NFloat.MaxValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsCanonical(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(NFloat.NegativeInfinity));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(NFloat.MinValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(-NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(NFloat.NaN));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(One));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsComplexNumber(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsEvenInteger(NFloat.NegativeInfinity));
+            Assert.True(NumberBaseHelper<NFloat>.IsEvenInteger(NFloat.MinValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsEvenInteger(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsEvenInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsEvenInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsEvenInteger(-NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsEvenInteger(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsEvenInteger(NFloat.NaN));
+            Assert.True(NumberBaseHelper<NFloat>.IsEvenInteger(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsEvenInteger(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsEvenInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsEvenInteger(MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsEvenInteger(One));
+            Assert.True(NumberBaseHelper<NFloat>.IsEvenInteger(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsEvenInteger(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsFiniteTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsFinite(NFloat.NegativeInfinity));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(NFloat.MinValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(NegativeOne));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(-MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(-NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsFinite(NFloat.NaN));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(Zero));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(MaxSubnormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(One));
+            Assert.True(NumberBaseHelper<NFloat>.IsFinite(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsFinite(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(NFloat.NegativeInfinity));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(NFloat.MinValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(-NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(NFloat.NaN));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(One));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsImaginaryNumber(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsInfinityTest()
+        {
+            Assert.True(NumberBaseHelper<NFloat>.IsInfinity(NFloat.NegativeInfinity));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(NFloat.MinValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(-NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(NFloat.NaN));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(One));
+            Assert.False(NumberBaseHelper<NFloat>.IsInfinity(NFloat.MaxValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsInfinity(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsInteger(NFloat.NegativeInfinity));
+            Assert.True(NumberBaseHelper<NFloat>.IsInteger(NFloat.MinValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsInteger(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsInteger(-NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsInteger(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsInteger(NFloat.NaN));
+            Assert.True(NumberBaseHelper<NFloat>.IsInteger(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsInteger(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsInteger(MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsInteger(One));
+            Assert.True(NumberBaseHelper<NFloat>.IsInteger(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsInteger(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNaNTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(NFloat.NegativeInfinity));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(NFloat.MinValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(-NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(NegativeZero));
+            Assert.True(NumberBaseHelper<NFloat>.IsNaN(NFloat.NaN));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(One));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsNaN(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNegativeTest()
+        {
+            Assert.True(NumberBaseHelper<NFloat>.IsNegative(NFloat.NegativeInfinity));
+            Assert.True(NumberBaseHelper<NFloat>.IsNegative(NFloat.MinValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsNegative(NegativeOne));
+            Assert.True(NumberBaseHelper<NFloat>.IsNegative(-MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsNegative(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsNegative(-NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsNegative(NegativeZero));
+            Assert.True(NumberBaseHelper<NFloat>.IsNegative(NFloat.NaN));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegative(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegative(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegative(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegative(MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegative(One));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegative(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegative(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNegativeInfinityTest()
+        {
+            Assert.True(NumberBaseHelper<NFloat>.IsNegativeInfinity(NFloat.NegativeInfinity));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(NFloat.MinValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(-NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(NFloat.NaN));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(One));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsNegativeInfinity(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsNormalTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsNormal(NFloat.NegativeInfinity));
+            Assert.True(NumberBaseHelper<NFloat>.IsNormal(NFloat.MinValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsNormal(NegativeOne));
+            Assert.True(NumberBaseHelper<NFloat>.IsNormal(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNormal(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsNormal(-NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsNormal(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsNormal(NFloat.NaN));
+            Assert.False(NumberBaseHelper<NFloat>.IsNormal(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsNormal(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsNormal(MaxSubnormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsNormal(MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsNormal(One));
+            Assert.True(NumberBaseHelper<NFloat>.IsNormal(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsNormal(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(NFloat.NegativeInfinity));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(NFloat.MinValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsOddInteger(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(-NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(NFloat.NaN));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsOddInteger(One));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsOddInteger(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsPositive(NFloat.NegativeInfinity));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositive(NFloat.MinValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositive(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositive(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositive(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositive(-NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositive(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositive(NFloat.NaN));
+            Assert.True(NumberBaseHelper<NFloat>.IsPositive(Zero));
+            Assert.True(NumberBaseHelper<NFloat>.IsPositive(NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsPositive(MaxSubnormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsPositive(MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsPositive(One));
+            Assert.True(NumberBaseHelper<NFloat>.IsPositive(NFloat.MaxValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsPositive(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsPositiveInfinityTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(NFloat.NegativeInfinity));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(NFloat.MinValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(-NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(NFloat.NaN));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(One));
+            Assert.False(NumberBaseHelper<NFloat>.IsPositiveInfinity(NFloat.MaxValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsPositiveInfinity(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(NFloat.NegativeInfinity));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(NFloat.MinValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(NegativeOne));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(-MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(-NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsRealNumber(NFloat.NaN));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(Zero));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(MaxSubnormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(One));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(NFloat.MaxValue));
+            Assert.True(NumberBaseHelper<NFloat>.IsRealNumber(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsSubnormalTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsSubnormal(NFloat.NegativeInfinity));
+            Assert.False(NumberBaseHelper<NFloat>.IsSubnormal(NFloat.MinValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsSubnormal(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsSubnormal(-MinNormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsSubnormal(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<NFloat>.IsSubnormal(-NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsSubnormal(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsSubnormal(NFloat.NaN));
+            Assert.False(NumberBaseHelper<NFloat>.IsSubnormal(Zero));
+            Assert.True(NumberBaseHelper<NFloat>.IsSubnormal(NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsSubnormal(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsSubnormal(MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsSubnormal(One));
+            Assert.False(NumberBaseHelper<NFloat>.IsSubnormal(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsSubnormal(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(NFloat.NegativeInfinity));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(NFloat.MinValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(NegativeOne));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(-MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(-NFloat.Epsilon));
+            Assert.True(NumberBaseHelper<NFloat>.IsZero(NegativeZero));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(NFloat.NaN));
+            Assert.True(NumberBaseHelper<NFloat>.IsZero(Zero));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(NFloat.Epsilon));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(MaxSubnormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(MinNormal));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(One));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(NFloat.MaxValue));
+            Assert.False(NumberBaseHelper<NFloat>.IsZero(NFloat.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeTest()
+        {
+            AssertBitwiseEqual(NFloat.NegativeInfinity, NumberBaseHelper<NFloat>.MaxMagnitude(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(NFloat.MinValue, NumberBaseHelper<NFloat>.MaxMagnitude(NFloat.MinValue, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitude(NegativeOne, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitude(-MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitude(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitude(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitude(NegativeZero, One));
+            AssertBitwiseEqual(NFloat.NaN, NumberBaseHelper<NFloat>.MaxMagnitude(NFloat.NaN, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitude(Zero, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitude(NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitude(MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitude(MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitude(One, One));
+            AssertBitwiseEqual(NFloat.MaxValue, NumberBaseHelper<NFloat>.MaxMagnitude(NFloat.MaxValue, One));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberBaseHelper<NFloat>.MaxMagnitude(NFloat.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void MaxMagnitudeNumberTest()
+        {
+            AssertBitwiseEqual(NFloat.NegativeInfinity, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(NFloat.MinValue, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(NFloat.MinValue, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(NegativeOne, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(-MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(-MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(NegativeZero, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(NFloat.NaN, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(Zero, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(NFloat.Epsilon, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(MaxSubnormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(One, One));
+            AssertBitwiseEqual(NFloat.MaxValue, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(NFloat.MaxValue, One));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, NumberBaseHelper<NFloat>.MaxMagnitudeNumber(NFloat.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void MinMagnitudeTest()
+        {
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MinMagnitude(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MinMagnitude(NFloat.MinValue, One));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.MinMagnitude(NegativeOne, One));
+            AssertBitwiseEqual(-MinNormal, NumberBaseHelper<NFloat>.MinMagnitude(-MinNormal, One));
+            AssertBitwiseEqual(-MaxSubnormal, NumberBaseHelper<NFloat>.MinMagnitude(-MaxSubnormal, One));
+            AssertBitwiseEqual(-NFloat.Epsilon, NumberBaseHelper<NFloat>.MinMagnitude(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(NegativeZero, NumberBaseHelper<NFloat>.MinMagnitude(NegativeZero, One));
+            AssertBitwiseEqual(NFloat.NaN, NumberBaseHelper<NFloat>.MinMagnitude(NFloat.NaN, One));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.MinMagnitude(Zero, One));
+            AssertBitwiseEqual(NFloat.Epsilon, NumberBaseHelper<NFloat>.MinMagnitude(NFloat.Epsilon, One));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<NFloat>.MinMagnitude(MaxSubnormal, One));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<NFloat>.MinMagnitude(MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MinMagnitude(One, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MinMagnitude(NFloat.MaxValue, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MinMagnitude(NFloat.PositiveInfinity, One));
+        }
+
+        [Fact]
+        public static void MinMagnitudeNumberTest()
+        {
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MinMagnitudeNumber(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MinMagnitudeNumber(NFloat.MinValue, One));
+            AssertBitwiseEqual(NegativeOne, NumberBaseHelper<NFloat>.MinMagnitudeNumber(NegativeOne, One));
+            AssertBitwiseEqual(-MinNormal, NumberBaseHelper<NFloat>.MinMagnitudeNumber(-MinNormal, One));
+            AssertBitwiseEqual(-MaxSubnormal, NumberBaseHelper<NFloat>.MinMagnitudeNumber(-MaxSubnormal, One));
+            AssertBitwiseEqual(-NFloat.Epsilon, NumberBaseHelper<NFloat>.MinMagnitudeNumber(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(NegativeZero, NumberBaseHelper<NFloat>.MinMagnitudeNumber(NegativeZero, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MinMagnitudeNumber(NFloat.NaN, One));
+            AssertBitwiseEqual(Zero, NumberBaseHelper<NFloat>.MinMagnitudeNumber(Zero, One));
+            AssertBitwiseEqual(NFloat.Epsilon, NumberBaseHelper<NFloat>.MinMagnitudeNumber(NFloat.Epsilon, One));
+            AssertBitwiseEqual(MaxSubnormal, NumberBaseHelper<NFloat>.MinMagnitudeNumber(MaxSubnormal, One));
+            AssertBitwiseEqual(MinNormal, NumberBaseHelper<NFloat>.MinMagnitudeNumber(MinNormal, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MinMagnitudeNumber(One, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MinMagnitudeNumber(NFloat.MaxValue, One));
+            AssertBitwiseEqual(One, NumberBaseHelper<NFloat>.MinMagnitudeNumber(NFloat.PositiveInfinity, One));
+        }
+
+        [Fact]
         public static void TryCreateFromByteTest()
         {
             NFloat result;
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x00, out result));
-            Assert.Equal(PositiveZero, result);
+            Assert.Equal(Zero, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x01, out result));
-            Assert.Equal(PositiveOne, result);
+            Assert.Equal(One, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<byte>(0x7F, out result));
             Assert.Equal((NFloat)127.0f, result);
@@ -2015,10 +2481,10 @@ namespace System.Runtime.InteropServices.Tests
             NFloat result;
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x0000, out result));
-            Assert.Equal(PositiveZero, result);
+            Assert.Equal(Zero, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x0001, out result));
-            Assert.Equal(PositiveOne, result);
+            Assert.Equal(One, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<char>((char)0x7FFF, out result));
             Assert.Equal((NFloat)32767.0f, result);
@@ -2036,10 +2502,10 @@ namespace System.Runtime.InteropServices.Tests
             NFloat result;
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x0000, out result));
-            Assert.Equal(PositiveZero, result);
+            Assert.Equal(Zero, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x0001, out result));
-            Assert.Equal(PositiveOne, result);
+            Assert.Equal(One, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<short>(0x7FFF, out result));
             Assert.Equal((NFloat)32767.0f, result);
@@ -2057,10 +2523,10 @@ namespace System.Runtime.InteropServices.Tests
             NFloat result;
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x00000000, out result));
-            Assert.Equal(PositiveZero, result);
+            Assert.Equal(Zero, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(0x00000001, out result));
-            Assert.Equal(PositiveOne, result);
+            Assert.Equal(One, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
             Assert.Equal(NegativeOne, result);
@@ -2089,10 +2555,10 @@ namespace System.Runtime.InteropServices.Tests
             NFloat result;
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x0000000000000000, out result));
-            Assert.Equal(PositiveZero, result);
+            Assert.Equal(Zero, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(0x0000000000000001, out result));
-            Assert.Equal(PositiveOne, result);
+            Assert.Equal(One, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
             Assert.Equal(NegativeOne, result);
@@ -2123,10 +2589,10 @@ namespace System.Runtime.InteropServices.Tests
             if (Environment.Is64BitProcess)
             {
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
-                Assert.Equal(PositiveZero, result);
+                Assert.Equal(Zero, result);
 
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
-                Assert.Equal(PositiveOne, result);
+                Assert.Equal(One, result);
 
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((NFloat)9223372036854775807.0, result);
@@ -2140,10 +2606,10 @@ namespace System.Runtime.InteropServices.Tests
             else
             {
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x00000000, out result));
-                Assert.Equal(PositiveZero, result);
+                Assert.Equal(Zero, result);
 
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x00000001, out result));
-                Assert.Equal(PositiveOne, result);
+                Assert.Equal(One, result);
 
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
                 Assert.Equal((NFloat)2147483647.0f, result);
@@ -2162,10 +2628,10 @@ namespace System.Runtime.InteropServices.Tests
             NFloat result;
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x00, out result));
-            Assert.Equal(PositiveZero, result);
+            Assert.Equal(Zero, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x01, out result));
-            Assert.Equal(PositiveOne, result);
+            Assert.Equal(One, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<sbyte>(0x7F, out result));
             Assert.Equal((NFloat)127.0f, result);
@@ -2183,10 +2649,10 @@ namespace System.Runtime.InteropServices.Tests
             NFloat result;
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x0000, out result));
-            Assert.Equal(PositiveZero, result);
+            Assert.Equal(Zero, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x0001, out result));
-            Assert.Equal(PositiveOne, result);
+            Assert.Equal(One, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<ushort>(0x7FFF, out result));
             Assert.Equal((NFloat)32767.0f, result);
@@ -2204,10 +2670,10 @@ namespace System.Runtime.InteropServices.Tests
             NFloat result;
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x00000000, out result));
-            Assert.Equal(PositiveZero, result);
+            Assert.Equal(Zero, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<uint>(0x00000001, out result));
-            Assert.Equal(PositiveOne, result);
+            Assert.Equal(One, result);
 
             if (Environment.Is64BitProcess)
             {
@@ -2239,10 +2705,10 @@ namespace System.Runtime.InteropServices.Tests
             NFloat result;
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x0000000000000000, out result));
-            Assert.Equal(PositiveZero, result);
+            Assert.Equal(Zero, result);
 
             Assert.True(NumberBaseHelper<NFloat>.TryCreate<ulong>(0x0000000000000001, out result));
-            Assert.Equal(PositiveOne, result);
+            Assert.Equal(One, result);
 
             if (Environment.Is64BitProcess)
             {
@@ -2276,10 +2742,10 @@ namespace System.Runtime.InteropServices.Tests
             if (Environment.Is64BitProcess)
             {
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
-                Assert.Equal(PositiveZero, result);
+                Assert.Equal(Zero, result);
 
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
-                Assert.Equal(PositiveOne, result);
+                Assert.Equal(One, result);
 
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
                 Assert.Equal((NFloat)9223372036854775807.0, result);
@@ -2294,10 +2760,10 @@ namespace System.Runtime.InteropServices.Tests
             else
             {
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x00000000, out result));
-                Assert.Equal(PositiveZero, result);
+                Assert.Equal(Zero, result);
 
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x00000001, out result));
-                Assert.Equal(PositiveOne, result);
+                Assert.Equal(One, result);
 
                 Assert.True(NumberBaseHelper<NFloat>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
                 Assert.Equal((NFloat)2147483647.0f, result);
@@ -2328,41 +2794,41 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void op_SubtractionTest()
         {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(NFloat.MinValue, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.MinValue, PositiveOne));
-            AssertBitwiseEqual(NegativeTwo, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(-NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(NFloat.NaN, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.NaN, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveZero, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(NFloat.MaxValue, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.MaxValue, PositiveOne));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.PositiveInfinity, PositiveOne));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(NFloat.MinValue, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.MinValue, One));
+            AssertBitwiseEqual(NegativeTwo, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NegativeOne, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(-MinNormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(-MaxSubnormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NegativeZero, One));
+            AssertBitwiseEqual(NFloat.NaN, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.NaN, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(Zero, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.Epsilon, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(MaxSubnormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(MinNormal, One));
+            AssertBitwiseEqual(Zero, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(One, One));
+            AssertBitwiseEqual(NFloat.MaxValue, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.MaxValue, One));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_Subtraction(NFloat.PositiveInfinity, One));
         }
 
         [Fact]
         public static void op_CheckedSubtractionTest()
         {
-            AssertBitwiseEqual(NFloat.NegativeInfinity, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.NegativeInfinity, PositiveOne));
-            AssertBitwiseEqual(NFloat.MinValue, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.MinValue, PositiveOne));
-            AssertBitwiseEqual(NegativeTwo, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NegativeOne, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(-MinNormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(-MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(-NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NegativeZero, PositiveOne));
-            AssertBitwiseEqual(NFloat.NaN, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.NaN, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(PositiveZero, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.Epsilon, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(MaxSubnormal, PositiveOne));
-            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(MinNormal, PositiveOne));
-            AssertBitwiseEqual(PositiveZero, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(PositiveOne, PositiveOne));
-            AssertBitwiseEqual(NFloat.MaxValue, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.MaxValue, PositiveOne));
-            AssertBitwiseEqual(NFloat.PositiveInfinity, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.PositiveInfinity, PositiveOne));
+            AssertBitwiseEqual(NFloat.NegativeInfinity, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.NegativeInfinity, One));
+            AssertBitwiseEqual(NFloat.MinValue, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.MinValue, One));
+            AssertBitwiseEqual(NegativeTwo, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NegativeOne, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(-MinNormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(-MaxSubnormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(-NFloat.Epsilon, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NegativeZero, One));
+            AssertBitwiseEqual(NFloat.NaN, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.NaN, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(Zero, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.Epsilon, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(MaxSubnormal, One));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(MinNormal, One));
+            AssertBitwiseEqual(Zero, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(One, One));
+            AssertBitwiseEqual(NFloat.MaxValue, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.MaxValue, One));
+            AssertBitwiseEqual(NFloat.PositiveInfinity, SubtractionOperatorsHelper<NFloat, NFloat, NFloat>.op_CheckedSubtraction(NFloat.PositiveInfinity, One));
         }
 
         //
@@ -2374,17 +2840,17 @@ namespace System.Runtime.InteropServices.Tests
         {
             AssertBitwiseEqual(NFloat.PositiveInfinity, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(NFloat.NegativeInfinity));
             AssertBitwiseEqual(NFloat.MaxValue, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(NFloat.MinValue));
-            AssertBitwiseEqual(PositiveOne, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(NegativeOne));
+            AssertBitwiseEqual(One, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(NegativeOne));
             AssertBitwiseEqual(MinNormal, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(-MinNormal));
             AssertBitwiseEqual(MaxSubnormal, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(-MaxSubnormal));
             AssertBitwiseEqual(NFloat.Epsilon, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(-NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveZero, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(NegativeZero));
+            AssertBitwiseEqual(Zero, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(NegativeZero));
             AssertBitwiseEqual(NFloat.NaN, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(NFloat.NaN));
-            AssertBitwiseEqual(NegativeZero, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(PositiveZero));
+            AssertBitwiseEqual(NegativeZero, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(Zero));
             AssertBitwiseEqual(-NFloat.Epsilon, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(NFloat.Epsilon));
             AssertBitwiseEqual(-MaxSubnormal, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(MaxSubnormal));
             AssertBitwiseEqual(-MinNormal, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(MinNormal));
-            AssertBitwiseEqual(NegativeOne, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(PositiveOne));
+            AssertBitwiseEqual(NegativeOne, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(One));
             AssertBitwiseEqual(NFloat.MinValue, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(NFloat.MaxValue));
             AssertBitwiseEqual(NFloat.NegativeInfinity, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_UnaryNegation(NFloat.PositiveInfinity));
         }
@@ -2394,17 +2860,17 @@ namespace System.Runtime.InteropServices.Tests
         {
             AssertBitwiseEqual(NFloat.PositiveInfinity, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NFloat.NegativeInfinity));
             AssertBitwiseEqual(NFloat.MaxValue, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NFloat.MinValue));
-            AssertBitwiseEqual(PositiveOne, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NegativeOne));
+            AssertBitwiseEqual(One, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NegativeOne));
             AssertBitwiseEqual(MinNormal, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(-MinNormal));
             AssertBitwiseEqual(MaxSubnormal, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(-MaxSubnormal));
             AssertBitwiseEqual(NFloat.Epsilon, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(-NFloat.Epsilon));
-            AssertBitwiseEqual(PositiveZero, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NegativeZero));
+            AssertBitwiseEqual(Zero, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NegativeZero));
             AssertBitwiseEqual(NFloat.NaN, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NFloat.NaN));
-            AssertBitwiseEqual(NegativeZero, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(PositiveZero));
+            AssertBitwiseEqual(NegativeZero, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(Zero));
             AssertBitwiseEqual(-NFloat.Epsilon, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NFloat.Epsilon));
             AssertBitwiseEqual(-MaxSubnormal, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(MaxSubnormal));
             AssertBitwiseEqual(-MinNormal, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(MinNormal));
-            AssertBitwiseEqual(NegativeOne, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(PositiveOne));
+            AssertBitwiseEqual(NegativeOne, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(One));
             AssertBitwiseEqual(NFloat.MinValue, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NFloat.MaxValue));
             AssertBitwiseEqual(NFloat.NegativeInfinity, UnaryNegationOperatorsHelper<NFloat, NFloat>.op_CheckedUnaryNegation(NFloat.PositiveInfinity));
         }
@@ -2424,11 +2890,11 @@ namespace System.Runtime.InteropServices.Tests
             AssertBitwiseEqual(-NFloat.Epsilon, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(-NFloat.Epsilon));
             AssertBitwiseEqual(NegativeZero, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(NegativeZero));
             AssertBitwiseEqual(NFloat.NaN, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(NFloat.NaN));
-            AssertBitwiseEqual(PositiveZero, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(PositiveZero));
+            AssertBitwiseEqual(Zero, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(Zero));
             AssertBitwiseEqual(NFloat.Epsilon, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(NFloat.Epsilon));
             AssertBitwiseEqual(MaxSubnormal, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(MaxSubnormal));
             AssertBitwiseEqual(MinNormal, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(MinNormal));
-            AssertBitwiseEqual(PositiveOne, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(PositiveOne));
+            AssertBitwiseEqual(One, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(One));
             AssertBitwiseEqual(NFloat.MaxValue, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(NFloat.MaxValue));
             AssertBitwiseEqual(NFloat.PositiveInfinity, UnaryPlusOperatorsHelper<NFloat, NFloat>.op_UnaryPlus(NFloat.PositiveInfinity));
         }

--- a/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
+++ b/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
@@ -31,6 +31,7 @@ namespace System.Numerics
         public int Sign { get { throw null; } }
         static System.Numerics.BigInteger System.Numerics.IAdditiveIdentity<System.Numerics.BigInteger,System.Numerics.BigInteger>.AdditiveIdentity { get { throw null; } }
         static System.Numerics.BigInteger System.Numerics.IMultiplicativeIdentity<System.Numerics.BigInteger,System.Numerics.BigInteger>.MultiplicativeIdentity { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Numerics.BigInteger>.Radix { get { throw null; } }
         static System.Numerics.BigInteger System.Numerics.ISignedNumber<System.Numerics.BigInteger>.NegativeOne { get { throw null; } }
         public static System.Numerics.BigInteger Zero { get { throw null; } }
         public static System.Numerics.BigInteger Abs(System.Numerics.BigInteger value) { throw null; }
@@ -58,7 +59,10 @@ namespace System.Numerics
         public int GetByteCount(bool isUnsigned = false) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Numerics.BigInteger GreatestCommonDivisor(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
+        public static bool IsEvenInteger(System.Numerics.BigInteger value) { throw null; }
         public static bool IsNegative(System.Numerics.BigInteger value) { throw null; }
+        public static bool IsOddInteger(System.Numerics.BigInteger value) { throw null; }
+        public static bool IsPositive(System.Numerics.BigInteger value) { throw null; }
         public static bool IsPow2(System.Numerics.BigInteger value) { throw null; }
         public static System.Numerics.BigInteger LeadingZeroCount(System.Numerics.BigInteger value) { throw null; }
         public static double Log(System.Numerics.BigInteger value) { throw null; }
@@ -193,13 +197,19 @@ namespace System.Numerics
         static System.Numerics.BigInteger System.Numerics.IDivisionOperators<System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger>.operator checked /(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         static System.Numerics.BigInteger System.Numerics.IIncrementOperators<System.Numerics.BigInteger>.operator checked ++(System.Numerics.BigInteger value) { throw null; }
         static System.Numerics.BigInteger System.Numerics.IMultiplyOperators<System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger>.operator checked *(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsCanonical(System.Numerics.BigInteger value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsComplexNumber(System.Numerics.BigInteger value) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsFinite(System.Numerics.BigInteger value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsImaginaryNumber(System.Numerics.BigInteger value) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsInfinity(System.Numerics.BigInteger value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsInteger(System.Numerics.BigInteger value) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsNaN(System.Numerics.BigInteger value) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsNegativeInfinity(System.Numerics.BigInteger value) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsNormal(System.Numerics.BigInteger value) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsPositiveInfinity(System.Numerics.BigInteger value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsRealNumber(System.Numerics.BigInteger value) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsSubnormal(System.Numerics.BigInteger value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsZero(System.Numerics.BigInteger value) { throw null; }
         static System.Numerics.BigInteger System.Numerics.INumberBase<System.Numerics.BigInteger>.MaxMagnitudeNumber(System.Numerics.BigInteger x, System.Numerics.BigInteger y) { throw null; }
         static System.Numerics.BigInteger System.Numerics.INumberBase<System.Numerics.BigInteger>.MinMagnitudeNumber(System.Numerics.BigInteger x, System.Numerics.BigInteger y) { throw null; }
         static System.Numerics.BigInteger System.Numerics.INumber<System.Numerics.BigInteger>.MaxNumber(System.Numerics.BigInteger x, System.Numerics.BigInteger y) { throw null; }
@@ -240,6 +250,7 @@ namespace System.Numerics
         static System.Numerics.Complex System.Numerics.IAdditiveIdentity<System.Numerics.Complex,System.Numerics.Complex>.AdditiveIdentity { get { throw null; } }
         static System.Numerics.Complex System.Numerics.IMultiplicativeIdentity<System.Numerics.Complex,System.Numerics.Complex>.MultiplicativeIdentity { get { throw null; } }
         static System.Numerics.Complex System.Numerics.INumberBase<System.Numerics.Complex>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Numerics.Complex>.Radix { get { throw null; } }
         static System.Numerics.Complex System.Numerics.INumberBase<System.Numerics.Complex>.Zero { get { throw null; } }
         static System.Numerics.Complex System.Numerics.ISignedNumber<System.Numerics.Complex>.NegativeOne { get { throw null; } }
         public static double Abs(System.Numerics.Complex value) { throw null; }
@@ -263,9 +274,21 @@ namespace System.Numerics
         public static System.Numerics.Complex Exp(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex FromPolarCoordinates(double magnitude, double phase) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool IsComplexNumber(System.Numerics.Complex value) { throw null; }
+        public static bool IsEvenInteger(System.Numerics.Complex value) { throw null; }
         public static bool IsFinite(System.Numerics.Complex value) { throw null; }
+        public static bool IsImaginaryNumber(System.Numerics.Complex value) { throw null; }
         public static bool IsInfinity(System.Numerics.Complex value) { throw null; }
+        public static bool IsInteger(System.Numerics.Complex value) { throw null; }
         public static bool IsNaN(System.Numerics.Complex value) { throw null; }
+        public static bool IsNegative(System.Numerics.Complex value) { throw null; }
+        public static bool IsNegativeInfinity(System.Numerics.Complex value) { throw null; }
+        public static bool IsNormal(System.Numerics.Complex value) { throw null; }
+        public static bool IsOddInteger(System.Numerics.Complex value) { throw null; }
+        public static bool IsPositive(System.Numerics.Complex value) { throw null; }
+        public static bool IsPositiveInfinity(System.Numerics.Complex value) { throw null; }
+        public static bool IsRealNumber(System.Numerics.Complex value) { throw null; }
+        public static bool IsSubnormal(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex Log(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex Log(System.Numerics.Complex value, double baseValue) { throw null; }
         public static System.Numerics.Complex Log10(System.Numerics.Complex value) { throw null; }
@@ -328,11 +351,8 @@ namespace System.Numerics
         static System.Numerics.Complex System.Numerics.IIncrementOperators<System.Numerics.Complex>.operator checked ++(System.Numerics.Complex value) { throw null; }
         static System.Numerics.Complex System.Numerics.IMultiplyOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>.operator checked *(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         static System.Numerics.Complex System.Numerics.INumberBase<System.Numerics.Complex>.Abs(System.Numerics.Complex value) { throw null; }
-        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsNegative(System.Numerics.Complex value) { throw null; }
-        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsNegativeInfinity(System.Numerics.Complex value) { throw null; }
-        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsNormal(System.Numerics.Complex value) { throw null; }
-        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsPositiveInfinity(System.Numerics.Complex value) { throw null; }
-        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsSubnormal(System.Numerics.Complex value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsCanonical(System.Numerics.Complex value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsZero(System.Numerics.Complex value) { throw null; }
         static System.Numerics.Complex System.Numerics.INumberBase<System.Numerics.Complex>.MaxMagnitudeNumber(System.Numerics.Complex x, System.Numerics.Complex y) { throw null; }
         static System.Numerics.Complex System.Numerics.INumberBase<System.Numerics.Complex>.MinMagnitudeNumber(System.Numerics.Complex x, System.Numerics.Complex y) { throw null; }
         static System.Numerics.Complex System.Numerics.ISubtractionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>.operator checked -(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -3885,6 +3885,9 @@ namespace System.Numerics
         // INumberBase
         //
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<BigInteger>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static BigInteger CreateChecked<TOther>(TOther value)
@@ -4101,11 +4104,35 @@ namespace System.Numerics
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<BigInteger>.IsCanonical(BigInteger value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        static bool INumberBase<BigInteger>.IsComplexNumber(BigInteger value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(BigInteger value)
+        {
+            value.AssertValid();
+
+            if (value._bits is null)
+            {
+                return (value._sign & 1) == 0;
+            }
+            return (value._bits[0] & 1) == 0;
+        }
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsFinite(TSelf)" />
         static bool INumberBase<BigInteger>.IsFinite(BigInteger value) => true;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        static bool INumberBase<BigInteger>.IsImaginaryNumber(BigInteger value) => false;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsInfinity(TSelf)" />
         static bool INumberBase<BigInteger>.IsInfinity(BigInteger value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        static bool INumberBase<BigInteger>.IsInteger(BigInteger value) => true;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNaN(TSelf)" />
         static bool INumberBase<BigInteger>.IsNaN(BigInteger value) => false;
@@ -4123,11 +4150,40 @@ namespace System.Numerics
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
         static bool INumberBase<BigInteger>.IsNormal(BigInteger value) => (value != 0);
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(BigInteger value)
+        {
+            value.AssertValid();
+
+            if (value._bits is null)
+            {
+                return (value._sign & 1) != 0;
+            }
+            return (value._bits[0] & 1) != 0;
+        }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(BigInteger value)
+        {
+            value.AssertValid();
+            return value._sign >= 0;
+        }
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
         static bool INumberBase<BigInteger>.IsPositiveInfinity(BigInteger value) => false;
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        static bool INumberBase<BigInteger>.IsRealNumber(BigInteger value) => true;
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
         static bool INumberBase<BigInteger>.IsSubnormal(BigInteger value) => false;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<BigInteger>.IsZero(BigInteger value)
+        {
+            value.AssertValid();
+            return value._sign == 0;
+        }
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static BigInteger MaxMagnitude(BigInteger x, BigInteger y)

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -925,6 +925,9 @@ namespace System.Numerics
         /// <inheritdoc cref="INumberBase{TSelf}.One" />
         static Complex INumberBase<Complex>.One => new Complex(1.0, 0.0);
 
+        /// <inheritdoc cref="INumberBase{TSelf}.Radix" />
+        static int INumberBase<Complex>.Radix => 2;
+
         /// <inheritdoc cref="INumberBase{TSelf}.Zero" />
         static Complex INumberBase<Complex>.Zero => new Complex(0.0, 0.0);
 
@@ -1135,8 +1138,23 @@ namespace System.Numerics
             }
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
+        static bool INumberBase<Complex>.IsCanonical(Complex value) => true;
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
+        public static bool IsComplexNumber(Complex value) => (value.m_real != 0.0) && (value.m_imaginary != 0.0);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsEvenInteger(TSelf)" />
+        public static bool IsEvenInteger(Complex value) => (value.m_imaginary == 0) && double.IsEvenInteger(value.m_real);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsImaginaryNumber(TSelf)" />
+        public static bool IsImaginaryNumber(Complex value) => (value.m_real == 0.0) && double.IsRealNumber(value.m_imaginary);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsInteger(TSelf)" />
+        public static bool IsInteger(Complex value) => (value.m_imaginary == 0) && double.IsInteger(value.m_real);
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
-        static bool INumberBase<Complex>.IsNegative(Complex value)
+        public static bool IsNegative(Complex value)
         {
             // since complex numbers do not have a well-defined concept of
             // negative we report false if this value has an imaginary part
@@ -1145,7 +1163,7 @@ namespace System.Numerics
         }
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNegativeInfinity(TSelf)" />
-        static bool INumberBase<Complex>.IsNegativeInfinity(Complex value)
+        public static bool IsNegativeInfinity(Complex value)
         {
             // since complex numbers do not have a well-defined concept of
             // negative we report false if this value has an imaginary part
@@ -1154,7 +1172,7 @@ namespace System.Numerics
         }
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsNormal(TSelf)" />
-        static bool INumberBase<Complex>.IsNormal(Complex value)
+        public static bool IsNormal(Complex value)
         {
             // much as IsFinite requires both part to be finite, we require both
             // part to be "normal" (finite, non-zero, and non-subnormal) to be true
@@ -1163,8 +1181,20 @@ namespace System.Numerics
                 && ((value.m_imaginary == 0.0) || double.IsNormal(value.m_imaginary));
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsOddInteger(TSelf)" />
+        public static bool IsOddInteger(Complex value) => (value.m_imaginary == 0) && double.IsOddInteger(value.m_real);
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsPositive(TSelf)" />
+        public static bool IsPositive(Complex value)
+        {
+            // since complex numbers do not have a well-defined concept of
+            // negative we report false if this value has an imaginary part
+
+            return (value.m_imaginary == 0.0) && double.IsPositive(value.m_real);
+        }
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsPositiveInfinity(TSelf)" />
-        static bool INumberBase<Complex>.IsPositiveInfinity(Complex value)
+        public static bool IsPositiveInfinity(Complex value)
         {
             // since complex numbers do not have a well-defined concept of
             // positive we report false if this value has an imaginary part
@@ -1172,14 +1202,20 @@ namespace System.Numerics
             return (value.m_imaginary == 0.0) && double.IsPositiveInfinity(value.m_real);
         }
 
+        /// <inheritdoc cref="INumberBase{TSelf}.IsRealNumber(TSelf)" />
+        public static bool IsRealNumber(Complex value) => (value.m_imaginary == 0.0) && double.IsRealNumber(value.m_real);
+
         /// <inheritdoc cref="INumberBase{TSelf}.IsSubnormal(TSelf)" />
-        static bool INumberBase<Complex>.IsSubnormal(Complex value)
+        public static bool IsSubnormal(Complex value)
         {
             // much as IsInfinite allows either part to be infinite, we allow either
             // part to be "subnormal" (finite, non-zero, and non-normal) to be true
 
             return double.IsSubnormal(value.m_real) || double.IsSubnormal(value.m_imaginary);
         }
+
+        /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
+        static bool INumberBase<Complex>.IsZero(Complex value) => (value.m_real == 0.0) && (value.m_imaginary == 0.0);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         public static Complex MaxMagnitude(Complex x, Complex y)

--- a/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
@@ -995,6 +995,12 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<BigInteger>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal(Zero, NumberBaseHelper<BigInteger>.Zero);
@@ -1411,6 +1417,48 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<BigInteger>.IsCanonical(Zero));
+            Assert.True(NumberBaseHelper<BigInteger>.IsCanonical(One));
+            Assert.True(NumberBaseHelper<BigInteger>.IsCanonical(Int64MaxValue));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsCanonical(Int64MinValue));
+            Assert.True(NumberBaseHelper<BigInteger>.IsCanonical(NegativeOne));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsCanonical(Int64MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<BigInteger>.IsCanonical(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<BigInteger>.IsComplexNumber(Zero));
+            Assert.False(NumberBaseHelper<BigInteger>.IsComplexNumber(One));
+            Assert.False(NumberBaseHelper<BigInteger>.IsComplexNumber(Int64MaxValue));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsComplexNumber(Int64MinValue));
+            Assert.False(NumberBaseHelper<BigInteger>.IsComplexNumber(NegativeOne));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsComplexNumber(Int64MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<BigInteger>.IsComplexNumber(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<BigInteger>.IsEvenInteger(Zero));
+            Assert.False(NumberBaseHelper<BigInteger>.IsEvenInteger(One));
+            Assert.False(NumberBaseHelper<BigInteger>.IsEvenInteger(Int64MaxValue));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsEvenInteger(Int64MinValue));
+            Assert.False(NumberBaseHelper<BigInteger>.IsEvenInteger(NegativeOne));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsEvenInteger(Int64MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<BigInteger>.IsEvenInteger(UInt64MaxValue));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<BigInteger>.IsFinite(Zero));
@@ -1425,6 +1473,20 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<BigInteger>.IsImaginaryNumber(Zero));
+            Assert.False(NumberBaseHelper<BigInteger>.IsImaginaryNumber(One));
+            Assert.False(NumberBaseHelper<BigInteger>.IsImaginaryNumber(Int64MaxValue));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsImaginaryNumber(Int64MinValue));
+            Assert.False(NumberBaseHelper<BigInteger>.IsImaginaryNumber(NegativeOne));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsImaginaryNumber(Int64MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<BigInteger>.IsImaginaryNumber(UInt64MaxValue));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<BigInteger>.IsInfinity(Zero));
@@ -1436,6 +1498,20 @@ namespace System.Numerics.Tests
 
             Assert.False(NumberBaseHelper<BigInteger>.IsInfinity(Int64MaxValuePlusOne));
             Assert.False(NumberBaseHelper<BigInteger>.IsInfinity(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<BigInteger>.IsInteger(Zero));
+            Assert.True(NumberBaseHelper<BigInteger>.IsInteger(One));
+            Assert.True(NumberBaseHelper<BigInteger>.IsInteger(Int64MaxValue));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsInteger(Int64MinValue));
+            Assert.True(NumberBaseHelper<BigInteger>.IsInteger(NegativeOne));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsInteger(Int64MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<BigInteger>.IsInteger(UInt64MaxValue));
         }
 
         [Fact]
@@ -1495,6 +1571,34 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<BigInteger>.IsOddInteger(Zero));
+            Assert.True(NumberBaseHelper<BigInteger>.IsOddInteger(One));
+            Assert.True(NumberBaseHelper<BigInteger>.IsOddInteger(Int64MaxValue));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsOddInteger(Int64MinValue));
+            Assert.True(NumberBaseHelper<BigInteger>.IsOddInteger(NegativeOne));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsOddInteger(Int64MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<BigInteger>.IsOddInteger(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<BigInteger>.IsPositive(Zero));
+            Assert.True(NumberBaseHelper<BigInteger>.IsPositive(One));
+            Assert.True(NumberBaseHelper<BigInteger>.IsPositive(Int64MaxValue));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsPositive(Int64MinValue));
+            Assert.False(NumberBaseHelper<BigInteger>.IsPositive(NegativeOne));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsPositive(Int64MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<BigInteger>.IsPositive(UInt64MaxValue));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<BigInteger>.IsPositiveInfinity(Zero));
@@ -1509,6 +1613,20 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<BigInteger>.IsRealNumber(Zero));
+            Assert.True(NumberBaseHelper<BigInteger>.IsRealNumber(One));
+            Assert.True(NumberBaseHelper<BigInteger>.IsRealNumber(Int64MaxValue));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsRealNumber(Int64MinValue));
+            Assert.True(NumberBaseHelper<BigInteger>.IsRealNumber(NegativeOne));
+
+            Assert.True(NumberBaseHelper<BigInteger>.IsRealNumber(Int64MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<BigInteger>.IsRealNumber(UInt64MaxValue));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<BigInteger>.IsSubnormal(Zero));
@@ -1520,6 +1638,20 @@ namespace System.Numerics.Tests
 
             Assert.False(NumberBaseHelper<BigInteger>.IsSubnormal(Int64MaxValuePlusOne));
             Assert.False(NumberBaseHelper<BigInteger>.IsSubnormal(UInt64MaxValue));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<BigInteger>.IsZero(Zero));
+            Assert.False(NumberBaseHelper<BigInteger>.IsZero(One));
+            Assert.False(NumberBaseHelper<BigInteger>.IsZero(Int64MaxValue));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsZero(Int64MinValue));
+            Assert.False(NumberBaseHelper<BigInteger>.IsZero(NegativeOne));
+
+            Assert.False(NumberBaseHelper<BigInteger>.IsZero(Int64MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<BigInteger>.IsZero(UInt64MaxValue));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime.Numerics/tests/ComplexTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/ComplexTests.GenericMath.cs
@@ -258,6 +258,12 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<Complex>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             AssertBitwiseEqual(0.0, NumberBaseHelper<Complex>.Zero);
@@ -692,6 +698,186 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(double.MinValue));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(-1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(-MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(-double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(-0.0));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(double.NaN));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(0.0));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(MaxSubnormal));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(double.MaxValue));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(double.PositiveInfinity));
+
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-1.0, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-1.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-1.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-0.0, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-0.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-0.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(double.NaN, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(double.NaN, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(double.NaN, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(double.NaN, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(double.NaN, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(0.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(0.0, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(0.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(0.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(1.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(1.0, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(1.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(1.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsCanonical(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(double.MinValue));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(-double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(double.NaN));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(double.PositiveInfinity));
+
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-1.0, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-1.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-1.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(double.NaN, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(double.NaN, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(double.NaN, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(1.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(1.0, -0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(1.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(1.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsComplexNumber(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Complex>.IsEvenInteger(double.MinValue));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(-double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsEvenInteger(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(double.NaN));
+            Assert.True(NumberBaseHelper<Complex>.IsEvenInteger(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsEvenInteger(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsEvenInteger(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.False(NumberBaseHelper<Complex>.IsFinite(double.NegativeInfinity));
@@ -752,6 +938,66 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(double.MinValue));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(-double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(double.NaN));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-0.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-0.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(0.0, double.NegativeInfinity)));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(0.0, 0.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(0.0, 1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsImaginaryNumber(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.True(NumberBaseHelper<Complex>.IsInfinity(double.NegativeInfinity));
@@ -809,6 +1055,66 @@ namespace System.Numerics.Tests
             Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(1.0, 0.0)));
             Assert.False(NumberBaseHelper<Complex>.IsInfinity(new Complex(1.0, 1.0)));
             Assert.True(NumberBaseHelper<Complex>.IsInfinity(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(double.MinValue));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(-double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(double.NaN));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(-1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(-1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(-0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(-0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsInteger(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsInteger(new Complex(1.0, double.PositiveInfinity)));
         }
 
         [Fact]
@@ -1052,6 +1358,126 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(double.MinValue));
+            Assert.True(NumberBaseHelper<Complex>.IsOddInteger(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(-double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(double.NaN));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsOddInteger(1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsOddInteger(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsOddInteger(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsOddInteger(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(double.MinValue));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(-double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(double.NaN));
+            Assert.True(NumberBaseHelper<Complex>.IsPositive(0.0));
+            Assert.True(NumberBaseHelper<Complex>.IsPositive(double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsPositive(MaxSubnormal));
+            Assert.True(NumberBaseHelper<Complex>.IsPositive(MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsPositive(1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsPositive(double.MaxValue));
+            Assert.True(NumberBaseHelper<Complex>.IsPositive(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-0.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-0.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsPositive(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsPositive(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsPositive(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsPositive(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsPositive(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<Complex>.IsPositiveInfinity(double.NegativeInfinity));
@@ -1112,6 +1538,66 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(double.MinValue));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(-1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(-MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(-double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(double.NaN));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(0.0));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(MaxSubnormal));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(MinNormal));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(1.0));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(double.MaxValue));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(1.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(1.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsRealNumber(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsRealNumber(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<Complex>.IsSubnormal(double.NegativeInfinity));
@@ -1169,6 +1655,66 @@ namespace System.Numerics.Tests
             Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(1.0, 0.0)));
             Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(1.0, 1.0)));
             Assert.False(NumberBaseHelper<Complex>.IsSubnormal(new Complex(1.0, double.PositiveInfinity)));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.False(NumberBaseHelper<Complex>.IsZero(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(double.MinValue));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(-1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(-MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(-double.Epsilon));
+            Assert.True(NumberBaseHelper<Complex>.IsZero(-0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(double.NaN));
+            Assert.True(NumberBaseHelper<Complex>.IsZero(0.0));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(double.Epsilon));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(MinNormal));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(1.0));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(double.MaxValue));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(double.PositiveInfinity));
+
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-1.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsZero(new Complex(-0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsZero(new Complex(-0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(-0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(double.NaN, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(double.NaN, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(double.NaN, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(double.NaN, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(double.NaN, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(double.NaN, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(double.NaN, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(0.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(0.0, -1.0)));
+            Assert.True(NumberBaseHelper<Complex>.IsZero(new Complex(0.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(0.0, double.NaN)));
+            Assert.True(NumberBaseHelper<Complex>.IsZero(new Complex(0.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(0.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(0.0, double.PositiveInfinity)));
+
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(1.0, double.NegativeInfinity)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(1.0, -1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(1.0, -0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(1.0, double.NaN)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(1.0, 0.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(1.0, 1.0)));
+            Assert.False(NumberBaseHelper<Complex>.IsZero(new Complex(1.0, double.PositiveInfinity)));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -723,6 +723,7 @@ namespace System
         static byte System.Numerics.IMinMaxValue<System.Byte>.MinValue { get { throw null; } }
         static byte System.Numerics.IMultiplicativeIdentity<System.Byte,System.Byte>.MultiplicativeIdentity { get { throw null; } }
         static byte System.Numerics.INumberBase<System.Byte>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Byte>.Radix { get { throw null; } }
         static byte System.Numerics.INumberBase<System.Byte>.Zero { get { throw null; } }
         public static byte Clamp(byte value, byte min, byte max) { throw null; }
         public int CompareTo(byte value) { throw null; }
@@ -735,6 +736,8 @@ namespace System
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsEvenInteger(byte value) { throw null; }
+        public static bool IsOddInteger(byte value) { throw null; }
         public static bool IsPow2(byte value) { throw null; }
         public static byte LeadingZeroCount(byte value) { throw null; }
         public static byte Log2(byte value) { throw null; }
@@ -791,14 +794,21 @@ namespace System
         static byte System.Numerics.IMultiplyOperators<byte, byte, byte>.operator checked *(byte left, byte right) { throw null; }
         static byte System.Numerics.IMultiplyOperators<byte, byte, byte>.operator *(byte left, byte right) { throw null; }
         static byte System.Numerics.INumberBase<byte>.Abs(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsCanonical(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsComplexNumber(byte value) { throw null; }
         static bool System.Numerics.INumberBase<byte>.IsFinite(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsImaginaryNumber(byte value) { throw null; }
         static bool System.Numerics.INumberBase<byte>.IsInfinity(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsInteger(byte value) { throw null; }
         static bool System.Numerics.INumberBase<byte>.IsNaN(byte value) { throw null; }
         static bool System.Numerics.INumberBase<byte>.IsNegative(byte value) { throw null; }
         static bool System.Numerics.INumberBase<byte>.IsNegativeInfinity(byte value) { throw null; }
         static bool System.Numerics.INumberBase<byte>.IsNormal(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsPositive(byte value) { throw null; }
         static bool System.Numerics.INumberBase<byte>.IsPositiveInfinity(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsRealNumber(byte value) { throw null; }
         static bool System.Numerics.INumberBase<byte>.IsSubnormal(byte value) { throw null; }
+        static bool System.Numerics.INumberBase<byte>.IsZero(byte value) { throw null; }
         static byte System.Numerics.INumberBase<byte>.MaxMagnitude(byte x, byte y) { throw null; }
         static byte System.Numerics.INumberBase<byte>.MaxMagnitudeNumber(byte x, byte y) { throw null; }
         static byte System.Numerics.INumberBase<byte>.MinMagnitude(byte x, byte y) { throw null; }
@@ -845,6 +855,7 @@ namespace System
         static char System.Numerics.IMinMaxValue<System.Char>.MinValue { get { throw null; } }
         static char System.Numerics.IMultiplicativeIdentity<System.Char,System.Char>.MultiplicativeIdentity { get { throw null; } }
         static char System.Numerics.INumberBase<System.Char>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Char>.Radix { get { throw null; } }
         static char System.Numerics.INumberBase<System.Char>.Zero { get { throw null; } }
         public int CompareTo(char value) { throw null; }
         public int CompareTo(object? value) { throw null; }
@@ -958,14 +969,23 @@ namespace System
         static char System.Numerics.INumberBase<char>.CreateChecked<TOther>(TOther value) { throw null; }
         static char System.Numerics.INumberBase<char>.CreateSaturating<TOther>(TOther value) { throw null; }
         static char System.Numerics.INumberBase<char>.CreateTruncating<TOther>(TOther value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsCanonical(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsComplexNumber(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsEvenInteger(char value) { throw null; }
         static bool System.Numerics.INumberBase<char>.IsFinite(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsImaginaryNumber(char value) { throw null; }
         static bool System.Numerics.INumberBase<char>.IsInfinity(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsInteger(char value) { throw null; }
         static bool System.Numerics.INumberBase<char>.IsNaN(char value) { throw null; }
         static bool System.Numerics.INumberBase<char>.IsNegative(char value) { throw null; }
         static bool System.Numerics.INumberBase<char>.IsNegativeInfinity(char value) { throw null; }
         static bool System.Numerics.INumberBase<char>.IsNormal(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsOddInteger(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsPositive(char value) { throw null; }
         static bool System.Numerics.INumberBase<char>.IsPositiveInfinity(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsRealNumber(char value) { throw null; }
         static bool System.Numerics.INumberBase<char>.IsSubnormal(char value) { throw null; }
+        static bool System.Numerics.INumberBase<char>.IsZero(char value) { throw null; }
         static char System.Numerics.INumberBase<char>.MaxMagnitude(char x, char y) { throw null; }
         static char System.Numerics.INumberBase<char>.MaxMagnitudeNumber(char x, char y) { throw null; }
         static char System.Numerics.INumberBase<char>.MinMagnitude(char x, char y) { throw null; }
@@ -1857,6 +1877,7 @@ namespace System
         static decimal System.Numerics.IMinMaxValue<System.Decimal>.MinValue { get { throw null; } }
         static decimal System.Numerics.IMultiplicativeIdentity<System.Decimal,System.Decimal>.MultiplicativeIdentity { get { throw null; } }
         static decimal System.Numerics.INumberBase<System.Decimal>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Decimal>.Radix { get { throw null; } }
         static decimal System.Numerics.INumberBase<System.Decimal>.Zero { get { throw null; } }
         static decimal System.Numerics.ISignedNumber<System.Decimal>.NegativeOne { get { throw null; } }
         public static decimal Abs(decimal value) { throw null; }
@@ -1880,7 +1901,12 @@ namespace System
         public static int GetBits(decimal d, System.Span<int> destination) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsCanonical(decimal value) { throw null; }
+        public static bool IsEvenInteger(decimal value) { throw null; }
+        public static bool IsInteger(decimal value) { throw null; }
         public static bool IsNegative(decimal value) { throw null; }
+        public static bool IsOddInteger(decimal value) { throw null; }
+        public static bool IsPositive(decimal value) { throw null; }
         public static decimal Max(decimal x, decimal y) { throw null; }
         public static decimal MaxMagnitude(decimal x, decimal y) { throw null; }
         public static decimal Min(decimal x, decimal y) { throw null; }
@@ -1973,13 +1999,17 @@ namespace System
         bool System.Numerics.IFloatingPoint<decimal>.TryWriteSignificandBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IFloatingPoint<decimal>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         static decimal System.Numerics.IIncrementOperators<decimal>.operator checked ++(decimal value) { throw null; }
+        static bool System.Numerics.INumberBase<decimal>.IsComplexNumber(decimal value) { throw null; }
         static bool System.Numerics.INumberBase<decimal>.IsFinite(decimal value) { throw null; }
+        static bool System.Numerics.INumberBase<decimal>.IsImaginaryNumber(decimal value) { throw null; }
         static bool System.Numerics.INumberBase<decimal>.IsInfinity(decimal value) { throw null; }
         static bool System.Numerics.INumberBase<decimal>.IsNaN(decimal value) { throw null; }
         static bool System.Numerics.INumberBase<decimal>.IsNegativeInfinity(decimal value) { throw null; }
         static bool System.Numerics.INumberBase<decimal>.IsNormal(decimal value) { throw null; }
         static bool System.Numerics.INumberBase<decimal>.IsPositiveInfinity(decimal value) { throw null; }
+        static bool System.Numerics.INumberBase<decimal>.IsRealNumber(decimal value) { throw null; }
         static bool System.Numerics.INumberBase<decimal>.IsSubnormal(decimal value) { throw null; }
+        static bool System.Numerics.INumberBase<decimal>.IsZero(decimal value) { throw null; }
         static decimal System.Numerics.INumberBase<decimal>.MaxMagnitudeNumber(decimal x, decimal y) { throw null; }
         static decimal System.Numerics.INumberBase<decimal>.MinMagnitudeNumber(decimal x, decimal y) { throw null; }
         static decimal System.Numerics.INumber<decimal>.MaxNumber(decimal x, decimal y) { throw null; }
@@ -2090,6 +2120,7 @@ namespace System
         static double System.Numerics.IMinMaxValue<System.Double>.MinValue { get { throw null; } }
         static double System.Numerics.IMultiplicativeIdentity<System.Double,System.Double>.MultiplicativeIdentity { get { throw null; } }
         static double System.Numerics.INumberBase<System.Double>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Double>.Radix { get { throw null; } }
         static double System.Numerics.INumberBase<System.Double>.Zero { get { throw null; } }
         static double System.Numerics.ISignedNumber<System.Double>.NegativeOne { get { throw null; } }
         public static double Abs(double value) { throw null; }
@@ -2127,14 +2158,19 @@ namespace System
         public System.TypeCode GetTypeCode() { throw null; }
         public static double Ieee754Remainder(double left, double right) { throw null; }
         public static int ILogB(double x) { throw null; }
+        public static bool IsEvenInteger(double value) { throw null; }
         public static bool IsFinite(double d) { throw null; }
         public static bool IsInfinity(double d) { throw null; }
+        public static bool IsInteger(double value) { throw null; }
         public static bool IsNaN(double d) { throw null; }
         public static bool IsNegative(double d) { throw null; }
         public static bool IsNegativeInfinity(double d) { throw null; }
         public static bool IsNormal(double d) { throw null; }
+        public static bool IsOddInteger(double value) { throw null; }
+        public static bool IsPositive(double value) { throw null; }
         public static bool IsPositiveInfinity(double d) { throw null; }
         public static bool IsPow2(double value) { throw null; }
+        public static bool IsRealNumber(double value) { throw null; }
         public static bool IsSubnormal(double d) { throw null; }
         public static double Log(double x) { throw null; }
         public static double Log(double x, double newBase) { throw null; }
@@ -2214,6 +2250,10 @@ namespace System
         static double System.Numerics.IModulusOperators<double, double, double>.operator %(double left, double right) { throw null; }
         static double System.Numerics.IMultiplyOperators<double, double, double>.operator checked *(double left, double right) { throw null; }
         static double System.Numerics.IMultiplyOperators<double, double, double>.operator *(double left, double right) { throw null; }
+        static bool System.Numerics.INumberBase<double>.IsCanonical(double value) { throw null; }
+        static bool System.Numerics.INumberBase<double>.IsComplexNumber(double value) { throw null; }
+        static bool System.Numerics.INumberBase<double>.IsImaginaryNumber(double value) { throw null; }
+        static bool System.Numerics.INumberBase<double>.IsZero(double value) { throw null; }
         static double System.Numerics.ISubtractionOperators<double, double, double>.operator checked -(double left, double right) { throw null; }
         static double System.Numerics.ISubtractionOperators<double, double, double>.operator -(double left, double right) { throw null; }
         static double System.Numerics.IUnaryNegationOperators<double, double>.operator checked -(double value) { throw null; }
@@ -2694,12 +2734,11 @@ namespace System
         public static System.Half One { get { throw null; } }
         public static System.Half Pi { get { throw null; } }
         public static System.Half PositiveInfinity { get { throw null; } }
-        public static System.Half Zero { get { throw null; } }
         static System.Half System.Numerics.IAdditiveIdentity<System.Half,System.Half>.AdditiveIdentity { get { throw null; } }
-        static System.Half System.Numerics.INumberBase<System.Half>.One { get { throw null; } }
-        static System.Half System.Numerics.INumberBase<System.Half>.Zero { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Half>.Radix { get { throw null; } }
         static System.Half System.Numerics.ISignedNumber<System.Half>.NegativeOne { get { throw null; } }
         public static System.Half Tau { get { throw null; } }
+        public static System.Half Zero { get { throw null; } }
         public static System.Half Abs(System.Half value) { throw null; }
         public static System.Half Acos(System.Half x) { throw null; }
         public static System.Half Acosh(System.Half x) { throw null; }
@@ -2734,14 +2773,19 @@ namespace System
         public override int GetHashCode() { throw null; }
         public static System.Half Ieee754Remainder(System.Half left, System.Half right) { throw null; }
         public static int ILogB(System.Half x) { throw null; }
+        public static bool IsEvenInteger(System.Half value) { throw null; }
         public static bool IsFinite(System.Half value) { throw null; }
         public static bool IsInfinity(System.Half value) { throw null; }
+        public static bool IsInteger(System.Half value) { throw null; }
         public static bool IsNaN(System.Half value) { throw null; }
         public static bool IsNegative(System.Half value) { throw null; }
         public static bool IsNegativeInfinity(System.Half value) { throw null; }
         public static bool IsNormal(System.Half value) { throw null; }
+        public static bool IsOddInteger(System.Half value) { throw null; }
+        public static bool IsPositive(System.Half value) { throw null; }
         public static bool IsPositiveInfinity(System.Half value) { throw null; }
         public static bool IsPow2(System.Half value) { throw null; }
+        public static bool IsRealNumber(System.Half value) { throw null; }
         public static bool IsSubnormal(System.Half value) { throw null; }
         public static System.Half Log(System.Half x) { throw null; }
         public static System.Half Log(System.Half x, System.Half newBase) { throw null; }
@@ -2813,6 +2857,10 @@ namespace System
         bool System.Numerics.IFloatingPoint<System.Half>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         static System.Half System.Numerics.IIncrementOperators<System.Half>.operator checked ++(System.Half value) { throw null; }
         static System.Half System.Numerics.IMultiplyOperators<System.Half, System.Half, System.Half>.operator checked *(System.Half left, System.Half right) { throw null; }
+        static bool System.Numerics.INumberBase<System.Half>.IsCanonical(System.Half value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Half>.IsComplexNumber(System.Half value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Half>.IsImaginaryNumber(System.Half value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Half>.IsZero(System.Half value) { throw null; }
         static System.Half System.Numerics.ISubtractionOperators<System.Half, System.Half, System.Half>.operator checked -(System.Half left, System.Half right) { throw null; }
         static System.Half System.Numerics.IUnaryNegationOperators<System.Half, System.Half>.operator checked -(System.Half value) { throw null; }
         public static System.Half Tan(System.Half x) { throw null; }
@@ -2967,6 +3015,7 @@ namespace System
         public static System.Int128 One { get { throw null; } }
         static System.Int128 System.Numerics.IAdditiveIdentity<System.Int128,System.Int128>.AdditiveIdentity { get { throw null; } }
         static System.Int128 System.Numerics.IMultiplicativeIdentity<System.Int128,System.Int128>.MultiplicativeIdentity { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Int128>.Radix { get { throw null; } }
         public static System.Int128 Zero { get { throw null; } }
         public static System.Int128 Abs(System.Int128 value) { throw null; }
         public static System.Int128 Clamp(System.Int128 value, System.Int128 min, System.Int128 max) { throw null; }
@@ -2980,7 +3029,10 @@ namespace System
         public bool Equals(System.Int128 other) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool IsEvenInteger(System.Int128 value) { throw null; }
         public static bool IsNegative(System.Int128 value) { throw null; }
+        public static bool IsOddInteger(System.Int128 value) { throw null; }
+        public static bool IsPositive(System.Int128 value) { throw null; }
         public static bool IsPow2(System.Int128 value) { throw null; }
         public static System.Int128 LeadingZeroCount(System.Int128 value) { throw null; }
         public static System.Int128 Log2(System.Int128 value) { throw null; }
@@ -3094,13 +3146,19 @@ namespace System
         int System.Numerics.IBinaryInteger<System.Int128>.GetShortestBitLength() { throw null; }
         bool System.Numerics.IBinaryInteger<System.Int128>.TryWriteBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IBinaryInteger<System.Int128>.TryWriteLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsCanonical(System.Int128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsComplexNumber(System.Int128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.Int128>.IsFinite(System.Int128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsImaginaryNumber(System.Int128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.Int128>.IsInfinity(System.Int128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsInteger(System.Int128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.Int128>.IsNaN(System.Int128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.Int128>.IsNegativeInfinity(System.Int128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.Int128>.IsNormal(System.Int128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.Int128>.IsPositiveInfinity(System.Int128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsRealNumber(System.Int128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.Int128>.IsSubnormal(System.Int128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.Int128>.IsZero(System.Int128 value) { throw null; }
         static System.Int128 System.Numerics.INumberBase<System.Int128>.MaxMagnitudeNumber(System.Int128 x, System.Int128 y) { throw null; }
         static System.Int128 System.Numerics.INumberBase<System.Int128>.MinMagnitudeNumber(System.Int128 x, System.Int128 y) { throw null; }
         static System.Int128 System.Numerics.INumber<System.Int128>.MaxNumber(System.Int128 x, System.Int128 y) { throw null; }
@@ -3129,6 +3187,7 @@ namespace System
         static short System.Numerics.IMinMaxValue<System.Int16>.MinValue { get { throw null; } }
         static short System.Numerics.IMultiplicativeIdentity<System.Int16,System.Int16>.MultiplicativeIdentity { get { throw null; } }
         static short System.Numerics.INumberBase<System.Int16>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Int16>.Radix { get { throw null; } }
         static short System.Numerics.INumberBase<System.Int16>.Zero { get { throw null; } }
         static short System.Numerics.ISignedNumber<System.Int16>.NegativeOne { get { throw null; } }
         public static short Abs(short value) { throw null; }
@@ -3144,7 +3203,10 @@ namespace System
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsEvenInteger(short value) { throw null; }
         public static bool IsNegative(short value) { throw null; }
+        public static bool IsOddInteger(short value) { throw null; }
+        public static bool IsPositive(short value) { throw null; }
         public static bool IsPow2(short value) { throw null; }
         public static short LeadingZeroCount(short value) { throw null; }
         public static short Log2(short value) { throw null; }
@@ -3202,13 +3264,19 @@ namespace System
         static short System.Numerics.IModulusOperators<short, short, short>.operator %(short left, short right) { throw null; }
         static short System.Numerics.IMultiplyOperators<short, short, short>.operator checked *(short left, short right) { throw null; }
         static short System.Numerics.IMultiplyOperators<short, short, short>.operator *(short left, short right) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsCanonical(short value) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsComplexNumber(short value) { throw null; }
         static bool System.Numerics.INumberBase<short>.IsFinite(short value) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsImaginaryNumber(short value) { throw null; }
         static bool System.Numerics.INumberBase<short>.IsInfinity(short value) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsInteger(short value) { throw null; }
         static bool System.Numerics.INumberBase<short>.IsNaN(short value) { throw null; }
         static bool System.Numerics.INumberBase<short>.IsNegativeInfinity(short value) { throw null; }
         static bool System.Numerics.INumberBase<short>.IsNormal(short value) { throw null; }
         static bool System.Numerics.INumberBase<short>.IsPositiveInfinity(short value) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsRealNumber(short value) { throw null; }
         static bool System.Numerics.INumberBase<short>.IsSubnormal(short value) { throw null; }
+        static bool System.Numerics.INumberBase<short>.IsZero(short value) { throw null; }
         static short System.Numerics.INumberBase<short>.MaxMagnitudeNumber(short x, short y) { throw null; }
         static short System.Numerics.INumberBase<short>.MinMagnitudeNumber(short x, short y) { throw null; }
         static short System.Numerics.INumber<short>.MaxNumber(short x, short y) { throw null; }
@@ -3245,6 +3313,7 @@ namespace System
         static int System.Numerics.IMinMaxValue<System.Int32>.MinValue { get { throw null; } }
         static int System.Numerics.IMultiplicativeIdentity<System.Int32,System.Int32>.MultiplicativeIdentity { get { throw null; } }
         static int System.Numerics.INumberBase<System.Int32>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Int32>.Radix { get { throw null; } }
         static int System.Numerics.INumberBase<System.Int32>.Zero { get { throw null; } }
         static int System.Numerics.ISignedNumber<System.Int32>.NegativeOne { get { throw null; } }
         public static int Abs(int value) { throw null; }
@@ -3260,7 +3329,10 @@ namespace System
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsEvenInteger(int value) { throw null; }
         public static bool IsNegative(int value) { throw null; }
+        public static bool IsOddInteger(int value) { throw null; }
+        public static bool IsPositive(int value) { throw null; }
         public static bool IsPow2(int value) { throw null; }
         public static int LeadingZeroCount(int value) { throw null; }
         public static int Log2(int value) { throw null; }
@@ -3318,13 +3390,19 @@ namespace System
         static int System.Numerics.IModulusOperators<int, int, int>.operator %(int left, int right) { throw null; }
         static int System.Numerics.IMultiplyOperators<int, int, int>.operator checked *(int left, int right) { throw null; }
         static int System.Numerics.IMultiplyOperators<int, int, int>.operator *(int left, int right) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsCanonical(int value) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsComplexNumber(int value) { throw null; }
         static bool System.Numerics.INumberBase<int>.IsFinite(int value) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsImaginaryNumber(int value) { throw null; }
         static bool System.Numerics.INumberBase<int>.IsInfinity(int value) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsInteger(int value) { throw null; }
         static bool System.Numerics.INumberBase<int>.IsNaN(int value) { throw null; }
         static bool System.Numerics.INumberBase<int>.IsNegativeInfinity(int value) { throw null; }
         static bool System.Numerics.INumberBase<int>.IsNormal(int value) { throw null; }
         static bool System.Numerics.INumberBase<int>.IsPositiveInfinity(int value) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsRealNumber(int value) { throw null; }
         static bool System.Numerics.INumberBase<int>.IsSubnormal(int value) { throw null; }
+        static bool System.Numerics.INumberBase<int>.IsZero(int value) { throw null; }
         static int System.Numerics.INumberBase<int>.MaxMagnitudeNumber(int x, int y) { throw null; }
         static int System.Numerics.INumberBase<int>.MinMagnitudeNumber(int x, int y) { throw null; }
         static int System.Numerics.INumber<int>.MaxNumber(int x, int y) { throw null; }
@@ -3361,6 +3439,7 @@ namespace System
         static long System.Numerics.IMinMaxValue<System.Int64>.MinValue { get { throw null; } }
         static long System.Numerics.IMultiplicativeIdentity<System.Int64,System.Int64>.MultiplicativeIdentity { get { throw null; } }
         static long System.Numerics.INumberBase<System.Int64>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Int64>.Radix { get { throw null; } }
         static long System.Numerics.INumberBase<System.Int64>.Zero { get { throw null; } }
         static long System.Numerics.ISignedNumber<System.Int64>.NegativeOne { get { throw null; } }
         public static long Abs(long value) { throw null; }
@@ -3376,7 +3455,10 @@ namespace System
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsEvenInteger(long value) { throw null; }
         public static bool IsNegative(long value) { throw null; }
+        public static bool IsOddInteger(long value) { throw null; }
+        public static bool IsPositive(long value) { throw null; }
         public static bool IsPow2(long value) { throw null; }
         public static long LeadingZeroCount(long value) { throw null; }
         public static long Log2(long value) { throw null; }
@@ -3434,13 +3516,19 @@ namespace System
         static long System.Numerics.IModulusOperators<long, long, long>.operator %(long left, long right) { throw null; }
         static long System.Numerics.IMultiplyOperators<long, long, long>.operator checked *(long left, long right) { throw null; }
         static long System.Numerics.IMultiplyOperators<long, long, long>.operator *(long left, long right) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsCanonical(long value) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsComplexNumber(long value) { throw null; }
         static bool System.Numerics.INumberBase<long>.IsFinite(long value) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsImaginaryNumber(long value) { throw null; }
         static bool System.Numerics.INumberBase<long>.IsInfinity(long value) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsInteger(long value) { throw null; }
         static bool System.Numerics.INumberBase<long>.IsNaN(long value) { throw null; }
         static bool System.Numerics.INumberBase<long>.IsNegativeInfinity(long value) { throw null; }
         static bool System.Numerics.INumberBase<long>.IsNormal(long value) { throw null; }
         static bool System.Numerics.INumberBase<long>.IsPositiveInfinity(long value) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsRealNumber(long value) { throw null; }
         static bool System.Numerics.INumberBase<long>.IsSubnormal(long value) { throw null; }
+        static bool System.Numerics.INumberBase<long>.IsZero(long value) { throw null; }
         static long System.Numerics.INumberBase<long>.MaxMagnitudeNumber(long x, long y) { throw null; }
         static long System.Numerics.INumberBase<long>.MinMagnitudeNumber(long x, long y) { throw null; }
         static long System.Numerics.INumber<long>.MaxNumber(long x, long y) { throw null; }
@@ -3483,6 +3571,7 @@ namespace System
         static nint System.Numerics.IMinMaxValue<nint>.MinValue { get { throw null; } }
         static nint System.Numerics.IMultiplicativeIdentity<nint,nint>.MultiplicativeIdentity { get { throw null; } }
         static nint System.Numerics.INumberBase<nint>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<nint>.Radix { get { throw null; } }
         static nint System.Numerics.INumberBase<nint>.Zero { get { throw null; } }
         static nint System.Numerics.ISignedNumber<nint>.NegativeOne { get { throw null; } }
         public static nint Abs(nint value) { throw null; }
@@ -3498,7 +3587,10 @@ namespace System
         public bool Equals(nint other) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool IsEvenInteger(nint value) { throw null; }
         public static bool IsNegative(nint value) { throw null; }
+        public static bool IsOddInteger(nint value) { throw null; }
+        public static bool IsPositive(nint value) { throw null; }
         public static bool IsPow2(nint value) { throw null; }
         public static nint LeadingZeroCount(nint value) { throw null; }
         public static nint Log2(nint value) { throw null; }
@@ -3552,13 +3644,19 @@ namespace System
         static nint System.Numerics.IModulusOperators<nint, nint, nint>.operator %(nint left, nint right) { throw null; }
         static nint System.Numerics.IMultiplyOperators<nint, nint, nint>.operator checked *(nint left, nint right) { throw null; }
         static nint System.Numerics.IMultiplyOperators<nint, nint, nint>.operator *(nint left, nint right) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsCanonical(nint value) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsComplexNumber(nint value) { throw null; }
         static bool System.Numerics.INumberBase<nint>.IsFinite(nint value) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsImaginaryNumber(nint value) { throw null; }
         static bool System.Numerics.INumberBase<nint>.IsInfinity(nint value) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsInteger(nint value) { throw null; }
         static bool System.Numerics.INumberBase<nint>.IsNaN(nint value) { throw null; }
         static bool System.Numerics.INumberBase<nint>.IsNegativeInfinity(nint value) { throw null; }
         static bool System.Numerics.INumberBase<nint>.IsNormal(nint value) { throw null; }
         static bool System.Numerics.INumberBase<nint>.IsPositiveInfinity(nint value) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsRealNumber(nint value) { throw null; }
         static bool System.Numerics.INumberBase<nint>.IsSubnormal(nint value) { throw null; }
+        static bool System.Numerics.INumberBase<nint>.IsZero(nint value) { throw null; }
         static nint System.Numerics.INumberBase<nint>.MaxMagnitudeNumber(nint x, nint y) { throw null; }
         static nint System.Numerics.INumberBase<nint>.MinMagnitudeNumber(nint x, nint y) { throw null; }
         static nint System.Numerics.INumber<nint>.MaxNumber(nint x, nint y) { throw null; }
@@ -4405,6 +4503,7 @@ namespace System
         static sbyte System.Numerics.IMinMaxValue<System.SByte>.MinValue { get { throw null; } }
         static sbyte System.Numerics.IMultiplicativeIdentity<System.SByte,System.SByte>.MultiplicativeIdentity { get { throw null; } }
         static sbyte System.Numerics.INumberBase<System.SByte>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.SByte>.Radix { get { throw null; } }
         static sbyte System.Numerics.INumberBase<System.SByte>.Zero { get { throw null; } }
         static sbyte System.Numerics.ISignedNumber<System.SByte>.NegativeOne { get { throw null; } }
         public static sbyte Abs(sbyte value) { throw null; }
@@ -4420,7 +4519,10 @@ namespace System
         public bool Equals(sbyte obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsEvenInteger(sbyte value) { throw null; }
         public static bool IsNegative(sbyte value) { throw null; }
+        public static bool IsOddInteger(sbyte value) { throw null; }
+        public static bool IsPositive(sbyte value) { throw null; }
         public static bool IsPow2(sbyte value) { throw null; }
         public static sbyte LeadingZeroCount(sbyte value) { throw null; }
         public static sbyte Log2(sbyte value) { throw null; }
@@ -4478,13 +4580,19 @@ namespace System
         static sbyte System.Numerics.IModulusOperators<sbyte, sbyte, sbyte>.operator %(sbyte left, sbyte right) { throw null; }
         static sbyte System.Numerics.IMultiplyOperators<sbyte, sbyte, sbyte>.operator checked *(sbyte left, sbyte right) { throw null; }
         static sbyte System.Numerics.IMultiplyOperators<sbyte, sbyte, sbyte>.operator *(sbyte left, sbyte right) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsCanonical(sbyte value) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsComplexNumber(sbyte value) { throw null; }
         static bool System.Numerics.INumberBase<sbyte>.IsFinite(sbyte value) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsImaginaryNumber(sbyte value) { throw null; }
         static bool System.Numerics.INumberBase<sbyte>.IsInfinity(sbyte value) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsInteger(sbyte value) { throw null; }
         static bool System.Numerics.INumberBase<sbyte>.IsNaN(sbyte value) { throw null; }
         static bool System.Numerics.INumberBase<sbyte>.IsNegativeInfinity(sbyte value) { throw null; }
         static bool System.Numerics.INumberBase<sbyte>.IsNormal(sbyte value) { throw null; }
         static bool System.Numerics.INumberBase<sbyte>.IsPositiveInfinity(sbyte value) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsRealNumber(sbyte value) { throw null; }
         static bool System.Numerics.INumberBase<sbyte>.IsSubnormal(sbyte value) { throw null; }
+        static bool System.Numerics.INumberBase<sbyte>.IsZero(sbyte value) { throw null; }
         static sbyte System.Numerics.INumberBase<sbyte>.MaxMagnitudeNumber(sbyte x, sbyte y) { throw null; }
         static sbyte System.Numerics.INumberBase<sbyte>.MinMagnitudeNumber(sbyte x, sbyte y) { throw null; }
         static sbyte System.Numerics.INumber<sbyte>.MaxNumber(sbyte x, sbyte y) { throw null; }
@@ -4542,6 +4650,7 @@ namespace System
         static float System.Numerics.IMinMaxValue<System.Single>.MinValue { get { throw null; } }
         static float System.Numerics.IMultiplicativeIdentity<System.Single,System.Single>.MultiplicativeIdentity { get { throw null; } }
         static float System.Numerics.INumberBase<System.Single>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.Single>.Radix { get { throw null; } }
         static float System.Numerics.INumberBase<System.Single>.Zero { get { throw null; } }
         static float System.Numerics.ISignedNumber<System.Single>.NegativeOne { get { throw null; } }
         public static float Abs(float value) { throw null; }
@@ -4579,14 +4688,19 @@ namespace System
         public System.TypeCode GetTypeCode() { throw null; }
         public static float Ieee754Remainder(float left, float right) { throw null; }
         public static int ILogB(float x) { throw null; }
+        public static bool IsEvenInteger(float value) { throw null; }
         public static bool IsFinite(float f) { throw null; }
         public static bool IsInfinity(float f) { throw null; }
+        public static bool IsInteger(float value) { throw null; }
         public static bool IsNaN(float f) { throw null; }
         public static bool IsNegative(float f) { throw null; }
         public static bool IsNegativeInfinity(float f) { throw null; }
         public static bool IsNormal(float f) { throw null; }
+        public static bool IsOddInteger(float value) { throw null; }
+        public static bool IsPositive(float value) { throw null; }
         public static bool IsPositiveInfinity(float f) { throw null; }
         public static bool IsPow2(float value) { throw null; }
+        public static bool IsRealNumber(float value) { throw null; }
         public static bool IsSubnormal(float f) { throw null; }
         public static float Log(float x) { throw null; }
         public static float Log(float x, float newBase) { throw null; }
@@ -4666,6 +4780,10 @@ namespace System
         static float System.Numerics.IModulusOperators<float, float, float>.operator %(float left, float right) { throw null; }
         static float System.Numerics.IMultiplyOperators<float, float, float>.operator checked *(float left, float right) { throw null; }
         static float System.Numerics.IMultiplyOperators<float, float, float>.operator *(float left, float right) { throw null; }
+        static bool System.Numerics.INumberBase<float>.IsCanonical(float value) { throw null; }
+        static bool System.Numerics.INumberBase<float>.IsComplexNumber(float value) { throw null; }
+        static bool System.Numerics.INumberBase<float>.IsImaginaryNumber(float value) { throw null; }
+        static bool System.Numerics.INumberBase<float>.IsZero(float value) { throw null; }
         static float System.Numerics.ISubtractionOperators<float, float, float>.operator checked -(float left, float right) { throw null; }
         static float System.Numerics.ISubtractionOperators<float, float, float>.operator -(float left, float right) { throw null; }
         static float System.Numerics.IUnaryNegationOperators<float, float>.operator checked -(float value) { throw null; }
@@ -5865,6 +5983,7 @@ namespace System
         public static System.UInt128 One { get { throw null; } }
         static System.UInt128 System.Numerics.IAdditiveIdentity<System.UInt128,System.UInt128>.AdditiveIdentity { get { throw null; } }
         static System.UInt128 System.Numerics.IMultiplicativeIdentity<System.UInt128,System.UInt128>.MultiplicativeIdentity { get { throw null; } }
+        static int System.Numerics.INumberBase<System.UInt128>.Radix { get { throw null; } }
         public static System.UInt128 Zero { get { throw null; } }
         public static System.UInt128 Clamp(System.UInt128 value, System.UInt128 min, System.UInt128 max) { throw null; }
         public int CompareTo(object? value) { throw null; }
@@ -5876,6 +5995,8 @@ namespace System
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(System.UInt128 other) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool IsEvenInteger(System.UInt128 value) { throw null; }
+        public static bool IsOddInteger(System.UInt128 value) { throw null; }
         public static bool IsPow2(System.UInt128 value) { throw null; }
         public static System.UInt128 LeadingZeroCount(System.UInt128 value) { throw null; }
         public static System.UInt128 Log2(System.UInt128 value) { throw null; }
@@ -5994,14 +6115,21 @@ namespace System
         bool System.Numerics.IBinaryInteger<System.UInt128>.TryWriteBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IBinaryInteger<System.UInt128>.TryWriteLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         static System.UInt128 System.Numerics.INumberBase<System.UInt128>.Abs(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsCanonical(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsComplexNumber(System.UInt128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.UInt128>.IsFinite(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsImaginaryNumber(System.UInt128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.UInt128>.IsInfinity(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsInteger(System.UInt128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.UInt128>.IsNaN(System.UInt128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.UInt128>.IsNegative(System.UInt128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.UInt128>.IsNegativeInfinity(System.UInt128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.UInt128>.IsNormal(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsPositive(System.UInt128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.UInt128>.IsPositiveInfinity(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsRealNumber(System.UInt128 value) { throw null; }
         static bool System.Numerics.INumberBase<System.UInt128>.IsSubnormal(System.UInt128 value) { throw null; }
+        static bool System.Numerics.INumberBase<System.UInt128>.IsZero(System.UInt128 value) { throw null; }
         static System.UInt128 System.Numerics.INumberBase<System.UInt128>.MaxMagnitude(System.UInt128 x, System.UInt128 y) { throw null; }
         static System.UInt128 System.Numerics.INumberBase<System.UInt128>.MaxMagnitudeNumber(System.UInt128 x, System.UInt128 y) { throw null; }
         static System.UInt128 System.Numerics.INumberBase<System.UInt128>.MinMagnitude(System.UInt128 x, System.UInt128 y) { throw null; }
@@ -6034,6 +6162,7 @@ namespace System
         static ushort System.Numerics.IMinMaxValue<System.UInt16>.MinValue { get { throw null; } }
         static ushort System.Numerics.IMultiplicativeIdentity<System.UInt16,System.UInt16>.MultiplicativeIdentity { get { throw null; } }
         static ushort System.Numerics.INumberBase<System.UInt16>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.UInt16>.Radix { get { throw null; } }
         static ushort System.Numerics.INumberBase<System.UInt16>.Zero { get { throw null; } }
         public static ushort Clamp(ushort value, ushort min, ushort max) { throw null; }
         public int CompareTo(object? value) { throw null; }
@@ -6046,6 +6175,8 @@ namespace System
         public bool Equals(ushort obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsEvenInteger(ushort value) { throw null; }
+        public static bool IsOddInteger(ushort value) { throw null; }
         public static bool IsPow2(ushort value) { throw null; }
         public static ushort LeadingZeroCount(ushort value) { throw null; }
         public static ushort Log2(ushort value) { throw null; }
@@ -6102,14 +6233,21 @@ namespace System
         static ushort System.Numerics.IMultiplyOperators<ushort, ushort, ushort>.operator checked *(ushort left, ushort right) { throw null; }
         static ushort System.Numerics.IMultiplyOperators<ushort, ushort, ushort>.operator *(ushort left, ushort right) { throw null; }
         static ushort System.Numerics.INumberBase<ushort>.Abs(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsCanonical(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsComplexNumber(ushort value) { throw null; }
         static bool System.Numerics.INumberBase<ushort>.IsFinite(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsImaginaryNumber(ushort value) { throw null; }
         static bool System.Numerics.INumberBase<ushort>.IsInfinity(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsInteger(ushort value) { throw null; }
         static bool System.Numerics.INumberBase<ushort>.IsNaN(ushort value) { throw null; }
         static bool System.Numerics.INumberBase<ushort>.IsNegative(ushort value) { throw null; }
         static bool System.Numerics.INumberBase<ushort>.IsNegativeInfinity(ushort value) { throw null; }
         static bool System.Numerics.INumberBase<ushort>.IsNormal(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsPositive(ushort value) { throw null; }
         static bool System.Numerics.INumberBase<ushort>.IsPositiveInfinity(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsRealNumber(ushort value) { throw null; }
         static bool System.Numerics.INumberBase<ushort>.IsSubnormal(ushort value) { throw null; }
+        static bool System.Numerics.INumberBase<ushort>.IsZero(ushort value) { throw null; }
         static ushort System.Numerics.INumberBase<ushort>.MaxMagnitude(ushort x, ushort y) { throw null; }
         static ushort System.Numerics.INumberBase<ushort>.MaxMagnitudeNumber(ushort x, ushort y) { throw null; }
         static ushort System.Numerics.INumberBase<ushort>.MinMagnitude(ushort x, ushort y) { throw null; }
@@ -6150,6 +6288,7 @@ namespace System
         static uint System.Numerics.IMinMaxValue<System.UInt32>.MinValue { get { throw null; } }
         static uint System.Numerics.IMultiplicativeIdentity<System.UInt32,System.UInt32>.MultiplicativeIdentity { get { throw null; } }
         static uint System.Numerics.INumberBase<System.UInt32>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.UInt32>.Radix { get { throw null; } }
         static uint System.Numerics.INumberBase<System.UInt32>.Zero { get { throw null; } }
         public static uint Clamp(uint value, uint min, uint max) { throw null; }
         public int CompareTo(object? value) { throw null; }
@@ -6162,6 +6301,8 @@ namespace System
         public bool Equals(uint obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsEvenInteger(uint value) { throw null; }
+        public static bool IsOddInteger(uint value) { throw null; }
         public static bool IsPow2(uint value) { throw null; }
         public static uint LeadingZeroCount(uint value) { throw null; }
         public static uint Log2(uint value) { throw null; }
@@ -6218,14 +6359,21 @@ namespace System
         static uint System.Numerics.IMultiplyOperators<uint, uint, uint>.operator checked *(uint left, uint right) { throw null; }
         static uint System.Numerics.IMultiplyOperators<uint, uint, uint>.operator *(uint left, uint right) { throw null; }
         static uint System.Numerics.INumberBase<uint>.Abs(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsCanonical(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsComplexNumber(uint value) { throw null; }
         static bool System.Numerics.INumberBase<uint>.IsFinite(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsImaginaryNumber(uint value) { throw null; }
         static bool System.Numerics.INumberBase<uint>.IsInfinity(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsInteger(uint value) { throw null; }
         static bool System.Numerics.INumberBase<uint>.IsNaN(uint value) { throw null; }
         static bool System.Numerics.INumberBase<uint>.IsNegative(uint value) { throw null; }
         static bool System.Numerics.INumberBase<uint>.IsNegativeInfinity(uint value) { throw null; }
         static bool System.Numerics.INumberBase<uint>.IsNormal(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsPositive(uint value) { throw null; }
         static bool System.Numerics.INumberBase<uint>.IsPositiveInfinity(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsRealNumber(uint value) { throw null; }
         static bool System.Numerics.INumberBase<uint>.IsSubnormal(uint value) { throw null; }
+        static bool System.Numerics.INumberBase<uint>.IsZero(uint value) { throw null; }
         static uint System.Numerics.INumberBase<uint>.MaxMagnitude(uint x, uint y) { throw null; }
         static uint System.Numerics.INumberBase<uint>.MaxMagnitudeNumber(uint x, uint y) { throw null; }
         static uint System.Numerics.INumberBase<uint>.MinMagnitude(uint x, uint y) { throw null; }
@@ -6266,6 +6414,7 @@ namespace System
         static ulong System.Numerics.IMinMaxValue<System.UInt64>.MinValue { get { throw null; } }
         static ulong System.Numerics.IMultiplicativeIdentity<System.UInt64,System.UInt64>.MultiplicativeIdentity { get { throw null; } }
         static ulong System.Numerics.INumberBase<System.UInt64>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<System.UInt64>.Radix { get { throw null; } }
         static ulong System.Numerics.INumberBase<System.UInt64>.Zero { get { throw null; } }
         public static ulong Clamp(ulong value, ulong min, ulong max) { throw null; }
         public int CompareTo(object? value) { throw null; }
@@ -6278,6 +6427,8 @@ namespace System
         public bool Equals(ulong obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsEvenInteger(ulong value) { throw null; }
+        public static bool IsOddInteger(ulong value) { throw null; }
         public static bool IsPow2(ulong value) { throw null; }
         public static ulong LeadingZeroCount(ulong value) { throw null; }
         public static ulong Log2(ulong value) { throw null; }
@@ -6334,14 +6485,21 @@ namespace System
         static ulong System.Numerics.IMultiplyOperators<ulong, ulong, ulong>.operator checked *(ulong left, ulong right) { throw null; }
         static ulong System.Numerics.IMultiplyOperators<ulong, ulong, ulong>.operator *(ulong left, ulong right) { throw null; }
         static ulong System.Numerics.INumberBase<ulong>.Abs(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsCanonical(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsComplexNumber(ulong value) { throw null; }
         static bool System.Numerics.INumberBase<ulong>.IsFinite(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsImaginaryNumber(ulong value) { throw null; }
         static bool System.Numerics.INumberBase<ulong>.IsInfinity(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsInteger(ulong value) { throw null; }
         static bool System.Numerics.INumberBase<ulong>.IsNaN(ulong value) { throw null; }
         static bool System.Numerics.INumberBase<ulong>.IsNegative(ulong value) { throw null; }
         static bool System.Numerics.INumberBase<ulong>.IsNegativeInfinity(ulong value) { throw null; }
         static bool System.Numerics.INumberBase<ulong>.IsNormal(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsPositive(ulong value) { throw null; }
         static bool System.Numerics.INumberBase<ulong>.IsPositiveInfinity(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsRealNumber(ulong value) { throw null; }
         static bool System.Numerics.INumberBase<ulong>.IsSubnormal(ulong value) { throw null; }
+        static bool System.Numerics.INumberBase<ulong>.IsZero(ulong value) { throw null; }
         static ulong System.Numerics.INumberBase<ulong>.MaxMagnitude(ulong x, ulong y) { throw null; }
         static ulong System.Numerics.INumberBase<ulong>.MaxMagnitudeNumber(ulong x, ulong y) { throw null; }
         static ulong System.Numerics.INumberBase<ulong>.MinMagnitude(ulong x, ulong y) { throw null; }
@@ -6387,6 +6545,7 @@ namespace System
         static nuint System.Numerics.IMinMaxValue<nuint>.MinValue { get { throw null; } }
         static nuint System.Numerics.IMultiplicativeIdentity<nuint,nuint>.MultiplicativeIdentity { get { throw null; } }
         static nuint System.Numerics.INumberBase<nuint>.One { get { throw null; } }
+        static int System.Numerics.INumberBase<nuint>.Radix { get { throw null; } }
         static nuint System.Numerics.INumberBase<nuint>.Zero { get { throw null; } }
         public static nuint Add(nuint pointer, int offset) { throw null; }
         public static nuint Clamp(nuint value, nuint min, nuint max) { throw null; }
@@ -6399,6 +6558,8 @@ namespace System
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(nuint other) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool IsEvenInteger(nuint value) { throw null; }
+        public static bool IsOddInteger(nuint value) { throw null; }
         public static bool IsPow2(nuint value) { throw null; }
         public static nuint LeadingZeroCount(nuint value) { throw null; }
         public static nuint Log2(nuint value) { throw null; }
@@ -6449,14 +6610,21 @@ namespace System
         static nuint System.Numerics.IMultiplyOperators<nuint, nuint, nuint>.operator checked *(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.IMultiplyOperators<nuint, nuint, nuint>.operator *(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.INumberBase<nuint>.Abs(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsCanonical(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsComplexNumber(nuint value) { throw null; }
         static bool System.Numerics.INumberBase<nuint>.IsFinite(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsImaginaryNumber(nuint value) { throw null; }
         static bool System.Numerics.INumberBase<nuint>.IsInfinity(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsInteger(nuint value) { throw null; }
         static bool System.Numerics.INumberBase<nuint>.IsNaN(nuint value) { throw null; }
         static bool System.Numerics.INumberBase<nuint>.IsNegative(nuint value) { throw null; }
         static bool System.Numerics.INumberBase<nuint>.IsNegativeInfinity(nuint value) { throw null; }
         static bool System.Numerics.INumberBase<nuint>.IsNormal(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsPositive(nuint value) { throw null; }
         static bool System.Numerics.INumberBase<nuint>.IsPositiveInfinity(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsRealNumber(nuint value) { throw null; }
         static bool System.Numerics.INumberBase<nuint>.IsSubnormal(nuint value) { throw null; }
+        static bool System.Numerics.INumberBase<nuint>.IsZero(nuint value) { throw null; }
         static nuint System.Numerics.INumberBase<nuint>.MaxMagnitude(nuint x, nuint y) { throw null; }
         static nuint System.Numerics.INumberBase<nuint>.MaxMagnitudeNumber(nuint x, nuint y) { throw null; }
         static nuint System.Numerics.INumberBase<nuint>.MinMagnitude(nuint x, nuint y) { throw null; }
@@ -10244,19 +10412,29 @@ namespace System.Numerics
     public partial interface INumberBase<TSelf> : System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf> where TSelf : System.Numerics.INumberBase<TSelf>
     {
         static abstract TSelf One { get; }
+        static abstract int Radix { get; }
         static abstract TSelf Zero { get; }
         static abstract TSelf Abs(TSelf value);
         static abstract TSelf CreateChecked<TOther>(TOther value) where TOther : INumberBase<TOther>;
         static abstract TSelf CreateSaturating<TOther>(TOther value) where TOther : INumberBase<TOther>;
         static abstract TSelf CreateTruncating<TOther>(TOther value) where TOther : INumberBase<TOther>;
+        static abstract bool IsCanonical(TSelf value);
+        static abstract bool IsComplexNumber(TSelf value);
+        static abstract bool IsEvenInteger(TSelf value);
         static abstract bool IsFinite(TSelf value);
+        static abstract bool IsImaginaryNumber(TSelf value);
         static abstract bool IsInfinity(TSelf value);
+        static abstract bool IsInteger(TSelf value);
         static abstract bool IsNaN(TSelf value);
         static abstract bool IsNegative(TSelf value);
         static abstract bool IsNegativeInfinity(TSelf value);
         static abstract bool IsNormal(TSelf value);
+        static abstract bool IsOddInteger(TSelf value);
+        static abstract bool IsPositive(TSelf value);
         static abstract bool IsPositiveInfinity(TSelf value);
+        static abstract bool IsRealNumber(TSelf value);
         static abstract bool IsSubnormal(TSelf value);
+        static abstract bool IsZero(TSelf value);
         static abstract TSelf MaxMagnitude(TSelf x, TSelf y);
         static abstract TSelf MaxMagnitudeNumber(TSelf x, TSelf y);
         static abstract TSelf MinMagnitude(TSelf x, TSelf y);

--- a/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
@@ -545,6 +545,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<byte>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal((byte)0x00, NumberBaseHelper<byte>.Zero);
@@ -957,6 +963,36 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<byte>.IsCanonical((byte)0x00));
+            Assert.True(NumberBaseHelper<byte>.IsCanonical((byte)0x01));
+            Assert.True(NumberBaseHelper<byte>.IsCanonical((byte)0x7F));
+            Assert.True(NumberBaseHelper<byte>.IsCanonical((byte)0x80));
+            Assert.True(NumberBaseHelper<byte>.IsCanonical((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<byte>.IsComplexNumber((byte)0x00));
+            Assert.False(NumberBaseHelper<byte>.IsComplexNumber((byte)0x01));
+            Assert.False(NumberBaseHelper<byte>.IsComplexNumber((byte)0x7F));
+            Assert.False(NumberBaseHelper<byte>.IsComplexNumber((byte)0x80));
+            Assert.False(NumberBaseHelper<byte>.IsComplexNumber((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<byte>.IsEvenInteger((byte)0x00));
+            Assert.False(NumberBaseHelper<byte>.IsEvenInteger((byte)0x01));
+            Assert.False(NumberBaseHelper<byte>.IsEvenInteger((byte)0x7F));
+            Assert.True(NumberBaseHelper<byte>.IsEvenInteger((byte)0x80));
+            Assert.False(NumberBaseHelper<byte>.IsEvenInteger((byte)0xFF));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<byte>.IsFinite((byte)0x00));
@@ -967,6 +1003,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<byte>.IsImaginaryNumber((byte)0x00));
+            Assert.False(NumberBaseHelper<byte>.IsImaginaryNumber((byte)0x01));
+            Assert.False(NumberBaseHelper<byte>.IsImaginaryNumber((byte)0x7F));
+            Assert.False(NumberBaseHelper<byte>.IsImaginaryNumber((byte)0x80));
+            Assert.False(NumberBaseHelper<byte>.IsImaginaryNumber((byte)0xFF));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<byte>.IsInfinity((byte)0x00));
@@ -974,6 +1020,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<byte>.IsInfinity((byte)0x7F));
             Assert.False(NumberBaseHelper<byte>.IsInfinity((byte)0x80));
             Assert.False(NumberBaseHelper<byte>.IsInfinity((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<byte>.IsInteger((byte)0x00));
+            Assert.True(NumberBaseHelper<byte>.IsInteger((byte)0x01));
+            Assert.True(NumberBaseHelper<byte>.IsInteger((byte)0x7F));
+            Assert.True(NumberBaseHelper<byte>.IsInteger((byte)0x80));
+            Assert.True(NumberBaseHelper<byte>.IsInteger((byte)0xFF));
         }
 
         [Fact]
@@ -1017,6 +1073,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<byte>.IsOddInteger((byte)0x00));
+            Assert.True(NumberBaseHelper<byte>.IsOddInteger((byte)0x01));
+            Assert.True(NumberBaseHelper<byte>.IsOddInteger((byte)0x7F));
+            Assert.False(NumberBaseHelper<byte>.IsOddInteger((byte)0x80));
+            Assert.True(NumberBaseHelper<byte>.IsOddInteger((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<byte>.IsPositive((byte)0x00));
+            Assert.True(NumberBaseHelper<byte>.IsPositive((byte)0x01));
+            Assert.True(NumberBaseHelper<byte>.IsPositive((byte)0x7F));
+            Assert.True(NumberBaseHelper<byte>.IsPositive((byte)0x80));
+            Assert.True(NumberBaseHelper<byte>.IsPositive((byte)0xFF));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<byte>.IsPositiveInfinity((byte)0x00));
@@ -1027,6 +1103,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<byte>.IsRealNumber((byte)0x00));
+            Assert.True(NumberBaseHelper<byte>.IsRealNumber((byte)0x01));
+            Assert.True(NumberBaseHelper<byte>.IsRealNumber((byte)0x7F));
+            Assert.True(NumberBaseHelper<byte>.IsRealNumber((byte)0x80));
+            Assert.True(NumberBaseHelper<byte>.IsRealNumber((byte)0xFF));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<byte>.IsSubnormal((byte)0x00));
@@ -1034,6 +1120,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<byte>.IsSubnormal((byte)0x7F));
             Assert.False(NumberBaseHelper<byte>.IsSubnormal((byte)0x80));
             Assert.False(NumberBaseHelper<byte>.IsSubnormal((byte)0xFF));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<byte>.IsZero((byte)0x00));
+            Assert.False(NumberBaseHelper<byte>.IsZero((byte)0x01));
+            Assert.False(NumberBaseHelper<byte>.IsZero((byte)0x7F));
+            Assert.False(NumberBaseHelper<byte>.IsZero((byte)0x80));
+            Assert.False(NumberBaseHelper<byte>.IsZero((byte)0xFF));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
@@ -544,6 +544,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<char>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal((char)0x0000, NumberBaseHelper<char>.Zero);
@@ -956,6 +962,36 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<char>.IsCanonical((char)0x0000));
+            Assert.True(NumberBaseHelper<char>.IsCanonical((char)0x0001));
+            Assert.True(NumberBaseHelper<char>.IsCanonical((char)0x7FFF));
+            Assert.True(NumberBaseHelper<char>.IsCanonical((char)0x8000));
+            Assert.True(NumberBaseHelper<char>.IsCanonical((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<char>.IsComplexNumber((char)0x0000));
+            Assert.False(NumberBaseHelper<char>.IsComplexNumber((char)0x0001));
+            Assert.False(NumberBaseHelper<char>.IsComplexNumber((char)0x7FFF));
+            Assert.False(NumberBaseHelper<char>.IsComplexNumber((char)0x8000));
+            Assert.False(NumberBaseHelper<char>.IsComplexNumber((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<char>.IsEvenInteger((char)0x0000));
+            Assert.False(NumberBaseHelper<char>.IsEvenInteger((char)0x0001));
+            Assert.False(NumberBaseHelper<char>.IsEvenInteger((char)0x7FFF));
+            Assert.True(NumberBaseHelper<char>.IsEvenInteger((char)0x8000));
+            Assert.False(NumberBaseHelper<char>.IsEvenInteger((char)0xFFFF));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<char>.IsFinite((char)0x0000));
@@ -966,6 +1002,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<char>.IsImaginaryNumber((char)0x0000));
+            Assert.False(NumberBaseHelper<char>.IsImaginaryNumber((char)0x0001));
+            Assert.False(NumberBaseHelper<char>.IsImaginaryNumber((char)0x7FFF));
+            Assert.False(NumberBaseHelper<char>.IsImaginaryNumber((char)0x8000));
+            Assert.False(NumberBaseHelper<char>.IsImaginaryNumber((char)0xFFFF));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<char>.IsInfinity((char)0x0000));
@@ -973,6 +1019,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<char>.IsInfinity((char)0x7FFF));
             Assert.False(NumberBaseHelper<char>.IsInfinity((char)0x8000));
             Assert.False(NumberBaseHelper<char>.IsInfinity((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<char>.IsInteger((char)0x0000));
+            Assert.True(NumberBaseHelper<char>.IsInteger((char)0x0001));
+            Assert.True(NumberBaseHelper<char>.IsInteger((char)0x7FFF));
+            Assert.True(NumberBaseHelper<char>.IsInteger((char)0x8000));
+            Assert.True(NumberBaseHelper<char>.IsInteger((char)0xFFFF));
         }
 
         [Fact]
@@ -1016,6 +1072,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<char>.IsOddInteger((char)0x0000));
+            Assert.True(NumberBaseHelper<char>.IsOddInteger((char)0x0001));
+            Assert.True(NumberBaseHelper<char>.IsOddInteger((char)0x7FFF));
+            Assert.False(NumberBaseHelper<char>.IsOddInteger((char)0x8000));
+            Assert.True(NumberBaseHelper<char>.IsOddInteger((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<char>.IsPositive((char)0x0000));
+            Assert.True(NumberBaseHelper<char>.IsPositive((char)0x0001));
+            Assert.True(NumberBaseHelper<char>.IsPositive((char)0x7FFF));
+            Assert.True(NumberBaseHelper<char>.IsPositive((char)0x8000));
+            Assert.True(NumberBaseHelper<char>.IsPositive((char)0xFFFF));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<char>.IsPositiveInfinity((char)0x0000));
@@ -1026,6 +1102,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<char>.IsRealNumber((char)0x0000));
+            Assert.True(NumberBaseHelper<char>.IsRealNumber((char)0x0001));
+            Assert.True(NumberBaseHelper<char>.IsRealNumber((char)0x7FFF));
+            Assert.True(NumberBaseHelper<char>.IsRealNumber((char)0x8000));
+            Assert.True(NumberBaseHelper<char>.IsRealNumber((char)0xFFFF));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<char>.IsSubnormal((char)0x0000));
@@ -1033,6 +1119,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<char>.IsSubnormal((char)0x7FFF));
             Assert.False(NumberBaseHelper<char>.IsSubnormal((char)0x8000));
             Assert.False(NumberBaseHelper<char>.IsSubnormal((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<char>.IsZero((char)0x0000));
+            Assert.False(NumberBaseHelper<char>.IsZero((char)0x0001));
+            Assert.False(NumberBaseHelper<char>.IsZero((char)0x7FFF));
+            Assert.False(NumberBaseHelper<char>.IsZero((char)0x8000));
+            Assert.False(NumberBaseHelper<char>.IsZero((char)0xFFFF));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/DecimalTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DecimalTests.GenericMath.cs
@@ -542,6 +542,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(10, NumberBaseHelper<decimal>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal(0.0m, NumberBaseHelper<decimal>.Zero);
@@ -1025,6 +1031,83 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(decimal.MinValue));
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(-1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(-0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(decimal.MaxValue));
+
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(-10m));
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(-1.2m));
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(-1m));
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(-0.1m));
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(-0m));
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(0m));
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(0.1m));
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(1m));
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(1.2m));
+            Assert.True(NumberBaseHelper<decimal>.IsCanonical(10m));
+
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(-10.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(-1.20m));
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(-0.10m));
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(0.10m));
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(1.20m));
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(10.0m));
+
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(0.0000000000000000000000000000m));
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(1.0000000000000000000000000000m));
+            Assert.False(NumberBaseHelper<decimal>.IsCanonical(10.000000000000000000000000000m));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<decimal>.IsComplexNumber(decimal.MinValue));
+            Assert.False(NumberBaseHelper<decimal>.IsComplexNumber(-1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsComplexNumber(-0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsComplexNumber(0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsComplexNumber(1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsComplexNumber(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(decimal.MinValue));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(-1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsEvenInteger(-0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsEvenInteger(0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(decimal.MaxValue));
+
+            Assert.True(NumberBaseHelper<decimal>.IsEvenInteger(-10m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(-1.2m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(-1m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(-0.1m));
+            Assert.True(NumberBaseHelper<decimal>.IsEvenInteger(-0m));
+            Assert.True(NumberBaseHelper<decimal>.IsEvenInteger(0m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(0.1m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(1m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(1.2m));
+            Assert.True(NumberBaseHelper<decimal>.IsEvenInteger(10m));
+
+            Assert.True(NumberBaseHelper<decimal>.IsEvenInteger(-10.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(-1.20m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(-0.10m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(0.10m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(1.20m));
+            Assert.True(NumberBaseHelper<decimal>.IsEvenInteger(10.0m));
+
+            Assert.True(NumberBaseHelper<decimal>.IsEvenInteger(0.0000000000000000000000000000m));
+            Assert.False(NumberBaseHelper<decimal>.IsEvenInteger(1.0000000000000000000000000000m));
+            Assert.True(NumberBaseHelper<decimal>.IsEvenInteger(10.000000000000000000000000000m));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<decimal>.IsFinite(decimal.MinValue));
@@ -1036,6 +1119,17 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<decimal>.IsImaginaryNumber(decimal.MinValue));
+            Assert.False(NumberBaseHelper<decimal>.IsImaginaryNumber(-1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsImaginaryNumber(-0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsImaginaryNumber(0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsImaginaryNumber(1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsImaginaryNumber(decimal.MaxValue));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<decimal>.IsInfinity(decimal.MinValue));
@@ -1044,6 +1138,39 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<decimal>.IsInfinity(0.0m));
             Assert.False(NumberBaseHelper<decimal>.IsInfinity(1.0m));
             Assert.False(NumberBaseHelper<decimal>.IsInfinity(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(decimal.MinValue));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(-1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(-0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(decimal.MaxValue));
+
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(-10m));
+            Assert.False(NumberBaseHelper<decimal>.IsInteger(-1.2m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(-1m));
+            Assert.False(NumberBaseHelper<decimal>.IsInteger(-0.1m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(-0m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(0m));
+            Assert.False(NumberBaseHelper<decimal>.IsInteger(0.1m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(1m));
+            Assert.False(NumberBaseHelper<decimal>.IsInteger(1.2m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(10m));
+
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(-10.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsInteger(-1.20m));
+            Assert.False(NumberBaseHelper<decimal>.IsInteger(-0.10m));
+            Assert.False(NumberBaseHelper<decimal>.IsInteger(0.10m));
+            Assert.False(NumberBaseHelper<decimal>.IsInteger(1.20m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(10.0m));
+
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(0.0000000000000000000000000000m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(1.0000000000000000000000000000m));
+            Assert.True(NumberBaseHelper<decimal>.IsInteger(10.000000000000000000000000000m));
         }
 
         [Fact]
@@ -1091,6 +1218,50 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<decimal>.IsOddInteger(decimal.MinValue));
+            Assert.True(NumberBaseHelper<decimal>.IsOddInteger(-1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(-0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsOddInteger(1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsOddInteger(decimal.MaxValue));
+
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(-10m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(-1.2m));
+            Assert.True(NumberBaseHelper<decimal>.IsOddInteger(-1m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(-0.1m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(-0m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(0m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(0.1m));
+            Assert.True(NumberBaseHelper<decimal>.IsOddInteger(1m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(1.2m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(10m));
+
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(-10.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(-1.20m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(-0.10m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(0.10m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(1.20m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(10.0m));
+
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(0.0000000000000000000000000000m));
+            Assert.True(NumberBaseHelper<decimal>.IsOddInteger(1.0000000000000000000000000000m));
+            Assert.False(NumberBaseHelper<decimal>.IsOddInteger(10.000000000000000000000000000m));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.False(NumberBaseHelper<decimal>.IsPositive(decimal.MinValue));
+            Assert.False(NumberBaseHelper<decimal>.IsPositive(-1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsPositive(-0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsPositive(0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsPositive(1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsPositive(decimal.MaxValue));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<decimal>.IsPositiveInfinity(decimal.MinValue));
@@ -1102,6 +1273,17 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<decimal>.IsRealNumber(decimal.MinValue));
+            Assert.True(NumberBaseHelper<decimal>.IsRealNumber(-1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsRealNumber(-0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsRealNumber(0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsRealNumber(1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsRealNumber(decimal.MaxValue));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<decimal>.IsSubnormal(decimal.MinValue));
@@ -1110,6 +1292,39 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<decimal>.IsSubnormal(0.0m));
             Assert.False(NumberBaseHelper<decimal>.IsSubnormal(1.0m));
             Assert.False(NumberBaseHelper<decimal>.IsSubnormal(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.False(NumberBaseHelper<decimal>.IsZero(decimal.MinValue));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(-1.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsZero(-0.0m));
+            Assert.True(NumberBaseHelper<decimal>.IsZero(0.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(1.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(decimal.MaxValue));
+
+            Assert.False(NumberBaseHelper<decimal>.IsZero(-10m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(-1.2m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(-1m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(-0.1m));
+            Assert.True(NumberBaseHelper<decimal>.IsZero(-0m));
+            Assert.True(NumberBaseHelper<decimal>.IsZero(0m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(0.1m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(1m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(1.2m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(10m));
+
+            Assert.False(NumberBaseHelper<decimal>.IsZero(-10.0m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(-1.20m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(-0.10m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(0.10m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(1.20m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(10.0m));
+
+            Assert.True(NumberBaseHelper<decimal>.IsZero(0.0000000000000000000000000000m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(1.0000000000000000000000000000m));
+            Assert.False(NumberBaseHelper<decimal>.IsZero(10.000000000000000000000000000m));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
@@ -988,6 +988,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<double>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             AssertBitwiseEqual(0.0, NumberBaseHelper<double>.Zero);
@@ -1482,23 +1488,103 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<double>.IsCanonical(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(double.MinValue));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(-1.0));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(-MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(-double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(-0.0));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(double.NaN));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(0.0));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(MaxSubnormal));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(1.0));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(double.MaxValue));
+            Assert.True(NumberBaseHelper<double>.IsCanonical(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(double.MinValue));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(-1.0));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(-double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(-0.0));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(double.NaN));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(0.0));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(1.0));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsComplexNumber(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsEvenInteger(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<double>.IsEvenInteger(double.MinValue));
+            Assert.False(NumberBaseHelper<double>.IsEvenInteger(-1.0));
+            Assert.False(NumberBaseHelper<double>.IsEvenInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsEvenInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsEvenInteger(-double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsEvenInteger(-0.0));
+            Assert.False(NumberBaseHelper<double>.IsEvenInteger(double.NaN));
+            Assert.True(NumberBaseHelper<double>.IsEvenInteger(0.0));
+            Assert.False(NumberBaseHelper<double>.IsEvenInteger(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsEvenInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsEvenInteger(MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsEvenInteger(1.0));
+            Assert.True(NumberBaseHelper<double>.IsEvenInteger(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsEvenInteger(double.PositiveInfinity));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.False(NumberBaseHelper<double>.IsFinite(double.NegativeInfinity));
             Assert.True(NumberBaseHelper<double>.IsFinite(double.MinValue));
-            Assert.True(NumberBaseHelper<double>.IsFinite(-1.0f));
+            Assert.True(NumberBaseHelper<double>.IsFinite(-1.0));
             Assert.True(NumberBaseHelper<double>.IsFinite(-MinNormal));
             Assert.True(NumberBaseHelper<double>.IsFinite(-MaxSubnormal));
             Assert.True(NumberBaseHelper<double>.IsFinite(-double.Epsilon));
-            Assert.True(NumberBaseHelper<double>.IsFinite(-0.0f));
+            Assert.True(NumberBaseHelper<double>.IsFinite(-0.0));
             Assert.False(NumberBaseHelper<double>.IsFinite(double.NaN));
-            Assert.True(NumberBaseHelper<double>.IsFinite(0.0f));
+            Assert.True(NumberBaseHelper<double>.IsFinite(0.0));
             Assert.True(NumberBaseHelper<double>.IsFinite(double.Epsilon));
             Assert.True(NumberBaseHelper<double>.IsFinite(MaxSubnormal));
             Assert.True(NumberBaseHelper<double>.IsFinite(MinNormal));
-            Assert.True(NumberBaseHelper<double>.IsFinite(1.0f));
+            Assert.True(NumberBaseHelper<double>.IsFinite(1.0));
             Assert.True(NumberBaseHelper<double>.IsFinite(double.MaxValue));
             Assert.False(NumberBaseHelper<double>.IsFinite(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(double.MinValue));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(-1.0));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(-double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(-0.0));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(double.NaN));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(0.0));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(1.0));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsImaginaryNumber(double.PositiveInfinity));
         }
 
         [Fact]
@@ -1506,19 +1592,39 @@ namespace System.Tests
         {
             Assert.True(NumberBaseHelper<double>.IsInfinity(double.NegativeInfinity));
             Assert.False(NumberBaseHelper<double>.IsInfinity(double.MinValue));
-            Assert.False(NumberBaseHelper<double>.IsInfinity(-1.0f));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(-1.0));
             Assert.False(NumberBaseHelper<double>.IsInfinity(-MinNormal));
             Assert.False(NumberBaseHelper<double>.IsInfinity(-MaxSubnormal));
             Assert.False(NumberBaseHelper<double>.IsInfinity(-double.Epsilon));
-            Assert.False(NumberBaseHelper<double>.IsInfinity(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(-0.0));
             Assert.False(NumberBaseHelper<double>.IsInfinity(double.NaN));
-            Assert.False(NumberBaseHelper<double>.IsInfinity(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(0.0));
             Assert.False(NumberBaseHelper<double>.IsInfinity(double.Epsilon));
             Assert.False(NumberBaseHelper<double>.IsInfinity(MaxSubnormal));
             Assert.False(NumberBaseHelper<double>.IsInfinity(MinNormal));
-            Assert.False(NumberBaseHelper<double>.IsInfinity(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsInfinity(1.0));
             Assert.False(NumberBaseHelper<double>.IsInfinity(double.MaxValue));
             Assert.True(NumberBaseHelper<double>.IsInfinity(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsInteger(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<double>.IsInteger(double.MinValue));
+            Assert.True(NumberBaseHelper<double>.IsInteger(-1.0));
+            Assert.False(NumberBaseHelper<double>.IsInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsInteger(-double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsInteger(-0.0));
+            Assert.False(NumberBaseHelper<double>.IsInteger(double.NaN));
+            Assert.True(NumberBaseHelper<double>.IsInteger(0.0));
+            Assert.False(NumberBaseHelper<double>.IsInteger(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsInteger(MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsInteger(1.0));
+            Assert.True(NumberBaseHelper<double>.IsInteger(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsInteger(double.PositiveInfinity));
         }
 
         [Fact]
@@ -1526,17 +1632,17 @@ namespace System.Tests
         {
             Assert.False(NumberBaseHelper<double>.IsNaN(double.NegativeInfinity));
             Assert.False(NumberBaseHelper<double>.IsNaN(double.MinValue));
-            Assert.False(NumberBaseHelper<double>.IsNaN(-1.0f));
+            Assert.False(NumberBaseHelper<double>.IsNaN(-1.0));
             Assert.False(NumberBaseHelper<double>.IsNaN(-MinNormal));
             Assert.False(NumberBaseHelper<double>.IsNaN(-MaxSubnormal));
             Assert.False(NumberBaseHelper<double>.IsNaN(-double.Epsilon));
-            Assert.False(NumberBaseHelper<double>.IsNaN(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNaN(-0.0));
             Assert.True(NumberBaseHelper<double>.IsNaN(double.NaN));
-            Assert.False(NumberBaseHelper<double>.IsNaN(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNaN(0.0));
             Assert.False(NumberBaseHelper<double>.IsNaN(double.Epsilon));
             Assert.False(NumberBaseHelper<double>.IsNaN(MaxSubnormal));
             Assert.False(NumberBaseHelper<double>.IsNaN(MinNormal));
-            Assert.False(NumberBaseHelper<double>.IsNaN(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsNaN(1.0));
             Assert.False(NumberBaseHelper<double>.IsNaN(double.MaxValue));
             Assert.False(NumberBaseHelper<double>.IsNaN(double.PositiveInfinity));
         }
@@ -1546,17 +1652,17 @@ namespace System.Tests
         {
             Assert.True(NumberBaseHelper<double>.IsNegative(double.NegativeInfinity));
             Assert.True(NumberBaseHelper<double>.IsNegative(double.MinValue));
-            Assert.True(NumberBaseHelper<double>.IsNegative(-1.0f));
+            Assert.True(NumberBaseHelper<double>.IsNegative(-1.0));
             Assert.True(NumberBaseHelper<double>.IsNegative(-MinNormal));
             Assert.True(NumberBaseHelper<double>.IsNegative(-MaxSubnormal));
             Assert.True(NumberBaseHelper<double>.IsNegative(-double.Epsilon));
-            Assert.True(NumberBaseHelper<double>.IsNegative(-0.0f));
+            Assert.True(NumberBaseHelper<double>.IsNegative(-0.0));
             Assert.True(NumberBaseHelper<double>.IsNegative(double.NaN));
-            Assert.False(NumberBaseHelper<double>.IsNegative(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegative(0.0));
             Assert.False(NumberBaseHelper<double>.IsNegative(double.Epsilon));
             Assert.False(NumberBaseHelper<double>.IsNegative(MaxSubnormal));
             Assert.False(NumberBaseHelper<double>.IsNegative(MinNormal));
-            Assert.False(NumberBaseHelper<double>.IsNegative(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegative(1.0));
             Assert.False(NumberBaseHelper<double>.IsNegative(double.MaxValue));
             Assert.False(NumberBaseHelper<double>.IsNegative(double.PositiveInfinity));
         }
@@ -1566,17 +1672,17 @@ namespace System.Tests
         {
             Assert.True(NumberBaseHelper<double>.IsNegativeInfinity(double.NegativeInfinity));
             Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(double.MinValue));
-            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-1.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-1.0));
             Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-MinNormal));
             Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-MaxSubnormal));
             Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-double.Epsilon));
-            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(-0.0));
             Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(double.NaN));
-            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(0.0));
             Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(double.Epsilon));
             Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(MaxSubnormal));
             Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(MinNormal));
-            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(1.0));
             Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(double.MaxValue));
             Assert.False(NumberBaseHelper<double>.IsNegativeInfinity(double.PositiveInfinity));
         }
@@ -1586,19 +1692,59 @@ namespace System.Tests
         {
             Assert.False(NumberBaseHelper<double>.IsNormal(double.NegativeInfinity));
             Assert.True(NumberBaseHelper<double>.IsNormal(double.MinValue));
-            Assert.True(NumberBaseHelper<double>.IsNormal(-1.0f));
+            Assert.True(NumberBaseHelper<double>.IsNormal(-1.0));
             Assert.True(NumberBaseHelper<double>.IsNormal(-MinNormal));
             Assert.False(NumberBaseHelper<double>.IsNormal(-MaxSubnormal));
             Assert.False(NumberBaseHelper<double>.IsNormal(-double.Epsilon));
-            Assert.False(NumberBaseHelper<double>.IsNormal(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNormal(-0.0));
             Assert.False(NumberBaseHelper<double>.IsNormal(double.NaN));
-            Assert.False(NumberBaseHelper<double>.IsNormal(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsNormal(0.0));
             Assert.False(NumberBaseHelper<double>.IsNormal(double.Epsilon));
             Assert.False(NumberBaseHelper<double>.IsNormal(MaxSubnormal));
             Assert.True(NumberBaseHelper<double>.IsNormal(MinNormal));
-            Assert.True(NumberBaseHelper<double>.IsNormal(1.0f));
+            Assert.True(NumberBaseHelper<double>.IsNormal(1.0));
             Assert.True(NumberBaseHelper<double>.IsNormal(double.MaxValue));
             Assert.False(NumberBaseHelper<double>.IsNormal(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(double.MinValue));
+            Assert.True(NumberBaseHelper<double>.IsOddInteger(-1.0));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(-double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(-0.0));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(double.NaN));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(0.0));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsOddInteger(1.0));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsOddInteger(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsPositive(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<double>.IsPositive(double.MinValue));
+            Assert.False(NumberBaseHelper<double>.IsPositive(-1.0));
+            Assert.False(NumberBaseHelper<double>.IsPositive(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsPositive(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsPositive(-double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsPositive(-0.0));
+            Assert.False(NumberBaseHelper<double>.IsPositive(double.NaN));
+            Assert.True(NumberBaseHelper<double>.IsPositive(0.0));
+            Assert.True(NumberBaseHelper<double>.IsPositive(double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsPositive(MaxSubnormal));
+            Assert.True(NumberBaseHelper<double>.IsPositive(MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsPositive(1.0));
+            Assert.True(NumberBaseHelper<double>.IsPositive(double.MaxValue));
+            Assert.True(NumberBaseHelper<double>.IsPositive(double.PositiveInfinity));
         }
 
         [Fact]
@@ -1606,19 +1752,39 @@ namespace System.Tests
         {
             Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(double.NegativeInfinity));
             Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(double.MinValue));
-            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-1.0f));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-1.0));
             Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-MinNormal));
             Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-MaxSubnormal));
             Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-double.Epsilon));
-            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(-0.0));
             Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(double.NaN));
-            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(0.0));
             Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(double.Epsilon));
             Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(MaxSubnormal));
             Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(MinNormal));
-            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(1.0));
             Assert.False(NumberBaseHelper<double>.IsPositiveInfinity(double.MaxValue));
             Assert.True(NumberBaseHelper<double>.IsPositiveInfinity(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(double.NegativeInfinity));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(double.MinValue));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(-1.0));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(-MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(-double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(-0.0));
+            Assert.False(NumberBaseHelper<double>.IsRealNumber(double.NaN));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(0.0));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(MaxSubnormal));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(MinNormal));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(1.0));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(double.MaxValue));
+            Assert.True(NumberBaseHelper<double>.IsRealNumber(double.PositiveInfinity));
         }
 
         [Fact]
@@ -1626,19 +1792,39 @@ namespace System.Tests
         {
             Assert.False(NumberBaseHelper<double>.IsSubnormal(double.NegativeInfinity));
             Assert.False(NumberBaseHelper<double>.IsSubnormal(double.MinValue));
-            Assert.False(NumberBaseHelper<double>.IsSubnormal(-1.0f));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(-1.0));
             Assert.False(NumberBaseHelper<double>.IsSubnormal(-MinNormal));
             Assert.True(NumberBaseHelper<double>.IsSubnormal(-MaxSubnormal));
             Assert.True(NumberBaseHelper<double>.IsSubnormal(-double.Epsilon));
-            Assert.False(NumberBaseHelper<double>.IsSubnormal(-0.0f));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(-0.0));
             Assert.False(NumberBaseHelper<double>.IsSubnormal(double.NaN));
-            Assert.False(NumberBaseHelper<double>.IsSubnormal(0.0f));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(0.0));
             Assert.True(NumberBaseHelper<double>.IsSubnormal(double.Epsilon));
             Assert.True(NumberBaseHelper<double>.IsSubnormal(MaxSubnormal));
             Assert.False(NumberBaseHelper<double>.IsSubnormal(MinNormal));
-            Assert.False(NumberBaseHelper<double>.IsSubnormal(1.0f));
+            Assert.False(NumberBaseHelper<double>.IsSubnormal(1.0));
             Assert.False(NumberBaseHelper<double>.IsSubnormal(double.MaxValue));
             Assert.False(NumberBaseHelper<double>.IsSubnormal(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.False(NumberBaseHelper<double>.IsZero(double.NegativeInfinity));
+            Assert.False(NumberBaseHelper<double>.IsZero(double.MinValue));
+            Assert.False(NumberBaseHelper<double>.IsZero(-1.0));
+            Assert.False(NumberBaseHelper<double>.IsZero(-MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsZero(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsZero(-double.Epsilon));
+            Assert.True(NumberBaseHelper<double>.IsZero(-0.0));
+            Assert.False(NumberBaseHelper<double>.IsZero(double.NaN));
+            Assert.True(NumberBaseHelper<double>.IsZero(0.0));
+            Assert.False(NumberBaseHelper<double>.IsZero(double.Epsilon));
+            Assert.False(NumberBaseHelper<double>.IsZero(MaxSubnormal));
+            Assert.False(NumberBaseHelper<double>.IsZero(MinNormal));
+            Assert.False(NumberBaseHelper<double>.IsZero(1.0));
+            Assert.False(NumberBaseHelper<double>.IsZero(double.MaxValue));
+            Assert.False(NumberBaseHelper<double>.IsZero(double.PositiveInfinity));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
@@ -1006,6 +1006,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<Half>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             AssertBitwiseEqual(Zero, NumberBaseHelper<Half>.Zero);
@@ -1500,6 +1506,66 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(Half.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(Half.MinValue));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(NegativeOne));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(-MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(-Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(NegativeZero));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(Half.NaN));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(Zero));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(MaxSubnormal));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(One));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(Half.MaxValue));
+            Assert.True(NumberBaseHelper<Half>.IsCanonical(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(Half.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(Half.MinValue));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(-Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(Half.NaN));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(One));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsComplexNumber(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsEvenInteger(Half.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Half>.IsEvenInteger(Half.MinValue));
+            Assert.False(NumberBaseHelper<Half>.IsEvenInteger(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsEvenInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsEvenInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsEvenInteger(-Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsEvenInteger(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsEvenInteger(Half.NaN));
+            Assert.True(NumberBaseHelper<Half>.IsEvenInteger(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsEvenInteger(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsEvenInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsEvenInteger(MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsEvenInteger(One));
+            Assert.True(NumberBaseHelper<Half>.IsEvenInteger(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsEvenInteger(Half.PositiveInfinity));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.False(NumberBaseHelper<Half>.IsFinite(Half.NegativeInfinity));
@@ -1520,6 +1586,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(Half.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(Half.MinValue));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(-Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(Half.NaN));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(One));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsImaginaryNumber(Half.PositiveInfinity));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.True(NumberBaseHelper<Half>.IsInfinity(Half.NegativeInfinity));
@@ -1537,6 +1623,26 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<Half>.IsInfinity(One));
             Assert.False(NumberBaseHelper<Half>.IsInfinity(Half.MaxValue));
             Assert.True(NumberBaseHelper<Half>.IsInfinity(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsInteger(Half.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Half>.IsInteger(Half.MinValue));
+            Assert.True(NumberBaseHelper<Half>.IsInteger(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsInteger(-Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsInteger(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsInteger(Half.NaN));
+            Assert.True(NumberBaseHelper<Half>.IsInteger(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsInteger(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsInteger(MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsInteger(One));
+            Assert.True(NumberBaseHelper<Half>.IsInteger(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsInteger(Half.PositiveInfinity));
         }
 
         [Fact]
@@ -1620,6 +1726,46 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(Half.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(Half.MinValue));
+            Assert.True(NumberBaseHelper<Half>.IsOddInteger(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(-Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(Half.NaN));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsOddInteger(One));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsOddInteger(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsPositive(Half.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Half>.IsPositive(Half.MinValue));
+            Assert.False(NumberBaseHelper<Half>.IsPositive(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsPositive(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsPositive(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsPositive(-Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsPositive(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsPositive(Half.NaN));
+            Assert.True(NumberBaseHelper<Half>.IsPositive(Zero));
+            Assert.True(NumberBaseHelper<Half>.IsPositive(Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsPositive(MaxSubnormal));
+            Assert.True(NumberBaseHelper<Half>.IsPositive(MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsPositive(One));
+            Assert.True(NumberBaseHelper<Half>.IsPositive(Half.MaxValue));
+            Assert.True(NumberBaseHelper<Half>.IsPositive(Half.PositiveInfinity));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<Half>.IsPositiveInfinity(Half.NegativeInfinity));
@@ -1640,6 +1786,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(Half.NegativeInfinity));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(Half.MinValue));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(NegativeOne));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(-MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(-Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsRealNumber(Half.NaN));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(Zero));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(MaxSubnormal));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(MinNormal));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(One));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(Half.MaxValue));
+            Assert.True(NumberBaseHelper<Half>.IsRealNumber(Half.PositiveInfinity));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<Half>.IsSubnormal(Half.NegativeInfinity));
@@ -1657,6 +1823,26 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<Half>.IsSubnormal(One));
             Assert.False(NumberBaseHelper<Half>.IsSubnormal(Half.MaxValue));
             Assert.False(NumberBaseHelper<Half>.IsSubnormal(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.False(NumberBaseHelper<Half>.IsZero(Half.NegativeInfinity));
+            Assert.False(NumberBaseHelper<Half>.IsZero(Half.MinValue));
+            Assert.False(NumberBaseHelper<Half>.IsZero(NegativeOne));
+            Assert.False(NumberBaseHelper<Half>.IsZero(-MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsZero(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsZero(-Half.Epsilon));
+            Assert.True(NumberBaseHelper<Half>.IsZero(NegativeZero));
+            Assert.False(NumberBaseHelper<Half>.IsZero(Half.NaN));
+            Assert.True(NumberBaseHelper<Half>.IsZero(Zero));
+            Assert.False(NumberBaseHelper<Half>.IsZero(Half.Epsilon));
+            Assert.False(NumberBaseHelper<Half>.IsZero(MaxSubnormal));
+            Assert.False(NumberBaseHelper<Half>.IsZero(MinNormal));
+            Assert.False(NumberBaseHelper<Half>.IsZero(One));
+            Assert.False(NumberBaseHelper<Half>.IsZero(Half.MaxValue));
+            Assert.False(NumberBaseHelper<Half>.IsZero(Half.PositiveInfinity));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int128Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int128Tests.GenericMath.cs
@@ -595,6 +595,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<Int128>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal(Zero, NumberBaseHelper<Int128>.Zero);
@@ -1258,6 +1264,36 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<Int128>.IsCanonical(Zero));
+            Assert.True(NumberBaseHelper<Int128>.IsCanonical(One));
+            Assert.True(NumberBaseHelper<Int128>.IsCanonical(MaxValue));
+            Assert.True(NumberBaseHelper<Int128>.IsCanonical(MinValue));
+            Assert.True(NumberBaseHelper<Int128>.IsCanonical(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<Int128>.IsComplexNumber(Zero));
+            Assert.False(NumberBaseHelper<Int128>.IsComplexNumber(One));
+            Assert.False(NumberBaseHelper<Int128>.IsComplexNumber(MaxValue));
+            Assert.False(NumberBaseHelper<Int128>.IsComplexNumber(MinValue));
+            Assert.False(NumberBaseHelper<Int128>.IsComplexNumber(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<Int128>.IsEvenInteger(Zero));
+            Assert.False(NumberBaseHelper<Int128>.IsEvenInteger(One));
+            Assert.False(NumberBaseHelper<Int128>.IsEvenInteger(MaxValue));
+            Assert.True(NumberBaseHelper<Int128>.IsEvenInteger(MinValue));
+            Assert.False(NumberBaseHelper<Int128>.IsEvenInteger(NegativeOne));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<Int128>.IsFinite(Zero));
@@ -1268,6 +1304,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<Int128>.IsImaginaryNumber(Zero));
+            Assert.False(NumberBaseHelper<Int128>.IsImaginaryNumber(One));
+            Assert.False(NumberBaseHelper<Int128>.IsImaginaryNumber(MaxValue));
+            Assert.False(NumberBaseHelper<Int128>.IsImaginaryNumber(MinValue));
+            Assert.False(NumberBaseHelper<Int128>.IsImaginaryNumber(NegativeOne));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<Int128>.IsInfinity(Zero));
@@ -1275,6 +1321,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<Int128>.IsInfinity(MaxValue));
             Assert.False(NumberBaseHelper<Int128>.IsInfinity(MinValue));
             Assert.False(NumberBaseHelper<Int128>.IsInfinity(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<Int128>.IsInteger(Zero));
+            Assert.True(NumberBaseHelper<Int128>.IsInteger(One));
+            Assert.True(NumberBaseHelper<Int128>.IsInteger(MaxValue));
+            Assert.True(NumberBaseHelper<Int128>.IsInteger(MinValue));
+            Assert.True(NumberBaseHelper<Int128>.IsInteger(NegativeOne));
         }
 
         [Fact]
@@ -1318,6 +1374,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<Int128>.IsOddInteger(Zero));
+            Assert.True(NumberBaseHelper<Int128>.IsOddInteger(One));
+            Assert.True(NumberBaseHelper<Int128>.IsOddInteger(MaxValue));
+            Assert.False(NumberBaseHelper<Int128>.IsOddInteger(MinValue));
+            Assert.True(NumberBaseHelper<Int128>.IsOddInteger(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<Int128>.IsPositive(Zero));
+            Assert.True(NumberBaseHelper<Int128>.IsPositive(One));
+            Assert.True(NumberBaseHelper<Int128>.IsPositive(MaxValue));
+            Assert.False(NumberBaseHelper<Int128>.IsPositive(MinValue));
+            Assert.False(NumberBaseHelper<Int128>.IsPositive(NegativeOne));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<Int128>.IsPositiveInfinity(Zero));
@@ -1328,6 +1404,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<Int128>.IsRealNumber(Zero));
+            Assert.True(NumberBaseHelper<Int128>.IsRealNumber(One));
+            Assert.True(NumberBaseHelper<Int128>.IsRealNumber(MaxValue));
+            Assert.True(NumberBaseHelper<Int128>.IsRealNumber(MinValue));
+            Assert.True(NumberBaseHelper<Int128>.IsRealNumber(NegativeOne));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<Int128>.IsSubnormal(Zero));
@@ -1335,6 +1421,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<Int128>.IsSubnormal(MaxValue));
             Assert.False(NumberBaseHelper<Int128>.IsSubnormal(MinValue));
             Assert.False(NumberBaseHelper<Int128>.IsSubnormal(NegativeOne));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<Int128>.IsZero(Zero));
+            Assert.False(NumberBaseHelper<Int128>.IsZero(One));
+            Assert.False(NumberBaseHelper<Int128>.IsZero(MaxValue));
+            Assert.False(NumberBaseHelper<Int128>.IsZero(MinValue));
+            Assert.False(NumberBaseHelper<Int128>.IsZero(NegativeOne));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
@@ -545,6 +545,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<short>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal((short)0x0000, NumberBaseHelper<short>.Zero);
@@ -957,6 +963,36 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<short>.IsCanonical((short)0x0000));
+            Assert.True(NumberBaseHelper<short>.IsCanonical((short)0x0001));
+            Assert.True(NumberBaseHelper<short>.IsCanonical((short)0x7FFF));
+            Assert.True(NumberBaseHelper<short>.IsCanonical(unchecked((short)0x8000)));
+            Assert.True(NumberBaseHelper<short>.IsCanonical(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<short>.IsComplexNumber((short)0x0000));
+            Assert.False(NumberBaseHelper<short>.IsComplexNumber((short)0x0001));
+            Assert.False(NumberBaseHelper<short>.IsComplexNumber((short)0x7FFF));
+            Assert.False(NumberBaseHelper<short>.IsComplexNumber(unchecked((short)0x8000)));
+            Assert.False(NumberBaseHelper<short>.IsComplexNumber(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<short>.IsEvenInteger((short)0x0000));
+            Assert.False(NumberBaseHelper<short>.IsEvenInteger((short)0x0001));
+            Assert.False(NumberBaseHelper<short>.IsEvenInteger((short)0x7FFF));
+            Assert.True(NumberBaseHelper<short>.IsEvenInteger(unchecked((short)0x8000)));
+            Assert.False(NumberBaseHelper<short>.IsEvenInteger(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<short>.IsFinite((short)0x0000));
@@ -967,6 +1003,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<short>.IsImaginaryNumber((short)0x0000));
+            Assert.False(NumberBaseHelper<short>.IsImaginaryNumber((short)0x0001));
+            Assert.False(NumberBaseHelper<short>.IsImaginaryNumber((short)0x7FFF));
+            Assert.False(NumberBaseHelper<short>.IsImaginaryNumber(unchecked((short)0x8000)));
+            Assert.False(NumberBaseHelper<short>.IsImaginaryNumber(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<short>.IsInfinity((short)0x0000));
@@ -974,6 +1020,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<short>.IsInfinity((short)0x7FFF));
             Assert.False(NumberBaseHelper<short>.IsInfinity(unchecked((short)0x8000)));
             Assert.False(NumberBaseHelper<short>.IsInfinity(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<short>.IsInteger((short)0x0000));
+            Assert.True(NumberBaseHelper<short>.IsInteger((short)0x0001));
+            Assert.True(NumberBaseHelper<short>.IsInteger((short)0x7FFF));
+            Assert.True(NumberBaseHelper<short>.IsInteger(unchecked((short)0x8000)));
+            Assert.True(NumberBaseHelper<short>.IsInteger(unchecked((short)0xFFFF)));
         }
 
         [Fact]
@@ -1017,6 +1073,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<short>.IsOddInteger((short)0x0000));
+            Assert.True(NumberBaseHelper<short>.IsOddInteger((short)0x0001));
+            Assert.True(NumberBaseHelper<short>.IsOddInteger((short)0x7FFF));
+            Assert.False(NumberBaseHelper<short>.IsOddInteger(unchecked((short)0x8000)));
+            Assert.True(NumberBaseHelper<short>.IsOddInteger(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<short>.IsPositive((short)0x0000));
+            Assert.True(NumberBaseHelper<short>.IsPositive((short)0x0001));
+            Assert.True(NumberBaseHelper<short>.IsPositive((short)0x7FFF));
+            Assert.False(NumberBaseHelper<short>.IsPositive(unchecked((short)0x8000)));
+            Assert.False(NumberBaseHelper<short>.IsPositive(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<short>.IsPositiveInfinity((short)0x0000));
@@ -1027,6 +1103,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<short>.IsRealNumber((short)0x0000));
+            Assert.True(NumberBaseHelper<short>.IsRealNumber((short)0x0001));
+            Assert.True(NumberBaseHelper<short>.IsRealNumber((short)0x7FFF));
+            Assert.True(NumberBaseHelper<short>.IsRealNumber(unchecked((short)0x8000)));
+            Assert.True(NumberBaseHelper<short>.IsRealNumber(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<short>.IsSubnormal((short)0x0000));
@@ -1034,6 +1120,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<short>.IsSubnormal((short)0x7FFF));
             Assert.False(NumberBaseHelper<short>.IsSubnormal(unchecked((short)0x8000)));
             Assert.False(NumberBaseHelper<short>.IsSubnormal(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<short>.IsZero((short)0x0000));
+            Assert.False(NumberBaseHelper<short>.IsZero((short)0x0001));
+            Assert.False(NumberBaseHelper<short>.IsZero((short)0x7FFF));
+            Assert.False(NumberBaseHelper<short>.IsZero(unchecked((short)0x8000)));
+            Assert.False(NumberBaseHelper<short>.IsZero(unchecked((short)0xFFFF)));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
@@ -545,6 +545,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<int>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal((int)0x00000000, NumberBaseHelper<int>.Zero);
@@ -957,6 +963,36 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<int>.IsCanonical((int)0x00000000));
+            Assert.True(NumberBaseHelper<int>.IsCanonical((int)0x00000001));
+            Assert.True(NumberBaseHelper<int>.IsCanonical((int)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<int>.IsCanonical(unchecked((int)0x80000000)));
+            Assert.True(NumberBaseHelper<int>.IsCanonical(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<int>.IsComplexNumber((int)0x00000000));
+            Assert.False(NumberBaseHelper<int>.IsComplexNumber((int)0x00000001));
+            Assert.False(NumberBaseHelper<int>.IsComplexNumber((int)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<int>.IsComplexNumber(unchecked((int)0x80000000)));
+            Assert.False(NumberBaseHelper<int>.IsComplexNumber(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<int>.IsEvenInteger((int)0x00000000));
+            Assert.False(NumberBaseHelper<int>.IsEvenInteger((int)0x00000001));
+            Assert.False(NumberBaseHelper<int>.IsEvenInteger((int)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<int>.IsEvenInteger(unchecked((int)0x80000000)));
+            Assert.False(NumberBaseHelper<int>.IsEvenInteger(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<int>.IsFinite((int)0x00000000));
@@ -967,6 +1003,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<int>.IsImaginaryNumber((int)0x00000000));
+            Assert.False(NumberBaseHelper<int>.IsImaginaryNumber((int)0x00000001));
+            Assert.False(NumberBaseHelper<int>.IsImaginaryNumber((int)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<int>.IsImaginaryNumber(unchecked((int)0x80000000)));
+            Assert.False(NumberBaseHelper<int>.IsImaginaryNumber(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<int>.IsInfinity((int)0x00000000));
@@ -974,6 +1020,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<int>.IsInfinity((int)0x7FFFFFFF));
             Assert.False(NumberBaseHelper<int>.IsInfinity(unchecked((int)0x80000000)));
             Assert.False(NumberBaseHelper<int>.IsInfinity(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<int>.IsInteger((int)0x00000000));
+            Assert.True(NumberBaseHelper<int>.IsInteger((int)0x00000001));
+            Assert.True(NumberBaseHelper<int>.IsInteger((int)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<int>.IsInteger(unchecked((int)0x80000000)));
+            Assert.True(NumberBaseHelper<int>.IsInteger(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]
@@ -1017,6 +1073,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<int>.IsOddInteger((int)0x00000000));
+            Assert.True(NumberBaseHelper<int>.IsOddInteger((int)0x00000001));
+            Assert.True(NumberBaseHelper<int>.IsOddInteger((int)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<int>.IsOddInteger(unchecked((int)0x80000000)));
+            Assert.True(NumberBaseHelper<int>.IsOddInteger(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<int>.IsPositive((int)0x00000000));
+            Assert.True(NumberBaseHelper<int>.IsPositive((int)0x00000001));
+            Assert.True(NumberBaseHelper<int>.IsPositive((int)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<int>.IsPositive(unchecked((int)0x80000000)));
+            Assert.False(NumberBaseHelper<int>.IsPositive(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<int>.IsPositiveInfinity((int)0x00000000));
@@ -1027,6 +1103,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<int>.IsRealNumber((int)0x00000000));
+            Assert.True(NumberBaseHelper<int>.IsRealNumber((int)0x00000001));
+            Assert.True(NumberBaseHelper<int>.IsRealNumber((int)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<int>.IsRealNumber(unchecked((int)0x80000000)));
+            Assert.True(NumberBaseHelper<int>.IsRealNumber(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<int>.IsSubnormal((int)0x00000000));
@@ -1034,6 +1120,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<int>.IsSubnormal((int)0x7FFFFFFF));
             Assert.False(NumberBaseHelper<int>.IsSubnormal(unchecked((int)0x80000000)));
             Assert.False(NumberBaseHelper<int>.IsSubnormal(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<int>.IsZero((int)0x00000000));
+            Assert.False(NumberBaseHelper<int>.IsZero((int)0x00000001));
+            Assert.False(NumberBaseHelper<int>.IsZero((int)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<int>.IsZero(unchecked((int)0x80000000)));
+            Assert.False(NumberBaseHelper<int>.IsZero(unchecked((int)0xFFFFFFFF)));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
@@ -545,6 +545,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<long>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal((long)0x0000000000000000, NumberBaseHelper<long>.Zero);
@@ -957,6 +963,36 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<long>.IsCanonical((long)0x0000000000000000));
+            Assert.True(NumberBaseHelper<long>.IsCanonical((long)0x0000000000000001));
+            Assert.True(NumberBaseHelper<long>.IsCanonical((long)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<long>.IsCanonical(unchecked((long)0x8000000000000000)));
+            Assert.True(NumberBaseHelper<long>.IsCanonical(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<long>.IsComplexNumber((long)0x0000000000000000));
+            Assert.False(NumberBaseHelper<long>.IsComplexNumber((long)0x0000000000000001));
+            Assert.False(NumberBaseHelper<long>.IsComplexNumber((long)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<long>.IsComplexNumber(unchecked((long)0x8000000000000000)));
+            Assert.False(NumberBaseHelper<long>.IsComplexNumber(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<long>.IsEvenInteger((long)0x0000000000000000));
+            Assert.False(NumberBaseHelper<long>.IsEvenInteger((long)0x0000000000000001));
+            Assert.False(NumberBaseHelper<long>.IsEvenInteger((long)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<long>.IsEvenInteger(unchecked((long)0x8000000000000000)));
+            Assert.False(NumberBaseHelper<long>.IsEvenInteger(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<long>.IsFinite((long)0x0000000000000000));
@@ -967,6 +1003,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<long>.IsImaginaryNumber((long)0x0000000000000000));
+            Assert.False(NumberBaseHelper<long>.IsImaginaryNumber((long)0x0000000000000001));
+            Assert.False(NumberBaseHelper<long>.IsImaginaryNumber((long)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<long>.IsImaginaryNumber(unchecked((long)0x8000000000000000)));
+            Assert.False(NumberBaseHelper<long>.IsImaginaryNumber(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<long>.IsInfinity((long)0x0000000000000000));
@@ -974,6 +1020,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<long>.IsInfinity((long)0x7FFFFFFFFFFFFFFF));
             Assert.False(NumberBaseHelper<long>.IsInfinity(unchecked((long)0x8000000000000000)));
             Assert.False(NumberBaseHelper<long>.IsInfinity(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<long>.IsInteger((long)0x0000000000000000));
+            Assert.True(NumberBaseHelper<long>.IsInteger((long)0x0000000000000001));
+            Assert.True(NumberBaseHelper<long>.IsInteger((long)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<long>.IsInteger(unchecked((long)0x8000000000000000)));
+            Assert.True(NumberBaseHelper<long>.IsInteger(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]
@@ -1017,6 +1073,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<long>.IsOddInteger((long)0x0000000000000000));
+            Assert.True(NumberBaseHelper<long>.IsOddInteger((long)0x0000000000000001));
+            Assert.True(NumberBaseHelper<long>.IsOddInteger((long)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<long>.IsOddInteger(unchecked((long)0x8000000000000000)));
+            Assert.True(NumberBaseHelper<long>.IsOddInteger(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<long>.IsPositive((long)0x0000000000000000));
+            Assert.True(NumberBaseHelper<long>.IsPositive((long)0x0000000000000001));
+            Assert.True(NumberBaseHelper<long>.IsPositive((long)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<long>.IsPositive(unchecked((long)0x8000000000000000)));
+            Assert.False(NumberBaseHelper<long>.IsPositive(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<long>.IsPositiveInfinity((long)0x0000000000000000));
@@ -1027,6 +1103,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<long>.IsRealNumber((long)0x0000000000000000));
+            Assert.True(NumberBaseHelper<long>.IsRealNumber((long)0x0000000000000001));
+            Assert.True(NumberBaseHelper<long>.IsRealNumber((long)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<long>.IsRealNumber(unchecked((long)0x8000000000000000)));
+            Assert.True(NumberBaseHelper<long>.IsRealNumber(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<long>.IsSubnormal((long)0x0000000000000000));
@@ -1034,6 +1120,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<long>.IsSubnormal((long)0x7FFFFFFFFFFFFFFF));
             Assert.False(NumberBaseHelper<long>.IsSubnormal(unchecked((long)0x8000000000000000)));
             Assert.False(NumberBaseHelper<long>.IsSubnormal(unchecked((long)0xFFFFFFFFFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<long>.IsZero((long)0x0000000000000000));
+            Assert.False(NumberBaseHelper<long>.IsZero((long)0x0000000000000001));
+            Assert.False(NumberBaseHelper<long>.IsZero((long)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<long>.IsZero(unchecked((long)0x8000000000000000)));
+            Assert.False(NumberBaseHelper<long>.IsZero(unchecked((long)0xFFFFFFFFFFFFFFFF)));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
@@ -1041,6 +1041,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<nint>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal((nint)0x00000000, NumberBaseHelper<nint>.Zero);
@@ -1574,6 +1580,69 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nint>.IsCanonical(unchecked((nint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsCanonical(unchecked((nint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nint>.IsCanonical(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nint>.IsCanonical(unchecked((nint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsCanonical(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nint>.IsCanonical((nint)0x00000000));
+                Assert.True(NumberBaseHelper<nint>.IsCanonical((nint)0x00000001));
+                Assert.True(NumberBaseHelper<nint>.IsCanonical((nint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nint>.IsCanonical(unchecked((nint)0x80000000)));
+                Assert.True(NumberBaseHelper<nint>.IsCanonical(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nint>.IsComplexNumber(unchecked((nint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsComplexNumber(unchecked((nint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nint>.IsComplexNumber(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nint>.IsComplexNumber(unchecked((nint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsComplexNumber(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nint>.IsComplexNumber((nint)0x00000000));
+                Assert.False(NumberBaseHelper<nint>.IsComplexNumber((nint)0x00000001));
+                Assert.False(NumberBaseHelper<nint>.IsComplexNumber((nint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nint>.IsComplexNumber(unchecked((nint)0x80000000)));
+                Assert.False(NumberBaseHelper<nint>.IsComplexNumber(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nint>.IsEvenInteger(unchecked((nint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsEvenInteger(unchecked((nint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nint>.IsEvenInteger(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nint>.IsEvenInteger(unchecked((nint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsEvenInteger(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nint>.IsEvenInteger((nint)0x00000000));
+                Assert.False(NumberBaseHelper<nint>.IsEvenInteger((nint)0x00000001));
+                Assert.False(NumberBaseHelper<nint>.IsEvenInteger((nint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nint>.IsEvenInteger(unchecked((nint)0x80000000)));
+                Assert.False(NumberBaseHelper<nint>.IsEvenInteger(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             if (Environment.Is64BitProcess)
@@ -1595,6 +1664,27 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nint>.IsImaginaryNumber(unchecked((nint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsImaginaryNumber(unchecked((nint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nint>.IsImaginaryNumber(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nint>.IsImaginaryNumber(unchecked((nint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsImaginaryNumber(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nint>.IsImaginaryNumber((nint)0x00000000));
+                Assert.False(NumberBaseHelper<nint>.IsImaginaryNumber((nint)0x00000001));
+                Assert.False(NumberBaseHelper<nint>.IsImaginaryNumber((nint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nint>.IsImaginaryNumber(unchecked((nint)0x80000000)));
+                Assert.False(NumberBaseHelper<nint>.IsImaginaryNumber(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             if (Environment.Is64BitProcess)
@@ -1612,6 +1702,27 @@ namespace System.Tests
                 Assert.False(NumberBaseHelper<nint>.IsInfinity((nint)0x7FFFFFFF));
                 Assert.False(NumberBaseHelper<nint>.IsInfinity(unchecked((nint)0x80000000)));
                 Assert.False(NumberBaseHelper<nint>.IsInfinity(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nint>.IsInteger(unchecked((nint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsInteger(unchecked((nint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nint>.IsInteger(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nint>.IsInteger(unchecked((nint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsInteger(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nint>.IsInteger((nint)0x00000000));
+                Assert.True(NumberBaseHelper<nint>.IsInteger((nint)0x00000001));
+                Assert.True(NumberBaseHelper<nint>.IsInteger((nint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nint>.IsInteger(unchecked((nint)0x80000000)));
+                Assert.True(NumberBaseHelper<nint>.IsInteger(unchecked((nint)0xFFFFFFFF)));
             }
         }
 
@@ -1700,6 +1811,48 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nint>.IsOddInteger(unchecked((nint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsOddInteger(unchecked((nint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nint>.IsOddInteger(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nint>.IsOddInteger(unchecked((nint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsOddInteger(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nint>.IsOddInteger((nint)0x00000000));
+                Assert.True(NumberBaseHelper<nint>.IsOddInteger((nint)0x00000001));
+                Assert.True(NumberBaseHelper<nint>.IsOddInteger((nint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nint>.IsOddInteger(unchecked((nint)0x80000000)));
+                Assert.True(NumberBaseHelper<nint>.IsOddInteger(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nint>.IsPositive(unchecked((nint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsPositive(unchecked((nint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nint>.IsPositive(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nint>.IsPositive(unchecked((nint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsPositive(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nint>.IsPositive((nint)0x00000000));
+                Assert.True(NumberBaseHelper<nint>.IsPositive((nint)0x00000001));
+                Assert.True(NumberBaseHelper<nint>.IsPositive((nint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nint>.IsPositive(unchecked((nint)0x80000000)));
+                Assert.False(NumberBaseHelper<nint>.IsPositive(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             if (Environment.Is64BitProcess)
@@ -1721,6 +1874,27 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nint>.IsRealNumber(unchecked((nint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsRealNumber(unchecked((nint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nint>.IsRealNumber(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nint>.IsRealNumber(unchecked((nint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nint>.IsRealNumber(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nint>.IsRealNumber((nint)0x00000000));
+                Assert.True(NumberBaseHelper<nint>.IsRealNumber((nint)0x00000001));
+                Assert.True(NumberBaseHelper<nint>.IsRealNumber((nint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nint>.IsRealNumber(unchecked((nint)0x80000000)));
+                Assert.True(NumberBaseHelper<nint>.IsRealNumber(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             if (Environment.Is64BitProcess)
@@ -1738,6 +1912,27 @@ namespace System.Tests
                 Assert.False(NumberBaseHelper<nint>.IsSubnormal((nint)0x7FFFFFFF));
                 Assert.False(NumberBaseHelper<nint>.IsSubnormal(unchecked((nint)0x80000000)));
                 Assert.False(NumberBaseHelper<nint>.IsSubnormal(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nint>.IsZero(unchecked((nint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsZero(unchecked((nint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nint>.IsZero(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nint>.IsZero(unchecked((nint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nint>.IsZero(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nint>.IsZero((nint)0x00000000));
+                Assert.False(NumberBaseHelper<nint>.IsZero((nint)0x00000001));
+                Assert.False(NumberBaseHelper<nint>.IsZero((nint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nint>.IsZero(unchecked((nint)0x80000000)));
+                Assert.False(NumberBaseHelper<nint>.IsZero(unchecked((nint)0xFFFFFFFF)));
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
@@ -545,6 +545,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<sbyte>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal((sbyte)0x00, NumberBaseHelper<sbyte>.Zero);
@@ -957,6 +963,36 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<sbyte>.IsCanonical((sbyte)0x00));
+            Assert.True(NumberBaseHelper<sbyte>.IsCanonical((sbyte)0x01));
+            Assert.True(NumberBaseHelper<sbyte>.IsCanonical((sbyte)0x7F));
+            Assert.True(NumberBaseHelper<sbyte>.IsCanonical(unchecked((sbyte)0x80)));
+            Assert.True(NumberBaseHelper<sbyte>.IsCanonical(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<sbyte>.IsComplexNumber((sbyte)0x00));
+            Assert.False(NumberBaseHelper<sbyte>.IsComplexNumber((sbyte)0x01));
+            Assert.False(NumberBaseHelper<sbyte>.IsComplexNumber((sbyte)0x7F));
+            Assert.False(NumberBaseHelper<sbyte>.IsComplexNumber(unchecked((sbyte)0x80)));
+            Assert.False(NumberBaseHelper<sbyte>.IsComplexNumber(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<sbyte>.IsEvenInteger((sbyte)0x00));
+            Assert.False(NumberBaseHelper<sbyte>.IsEvenInteger((sbyte)0x01));
+            Assert.False(NumberBaseHelper<sbyte>.IsEvenInteger((sbyte)0x7F));
+            Assert.True(NumberBaseHelper<sbyte>.IsEvenInteger(unchecked((sbyte)0x80)));
+            Assert.False(NumberBaseHelper<sbyte>.IsEvenInteger(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<sbyte>.IsFinite((sbyte)0x00));
@@ -967,6 +1003,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<sbyte>.IsImaginaryNumber((sbyte)0x00));
+            Assert.False(NumberBaseHelper<sbyte>.IsImaginaryNumber((sbyte)0x01));
+            Assert.False(NumberBaseHelper<sbyte>.IsImaginaryNumber((sbyte)0x7F));
+            Assert.False(NumberBaseHelper<sbyte>.IsImaginaryNumber(unchecked((sbyte)0x80)));
+            Assert.False(NumberBaseHelper<sbyte>.IsImaginaryNumber(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<sbyte>.IsInfinity((sbyte)0x00));
@@ -974,6 +1020,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<sbyte>.IsInfinity((sbyte)0x7F));
             Assert.False(NumberBaseHelper<sbyte>.IsInfinity(unchecked((sbyte)0x80)));
             Assert.False(NumberBaseHelper<sbyte>.IsInfinity(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<sbyte>.IsInteger((sbyte)0x00));
+            Assert.True(NumberBaseHelper<sbyte>.IsInteger((sbyte)0x01));
+            Assert.True(NumberBaseHelper<sbyte>.IsInteger((sbyte)0x7F));
+            Assert.True(NumberBaseHelper<sbyte>.IsInteger(unchecked((sbyte)0x80)));
+            Assert.True(NumberBaseHelper<sbyte>.IsInteger(unchecked((sbyte)0xFF)));
         }
 
         [Fact]
@@ -1017,6 +1073,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<sbyte>.IsOddInteger((sbyte)0x00));
+            Assert.True(NumberBaseHelper<sbyte>.IsOddInteger((sbyte)0x01));
+            Assert.True(NumberBaseHelper<sbyte>.IsOddInteger((sbyte)0x7F));
+            Assert.False(NumberBaseHelper<sbyte>.IsOddInteger(unchecked((sbyte)0x80)));
+            Assert.True(NumberBaseHelper<sbyte>.IsOddInteger(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<sbyte>.IsPositive((sbyte)0x00));
+            Assert.True(NumberBaseHelper<sbyte>.IsPositive((sbyte)0x01));
+            Assert.True(NumberBaseHelper<sbyte>.IsPositive((sbyte)0x7F));
+            Assert.False(NumberBaseHelper<sbyte>.IsPositive(unchecked((sbyte)0x80)));
+            Assert.False(NumberBaseHelper<sbyte>.IsPositive(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<sbyte>.IsPositiveInfinity((sbyte)0x00));
@@ -1027,6 +1103,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<sbyte>.IsRealNumber((sbyte)0x00));
+            Assert.True(NumberBaseHelper<sbyte>.IsRealNumber((sbyte)0x01));
+            Assert.True(NumberBaseHelper<sbyte>.IsRealNumber((sbyte)0x7F));
+            Assert.True(NumberBaseHelper<sbyte>.IsRealNumber(unchecked((sbyte)0x80)));
+            Assert.True(NumberBaseHelper<sbyte>.IsRealNumber(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<sbyte>.IsSubnormal((sbyte)0x00));
@@ -1034,6 +1120,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<sbyte>.IsSubnormal((sbyte)0x7F));
             Assert.False(NumberBaseHelper<sbyte>.IsSubnormal(unchecked((sbyte)0x80)));
             Assert.False(NumberBaseHelper<sbyte>.IsSubnormal(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<sbyte>.IsZero((sbyte)0x00));
+            Assert.False(NumberBaseHelper<sbyte>.IsZero((sbyte)0x01));
+            Assert.False(NumberBaseHelper<sbyte>.IsZero((sbyte)0x7F));
+            Assert.False(NumberBaseHelper<sbyte>.IsZero(unchecked((sbyte)0x80)));
+            Assert.False(NumberBaseHelper<sbyte>.IsZero(unchecked((sbyte)0xFF)));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
@@ -988,6 +988,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<float>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.Zero);
@@ -1482,6 +1488,66 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<float>.IsCanonical(float.NegativeInfinity));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(float.MinValue));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(-1.0f));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(-MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(-float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(-0.0f));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(float.NaN));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(0.0f));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(MaxSubnormal));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(1.0f));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(float.MaxValue));
+            Assert.True(NumberBaseHelper<float>.IsCanonical(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(float.NegativeInfinity));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(float.MinValue));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(-float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(float.NaN));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(1.0f));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsComplexNumber(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsEvenInteger(float.NegativeInfinity));
+            Assert.True(NumberBaseHelper<float>.IsEvenInteger(float.MinValue));
+            Assert.False(NumberBaseHelper<float>.IsEvenInteger(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsEvenInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsEvenInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsEvenInteger(-float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsEvenInteger(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsEvenInteger(float.NaN));
+            Assert.True(NumberBaseHelper<float>.IsEvenInteger(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsEvenInteger(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsEvenInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsEvenInteger(MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsEvenInteger(1.0f));
+            Assert.True(NumberBaseHelper<float>.IsEvenInteger(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsEvenInteger(float.PositiveInfinity));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.False(NumberBaseHelper<float>.IsFinite(float.NegativeInfinity));
@@ -1502,6 +1568,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(float.NegativeInfinity));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(float.MinValue));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(-float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(float.NaN));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(1.0f));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsImaginaryNumber(float.PositiveInfinity));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.True(NumberBaseHelper<float>.IsInfinity(float.NegativeInfinity));
@@ -1519,6 +1605,26 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<float>.IsInfinity(1.0f));
             Assert.False(NumberBaseHelper<float>.IsInfinity(float.MaxValue));
             Assert.True(NumberBaseHelper<float>.IsInfinity(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsInteger(float.NegativeInfinity));
+            Assert.True(NumberBaseHelper<float>.IsInteger(float.MinValue));
+            Assert.True(NumberBaseHelper<float>.IsInteger(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsInteger(-float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsInteger(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsInteger(float.NaN));
+            Assert.True(NumberBaseHelper<float>.IsInteger(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsInteger(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsInteger(MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsInteger(1.0f));
+            Assert.True(NumberBaseHelper<float>.IsInteger(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsInteger(float.PositiveInfinity));
         }
 
         [Fact]
@@ -1602,6 +1708,46 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(float.NegativeInfinity));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(float.MinValue));
+            Assert.True(NumberBaseHelper<float>.IsOddInteger(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(-float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(float.NaN));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsOddInteger(1.0f));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsOddInteger(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsPositive(float.NegativeInfinity));
+            Assert.False(NumberBaseHelper<float>.IsPositive(float.MinValue));
+            Assert.False(NumberBaseHelper<float>.IsPositive(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsPositive(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsPositive(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsPositive(-float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsPositive(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsPositive(float.NaN));
+            Assert.True(NumberBaseHelper<float>.IsPositive(0.0f));
+            Assert.True(NumberBaseHelper<float>.IsPositive(float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsPositive(MaxSubnormal));
+            Assert.True(NumberBaseHelper<float>.IsPositive(MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsPositive(1.0f));
+            Assert.True(NumberBaseHelper<float>.IsPositive(float.MaxValue));
+            Assert.True(NumberBaseHelper<float>.IsPositive(float.PositiveInfinity));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<float>.IsPositiveInfinity(float.NegativeInfinity));
@@ -1622,6 +1768,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(float.NegativeInfinity));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(float.MinValue));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(-1.0f));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(-MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(-MaxSubnormal));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(-float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsRealNumber(float.NaN));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(0.0f));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(MaxSubnormal));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(MinNormal));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(1.0f));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(float.MaxValue));
+            Assert.True(NumberBaseHelper<float>.IsRealNumber(float.PositiveInfinity));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<float>.IsSubnormal(float.NegativeInfinity));
@@ -1639,6 +1805,26 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<float>.IsSubnormal(1.0f));
             Assert.False(NumberBaseHelper<float>.IsSubnormal(float.MaxValue));
             Assert.False(NumberBaseHelper<float>.IsSubnormal(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.False(NumberBaseHelper<float>.IsZero(float.NegativeInfinity));
+            Assert.False(NumberBaseHelper<float>.IsZero(float.MinValue));
+            Assert.False(NumberBaseHelper<float>.IsZero(-1.0f));
+            Assert.False(NumberBaseHelper<float>.IsZero(-MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsZero(-MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsZero(-float.Epsilon));
+            Assert.True(NumberBaseHelper<float>.IsZero(-0.0f));
+            Assert.False(NumberBaseHelper<float>.IsZero(float.NaN));
+            Assert.True(NumberBaseHelper<float>.IsZero(0.0f));
+            Assert.False(NumberBaseHelper<float>.IsZero(float.Epsilon));
+            Assert.False(NumberBaseHelper<float>.IsZero(MaxSubnormal));
+            Assert.False(NumberBaseHelper<float>.IsZero(MinNormal));
+            Assert.False(NumberBaseHelper<float>.IsZero(1.0f));
+            Assert.False(NumberBaseHelper<float>.IsZero(float.MaxValue));
+            Assert.False(NumberBaseHelper<float>.IsZero(float.PositiveInfinity));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt128Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt128Tests.GenericMath.cs
@@ -594,6 +594,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<UInt128>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal(Zero, NumberBaseHelper<UInt128>.Zero);
@@ -1231,6 +1237,36 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<UInt128>.IsCanonical(Zero));
+            Assert.True(NumberBaseHelper<UInt128>.IsCanonical(One));
+            Assert.True(NumberBaseHelper<UInt128>.IsCanonical(Int128MaxValue));
+            Assert.True(NumberBaseHelper<UInt128>.IsCanonical(Int128MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<UInt128>.IsCanonical(MaxValue));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<UInt128>.IsComplexNumber(Zero));
+            Assert.False(NumberBaseHelper<UInt128>.IsComplexNumber(One));
+            Assert.False(NumberBaseHelper<UInt128>.IsComplexNumber(Int128MaxValue));
+            Assert.False(NumberBaseHelper<UInt128>.IsComplexNumber(Int128MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<UInt128>.IsComplexNumber(MaxValue));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<UInt128>.IsEvenInteger(Zero));
+            Assert.False(NumberBaseHelper<UInt128>.IsEvenInteger(One));
+            Assert.False(NumberBaseHelper<UInt128>.IsEvenInteger(Int128MaxValue));
+            Assert.True(NumberBaseHelper<UInt128>.IsEvenInteger(Int128MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<UInt128>.IsEvenInteger(MaxValue));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<UInt128>.IsFinite(Zero));
@@ -1241,6 +1277,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<UInt128>.IsImaginaryNumber(Zero));
+            Assert.False(NumberBaseHelper<UInt128>.IsImaginaryNumber(One));
+            Assert.False(NumberBaseHelper<UInt128>.IsImaginaryNumber(Int128MaxValue));
+            Assert.False(NumberBaseHelper<UInt128>.IsImaginaryNumber(Int128MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<UInt128>.IsImaginaryNumber(MaxValue));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<UInt128>.IsInfinity(Zero));
@@ -1248,6 +1294,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<UInt128>.IsInfinity(Int128MaxValue));
             Assert.False(NumberBaseHelper<UInt128>.IsInfinity(Int128MaxValuePlusOne));
             Assert.False(NumberBaseHelper<UInt128>.IsInfinity(MaxValue));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<UInt128>.IsInteger(Zero));
+            Assert.True(NumberBaseHelper<UInt128>.IsInteger(One));
+            Assert.True(NumberBaseHelper<UInt128>.IsInteger(Int128MaxValue));
+            Assert.True(NumberBaseHelper<UInt128>.IsInteger(Int128MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<UInt128>.IsInteger(MaxValue));
         }
 
         [Fact]
@@ -1291,6 +1347,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<UInt128>.IsOddInteger(Zero));
+            Assert.True(NumberBaseHelper<UInt128>.IsOddInteger(One));
+            Assert.True(NumberBaseHelper<UInt128>.IsOddInteger(Int128MaxValue));
+            Assert.False(NumberBaseHelper<UInt128>.IsOddInteger(Int128MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<UInt128>.IsOddInteger(MaxValue));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<UInt128>.IsPositive(Zero));
+            Assert.True(NumberBaseHelper<UInt128>.IsPositive(One));
+            Assert.True(NumberBaseHelper<UInt128>.IsPositive(Int128MaxValue));
+            Assert.True(NumberBaseHelper<UInt128>.IsPositive(Int128MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<UInt128>.IsPositive(MaxValue));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<UInt128>.IsPositiveInfinity(Zero));
@@ -1301,6 +1377,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<UInt128>.IsRealNumber(Zero));
+            Assert.True(NumberBaseHelper<UInt128>.IsRealNumber(One));
+            Assert.True(NumberBaseHelper<UInt128>.IsRealNumber(Int128MaxValue));
+            Assert.True(NumberBaseHelper<UInt128>.IsRealNumber(Int128MaxValuePlusOne));
+            Assert.True(NumberBaseHelper<UInt128>.IsRealNumber(MaxValue));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<UInt128>.IsSubnormal(Zero));
@@ -1308,6 +1394,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<UInt128>.IsSubnormal(Int128MaxValue));
             Assert.False(NumberBaseHelper<UInt128>.IsSubnormal(Int128MaxValuePlusOne));
             Assert.False(NumberBaseHelper<UInt128>.IsSubnormal(MaxValue));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<UInt128>.IsZero(Zero));
+            Assert.False(NumberBaseHelper<UInt128>.IsZero(One));
+            Assert.False(NumberBaseHelper<UInt128>.IsZero(Int128MaxValue));
+            Assert.False(NumberBaseHelper<UInt128>.IsZero(Int128MaxValuePlusOne));
+            Assert.False(NumberBaseHelper<UInt128>.IsZero(MaxValue));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
@@ -545,6 +545,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<ushort>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.Zero);
@@ -957,6 +963,36 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<ushort>.IsCanonical((ushort)0x0000));
+            Assert.True(NumberBaseHelper<ushort>.IsCanonical((ushort)0x0001));
+            Assert.True(NumberBaseHelper<ushort>.IsCanonical((ushort)0x7FFF));
+            Assert.True(NumberBaseHelper<ushort>.IsCanonical((ushort)0x8000));
+            Assert.True(NumberBaseHelper<ushort>.IsCanonical((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<ushort>.IsComplexNumber((ushort)0x0000));
+            Assert.False(NumberBaseHelper<ushort>.IsComplexNumber((ushort)0x0001));
+            Assert.False(NumberBaseHelper<ushort>.IsComplexNumber((ushort)0x7FFF));
+            Assert.False(NumberBaseHelper<ushort>.IsComplexNumber((ushort)0x8000));
+            Assert.False(NumberBaseHelper<ushort>.IsComplexNumber((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<ushort>.IsEvenInteger((ushort)0x0000));
+            Assert.False(NumberBaseHelper<ushort>.IsEvenInteger((ushort)0x0001));
+            Assert.False(NumberBaseHelper<ushort>.IsEvenInteger((ushort)0x7FFF));
+            Assert.True(NumberBaseHelper<ushort>.IsEvenInteger((ushort)0x8000));
+            Assert.False(NumberBaseHelper<ushort>.IsEvenInteger((ushort)0xFFFF));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<ushort>.IsFinite((ushort)0x0000));
@@ -967,6 +1003,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<ushort>.IsImaginaryNumber((ushort)0x0000));
+            Assert.False(NumberBaseHelper<ushort>.IsImaginaryNumber((ushort)0x0001));
+            Assert.False(NumberBaseHelper<ushort>.IsImaginaryNumber((ushort)0x7FFF));
+            Assert.False(NumberBaseHelper<ushort>.IsImaginaryNumber((ushort)0x8000));
+            Assert.False(NumberBaseHelper<ushort>.IsImaginaryNumber((ushort)0xFFFF));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<ushort>.IsInfinity((ushort)0x0000));
@@ -974,6 +1020,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<ushort>.IsInfinity((ushort)0x7FFF));
             Assert.False(NumberBaseHelper<ushort>.IsInfinity((ushort)0x8000));
             Assert.False(NumberBaseHelper<ushort>.IsInfinity((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<ushort>.IsInteger((ushort)0x0000));
+            Assert.True(NumberBaseHelper<ushort>.IsInteger((ushort)0x0001));
+            Assert.True(NumberBaseHelper<ushort>.IsInteger((ushort)0x7FFF));
+            Assert.True(NumberBaseHelper<ushort>.IsInteger((ushort)0x8000));
+            Assert.True(NumberBaseHelper<ushort>.IsInteger((ushort)0xFFFF));
         }
 
         [Fact]
@@ -1017,6 +1073,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<ushort>.IsOddInteger((ushort)0x0000));
+            Assert.True(NumberBaseHelper<ushort>.IsOddInteger((ushort)0x0001));
+            Assert.True(NumberBaseHelper<ushort>.IsOddInteger((ushort)0x7FFF));
+            Assert.False(NumberBaseHelper<ushort>.IsOddInteger((ushort)0x8000));
+            Assert.True(NumberBaseHelper<ushort>.IsOddInteger((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<ushort>.IsPositive((ushort)0x0000));
+            Assert.True(NumberBaseHelper<ushort>.IsPositive((ushort)0x0001));
+            Assert.True(NumberBaseHelper<ushort>.IsPositive((ushort)0x7FFF));
+            Assert.True(NumberBaseHelper<ushort>.IsPositive((ushort)0x8000));
+            Assert.True(NumberBaseHelper<ushort>.IsPositive((ushort)0xFFFF));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<ushort>.IsPositiveInfinity((ushort)0x0000));
@@ -1027,6 +1103,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<ushort>.IsRealNumber((ushort)0x0000));
+            Assert.True(NumberBaseHelper<ushort>.IsRealNumber((ushort)0x0001));
+            Assert.True(NumberBaseHelper<ushort>.IsRealNumber((ushort)0x7FFF));
+            Assert.True(NumberBaseHelper<ushort>.IsRealNumber((ushort)0x8000));
+            Assert.True(NumberBaseHelper<ushort>.IsRealNumber((ushort)0xFFFF));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<ushort>.IsSubnormal((ushort)0x0000));
@@ -1034,6 +1120,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<ushort>.IsSubnormal((ushort)0x7FFF));
             Assert.False(NumberBaseHelper<ushort>.IsSubnormal((ushort)0x8000));
             Assert.False(NumberBaseHelper<ushort>.IsSubnormal((ushort)0xFFFF));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<ushort>.IsZero((ushort)0x0000));
+            Assert.False(NumberBaseHelper<ushort>.IsZero((ushort)0x0001));
+            Assert.False(NumberBaseHelper<ushort>.IsZero((ushort)0x7FFF));
+            Assert.False(NumberBaseHelper<ushort>.IsZero((ushort)0x8000));
+            Assert.False(NumberBaseHelper<ushort>.IsZero((ushort)0xFFFF));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
@@ -546,6 +546,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<uint>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal((uint)0x00000000, NumberBaseHelper<uint>.Zero);
@@ -958,6 +964,36 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<uint>.IsCanonical((uint)0x00000000));
+            Assert.True(NumberBaseHelper<uint>.IsCanonical((uint)0x00000001));
+            Assert.True(NumberBaseHelper<uint>.IsCanonical((uint)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<uint>.IsCanonical((uint)0x80000000));
+            Assert.True(NumberBaseHelper<uint>.IsCanonical((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<uint>.IsComplexNumber((uint)0x00000000));
+            Assert.False(NumberBaseHelper<uint>.IsComplexNumber((uint)0x00000001));
+            Assert.False(NumberBaseHelper<uint>.IsComplexNumber((uint)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<uint>.IsComplexNumber((uint)0x80000000));
+            Assert.False(NumberBaseHelper<uint>.IsComplexNumber((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<uint>.IsEvenInteger((uint)0x00000000));
+            Assert.False(NumberBaseHelper<uint>.IsEvenInteger((uint)0x00000001));
+            Assert.False(NumberBaseHelper<uint>.IsEvenInteger((uint)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<uint>.IsEvenInteger((uint)0x80000000));
+            Assert.False(NumberBaseHelper<uint>.IsEvenInteger((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<uint>.IsFinite((uint)0x00000000));
@@ -968,6 +1004,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<uint>.IsImaginaryNumber((uint)0x00000000));
+            Assert.False(NumberBaseHelper<uint>.IsImaginaryNumber((uint)0x00000001));
+            Assert.False(NumberBaseHelper<uint>.IsImaginaryNumber((uint)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<uint>.IsImaginaryNumber((uint)0x80000000));
+            Assert.False(NumberBaseHelper<uint>.IsImaginaryNumber((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<uint>.IsInfinity((uint)0x00000000));
@@ -975,6 +1021,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<uint>.IsInfinity((uint)0x7FFFFFFF));
             Assert.False(NumberBaseHelper<uint>.IsInfinity((uint)0x80000000));
             Assert.False(NumberBaseHelper<uint>.IsInfinity((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<uint>.IsInteger((uint)0x00000000));
+            Assert.True(NumberBaseHelper<uint>.IsInteger((uint)0x00000001));
+            Assert.True(NumberBaseHelper<uint>.IsInteger((uint)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<uint>.IsInteger((uint)0x80000000));
+            Assert.True(NumberBaseHelper<uint>.IsInteger((uint)0xFFFFFFFF));
         }
 
         [Fact]
@@ -1018,6 +1074,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<uint>.IsOddInteger((uint)0x00000000));
+            Assert.True(NumberBaseHelper<uint>.IsOddInteger((uint)0x00000001));
+            Assert.True(NumberBaseHelper<uint>.IsOddInteger((uint)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<uint>.IsOddInteger((uint)0x80000000));
+            Assert.True(NumberBaseHelper<uint>.IsOddInteger((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<uint>.IsPositive((uint)0x00000000));
+            Assert.True(NumberBaseHelper<uint>.IsPositive((uint)0x00000001));
+            Assert.True(NumberBaseHelper<uint>.IsPositive((uint)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<uint>.IsPositive((uint)0x80000000));
+            Assert.True(NumberBaseHelper<uint>.IsPositive((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<uint>.IsPositiveInfinity((uint)0x00000000));
@@ -1028,6 +1104,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<uint>.IsRealNumber((uint)0x00000000));
+            Assert.True(NumberBaseHelper<uint>.IsRealNumber((uint)0x00000001));
+            Assert.True(NumberBaseHelper<uint>.IsRealNumber((uint)0x7FFFFFFF));
+            Assert.True(NumberBaseHelper<uint>.IsRealNumber((uint)0x80000000));
+            Assert.True(NumberBaseHelper<uint>.IsRealNumber((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<uint>.IsSubnormal((uint)0x00000000));
@@ -1035,6 +1121,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<uint>.IsSubnormal((uint)0x7FFFFFFF));
             Assert.False(NumberBaseHelper<uint>.IsSubnormal((uint)0x80000000));
             Assert.False(NumberBaseHelper<uint>.IsSubnormal((uint)0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<uint>.IsZero((uint)0x00000000));
+            Assert.False(NumberBaseHelper<uint>.IsZero((uint)0x00000001));
+            Assert.False(NumberBaseHelper<uint>.IsZero((uint)0x7FFFFFFF));
+            Assert.False(NumberBaseHelper<uint>.IsZero((uint)0x80000000));
+            Assert.False(NumberBaseHelper<uint>.IsZero((uint)0xFFFFFFFF));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
@@ -544,6 +544,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<ulong>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal((ulong)0x0000000000000000, NumberBaseHelper<ulong>.Zero);
@@ -956,6 +962,36 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            Assert.True(NumberBaseHelper<ulong>.IsCanonical((ulong)0x0000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsCanonical((ulong)0x0000000000000001));
+            Assert.True(NumberBaseHelper<ulong>.IsCanonical((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<ulong>.IsCanonical((ulong)0x8000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsCanonical((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            Assert.False(NumberBaseHelper<ulong>.IsComplexNumber((ulong)0x0000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsComplexNumber((ulong)0x0000000000000001));
+            Assert.False(NumberBaseHelper<ulong>.IsComplexNumber((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<ulong>.IsComplexNumber((ulong)0x8000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsComplexNumber((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<ulong>.IsEvenInteger((ulong)0x0000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsEvenInteger((ulong)0x0000000000000001));
+            Assert.False(NumberBaseHelper<ulong>.IsEvenInteger((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<ulong>.IsEvenInteger((ulong)0x8000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsEvenInteger((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             Assert.True(NumberBaseHelper<ulong>.IsFinite((ulong)0x0000000000000000));
@@ -966,6 +1002,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            Assert.False(NumberBaseHelper<ulong>.IsImaginaryNumber((ulong)0x0000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsImaginaryNumber((ulong)0x0000000000000001));
+            Assert.False(NumberBaseHelper<ulong>.IsImaginaryNumber((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<ulong>.IsImaginaryNumber((ulong)0x8000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsImaginaryNumber((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             Assert.False(NumberBaseHelper<ulong>.IsInfinity((ulong)0x0000000000000000));
@@ -973,6 +1019,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<ulong>.IsInfinity((ulong)0x7FFFFFFFFFFFFFFF));
             Assert.False(NumberBaseHelper<ulong>.IsInfinity((ulong)0x8000000000000000));
             Assert.False(NumberBaseHelper<ulong>.IsInfinity((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            Assert.True(NumberBaseHelper<ulong>.IsInteger((ulong)0x0000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsInteger((ulong)0x0000000000000001));
+            Assert.True(NumberBaseHelper<ulong>.IsInteger((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<ulong>.IsInteger((ulong)0x8000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsInteger((ulong)0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]
@@ -1016,6 +1072,26 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            Assert.False(NumberBaseHelper<ulong>.IsOddInteger((ulong)0x0000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsOddInteger((ulong)0x0000000000000001));
+            Assert.True(NumberBaseHelper<ulong>.IsOddInteger((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<ulong>.IsOddInteger((ulong)0x8000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsOddInteger((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            Assert.True(NumberBaseHelper<ulong>.IsPositive((ulong)0x0000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsPositive((ulong)0x0000000000000001));
+            Assert.True(NumberBaseHelper<ulong>.IsPositive((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<ulong>.IsPositive((ulong)0x8000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsPositive((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             Assert.False(NumberBaseHelper<ulong>.IsPositiveInfinity((ulong)0x0000000000000000));
@@ -1026,6 +1102,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            Assert.True(NumberBaseHelper<ulong>.IsRealNumber((ulong)0x0000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsRealNumber((ulong)0x0000000000000001));
+            Assert.True(NumberBaseHelper<ulong>.IsRealNumber((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.True(NumberBaseHelper<ulong>.IsRealNumber((ulong)0x8000000000000000));
+            Assert.True(NumberBaseHelper<ulong>.IsRealNumber((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             Assert.False(NumberBaseHelper<ulong>.IsSubnormal((ulong)0x0000000000000000));
@@ -1033,6 +1119,16 @@ namespace System.Tests
             Assert.False(NumberBaseHelper<ulong>.IsSubnormal((ulong)0x7FFFFFFFFFFFFFFF));
             Assert.False(NumberBaseHelper<ulong>.IsSubnormal((ulong)0x8000000000000000));
             Assert.False(NumberBaseHelper<ulong>.IsSubnormal((ulong)0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            Assert.True(NumberBaseHelper<ulong>.IsZero((ulong)0x0000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsZero((ulong)0x0000000000000001));
+            Assert.False(NumberBaseHelper<ulong>.IsZero((ulong)0x7FFFFFFFFFFFFFFF));
+            Assert.False(NumberBaseHelper<ulong>.IsZero((ulong)0x8000000000000000));
+            Assert.False(NumberBaseHelper<ulong>.IsZero((ulong)0xFFFFFFFFFFFFFFFF));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
@@ -1033,6 +1033,12 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void RadixTest()
+        {
+            Assert.Equal(2, NumberBaseHelper<nuint>.Radix);
+        }
+
+        [Fact]
         public static void ZeroTest()
         {
             Assert.Equal((nuint)0x00000000, NumberBaseHelper<nuint>.Zero);
@@ -1555,6 +1561,69 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsCanonicalTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsCanonical(unchecked((nuint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsCanonical(unchecked((nuint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nuint>.IsCanonical(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nuint>.IsCanonical(unchecked((nuint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsCanonical(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsCanonical((nuint)0x00000000));
+                Assert.True(NumberBaseHelper<nuint>.IsCanonical((nuint)0x00000001));
+                Assert.True(NumberBaseHelper<nuint>.IsCanonical((nuint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nuint>.IsCanonical((nuint)0x80000000));
+                Assert.True(NumberBaseHelper<nuint>.IsCanonical((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsComplexNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsComplexNumber(unchecked((nuint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsComplexNumber(unchecked((nuint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nuint>.IsComplexNumber(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nuint>.IsComplexNumber(unchecked((nuint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsComplexNumber(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsComplexNumber((nuint)0x00000000));
+                Assert.False(NumberBaseHelper<nuint>.IsComplexNumber((nuint)0x00000001));
+                Assert.False(NumberBaseHelper<nuint>.IsComplexNumber((nuint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nuint>.IsComplexNumber((nuint)0x80000000));
+                Assert.False(NumberBaseHelper<nuint>.IsComplexNumber((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsEvenIntegerTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsEvenInteger(unchecked((nuint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsEvenInteger(unchecked((nuint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nuint>.IsEvenInteger(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nuint>.IsEvenInteger(unchecked((nuint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsEvenInteger(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsEvenInteger((nuint)0x00000000));
+                Assert.False(NumberBaseHelper<nuint>.IsEvenInteger((nuint)0x00000001));
+                Assert.False(NumberBaseHelper<nuint>.IsEvenInteger((nuint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nuint>.IsEvenInteger((nuint)0x80000000));
+                Assert.False(NumberBaseHelper<nuint>.IsEvenInteger((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
         public static void IsFiniteTest()
         {
             if (Environment.Is64BitProcess)
@@ -1576,6 +1645,27 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsImaginaryNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsImaginaryNumber(unchecked((nuint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsImaginaryNumber(unchecked((nuint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nuint>.IsImaginaryNumber(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nuint>.IsImaginaryNumber(unchecked((nuint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsImaginaryNumber(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsImaginaryNumber((nuint)0x00000000));
+                Assert.False(NumberBaseHelper<nuint>.IsImaginaryNumber((nuint)0x00000001));
+                Assert.False(NumberBaseHelper<nuint>.IsImaginaryNumber((nuint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nuint>.IsImaginaryNumber((nuint)0x80000000));
+                Assert.False(NumberBaseHelper<nuint>.IsImaginaryNumber((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
         public static void IsInfinityTest()
         {
             if (Environment.Is64BitProcess)
@@ -1593,6 +1683,27 @@ namespace System.Tests
                 Assert.False(NumberBaseHelper<nuint>.IsInfinity((nuint)0x7FFFFFFF));
                 Assert.False(NumberBaseHelper<nuint>.IsInfinity((nuint)0x80000000));
                 Assert.False(NumberBaseHelper<nuint>.IsInfinity((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsIntegerTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsInteger(unchecked((nuint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsInteger(unchecked((nuint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nuint>.IsInteger(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nuint>.IsInteger(unchecked((nuint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsInteger(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsInteger((nuint)0x00000000));
+                Assert.True(NumberBaseHelper<nuint>.IsInteger((nuint)0x00000001));
+                Assert.True(NumberBaseHelper<nuint>.IsInteger((nuint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nuint>.IsInteger((nuint)0x80000000));
+                Assert.True(NumberBaseHelper<nuint>.IsInteger((nuint)0xFFFFFFFF));
             }
         }
 
@@ -1681,6 +1792,48 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsOddIntegerTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsOddInteger(unchecked((nuint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsOddInteger(unchecked((nuint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nuint>.IsOddInteger(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nuint>.IsOddInteger(unchecked((nuint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsOddInteger(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.False(NumberBaseHelper<nuint>.IsOddInteger((nuint)0x00000000));
+                Assert.True(NumberBaseHelper<nuint>.IsOddInteger((nuint)0x00000001));
+                Assert.True(NumberBaseHelper<nuint>.IsOddInteger((nuint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nuint>.IsOddInteger((nuint)0x80000000));
+                Assert.True(NumberBaseHelper<nuint>.IsOddInteger((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsPositiveTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsPositive(unchecked((nuint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsPositive(unchecked((nuint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nuint>.IsPositive(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nuint>.IsPositive(unchecked((nuint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsPositive(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsPositive((nuint)0x00000000));
+                Assert.True(NumberBaseHelper<nuint>.IsPositive((nuint)0x00000001));
+                Assert.True(NumberBaseHelper<nuint>.IsPositive((nuint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nuint>.IsPositive((nuint)0x80000000));
+                Assert.True(NumberBaseHelper<nuint>.IsPositive((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
         public static void IsPositiveInfinityTest()
         {
             if (Environment.Is64BitProcess)
@@ -1702,6 +1855,27 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsRealNumberTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsRealNumber(unchecked((nuint)0x0000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsRealNumber(unchecked((nuint)0x0000000000000001)));
+                Assert.True(NumberBaseHelper<nuint>.IsRealNumber(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.True(NumberBaseHelper<nuint>.IsRealNumber(unchecked((nuint)0x8000000000000000)));
+                Assert.True(NumberBaseHelper<nuint>.IsRealNumber(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsRealNumber((nuint)0x00000000));
+                Assert.True(NumberBaseHelper<nuint>.IsRealNumber((nuint)0x00000001));
+                Assert.True(NumberBaseHelper<nuint>.IsRealNumber((nuint)0x7FFFFFFF));
+                Assert.True(NumberBaseHelper<nuint>.IsRealNumber((nuint)0x80000000));
+                Assert.True(NumberBaseHelper<nuint>.IsRealNumber((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
         public static void IsSubnormalTest()
         {
             if (Environment.Is64BitProcess)
@@ -1719,6 +1893,27 @@ namespace System.Tests
                 Assert.False(NumberBaseHelper<nuint>.IsSubnormal((nuint)0x7FFFFFFF));
                 Assert.False(NumberBaseHelper<nuint>.IsSubnormal((nuint)0x80000000));
                 Assert.False(NumberBaseHelper<nuint>.IsSubnormal((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void IsZeroTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsZero(unchecked((nuint)0x0000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsZero(unchecked((nuint)0x0000000000000001)));
+                Assert.False(NumberBaseHelper<nuint>.IsZero(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.False(NumberBaseHelper<nuint>.IsZero(unchecked((nuint)0x8000000000000000)));
+                Assert.False(NumberBaseHelper<nuint>.IsZero(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.True(NumberBaseHelper<nuint>.IsZero((nuint)0x00000000));
+                Assert.False(NumberBaseHelper<nuint>.IsZero((nuint)0x00000001));
+                Assert.False(NumberBaseHelper<nuint>.IsZero((nuint)0x7FFFFFFF));
+                Assert.False(NumberBaseHelper<nuint>.IsZero((nuint)0x80000000));
+                Assert.False(NumberBaseHelper<nuint>.IsZero((nuint)0xFFFFFFFF));
             }
         }
 


### PR DESCRIPTION
This covers the last of the "new APIs". After this is just the PR to refactor the `Create*` APIs to match API review feedback.