### PR TITLE
Enable W^X by default

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -727,7 +727,7 @@ RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_LTTng, W("LTTng"), 1, "If COMPlus_LTTng is 
 //
 // Executable code
 //
-RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableWriteXorExecute, W("EnableWriteXorExecute"), 0, "Enable W^X for executable memory.");
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableWriteXorExecute, W("EnableWriteXorExecute"), 1, "Enable W^X for executable memory.");
 
 #ifdef FEATURE_GDBJIT
 ///


### PR DESCRIPTION
This change enables the W^X by default. In the recent past, I've made
some changes to the related runtime code to improve the startup
performance with W^X enabled by reducing the number of times writeable
mappings need to be created. The current startup time regression is
about 5..10% (measured using ASPNet plaintext, json, fortunes and
orchard benchmarks on x64 windows and linux and arm64 linux).
The steady state performance is the same with and without the W^X
enabled.
There are still opportunities for improving the startup performance,
e.g. in the dynamic helpers, but it is time to enable W^X by default so
that if there are unexpected consequences that were not caught by the
benchmarking, we still have time to fix them for .NET 7.