### PR TITLE
Fix address adjustment in bundle unmap for macos universal binaries

### DIFF
--- a/src/native/corehost/bundle/info.cpp
+++ b/src/native/corehost/bundle/info.cpp
@@ -125,14 +125,15 @@ char* info_t::config_t::map(const pal::string_t& path, const location_t* &locati
 
     trace::info(_X("Mapped bundle for [%s]"), path.c_str());
 
-    return addr + location->offset + app->m_offset_in_file;
+    // Adjust to the beginning of the bundle
+    return addr + (location->offset + app->m_offset_in_file);
 }
 
 void info_t::config_t::unmap(const char* addr, const location_t* location)
 {
-    // Adjust to the beginning of the bundle.
     const bundle::info_t* app = bundle::info_t::the_app;
-    addr -= location->offset - app->m_offset_in_file;
+    // Reverse the adjustment to the beginning of the bundle
+    addr = addr - (location->offset + app->m_offset_in_file);
 
     bundle::info_t::the_app->unmap_bundle(addr);
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/69010

We map the entire file and then adjust the pointer to get to the bundle. When we need to unmap, having the bundle pointer, we reverse the adjustment to get the address of the mapping.
The math for reversing the adjustment was incorrect. The adjustment due to embedding in a larger container (such as universal binary) was applied with a wrong sign. For large binaries we could offset the pointer beyond the mapping and unmap something random - if there is nothing mapped there, no harm, just a leak, but if something is mapped (like our own binary) we could cause crashes.

