### PR TITLE
Fix setting of DacpHeapSegmentData::highAllocMark on DAC side.

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2856,27 +2856,13 @@ ClrDataAccess::GetHeapSegmentData(CLRDATA_ADDRESS seg, struct DacpHeapSegmentDat
             heapSegment->gc_heap = NULL;
             heapSegment->background_allocated = (CLRDATA_ADDRESS)(ULONG_PTR)pSegment->background_allocated;
 
-            heapSegment->highAllocMark = heapSegment->allocated;
-
-            if (heapSegment->next == NULL)
+            if (seg == (CLRDATA_ADDRESS)*g_gcDacGlobals->ephemeral_heap_segment)
             {
-                if (IsRegionGCEnabled())
-                {
-                    // regions case
-                    CLRDATA_ADDRESS alloc_allocated = (CLRDATA_ADDRESS)*g_gcDacGlobals->alloc_allocated;
-                    if (heapSegment->mem <= alloc_allocated && alloc_allocated <= heapSegment->committed)
-                    {
-                        heapSegment->highAllocMark = alloc_allocated;
-                    }
-                }
-                else
-                {
-                    // segment case
-                    if (seg == (CLRDATA_ADDRESS)*g_gcDacGlobals->ephemeral_heap_segment)
-                    {
-                        heapSegment->highAllocMark = (CLRDATA_ADDRESS)*g_gcDacGlobals->alloc_allocated;
-                    }
-                }
+                heapSegment->highAllocMark = (CLRDATA_ADDRESS)*g_gcDacGlobals->alloc_allocated;
+            }
+            else
+            {
+                heapSegment->highAllocMark = heapSegment->allocated;
             }
         }
     }

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2855,6 +2855,29 @@ ClrDataAccess::GetHeapSegmentData(CLRDATA_ADDRESS seg, struct DacpHeapSegmentDat
             heapSegment->flags = pSegment->flags;
             heapSegment->gc_heap = NULL;
             heapSegment->background_allocated = (CLRDATA_ADDRESS)(ULONG_PTR)pSegment->background_allocated;
+
+            heapSegment->highAllocMark = heapSegment->allocated;
+
+            if (heapSegment->next == NULL)
+            {
+                if (IsRegionGCEnabled())
+                {
+                    // regions case
+                    CLRDATA_ADDRESS alloc_allocated = (CLRDATA_ADDRESS)*g_gcDacGlobals->alloc_allocated;
+                    if (heapSegment->mem <= alloc_allocated && alloc_allocated <= heapSegment->committed)
+                    {
+                        heapSegment->highAllocMark = alloc_allocated;
+                    }
+                }
+                else
+                {
+                    // segment case
+                    if (seg == (CLRDATA_ADDRESS)*g_gcDacGlobals->ephemeral_heap_segment)
+                    {
+                        heapSegment->highAllocMark = (CLRDATA_ADDRESS)*g_gcDacGlobals->alloc_allocated;
+                    }
+                }
+            }
         }
     }
 

--- a/src/coreclr/debug/daccess/request_svr.cpp
+++ b/src/coreclr/debug/daccess/request_svr.cpp
@@ -48,29 +48,15 @@ HRESULT GetServerHeapData(CLRDATA_ADDRESS addr, DacpHeapSegmentData *pSegment)
     pSegment->next = (CLRDATA_ADDRESS)dac_cast<TADDR>(pHeapSegment->next);
     pSegment->gc_heap = (CLRDATA_ADDRESS)pHeapSegment->heap;
 
-    heapSegment->highAllocMark = heapSegment->allocated;
+    dac_gc_heap heap = LoadGcHeapData(pSegment->gc_heap);
 
-    if (pSegment->next == NULL)
+    if (pSegment->segmentAddr == heap.ephemeral_heap_segment.GetAddr())
     {
-        dac_gc_heap heap = LoadGcHeapData(pSegment->gc_heap);
-        if (IsRegionGCEnabled())
-        {
-            // regions case
-            CLRDATA_ADDRESS alloc_allocated = (CLRDATA_ADDRESS)heap.alloc_allocated;
-            if (pSegment->mem <= alloc_allocated && alloc_allocated <= pSegment->committed)
-            {
-                pSegment->highAllocMark = alloc_allocated;
-            }
-        }
-        else
-        {
-            // segments case
-            dac_generation generation_0 = ServerGenerationTableIndex(pSegment->gc_heap, 0);
-            if (addr == (CLRDATA_ADDRESS)dac_cast<TADDR>(generation_0.start_segment))
-            {
-                pSegment->highAllocMark = (CLRDATA_ADDRESS)heap.alloc_allocated;
-            }
-        }
+        pSegment->highAllocMark = (CLRDATA_ADDRESS)(ULONG_PTR)heap.alloc_allocated;
+    }
+    else
+    {
+        pSegment->highAllocMark = pSegment->allocated;
     }
 
     return S_OK;

--- a/src/coreclr/debug/daccess/request_svr.cpp
+++ b/src/coreclr/debug/daccess/request_svr.cpp
@@ -48,7 +48,8 @@ HRESULT GetServerHeapData(CLRDATA_ADDRESS addr, DacpHeapSegmentData *pSegment)
     pSegment->next = (CLRDATA_ADDRESS)dac_cast<TADDR>(pHeapSegment->next);
     pSegment->gc_heap = (CLRDATA_ADDRESS)pHeapSegment->heap;
 
-    dac_gc_heap heap = LoadGcHeapData(pSegment->gc_heap);
+    TADDR heapAddress = TO_TADDR(pSegment->gc_heap);
+    dac_gc_heap heap = LoadGcHeapData(heapAddress);
 
     if (pSegment->segmentAddr == heap.ephemeral_heap_segment.GetAddr())
     {

--- a/src/coreclr/inc/dacprivate.h
+++ b/src/coreclr/inc/dacprivate.h
@@ -791,10 +791,9 @@ struct MSLAYOUT DacpHeapSegmentData
     {
         HRESULT hr = sos->GetHeapSegmentData(addr, this);
 
-        // if this is the start segment, set highAllocMark too.
-        if (SUCCEEDED(hr))
+        // if this is the start segment, and the Dac hasn't set highAllocMark, set it here.
+        if (SUCCEEDED(hr) && this->highAllocMark == 0)
         {
-            // TODO:  This needs to be put on the Dac side.
             if (this->segmentAddr == heap.generation_table[0].start_segment)
                 highAllocMark = heap.alloc_allocated;
             else

--- a/src/coreclr/inc/dacprivate.h
+++ b/src/coreclr/inc/dacprivate.h
@@ -794,7 +794,7 @@ struct MSLAYOUT DacpHeapSegmentData
         // if this is the start segment, and the Dac hasn't set highAllocMark, set it here.
         if (SUCCEEDED(hr) && this->highAllocMark == 0)
         {
-            if (this->segmentAddr == heap.generation_table[0].start_segment)
+            if (this->segmentAddr == heap.ephemeral_heap_segment)
                 highAllocMark = heap.alloc_allocated;
             else
                 highAllocMark = allocated;

--- a/src/coreclr/inc/dacprivate.h
+++ b/src/coreclr/inc/dacprivate.h
@@ -789,6 +789,9 @@ struct MSLAYOUT DacpHeapSegmentData
 
     HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr, const DacpGcHeapDetails& heap)
     {
+        // clear this here to make sure we don't get stale values
+        this->highAllocMark = 0;
+
         HRESULT hr = sos->GetHeapSegmentData(addr, this);
 
         // if this is the start segment, and the Dac hasn't set highAllocMark, set it here.


### PR DESCRIPTION
Fix setting of DacpHeapSegmentData::highAllocMark on DAC side. Keep some logic for backward compat in dacprivate.h, the copy here and the one in the Diagnostics repo, so that a new SOS can work correctly with an older DAC.

The PR in the diagnostics repo is this: https://github.com/dotnet/diagnostics/pull/3062
