### PR TITLE
Fix handling of hardware exceptions in native code on Unix

### DIFF
--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -4523,6 +4523,7 @@ private:
         ExceptionPointers.ContextRecord = ex.ExceptionPointers.ContextRecord;
         TargetFrameSp = ex.TargetFrameSp;
         RecordsOnStack = ex.RecordsOnStack;
+        IsExternal = ex.IsExternal;
         ManagedToNativeExceptionCallback = ex.ManagedToNativeExceptionCallback;
         ManagedToNativeExceptionCallbackContext = ex.ManagedToNativeExceptionCallbackContext;
 
@@ -4544,6 +4545,9 @@ public:
     // Target frame stack pointer set before the 2nd pass.
     SIZE_T TargetFrameSp;
     bool RecordsOnStack;
+    // The exception is a hardware exception coming from a native code out of
+    // the well known runtime helpers
+    bool IsExternal;
 
     void(*ManagedToNativeExceptionCallback)(void* context);
     void* ManagedToNativeExceptionCallbackContext;
@@ -4554,6 +4558,7 @@ public:
         ExceptionPointers.ContextRecord = pContextRecord;
         TargetFrameSp = NoTargetFrameSp;
         RecordsOnStack = onStack;
+        IsExternal = false;
         ManagedToNativeExceptionCallback = NULL;
         ManagedToNativeExceptionCallbackContext = NULL;
     }
@@ -4592,6 +4597,7 @@ public:
         ExceptionPointers.ContextRecord = NULL;
         TargetFrameSp = NoTargetFrameSp;
         RecordsOnStack = false;
+        IsExternal = false;
         ManagedToNativeExceptionCallback = NULL;
         ManagedToNativeExceptionCallbackContext = NULL;
     }
@@ -4898,6 +4904,7 @@ public:
     {                                   \
         try                             \
         {                               \
+            HardwareExceptionHolder     \
             tryBlock(__param);          \
         }                               \
         catch (...)                     \

--- a/src/coreclr/pal/src/exception/seh.cpp
+++ b/src/coreclr/pal/src/exception/seh.cpp
@@ -277,6 +277,7 @@ SEHProcessException(PAL_SEHException* exception)
         if (CatchHardwareExceptionHolder::IsEnabled())
         {
             EnsureExceptionRecordsOnHeap(exception);
+            exception->IsExternal = true;
             PAL_ThrowExceptionFromContext(exception->GetContextRecord(), exception);
         }
     }

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -4569,7 +4569,13 @@ VOID DECLSPEC_NORETURN UnwindManagedExceptionPass1(PAL_SEHException& ex, CONTEXT
         // This is the first time we see the managed exception, set its context to the managed frame that has caused
         // the exception to be thrown
         *ex.GetContextRecord() = *frameContext;
-        ex.GetExceptionRecord()->ExceptionAddress = (VOID*)controlPc;
+
+        // Move the exception address to the first managed frame on the stack except for the hardware exceptions 
+        // stemming from from a native code out of the well known runtime helpers
+        if (!ex.IsExternal)
+        {
+            ex.GetExceptionRecord()->ExceptionAddress = (VOID*)controlPc;
+        }
     }
 
     ex.GetExceptionRecord()->ExceptionFlags = 0;


### PR DESCRIPTION
This change fixes handling of hardware exceptions like sigsegv or
division by zero that happen in native code out of our runtime helpers
and that is enclosed in the PAL_TRY / PAL_EXCEPT or PAL_FINALLY.
The current implementation was working only for the DAC code. There is a
new need to use it in SuperPMI to ensure that a log is written even in case
an access violation occured in JIT.
It still requires the shared library that wants to use it to be compiled
with FEATURE_ENABLE_HARDWARE_EXCEPTIONS, so nothing has changed for
coreclr or JIT. It also requires the PAL of that shared library to be
initialized with PAL_INITIALIZE_REGISTER_SIGNALS on Linux. On macOS,
this is not needed.