### PR TITLE
Fix W^X executable memory releasing on Unix

### DIFF
--- a/src/coreclr/minipal/Unix/doublemapping.cpp
+++ b/src/coreclr/minipal/Unix/doublemapping.cpp
@@ -79,7 +79,7 @@ void VMToOSInterface::DestroyDoubleMemoryMapper(void *mapperHandle)
 #endif
 }
 
-extern "C" void* PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(const void* lpBeginAddress, const void* lpEndAddress, size_t dwSize);
+extern "C" void* PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(const void* lpBeginAddress, const void* lpEndAddress, size_t dwSize, int fStoreAllocationInfo);
 
 #ifdef TARGET_OSX
 bool IsMapJitFlagNeeded()
@@ -125,7 +125,7 @@ void* VMToOSInterface::ReserveDoubleMappedMemory(void *mapperHandle, size_t offs
         rangeEnd = (void*)SIZE_MAX;
     }
 
-    void* result = PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(rangeStart, rangeEnd, size);
+    void* result = PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(rangeStart, rangeEnd, size, 0 /* fStoreAllocationInfo */);
 #ifndef TARGET_OSX
     if (result != NULL)
     {

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -2832,7 +2832,8 @@ PALAPI
 PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(
     IN LPCVOID lpBeginAddress,
     IN LPCVOID lpEndAddress,
-    IN SIZE_T dwSize);
+    IN SIZE_T dwSize,
+    IN BOOL storeAllocationInfo);
 
 PALIMPORT
 void

--- a/src/coreclr/pal/src/map/virtual.cpp
+++ b/src/coreclr/pal/src/map/virtual.cpp
@@ -1263,21 +1263,24 @@ Function:
   lpBeginAddress - Inclusive beginning of range
   lpEndAddress - Exclusive end of range
   dwSize - Number of bytes to allocate
+  fStoreAllocationInfo - TRUE to indicate that the allocation should be registered in the PAL allocation list
 --*/
 LPVOID
 PALAPI
 PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(
     IN LPCVOID lpBeginAddress,
     IN LPCVOID lpEndAddress,
-    IN SIZE_T dwSize)
+    IN SIZE_T dwSize,
+    IN BOOL fStoreAllocationInfo)
 {
 #ifdef HOST_64BIT
     PERF_ENTRY(PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange);
     ENTRY(
-        "PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(lpBeginAddress = %p, lpEndAddress = %p, dwSize = %Iu)\n",
+        "PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(lpBeginAddress = %p, lpEndAddress = %p, dwSize = %Iu, fStoreAllocationInfo = %d)\n",
         lpBeginAddress,
         lpEndAddress,
-        dwSize);
+        dwSize,
+        fStoreAllocationInfo);
 
     _ASSERTE(lpBeginAddress <= lpEndAddress);
 
@@ -1292,7 +1295,7 @@ PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(
     if (address != nullptr)
     {
         _ASSERTE(IS_ALIGNED(address, GetVirtualPageSize()));
-        if (!VIRTUALStoreAllocationInfo((UINT_PTR)address, reservationSize, MEM_RESERVE | MEM_RESERVE_EXECUTABLE, PAGE_NOACCESS))
+        if (fStoreAllocationInfo && !VIRTUALStoreAllocationInfo((UINT_PTR)address, reservationSize, MEM_RESERVE | MEM_RESERVE_EXECUTABLE, PAGE_NOACCESS))
         {
             ASSERT("Unable to store the structure in the list.\n");
             munmap(address, reservationSize);

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -405,7 +405,7 @@ BYTE * ClrVirtualAllocWithinRange(const BYTE *pMinAddr,
     }
 
 #ifdef HOST_UNIX
-    pResult = (BYTE *)PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(pMinAddr, pMaxAddr, dwSize);
+    pResult = (BYTE *)PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(pMinAddr, pMaxAddr, dwSize, TRUE /* fStoreAllocationInfo */);
     if (pResult != nullptr)
     {
         return pResult;


### PR DESCRIPTION
The `PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange` API that
the `ExecutableAllocator` uses on Unix to reserve VA space for executable
memory was registering the allocated memory range in the PAL in the list
of allocated memory blocks. But the `ExecutableAllocator` is releasing
that memory just using `unmap`, so the block remained registered in that
list after the `unmap`. That resulted in an assert in the sanity check of
the list when the PAL virtual memory allocator got the VA range that was
unmapped, but found it in the list.
In the coreclr and libraries tests, it only happened in single library test and 
it was discovered in my other PR.

The fix is to add a parameter to the
`PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange` to specify
whether the allocated memory should be added to the list of allocation
info or not.