### PR TITLE
[wasm] retrieve results from browser bench sample

### DIFF
--- a/src/mono/sample/wasm/Directory.Build.targets
+++ b/src/mono/sample/wasm/Directory.Build.targets
@@ -40,6 +40,10 @@
   <Target Name="RunSampleWithBrowser" DependsOnTargets="BuildSampleInTree;CheckServe">
     <Exec Command="$(_Dotnet) serve -o -d:bin/$(Configuration)/AppBundle -p:8000 --mime .mjs=text/javascript" IgnoreExitCode="true" YieldDuringToolExecution="true" />
   </Target>
+  <Target Name="RunSampleWithBrowserAndSimpleServer" DependsOnTargets="BuildSampleInTree">
+    <Exec Command="$(_Dotnet) build -c $(Configuration) ..\simple-server\HttpServer.csproj" />
+    <Exec WorkingDirectory="bin/$(Configuration)/AppBundle" Command="..\..\..\..\simple-server\bin\$(Configuration)\net6.0\HttpServer" />
+  </Target>
 
   <Target Name="TriggerGenerateRunScript"
           Condition="'$(GenerateRunScriptForSample)' == 'true'"

--- a/src/mono/sample/wasm/browser-bench/Program.cs
+++ b/src/mono/sample/wasm/browser-bench/Program.cs
@@ -82,6 +82,7 @@ namespace Sample
             set { task = value; }
         }
         List<BenchTask.Result> results = new();
+        Dictionary<string, double> minTimes = new();
         bool resultsReturned;
 
         bool NextTask()
@@ -146,9 +147,9 @@ namespace Sample
 
         string ResultsSummary()
         {
-            var minTimes = ProcessResults();
+            ProcessResults();
             if (JsonResults)
-                PrintJsonResults(minTimes);
+                PrintJsonResults();
 
             StringBuilder sb = new($"{formatter.NewLine}Summary{formatter.NewLine}");
             foreach (var key in minTimes.Keys)
@@ -175,9 +176,9 @@ namespace Sample
             return sb.ToString();
         }
 
-        private Dictionary<string, double> ProcessResults()
+        private void ProcessResults()
         {
-            Dictionary<string, double> minTimes = new Dictionary<string, double>();
+            minTimes.Clear();
 
             foreach (var result in results)
             {
@@ -189,24 +190,31 @@ namespace Sample
 
                 minTimes[key] = t;
             }
-
-            return minTimes;
         }
 
         class JsonResultsData
         {
             public List<BenchTask.Result> results;
             public Dictionary<string, double> minTimes;
+            public DateTime timeStamp;
         }
 
-        private void PrintJsonResults(Dictionary<string, double> minTimes)
+        public static string GetFullJsonResults()
         {
-            DateTime now = DateTime.Now;
+            return instance.GetJsonResults();
+        }
+
+        string GetJsonResults ()
+        {
             var options = new JsonSerializerOptions { IncludeFields = true, WriteIndented = true };
-            var jsonObject = new JsonResultsData { results = results, minTimes = minTimes };
-            var str = JsonSerializer.Serialize(jsonObject, options);
+            var jsonObject = new JsonResultsData { results = results, minTimes = minTimes, timeStamp = DateTime.UtcNow };
+            return JsonSerializer.Serialize(jsonObject, options);
+        }
+
+        private void PrintJsonResults()
+        {
             Console.WriteLine("=== json results start ===");
-            Console.WriteLine(str);
+            Console.WriteLine(GetJsonResults ());
             Console.WriteLine("=== json results end ===");
         }
     }

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -20,5 +20,6 @@
     <_SampleAssembly> Wasm.Browser.Bench.Sample.dll</_SampleAssembly>
   </PropertyGroup>
 
-  <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowser" />
+  <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowserAndSimpleServer" />
+
 </Project>

--- a/src/mono/sample/wasm/browser-bench/main.js
+++ b/src/mono/sample/wasm/browser-bench/main.js
@@ -5,11 +5,13 @@
 
 let runBenchmark;
 let setTasks;
+let getFullJsonResults;
 
 class MainApp {
     init({ BINDING }) {
         runBenchmark = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:RunBenchmark");
         setTasks = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:SetTasks");
+        getFullJsonResults = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:GetFullJsonResults");
 
         var url = new URL(decodeURI(window.location));
         let tasks = url.searchParams.getAll('task');
@@ -29,6 +31,14 @@ class MainApp {
                 setTimeout(() => { this.yieldBench(); }, 0);
             } else {
                 document.getElementById("out").innerHTML += "Finished";
+                fetch("/results.json", {
+                    method: 'POST',
+                    body: getFullJsonResults()
+                }).then (r => { console.log("post request complete, response: ", r); });
+                fetch("/results.html", {
+                    method: 'POST',
+                    body: document.getElementById("out").innerHTML
+                }).then (r => { console.log("post request complete, response: ", r); });
             }
         });
     }

--- a/src/mono/sample/wasm/simple-server/Directory.Build.props
+++ b/src/mono/sample/wasm/simple-server/Directory.Build.props
@@ -1,0 +1,2 @@
+<!-- supress loading of upper dirs Directory.Build.props -->
+<Project/>

--- a/src/mono/sample/wasm/simple-server/Directory.Build.targets
+++ b/src/mono/sample/wasm/simple-server/Directory.Build.targets
@@ -1,0 +1,2 @@
+<!-- supress loading of upper dirs Directory.Build.targets -->
+<Project/>

--- a/src/mono/sample/wasm/simple-server/HttpServer.csproj
+++ b/src/mono/sample/wasm/simple-server/HttpServer.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/mono/sample/wasm/simple-server/Program.cs
+++ b/src/mono/sample/wasm/simple-server/Program.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace HttpServer
 {
@@ -11,7 +13,6 @@ namespace HttpServer
 
         public static int Main()
         {
-
             if (!HttpListener.IsSupported)
             {
                 Console.WriteLine("error: HttpListener is not supported.");
@@ -45,9 +46,39 @@ namespace HttpServer
             }
 
             Console.WriteLine($"Listening on {url}");
+            OpenUrl(url);
 
             while (true)
                 HandleRequest(listener);
+        }
+
+        private void OpenUrl(string url)
+        {
+            var proc = new Process();
+            var si = new ProcessStartInfo();
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                si.FileName = url;
+                si.UseShellExecute = true;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                si.FileName = "xdg-open";
+                si.ArgumentList.Add(url);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                si.FileName = "open";
+                si.ArgumentList.Add(url);
+            }
+            else
+            {
+                System.Console.WriteLine("Don't know how to open url on this OS platform");
+            }
+
+            proc.StartInfo = si;
+            proc.Start();
         }
 
         private void HandleRequest(HttpListener listener)

--- a/src/mono/sample/wasm/simple-server/Program.cs
+++ b/src/mono/sample/wasm/simple-server/Program.cs
@@ -1,0 +1,160 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+
+namespace HttpServer
+{
+    public sealed class Program
+    {
+        private bool Verbose = false;
+
+        public static int Main()
+        {
+
+            if (!HttpListener.IsSupported)
+            {
+                Console.WriteLine("error: HttpListener is not supported.");
+                return -1;
+            }
+
+            // retry upto 9 times to find free port
+            for (int i = 0; i < 10; i++)
+            {
+                if (new Program().StartServer())
+                    break;
+            }
+
+            return 0;
+        }
+
+        private bool StartServer()
+        {
+            var port = 8000 + Random.Shared.Next(1000);
+            var listener = new HttpListener();
+            var url = $"http://localhost:{port}/";
+            listener.Prefixes.Add(url);
+
+            try
+            {
+                listener.Start();
+            }
+            catch (HttpListenerException)
+            {
+                return false;
+            }
+
+            Console.WriteLine($"Listening on {url}");
+
+            while (true)
+                HandleRequest(listener);
+        }
+
+        private void HandleRequest(HttpListener listener)
+        {
+            var context = listener.GetContext();
+            if (Verbose)
+                Console.WriteLine($"request url: {context.Request.Url}");
+
+            if (context.Request.HttpMethod == "GET")
+                ServeAsync(context);
+            else if (context.Request.HttpMethod == "POST")
+                ReceivePostAsync(context);
+        }
+
+        private async void ReceivePostAsync(HttpListenerContext context)
+        {
+            if (Verbose)
+            {
+                Console.WriteLine("got POST request");
+                Console.WriteLine($"  content type: {context.Request.ContentType}");
+            }
+
+            var url = context.Request.Url;
+            if (url == null)
+                return;
+
+            var path = url.LocalPath;
+            var contentType = context.Request.ContentType;
+            if (contentType != null && contentType.StartsWith("text/plain") && path.StartsWith("/"))
+            {
+                path = path.Substring(1);
+                if (Verbose)
+                    Console.WriteLine($"  writting POST stream to '{path}' file");
+
+                var content = await new StreamReader(context.Request.InputStream).ReadToEndAsync().ConfigureAwait(false);
+                await File.WriteAllTextAsync(path, content).ConfigureAwait(false);
+            }
+            else
+                return;
+
+            var stream = context.Response.OutputStream;
+            stream.Close();
+            context.Response.Close();
+        }
+
+        private async void ServeAsync(HttpListenerContext context)
+        {
+            if (Verbose)
+                Console.WriteLine("got GET request");
+
+            var request = context.Request;
+            var url = request.Url;
+            if (url == null)
+                return;
+
+            string path = url.LocalPath == "/" ? "index.html" : url.LocalPath;
+            if (Verbose)
+                Console.WriteLine($"  serving: {path}");
+
+            if (path.StartsWith("/"))
+                path = path.Substring(1);
+
+            byte[]? buffer;
+            try
+            {
+                buffer = await File.ReadAllBytesAsync(path).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                buffer = null;
+            }
+
+            if (buffer != null)
+            {
+                string? contentType = null;
+                if (path.EndsWith(".wasm"))
+                    contentType = "application/wasm";
+
+                if (contentType != null)
+                    context.Response.ContentType = contentType;
+
+                context.Response.ContentLength64 = buffer.Length;
+                context.Response.AppendHeader("cache-control", "public, max-age=31536000");
+                var stream = context.Response.OutputStream;
+                try
+                {
+                    await stream.WriteAsync(buffer).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    if (Verbose)
+                        Console.WriteLine($"interrupted: {e.Message}");
+                }
+
+                stream.Close();
+                context.Response.Close();
+            }
+            else
+            {
+                if (Verbose)
+                    Console.WriteLine("  => not found");
+
+                context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+            }
+
+            if (Verbose)
+                Console.WriteLine($"finished url: {context.Request.Url}");
+        }
+    }
+}


### PR DESCRIPTION
Add simple http server to serve files for the browser-bench sample and let it collect the results at the end.

The results are sent as POST requests and the simple server saves them to the host storage.