### PR TITLE
Better createdump error messages

### DIFF
--- a/src/coreclr/debug/createdump/crashreportwriter.cpp
+++ b/src/coreclr/debug/createdump/crashreportwriter.cpp
@@ -271,7 +271,7 @@ CrashReportWriter::OpenWriter(const char* fileName)
     m_fd = open(fileName, O_WRONLY|O_CREAT|O_TRUNC, S_IWUSR | S_IRUSR);
     if (m_fd == -1)
     {
-        printf_error("Could not create json file %s: %d %s\n", fileName, errno, strerror(errno));
+        printf_error("Could not create json file '%s': %s (%d)\n", fileName, strerror(errno), errno);
         return false;
     }
     Write("{\n");

--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -109,6 +109,7 @@ typedef int T_CONTEXT;
 extern bool FormatDumpName(std::string& name, const char* pattern, const char* exename, int pid);
 extern bool CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP_TYPE minidumpType, bool crashReport, int crashThread, int signal);
 
+extern std::string GetLastErrorString();
 extern void printf_status(const char* format, ...);
 extern void printf_error(const char* format, ...);
 

--- a/src/coreclr/debug/createdump/createdumpwindows.cpp
+++ b/src/coreclr/debug/createdump/createdumpwindows.cpp
@@ -20,12 +20,12 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
     hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
     if (hProcess == NULL)
     {
-        printf_error("Invalid process id '%d' error %d\n", pid, GetLastError());
+        printf_error("Invalid process id '%d' - %s\n", pid, GetLastErrorString().c_str());
         goto exit;
     }
     if (GetModuleBaseNameA(hProcess, NULL, pszName, MAX_LONGPATH) <= 0)
     {
-        printf_error("Get process name FAILED %d\n", GetLastError());
+        printf_error("Get process name FAILED - %s\n", GetLastErrorString().c_str());
         goto exit;
     }
     if (!FormatDumpName(dumpPath, dumpPathTemplate, pszName, pid))
@@ -37,7 +37,7 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
     hFile = CreateFileA(dumpPath.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
     {
-        printf_error("Invalid dump path '%s' error %d\n", dumpPath.c_str(), GetLastError());
+        printf_error("Invalid dump path '%s' - %s\n", dumpPath.c_str(), GetLastErrorString().c_str());
         goto exit;
     }
 
@@ -52,9 +52,9 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
         else
         {
             int err = GetLastError();
-            if (err != HRESULT_FROM_WIN32(ERROR_PARTIAL_COPY))
+            if (err != ERROR_PARTIAL_COPY)
             {
-                printf_error("Write dump FAILED 0x%08x\n", err);
+                printf_error("MiniDumpWriteDump - %s\n", GetLastErrorString().c_str());
                 break;
             }
         }

--- a/src/coreclr/debug/createdump/dumpwriter.cpp
+++ b/src/coreclr/debug/createdump/dumpwriter.cpp
@@ -26,7 +26,7 @@ DumpWriter::OpenDump(const char* dumpFileName)
     m_fd = open(dumpFileName, O_WRONLY|O_CREAT|O_TRUNC, S_IWUSR | S_IRUSR);
     if (m_fd == -1)
     {
-        printf_error("Could not open output %s: %d %s\n", dumpFileName, errno, strerror(errno));
+        printf_error("Could not create output file '%s': %s (%d)\n", dumpFileName, strerror(errno), errno);
         return false;
     }
     return true;
@@ -46,7 +46,7 @@ DumpWriter::WriteData(int fd, const void* buffer, size_t length)
         } while (written == -1 && errno == EINTR);
 
         if (written < 1) {
-            printf_error("WriteData FAILED %d %s\n", errno, strerror(errno));
+            printf_error("Error writing data to dump file: %s (%d)\n", strerror(errno), errno);
             return false;
         }
         done += written;

--- a/src/coreclr/debug/createdump/threadinfomac.cpp
+++ b/src/coreclr/debug/createdump/threadinfomac.cpp
@@ -23,7 +23,7 @@ ThreadInfo::~ThreadInfo()
     kern_return_t result = ::mach_port_deallocate(mach_task_self(), m_port);
     if (result != KERN_SUCCESS)
     {
-        printf_error("~ThreadInfo: mach_port_deallocate FAILED %x %s\n", result, mach_error_string(result));
+        printf_error("Internal error: ~ThreadInfo: mach_port_deallocate FAILED %s (%x)\n", mach_error_string(result), result);
     }
 }
 
@@ -38,7 +38,7 @@ ThreadInfo::Initialize()
     kern_return_t result = ::thread_get_state(Port(), x86_THREAD_STATE64, (thread_state_t)&m_gpRegisters, &stateCount);
     if (result != KERN_SUCCESS)
     {
-        printf_error("thread_get_state(%x) FAILED %x %s\n", m_tid, result, mach_error_string(result));
+        printf_error("thread_get_state(%x) FAILED %s (%x)\n", m_tid, mach_error_string(result), result);
         return false;
     }
 
@@ -46,7 +46,7 @@ ThreadInfo::Initialize()
     result = ::thread_get_state(Port(), x86_FLOAT_STATE64, (thread_state_t)&m_fpRegisters, &stateCount);
     if (result != KERN_SUCCESS)
     {
-        printf_error("thread_get_state(%x) FAILED %x %s\n", m_tid, result, mach_error_string(result));
+        printf_error("thread_get_state(%x) FAILED %s (%x)\n", m_tid, mach_error_string(result), result);
         return false;
     }
 #elif defined(__aarch64__)
@@ -54,7 +54,7 @@ ThreadInfo::Initialize()
     kern_return_t result = ::thread_get_state(Port(), ARM_THREAD_STATE64, (thread_state_t)&m_gpRegisters, &stateCount);
     if (result != KERN_SUCCESS)
     {
-        printf_error("thread_get_state(%x) FAILED %x %s\n", m_tid, result, mach_error_string(result));
+        printf_error("thread_get_state(%x) FAILED %s (%x)\n", m_tid,  mach_error_string(result), result);
         return false;
     }
 
@@ -62,7 +62,7 @@ ThreadInfo::Initialize()
     result = ::thread_get_state(Port(), ARM_NEON_STATE64, (thread_state_t)&m_fpRegisters, &stateCount);
     if (result != KERN_SUCCESS)
     {
-        printf_error("thread_get_state(%x) FAILED %x %s\n", m_tid, result, mach_error_string(result));
+        printf_error("thread_get_state(%x) FAILED %s (%x)\n", m_tid, mach_error_string(result), result);
         return false;
     }
 #else

--- a/src/coreclr/debug/createdump/threadinfounix.cpp
+++ b/src/coreclr/debug/createdump/threadinfounix.cpp
@@ -71,7 +71,7 @@ ThreadInfo::GetRegistersWithPTrace()
     struct iovec gpRegsVec = { &m_gpRegisters, sizeof(m_gpRegisters) };
     if (ptrace((__ptrace_request)PTRACE_GETREGSET, m_tid, NT_PRSTATUS, &gpRegsVec) == -1)
     {
-        printf_error("ptrace(PTRACE_GETREGSET, %d, NT_PRSTATUS) FAILED %d (%s)\n", m_tid, errno, strerror(errno));
+        printf_error("ptrace(PTRACE_GETREGSET, %d, NT_PRSTATUS) FAILED %s (%d)\n", m_tid, strerror(errno), errno);
         return false;
     }
     assert(sizeof(m_gpRegisters) == gpRegsVec.iov_len);
@@ -82,7 +82,7 @@ ThreadInfo::GetRegistersWithPTrace()
 #if defined(__arm__)
         // Some aarch64 kernels may not support NT_FPREGSET for arm processes. We treat this failure as non-fatal.
 #else
-        printf_error("ptrace(PTRACE_GETREGSET, %d, NT_FPREGSET) FAILED %d (%s)\n", m_tid, errno, strerror(errno));
+        printf_error("ptrace(PTRACE_GETREGSET, %d, NT_FPREGSET) FAILED %s (%d)\n", m_tid, strerror(errno), errno);
         return false;
 #endif
     }
@@ -91,7 +91,7 @@ ThreadInfo::GetRegistersWithPTrace()
 #if defined(__i386__)
     if (ptrace((__ptrace_request)PTRACE_GETFPXREGS, m_tid, nullptr, &m_fpxRegisters) == -1)
     {
-        printf_error("ptrace(GETFPXREGS, %d) FAILED %d (%s)\n", m_tid, errno, strerror(errno));
+        printf_error("ptrace(GETFPXREGS, %d) FAILED %s (%d)\n", m_tid, strerror(errno), errno);
         return false;
     }
 #elif defined(__arm__) && defined(__VFP_FP__) && !defined(__SOFTFP__)
@@ -102,7 +102,7 @@ ThreadInfo::GetRegistersWithPTrace()
 
     if (ptrace((__ptrace_request)PTRACE_GETVFPREGS, m_tid, nullptr, &m_vfpRegisters) == -1)
     {
-        printf_error("ptrace(PTRACE_GETVFPREGS, %d) FAILED %d (%s)\n", m_tid, errno, strerror(errno));
+        printf_error("ptrace(PTRACE_GETVFPREGS, %d) FAILED %s (%d)\n", m_tid, strerror(errno), errno);
         return false;
     }
 #endif

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -451,7 +451,9 @@ PALAPI
 PAL_GenerateCoreDump(
     IN LPCSTR dumpName,
     IN INT dumpType,
-    IN ULONG32 flags);
+    IN ULONG32 flags,
+    LPSTR errorMessageBuffer,
+    INT cbErrorMessageBuffer);
 
 typedef VOID (*PPAL_STARTUP_CALLBACK)(
     char *modulePath,

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2442,12 +2442,8 @@ PROCCreateCrashDump(
             // Read createdump's stderr
             int bytesRead = 0;
             int count = 0;
-            while ((count = read(parent_pipe, errorMessageBuffer + bytesRead, cbErrorMessageBuffer - bytesRead)) != 0)
+            while ((count = read(parent_pipe, errorMessageBuffer + bytesRead, cbErrorMessageBuffer - bytesRead)) > 0)
             {
-                if (count < 0)
-                {
-                    break;
-                }
                 bytesRead += count;
             }
             errorMessageBuffer[bytesRead] = 0;

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2371,24 +2371,56 @@ Function:
 (no return value)
 --*/
 BOOL
-PROCCreateCrashDump(std::vector<const char*>& argv)
+PROCCreateCrashDump(
+    std::vector<const char*>& argv,
+    LPSTR errorMessageBuffer,
+    INT cbErrorMessageBuffer)
 {
+    _ASSERTE(argv.size() > 0);
+    _ASSERTE(errorMessageBuffer == nullptr || cbErrorMessageBuffer > 0);
+
+    int pipe_descs[2];
+    if (pipe(pipe_descs) == -1)
+    {
+        if (errorMessageBuffer != nullptr)
+        {
+            sprintf_s(errorMessageBuffer, cbErrorMessageBuffer, "Problem launching createdump: pipe() FAILED %s (%d)\n", strerror(errno), errno);
+        }
+        return false;
+    }
+    // [0] is read end, [1] is write end
+    int parent_pipe = pipe_descs[0];
+    int child_pipe = pipe_descs[1];
+
     // Fork the core dump child process.
     pid_t childpid = fork();
 
     // If error, write an error to trace log and abort
     if (childpid == -1)
     {
-        ERROR("PROCCreateCrashDump: fork() FAILED %d (%s)\n", errno, strerror(errno));
+        if (errorMessageBuffer != nullptr)
+        {
+            sprintf_s(errorMessageBuffer, cbErrorMessageBuffer, "Problem launching createdump: fork() FAILED %s (%d)\n", strerror(errno), errno);
+        }
+        close(pipe_descs[0]);
+        close(pipe_descs[1]);
         return false;
     }
     else if (childpid == 0)
     {
-        // Child process
+        // Close the read end of the pipe, the child doesn't need it
+        close(parent_pipe);
+
+        // Only dup the child's stderr if there is error buffer
+        if (errorMessageBuffer != nullptr)
+        {
+            dup2(child_pipe, STDERR_FILENO);
+        }
+        // Execute the createdump program
         if (execve(argv[0], (char**)argv.data(), palEnvironment) == -1)
         {
-            ERROR("PROCCreateCrashDump: execve() FAILED %d (%s)\n", errno, strerror(errno));
-            return false;
+            fprintf(stderr, "Problem launching createdump (may not have execute permissions): execve(%s) FAILED %s (%d)\n", argv[0], strerror(errno), errno);
+            exit(-1);
         }
     }
     else
@@ -2399,16 +2431,40 @@ PROCCreateCrashDump(std::vector<const char*>& argv)
         {
             // Ignore any error because on some CentOS and OpenSUSE distros, it isn't
             // supported but createdump works just fine.
-            ERROR("PROCCreateCrashDump: prctl() FAILED %d (%s)\n", errno, strerror(errno));
+            ERROR("PROCCreateCrashDump: prctl() FAILED %s (%d)\n", errno, strerror(errno));
         }
 #endif // HAVE_PRCTL_H && HAVE_PR_SET_PTRACER
+        close(child_pipe);
+
+        // Read createdump's stderr messages (if any)
+        if (errorMessageBuffer != nullptr)
+        {
+            // Read createdump's stderr
+            int bytesRead = 0;
+            int count = 0;
+            while ((count = read(parent_pipe, errorMessageBuffer + bytesRead, cbErrorMessageBuffer - bytesRead)) != 0)
+            {
+                if (count < 0)
+                {
+                    break;
+                }
+                bytesRead += count;
+            }
+            errorMessageBuffer[bytesRead] = 0;
+            if (bytesRead > 0)
+            {
+                fputs(errorMessageBuffer, stderr);
+            }
+        }
+        close(parent_pipe);
+
         // Parent waits until the child process is done
         int wstatus = 0;
         int result = waitpid(childpid, &wstatus, 0);
         if (result != childpid)
         {
-            ERROR("PROCCreateCrashDump: waitpid() FAILED result %d wstatus %d errno %d (%s)\n",
-                result, wstatus, errno, strerror(errno));
+            ERROR("PROCCreateCrashDump: waitpid() FAILED result %d wstatus %d errno %s (%d)\n",
+                result, wstatus, strerror(errno), errno);
             return false;
         }
         return !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) == 0;
@@ -2509,7 +2565,9 @@ BOOL
 PAL_GenerateCoreDump(
     LPCSTR dumpName,
     INT dumpType,
-    ULONG32 flags)
+    ULONG32 flags,
+    LPSTR errorMessageBuffer,
+    INT cbErrorMessageBuffer)
 {
     std::vector<const char*> argvCreateDump;
 
@@ -2526,7 +2584,7 @@ PAL_GenerateCoreDump(
     BOOL result = PROCBuildCreateDumpCommandLine(argvCreateDump, &program, &pidarg, dumpName, nullptr, dumpType, flags);
     if (result)
     {
-        result = PROCCreateCrashDump(argvCreateDump);
+        result = PROCCreateCrashDump(argvCreateDump, errorMessageBuffer, cbErrorMessageBuffer);
     }
     free(program);
     free(pidarg);
@@ -2578,7 +2636,7 @@ PROCCreateCrashDumpIfEnabled(int signal)
             argv.push_back(nullptr);
         }
 
-        PROCCreateCrashDump(argv);
+        PROCCreateCrashDump(argv, nullptr, 0);
 
         free(signalArg);
         free(crashThreadArg);

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -188,7 +188,11 @@ ds_rt_config_value_get_default_port_suspend (void)
 
 static
 ds_ipc_result_t
-ds_rt_generate_core_dump (DiagnosticsDumpCommandId commandId, DiagnosticsGenerateCoreDumpCommandPayload *payload)
+ds_rt_generate_core_dump (
+    DiagnosticsDumpCommandId commandId,
+    DiagnosticsGenerateCoreDumpCommandPayload *payload,
+    ep_char8_t *errorMessageBuffer,
+    int32_t cbErrorMessageBuffer)
 {
 	STATIC_CONTRACT_NOTHROW;
 
@@ -201,10 +205,12 @@ ds_rt_generate_core_dump (DiagnosticsDumpCommandId commandId, DiagnosticsGenerat
  			// For the old commmand, this payload field is a bool of whether to enable logging
  			flags = flags != 0 ? GenerateDumpFlagsLoggingEnabled : 0;
 		}
-		if (GenerateDump (reinterpret_cast<LPCWSTR>(ds_generate_core_dump_command_payload_get_dump_name (payload)),
-			static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload)),
-			flags))
+        LPCWSTR dumpName = reinterpret_cast<LPCWSTR>(ds_generate_core_dump_command_payload_get_dump_name (payload));
+        int32_t dumpType = static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload));
+		if (GenerateDump(dumpName, dumpType, flags, errorMessageBuffer, cbErrorMessageBuffer))
+        {
 			result = DS_IPC_S_OK;
+        }
 	}
 	EX_CATCH {}
 	EX_END_CATCH(SwallowAllExceptions);

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -189,10 +189,10 @@ ds_rt_config_value_get_default_port_suspend (void)
 static
 ds_ipc_result_t
 ds_rt_generate_core_dump (
-    DiagnosticsDumpCommandId commandId,
-    DiagnosticsGenerateCoreDumpCommandPayload *payload,
-    ep_char8_t *errorMessageBuffer,
-    int32_t cbErrorMessageBuffer)
+	DiagnosticsDumpCommandId commandId,
+	DiagnosticsGenerateCoreDumpCommandPayload *payload,
+	ep_char8_t *errorMessageBuffer,
+	int32_t cbErrorMessageBuffer)
 {
 	STATIC_CONTRACT_NOTHROW;
 
@@ -200,17 +200,17 @@ ds_rt_generate_core_dump (
 	EX_TRY
 	{
 		uint32_t flags = ds_generate_core_dump_command_payload_get_flags(payload);
- 		if (commandId == DS_DUMP_COMMANDID_GENERATE_CORE_DUMP)
- 		{
- 			// For the old commmand, this payload field is a bool of whether to enable logging
- 			flags = flags != 0 ? GenerateDumpFlagsLoggingEnabled : 0;
+		if (commandId == DS_DUMP_COMMANDID_GENERATE_CORE_DUMP)
+		{
+			// For the old commmand, this payload field is a bool of whether to enable logging
+			flags = flags != 0 ? GenerateDumpFlagsLoggingEnabled : 0;
 		}
-        LPCWSTR dumpName = reinterpret_cast<LPCWSTR>(ds_generate_core_dump_command_payload_get_dump_name (payload));
-        int32_t dumpType = static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload));
+		LPCWSTR dumpName = reinterpret_cast<LPCWSTR>(ds_generate_core_dump_command_payload_get_dump_name (payload));
+		int32_t dumpType = static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload));
 		if (GenerateDump(dumpName, dumpType, flags, errorMessageBuffer, cbErrorMessageBuffer))
-        {
+		{
 			result = DS_IPC_S_OK;
-        }
+		}
 	}
 	EX_CATCH {}
 	EX_END_CATCH(SwallowAllExceptions);

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4101,7 +4101,10 @@ LaunchCreateDump(LPCWSTR lpCommandLine)
         if (WszCreateProcess(NULL, lpCommandLine, NULL, NULL, TRUE, 0, NULL, NULL, &StartupInfo, &processInformation))
         {
             WaitForSingleObject(processInformation.hProcess, INFINITE);
-            fSuccess = true;
+
+            DWORD exitCode = 0;
+            GetExitCodeProcess(processInformation.hProcess, &exitCode);
+            fSuccess = exitCode == 0;
         }
     }
     EX_CATCH
@@ -4176,7 +4179,9 @@ InitializeCrashDump()
 bool GenerateDump(
     LPCWSTR dumpName,
     INT dumpType,
-    ULONG32 flags)
+    ULONG32 flags,
+    LPSTR errorMessageBuffer,
+    INT cbErrorMessageBuffer)
 {
 #ifdef TARGET_UNIX
     MAKE_UTF8PTR_FROMWIDE_NOTHROW (dumpNameUtf8, dumpName);
@@ -4186,7 +4191,7 @@ bool GenerateDump(
     }
     else
     {
-        return PAL_GenerateCoreDump(dumpNameUtf8, dumpType, flags);
+        return PAL_GenerateCoreDump(dumpNameUtf8, dumpType, flags, errorMessageBuffer, cbErrorMessageBuffer);
     }
 #else // TARGET_UNIX
     return GenerateCrashDump(dumpName, dumpType, flags & GenerateDumpFlagsLoggingEnabled);

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -208,7 +208,7 @@ enum
 void InitializeCrashDump();
 void CreateCrashDumpIfEnabled(bool stackoverflow = false);
 #endif
-bool GenerateDump(LPCWSTR dumpName, INT dumpType, ULONG32 flags);
+bool GenerateDump(LPCWSTR dumpName, INT dumpType, ULONG32 flags, LPSTR errorMessageBuffer, INT cbErrorMessageBuffer);
 
 // Generates crash dumps if enabled for both Windows and Linux
 void CrashDumpAndTerminateProcess(UINT exitCode);

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1695,7 +1695,7 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGene
             {
                 EX_TRY
                 {
-                    GenerateDump (GENAWARE_DUMP_FILE_NAME, 2, GenerateDumpFlagsNone);
+                    GenerateDump (GENAWARE_DUMP_FILE_NAME, 2, GenerateDumpFlagsNone, nullptr, 0);
                 }
                 EX_CATCH {}
                 EX_END_CATCH(SwallowAllExceptions);

--- a/src/mono/mono/eventpipe/ds-rt-mono.h
+++ b/src/mono/mono/eventpipe/ds-rt-mono.h
@@ -172,7 +172,11 @@ ds_rt_config_value_get_default_port_suspend (void)
 static
 inline
 ds_ipc_result_t
-ds_rt_generate_core_dump (DiagnosticsDumpCommandId commandId, DiagnosticsGenerateCoreDumpCommandPayload *payload)
+ds_rt_generate_core_dump (
+	DiagnosticsDumpCommandId commandId,
+	DiagnosticsGenerateCoreDumpCommandPayload *payload,
+	ep_char8_t *errorMessageBuffer,
+	int32_t cbErrorMessageBuffer)
 {
 	// TODO: Implement.
 	return DS_IPC_E_NOTSUPPORTED;

--- a/src/native/eventpipe/ds-dump-protocol.c
+++ b/src/native/eventpipe/ds-dump-protocol.c
@@ -8,6 +8,8 @@
 #include "ds-dump-protocol.h"
 #include "ds-rt.h"
 
+const ep_char16_t empty_string [1] = { 0 };
+
 /*
  * Forward declares of all static functions.
  */
@@ -154,10 +156,7 @@ dump_protocol_generate_core_dump_response_flatten (
 	*size -= sizeof (response->error);
 
 	// LPCWSTR error message - if there is no error_message (NULL) then write an empty string
-	success &= ds_ipc_message_try_write_string_utf16_t (
-		buffer,
-		size,
-		response->error_message != NULL ? response->error_message : (const ep_char16_t*)u"");
+	success &= ds_ipc_message_try_write_string_utf16_t (buffer, size, response->error_message != NULL ? response->error_message : empty_string);
 
 	// Assert we've used the whole buffer we were given
 	EP_ASSERT(*size == 0);

--- a/src/native/eventpipe/ds-dump-protocol.c
+++ b/src/native/eventpipe/ds-dump-protocol.c
@@ -157,7 +157,7 @@ dump_protocol_generate_core_dump_response_flatten (
 	success &= ds_ipc_message_try_write_string_utf16_t (
 		buffer,
 		size,
-		response->error_message != NULL ? response->error_message : reinterpret_cast<const ep_char16_t*>(u""));
+		response->error_message != NULL ? response->error_message : (const ep_char16_t*)u"");
 
 	// Assert we've used the whole buffer we were given
 	EP_ASSERT(*size == 0);

--- a/src/native/eventpipe/ds-dump-protocol.c
+++ b/src/native/eventpipe/ds-dump-protocol.c
@@ -100,7 +100,7 @@ dump_protocol_generate_core_dump_response_flatten (
 	uint8_t **buffer,
 	uint16_t *size)
 {
-    DiagnosticsGenerateCoreDumpResponsePayload *response = (DiagnosticsGenerateCoreDumpResponsePayload*)payload;
+	DiagnosticsGenerateCoreDumpResponsePayload *response = (DiagnosticsGenerateCoreDumpResponsePayload*)payload;
 
 	EP_ASSERT (payload != NULL);
 	EP_ASSERT (buffer != NULL);
@@ -120,7 +120,7 @@ dump_protocol_generate_core_dump_response_flatten (
 	// Assert we've used the whole buffer we were given
 	EP_ASSERT(*size == 0);
 
-    return success;
+	return success;
 }
 
 static
@@ -128,28 +128,28 @@ void
 dump_protocol_generate_core_dump_response (
 	DiagnosticsIpcStream *stream,
 	ds_ipc_result_t error,
-    ep_char8_t * errorText)
+	ep_char8_t * errorText)
 {
-    DiagnosticsGenerateCoreDumpResponsePayload payload;
+	DiagnosticsGenerateCoreDumpResponsePayload payload;
 	DiagnosticsIpcMessage message;
 	ds_ipc_message_init (&message);
 
-    // Initialize payload
-    payload.error = error;
-    payload.error_message = ep_rt_utf8_to_utf16_string (errorText, -1);
+	// Initialize payload
+	payload.error = error;
+	payload.error_message = ep_rt_utf8_to_utf16_string (errorText, -1);
 
-    // Get the size of the payload
-    size_t payload_size = sizeof(payload.error);
+	// Get the size of the payload
+	size_t payload_size = sizeof(payload.error);
 	payload_size += sizeof(uint32_t);
-    payload_size += (payload.error_message != NULL) ? (ep_rt_utf16_string_len (payload.error_message) + 1) * sizeof(ep_char16_t) : 0;
+	payload_size += (payload.error_message != NULL) ? (ep_rt_utf16_string_len (payload.error_message) + 1) * sizeof(ep_char16_t) : 0;
 
-    // Initialize response message
+	// Initialize response message
 	bool result = ds_ipc_message_initialize_buffer (
-        &message,
-        ds_ipc_header_get_generic_error (),
-        &payload,
-        (uint16_t)payload_size,
-        dump_protocol_generate_core_dump_response_flatten);
+		&message,
+		ds_ipc_header_get_generic_error (),
+		&payload,
+		(uint16_t)payload_size,
+		dump_protocol_generate_core_dump_response_flatten);
 
 	if (result)
 		ds_ipc_message_send (&message, stream);
@@ -180,17 +180,17 @@ dump_protocol_helper_generate_core_dump (
 		ep_raise_error ();
 	}
 
-    ep_char8_t errorMessage[1024];
-    errorMessage[0] = '\0';
+	ep_char8_t errorMessage[1024];
+	errorMessage[0] = '\0';
 
 	ipc_result = ds_rt_generate_core_dump (commandId, payload, errorMessage, sizeof(errorMessage));
 	if (ipc_result != DS_IPC_S_OK) {
-        if (commandId == DS_DUMP_COMMANDID_GENERATE_CORE_DUMP3) {
-            dump_protocol_generate_core_dump_response (stream, ipc_result, errorMessage);
-        }
-        else {
-            ds_ipc_message_send_error (stream, ipc_result);
-        }
+		if (commandId == DS_DUMP_COMMANDID_GENERATE_CORE_DUMP3) {
+			dump_protocol_generate_core_dump_response (stream, ipc_result, errorMessage);
+		}
+		else {
+			ds_ipc_message_send_error (stream, ipc_result);
+		}
 		ep_raise_error ();
 	} else {
 		ds_ipc_message_send_success (stream, ipc_result);

--- a/src/native/eventpipe/ds-dump-protocol.h
+++ b/src/native/eventpipe/ds-dump-protocol.h
@@ -73,7 +73,7 @@ struct _DiagnosticsGenerateCoreDumpResponsePayload_Internal {
 	// uint = 4 little endian bytes
 	// string = (array<char> where the last char must = 0) or (length = 0)
 
-	int32_t error;
+	ds_ipc_result_t error;
 	ep_char16_t *error_message;
 };
 

--- a/src/native/eventpipe/ds-dump-protocol.h
+++ b/src/native/eventpipe/ds-dump-protocol.h
@@ -61,5 +61,27 @@ ds_dump_protocol_helper_handle_ipc_message (
 	DiagnosticsIpcMessage *message,
 	DiagnosticsIpcStream *stream);
 
+/*
+* DiagnosticsGenerateCoreDumpResponsePayload
+*/
+
+#if defined(DS_INLINE_GETTER_SETTER) || defined(DS_IMPL_DUMP_PROTOCOL_GETTER_SETTER)
+struct _DiagnosticsGenerateCoreDumpResponsePayload {
+#else
+struct _DiagnosticsGenerateCoreDumpResponsePayload_Internal {
+#endif
+	// uint = 4 little endian bytes
+	// string = (array<char> where the last char must = 0) or (length = 0)
+
+	int32_t error;
+	const ep_char16_t *error_message;
+};
+
+#if !defined(DS_INLINE_GETTER_SETTER) && !defined(DS_IMPL_DUMP_PROTOCOL_GETTER_SETTER)
+struct _DiagnosticsGenerateCoreDumpResponsePayload {
+	uint8_t _internal [sizeof (struct _DiagnosticsGenerateCoreDumpResponsePayload_Internal)];
+};
+#endif
+
 #endif /* ENABLE_PERFTRACING */
 #endif /* __DIAGNOSTICS_DUMP_PROTOCOL_H__ */

--- a/src/native/eventpipe/ds-dump-protocol.h
+++ b/src/native/eventpipe/ds-dump-protocol.h
@@ -74,7 +74,7 @@ struct _DiagnosticsGenerateCoreDumpResponsePayload_Internal {
 	// string = (array<char> where the last char must = 0) or (length = 0)
 
 	int32_t error;
-	const ep_char16_t *error_message;
+	ep_char16_t *error_message;
 };
 
 #if !defined(DS_INLINE_GETTER_SETTER) && !defined(DS_IMPL_DUMP_PROTOCOL_GETTER_SETTER)

--- a/src/native/eventpipe/ds-rt.h
+++ b/src/native/eventpipe/ds-rt.h
@@ -87,7 +87,7 @@ ds_rt_config_value_get_default_port_suspend (void);
 
 static
 ds_ipc_result_t
-ds_rt_generate_core_dump (DiagnosticsDumpCommandId commandId, DiagnosticsGenerateCoreDumpCommandPayload *payload);
+ds_rt_generate_core_dump (DiagnosticsDumpCommandId commandId, DiagnosticsGenerateCoreDumpCommandPayload *payload, ep_char8_t *errorMessageBuffer, int32_t cbErrorMessageBuffer);
 
 /*
  * DiagnosticsIpc.

--- a/src/native/eventpipe/ds-types.h
+++ b/src/native/eventpipe/ds-types.h
@@ -20,6 +20,7 @@ typedef struct _DiagnosticsStartupProfilerCommandPayload DiagnosticsStartupProfi
 typedef struct _DiagnosticsConnectPort DiagnosticsConnectPort;
 typedef struct _DiagnosticsEnvironmentInfoPayload DiagnosticsEnvironmentInfoPayload;
 typedef struct _DiagnosticsGenerateCoreDumpCommandPayload DiagnosticsGenerateCoreDumpCommandPayload;
+typedef struct _DiagnosticsGenerateCoreDumpResponsePayload DiagnosticsGenerateCoreDumpResponsePayload;
 typedef struct _DiagnosticsSetEnvironmentVariablePayload DiagnosticsSetEnvironmentVariablePayload;
 typedef struct _DiagnosticsGetEnvironmentVariablePayload DiagnosticsGetEnvironmentVariablePayload;
 typedef struct _DiagnosticsIpcHeader DiagnosticsIpcHeader;
@@ -45,6 +46,7 @@ typedef enum {
 	DS_DUMP_COMMANDID_RESERVED = 0x00,
 	DS_DUMP_COMMANDID_GENERATE_CORE_DUMP = 0x01,
 	DS_DUMP_COMMANDID_GENERATE_CORE_DUMP2 = 0x02,
+	DS_DUMP_COMMANDID_GENERATE_CORE_DUMP3 = 0x03,
 	// future
 } DiagnosticsDumpCommandId;
 

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -121,9 +121,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="logDumpGeneration">When set to true, display the dump generation debug log to the console.</param>
         public void WriteDump(DumpType dumpType, string dumpPath, bool logDumpGeneration = false)
         {
-            IpcMessage request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration);
-            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
-            ValidateResponseMessage(response, nameof(WriteDump));
+            WriteDump(dumpType, dumpPath, logDumpGeneration ? WriteDumpFlags.LoggingEnabled : WriteDumpFlags.None);
         }
 
         /// <summary>
@@ -134,15 +132,22 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="flags">logging and crash report flags. On runtimes less than 6.0, only LoggingEnabled is supported.</param>
         public void WriteDump(DumpType dumpType, string dumpPath, WriteDumpFlags flags)
         {
-            IpcMessage request = CreateWriteDumpMessage2(dumpType, dumpPath, flags);
+            IpcMessage request = CreateWriteDumpMessage(DumpCommandId.GenerateCoreDump3, dumpType, dumpPath, flags);
             IpcMessage response = IpcClient.SendMessage(_endpoint, request);
-            if (!ValidateResponseMessage(response, nameof(WriteDump), ValidateResponseOptions.UnknownCommandReturnsFalse))
+            if (!ValidateResponseMessage(response, "Write dump", ValidateResponseOptions.UnknownCommandReturnsFalse | ValidateResponseOptions.ErrorMessageReturned))
             {
-                if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                request = CreateWriteDumpMessage(DumpCommandId.GenerateCoreDump2, dumpType, dumpPath, flags);
+                response = IpcClient.SendMessage(_endpoint, request);
+                if (!ValidateResponseMessage(response, "Write dump", ValidateResponseOptions.UnknownCommandReturnsFalse))
                 {
-                    throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                    if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                    {
+                        throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                    }
+                    request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0);
+                    response = IpcClient.SendMessage(_endpoint, request);
+                    ValidateResponseMessage(response, "Write dump");
                 }
-                WriteDump(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0);
             }
         }
 
@@ -153,11 +158,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="dumpPath">Full path to the dump to be generated. By default it is /tmp/coredump.{pid}</param>
         /// <param name="logDumpGeneration">When set to true, display the dump generation debug log to the console.</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
-        public async Task WriteDumpAsync(DumpType dumpType, string dumpPath, bool logDumpGeneration, CancellationToken token)
+        public Task WriteDumpAsync(DumpType dumpType, string dumpPath, bool logDumpGeneration, CancellationToken token)
         {
-            IpcMessage request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration);
-            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
-            ValidateResponseMessage(response, nameof(WriteDumpAsync));
+            return WriteDumpAsync(dumpType, dumpPath, logDumpGeneration ? WriteDumpFlags.LoggingEnabled : WriteDumpFlags.None, token);
         }
 
         /// <summary>
@@ -169,15 +172,22 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="token">The token to monitor for cancellation requests.</param>
         public async Task WriteDumpAsync(DumpType dumpType, string dumpPath, WriteDumpFlags flags, CancellationToken token)
         {
-            IpcMessage request = CreateWriteDumpMessage2(dumpType, dumpPath, flags);
+            IpcMessage request = CreateWriteDumpMessage(DumpCommandId.GenerateCoreDump3, dumpType, dumpPath, flags);
             IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
-            if (!ValidateResponseMessage(response, nameof(WriteDumpAsync), ValidateResponseOptions.UnknownCommandReturnsFalse))
+            if (!ValidateResponseMessage(response, "Write dump", ValidateResponseOptions.UnknownCommandReturnsFalse | ValidateResponseOptions.ErrorMessageReturned))
             {
-                if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                request = CreateWriteDumpMessage(DumpCommandId.GenerateCoreDump2, dumpType, dumpPath, flags);
+                response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+                if (!ValidateResponseMessage(response, "Write dump", ValidateResponseOptions.UnknownCommandReturnsFalse))
                 {
-                    throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                    if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                    {
+                        throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                    }
+                    request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0);
+                    response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+                    ValidateResponseMessage(response, "Write dump");
                 }
-                await WriteDumpAsync(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0, token);
             }
         }
 
@@ -522,13 +532,13 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return new IpcMessage(DiagnosticsServerCommandSet.Dump, (byte)DumpCommandId.GenerateCoreDump, payload);
         }
 
-        private static IpcMessage CreateWriteDumpMessage2(DumpType dumpType, string dumpPath, WriteDumpFlags flags)
+        private static IpcMessage CreateWriteDumpMessage(DumpCommandId command, DumpType dumpType, string dumpPath, WriteDumpFlags flags)
         {
             if (string.IsNullOrEmpty(dumpPath))
                 throw new ArgumentNullException($"{nameof(dumpPath)} required");
 
             byte[] payload = SerializePayload(dumpPath, (uint)dumpType, (uint)flags);
-            return new IpcMessage(DiagnosticsServerCommandSet.Dump, (byte)DumpCommandId.GenerateCoreDump2, payload);
+            return new IpcMessage(DiagnosticsServerCommandSet.Dump, (byte)command, payload);
         }
 
         private static ProcessInfo GetProcessInfoFromResponse(IpcResponse response, string operationName)
@@ -552,8 +562,13 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
             switch ((DiagnosticsServerResponseId)responseMessage.Header.CommandId)
             {
+                case DiagnosticsServerResponseId.OK:
+                    return true;
+
                 case DiagnosticsServerResponseId.Error:
                     uint hr = BitConverter.ToUInt32(responseMessage.Payload, 0);
+                    int index = sizeof(uint);
+                    string message = null;
                     switch (hr)
                     {
                         case (uint)DiagnosticsIpcError.UnknownCommand:
@@ -562,18 +577,37 @@ namespace Microsoft.Diagnostics.NETCore.Client
                                 return false;
                             }
                             throw new UnsupportedCommandException($"{operationName} failed - Command is not supported.");
+
                         case (uint)DiagnosticsIpcError.ProfilerAlreadyActive:
                             throw new ProfilerAlreadyActiveException($"{operationName} failed - A profiler is already loaded.");
+
                         case (uint)DiagnosticsIpcError.InvalidArgument:
                             if (options.HasFlag(ValidateResponseOptions.InvalidArgumentIsRequiresSuspension))
                             {
                                 throw new ServerErrorException($"{operationName} failed - The runtime must be suspended for this command.");
                             }
                             throw new UnsupportedCommandException($"{operationName} failed - Invalid command argument.");
+
+                        case (uint)DiagnosticsIpcError.NotSupported:
+                            throw new NotSupportedException($"{operationName} - Not supported by this runtime.");
+
+                        // Only this error code (E_FAIL) can have a error message
+                        case (uint)DiagnosticsIpcError.Fail:
+                            if (options.HasFlag(ValidateResponseOptions.ErrorMessageReturned))
+                            {
+                                message = IpcHelpers.ReadString(responseMessage.Payload, ref index);
+                            }
+                            break;
+
+                        default:
+                            break;
                     }
-                    throw new ServerErrorException($"{operationName} failed - HRESULT: 0x{hr:X8}");
-                case DiagnosticsServerResponseId.OK:
-                    return true;
+                    if (string.IsNullOrWhiteSpace(message))
+                    {
+                        message = $"{operationName} - HRESULT: 0x{hr:X8}.";
+                    }
+                    throw new ServerErrorException(message);
+
                 default:
                     throw new ServerErrorException($"{operationName} failed - Server responded with unknown response.");
             }
@@ -585,6 +619,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             None = 0x0,
             UnknownCommandReturnsFalse = 0x1,
             InvalidArgumentIsRequiresSuspension = 0x2,
+            ErrorMessageReturned = 0x4,
         }
     }
 }

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -589,22 +589,21 @@ namespace Microsoft.Diagnostics.NETCore.Client
                             throw new UnsupportedCommandException($"{operationName} failed - Invalid command argument.");
 
                         case (uint)DiagnosticsIpcError.NotSupported:
-                            throw new NotSupportedException($"{operationName} - Not supported by this runtime.");
-
-                        // Only this error code (E_FAIL) can have a error message
-                        case (uint)DiagnosticsIpcError.Fail:
-                            if (options.HasFlag(ValidateResponseOptions.ErrorMessageReturned))
-                            {
-                                message = IpcHelpers.ReadString(responseMessage.Payload, ref index);
-                            }
+                            message = $"{operationName} - Not supported by this runtime.";
                             break;
 
                         default:
                             break;
                     }
+                    // Check if the command can return an error message and if the payload is big enough to contain the
+                    // error code (uint) and the string length (uint).
+                    if (options.HasFlag(ValidateResponseOptions.ErrorMessageReturned) && responseMessage.Payload.Length >= (sizeof(uint) * 2))
+                    {
+                        message = IpcHelpers.ReadString(responseMessage.Payload, ref index);
+                    }
                     if (string.IsNullOrWhiteSpace(message))
                     {
-                        message = $"{operationName} - HRESULT: 0x{hr:X8}.";
+                        message = $"{operationName} failed - HRESULT: 0x{hr:X8}.";
                     }
                     throw new ServerErrorException(message);
 

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
     {
         GenerateCoreDump = 0x01,
         GenerateCoreDump2 = 0x02,
+        GenerateCoreDump3 = 0x03,
     }
 
     internal enum ProfilerCommandId : byte

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
     /// </summary>
     internal enum DiagnosticsIpcError : uint
     {
+        Fail                  = 0x80004005,
         InvalidArgument       = 0x80070057,
+        NotSupported          = 0x80131515,
         ProfilerAlreadyActive = 0x8013136A,
         BadEncoding           = 0x80131384,
         UnknownCommand        = 0x80131385,


### PR DESCRIPTION
Redirect stderr when launching createdump to get any error text.

Added a new generate core dump ipc message that allows a error message string
to be returned for more detail on createdump errors.

Fixes or improves:
https://github.com/dotnet/runtime/issues/54521
https://github.com/dotnet/runtime/issues/64069
https://github.com/dotnet/diagnostics/issues/3064
https://github.com/dotnet/diagnostics/issues/2976

