### PR TITLE
Switch from malloc to stackAlloc for bindings invokes

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -185,7 +185,10 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public static void InvokeUnboxLongFail()
         {
-            var ex = Assert.Throws<JSException>(() => Runtime.InvokeJS(@"App.call_test_method (""InvokeReturnLong"");"));
+            var ex = Assert.Throws<JSException>(() => Runtime.InvokeJS(@"
+                console.log(""the exception in InvokeReturnLong after this is intentional"");
+                App.call_test_method (""InvokeReturnLong"");
+            "));
             Assert.Contains("int64 not available", ex.Message);
         }
 
@@ -335,7 +338,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             Runtime.InvokeJS(@"
                 var obj = {myInt: 100, myDouble: 4.5, myString: ""Hic Sunt Dracones"", myBoolean: true};
-                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);		
+                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);
             ");
 
             Assert.Equal(100, HelperMarshal._jsProperties[0]);
@@ -349,8 +352,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             Runtime.InvokeJS(@"
                 var obj = {myInt: 200, myDouble: 0, myString: ""foo"", myBoolean: false};
-                App.call_test_method (""PopulateObjectProperties"", [ obj, false ]);		
-                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);		
+                App.call_test_method (""PopulateObjectProperties"", [ obj, false ]);
+                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);
             ");
 
             Assert.Equal(100, HelperMarshal._jsProperties[0]);
@@ -365,8 +368,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             // This test will not create the properties if they do not already exist
             Runtime.InvokeJS(@"
                 var obj = {myInt: 200};
-                App.call_test_method (""PopulateObjectProperties"", [ obj, false ]);		
-                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);		
+                App.call_test_method (""PopulateObjectProperties"", [ obj, false ]);
+                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);
             ");
 
             Assert.Equal(100, HelperMarshal._jsProperties[0]);
@@ -378,7 +381,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public static void SetObjectPropertiesIfNotExistsTrue()
         {
-            // This test will set the value of the property if it exists and will create and 
+            // This test will set the value of the property if it exists and will create and
             // set the value if it does not exists
             Runtime.InvokeJS(@"
                 var obj = {myInt: 200};
@@ -398,7 +401,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Runtime.InvokeJS(@"
                 var buffer = new ArrayBuffer(16);
                 var uint8View = new Uint8Array(buffer);
-                App.call_test_method (""MarshalByteBuffer"", [ uint8View ]);		
+                App.call_test_method (""MarshalByteBuffer"", [ uint8View ]);
             ");
 
             Assert.Equal(16, HelperMarshal._byteBuffer.Length);

--- a/src/mono/wasm/runtime/js-to-cs.ts
+++ b/src/mono/wasm/runtime/js-to-cs.ts
@@ -67,6 +67,9 @@ export function _js_to_mono_obj_unsafe(should_add_in_flight: boolean, js_obj: an
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function js_to_mono_obj_root(js_obj: any, result: WasmRoot<MonoObject>, should_add_in_flight: boolean): void {
+    if (is_nullish(result))
+        throw new Error("Expected (value, WasmRoot, boolean)");
+
     switch (true) {
         case js_obj === null:
         case typeof js_obj === "undefined":

--- a/src/mono/wasm/runtime/method-binding.ts
+++ b/src/mono/wasm/runtime/method-binding.ts
@@ -216,7 +216,6 @@ export function _compile_converter_for_marshal_string(args_marshal: string/*Args
 
     const closure: any = {
         Module,
-        _malloc: Module._malloc,
         setI32,
         setU32,
         setF32,
@@ -230,7 +229,7 @@ export function _compile_converter_for_marshal_string(args_marshal: string/*Args
 
     body.push(
         "if (!method) throw new Error('no method provided');",
-        `if (!buffer) buffer = _malloc (${bufferSizeBytes});`,
+        "if (!buffer) throw new Error('no buffer provided');",
         `let indirectStart = buffer + ${indirectBaseOffset};`,
         ""
     );
@@ -405,7 +404,7 @@ export function mono_bind_method(method: MonoMethod, this_arg: null, args_marsha
     }
 
     // FIXME
-    const unbox_buffer_size = 8192;
+    const unbox_buffer_size = 128;
     const unbox_buffer = Module._malloc(unbox_buffer_size);
 
     const token: BoundMethodToken = {

--- a/src/mono/wasm/runtime/method-binding.ts
+++ b/src/mono/wasm/runtime/method-binding.ts
@@ -208,9 +208,6 @@ export function _compile_converter_for_marshal_string(args_marshal: string/*Args
     let body = [];
     let argumentNames = ["buffer", "rootBuffer", "method"];
 
-    // worst-case allocation size instead of allocating dynamically, plus padding
-    const bufferSizeBytes = converter.size + (args_marshal.length * 4) + 16;
-
     // ensure the indirect values are 8-byte aligned so that aligned loads and stores will work
     const indirectBaseOffset = ((((args_marshal.length * 4) + 7) / 8) | 0) * 8;
 

--- a/src/mono/wasm/runtime/method-calls.ts
+++ b/src/mono/wasm/runtime/method-calls.ts
@@ -40,6 +40,7 @@ function _verify_args_for_method_call(args_marshal: string/*ArgsMarshalString*/,
     return has_args_marshal && has_args;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function _get_buffer_for_method_call(converter: Converter, token: BoundMethodToken | null): VoidPtr | undefined {
     if (!converter)
         return VoidPtrNull;

--- a/src/mono/wasm/runtime/method-calls.ts
+++ b/src/mono/wasm/runtime/method-calls.ts
@@ -44,14 +44,7 @@ export function _get_buffer_for_method_call(converter: Converter, token: BoundMe
     if (!converter)
         return VoidPtrNull;
 
-    let result = VoidPtrNull;
-    if (token !== null) {
-        result = token.scratchBuffer || VoidPtrNull;
-        token.scratchBuffer = VoidPtrNull;
-    } else {
-        result = converter.scratchBuffer || VoidPtrNull;
-        converter.scratchBuffer = VoidPtrNull;
-    }
+    const result = Module.stackAlloc(converter.size + 64);
     return result;
 }
 
@@ -107,13 +100,6 @@ function _release_buffer_from_method_call(
 ) {
     if (!converter || !buffer)
         return;
-
-    if (token && !token.scratchBuffer)
-        token.scratchBuffer = buffer;
-    else if (!converter.scratchBuffer)
-        converter.scratchBuffer = coerceNull(buffer);
-    else if (buffer)
-        Module._free(buffer);
 }
 
 function _convert_exception_for_method_call(result: WasmRoot<MonoString>, exception: WasmRoot<MonoObject>) {

--- a/src/mono/wasm/runtime/method-calls.ts
+++ b/src/mono/wasm/runtime/method-calls.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { mono_wasm_new_root, mono_wasm_new_root_buffer, WasmRoot, WasmRootBuffer, mono_wasm_new_external_root } from "./roots";
+import { mono_wasm_new_root, WasmRoot, mono_wasm_new_external_root } from "./roots";
 import {
     JSHandle, MonoArray, MonoMethod, MonoObject,
     MonoObjectNull, MonoString, coerceNull as coerceNull,
@@ -38,73 +38,6 @@ function _verify_args_for_method_call(args_marshal: string/*ArgsMarshalString*/,
     }
 
     return has_args_marshal && has_args;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function _get_buffer_for_method_call(converter: Converter, token: BoundMethodToken | null): VoidPtr | undefined {
-    if (!converter)
-        return VoidPtrNull;
-
-    // worst case length
-    const bufferSizeBytes = converter.size + ((converter.args_marshal || "").length * 4);
-    const result = Module.stackAlloc(bufferSizeBytes);
-    // debug fill pattern
-    Module.HEAPU8.fill(0xCA, <any>result, bufferSizeBytes);
-    return result;
-}
-
-export function _get_args_root_buffer_for_method_call(converter: Converter, token: BoundMethodToken | null): WasmRootBuffer | undefined {
-    if (!converter)
-        return undefined;
-
-    if (!converter.needs_root_buffer)
-        return undefined;
-
-    let result = null;
-    if (token !== null) {
-        result = token.scratchRootBuffer;
-        token.scratchRootBuffer = null;
-    } else {
-        result = converter.scratchRootBuffer;
-        converter.scratchRootBuffer = null;
-    }
-
-    if (result === null) {
-        // TODO: Expand the converter's heap allocation and then use
-        //  mono_wasm_new_root_buffer_from_pointer instead. Not that important
-        //  at present because the scratch buffer will be reused unless we are
-        //  recursing through a re-entrant call
-        result = mono_wasm_new_root_buffer(converter.steps.length);
-        // FIXME
-        (<any>result).converter = converter;
-    }
-
-    return result;
-}
-
-function _release_args_root_buffer_from_method_call(
-    converter?: Converter, token?: BoundMethodToken | null, argsRootBuffer?: WasmRootBuffer
-) {
-    if (!argsRootBuffer || !converter)
-        return;
-
-    // Store the arguments root buffer for re-use in later calls
-    if (token && (token.scratchRootBuffer === null)) {
-        argsRootBuffer.clear();
-        token.scratchRootBuffer = argsRootBuffer;
-    } else if (!converter.scratchRootBuffer) {
-        argsRootBuffer.clear();
-        converter.scratchRootBuffer = argsRootBuffer;
-    } else {
-        argsRootBuffer.release();
-    }
-}
-
-function _release_buffer_from_method_call(
-    converter: Converter | undefined, token?: BoundMethodToken | null, buffer?: VoidPtr
-) {
-    if (!converter || !buffer)
-        return;
 }
 
 function _convert_exception_for_method_call(result: WasmRoot<MonoString>, exception: WasmRoot<MonoObject>) {
@@ -153,7 +86,8 @@ export function call_method_ref(method: MonoMethod, this_arg: WasmRoot<MonoObjec
 
     const needs_converter = _verify_args_for_method_call(args_marshal, args);
 
-    let buffer = VoidPtrNull, converter = undefined, argsRootBuffer = undefined;
+    let buffer = VoidPtrNull, converter = undefined;
+    const sp = Module.stackSave();
     let is_result_marshaled = true;
 
     // TODO: Only do this if the signature needs marshaling
@@ -165,36 +99,33 @@ export function call_method_ref(method: MonoMethod, this_arg: WasmRoot<MonoObjec
 
         is_result_marshaled = _decide_if_result_is_marshaled(converter, args.length);
 
-        argsRootBuffer = _get_args_root_buffer_for_method_call(converter, null);
-
-        const scratchBuffer = _get_buffer_for_method_call(converter, null);
-
-        buffer = converter.compiled_variadic_function!(scratchBuffer, argsRootBuffer, method, args);
+        buffer = converter.compiled_variadic_function!(method, args);
     }
-    return _call_method_with_converted_args(method, <any>this_arg_ref, converter, null, buffer, is_result_marshaled, argsRootBuffer);
+
+    return _call_method_with_converted_args(method, <any>this_arg_ref, converter, null, buffer, is_result_marshaled, sp);
 }
 
 
 export function _handle_exception_for_call(
     converter: Converter | undefined, token: BoundMethodToken | null,
     buffer: VoidPtr, resultRoot: WasmRoot<MonoString>,
-    exceptionRoot: WasmRoot<MonoObject>, argsRootBuffer?: WasmRootBuffer
+    exceptionRoot: WasmRoot<MonoObject>, sp: VoidPtr
 ): void {
     const exc = _convert_exception_for_method_call(resultRoot, exceptionRoot);
     if (!exc)
         return;
 
-    _teardown_after_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);
+    _teardown_after_call(converter, token, buffer, resultRoot, exceptionRoot, sp);
     throw exc;
 }
 
 function _handle_exception_and_produce_result_for_call(
     converter: Converter | undefined, token: BoundMethodToken | null,
     buffer: VoidPtr, resultRoot: WasmRoot<MonoString>,
-    exceptionRoot: WasmRoot<MonoObject>, argsRootBuffer: WasmRootBuffer | undefined,
+    exceptionRoot: WasmRoot<MonoObject>, sp: VoidPtr,
     is_result_marshaled: boolean
 ): any {
-    _handle_exception_for_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);
+    _handle_exception_for_call(converter, token, buffer, resultRoot, exceptionRoot, sp);
 
     let result: any;
 
@@ -203,18 +134,17 @@ function _handle_exception_and_produce_result_for_call(
     else
         result = resultRoot.value;
 
-    _teardown_after_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);
+    _teardown_after_call(converter, token, buffer, resultRoot, exceptionRoot, sp);
     return result;
 }
 
 export function _teardown_after_call(
     converter: Converter | undefined, token: BoundMethodToken | null,
     buffer: VoidPtr, resultRoot: WasmRoot<any>,
-    exceptionRoot: WasmRoot<any>, argsRootBuffer?: WasmRootBuffer
+    exceptionRoot: WasmRoot<any>, sp: VoidPtr
 ): void {
     _release_temp_frame();
-    _release_args_root_buffer_from_method_call(converter, token, argsRootBuffer);
-    _release_buffer_from_method_call(converter, token, buffer);
+    Module.stackRestore(sp);
 
     if (typeof (resultRoot) === "object") {
         resultRoot.clear();
@@ -235,11 +165,11 @@ export function _teardown_after_call(
 function _call_method_with_converted_args(
     method: MonoMethod, this_arg_ref: MonoObjectRef, converter: Converter | undefined,
     token: BoundMethodToken | null, buffer: VoidPtr,
-    is_result_marshaled: boolean, argsRootBuffer?: WasmRootBuffer
+    is_result_marshaled: boolean, sp: VoidPtr
 ): any {
     const resultRoot = mono_wasm_new_root<MonoString>(), exceptionRoot = mono_wasm_new_root<MonoObject>();
     cwraps.mono_wasm_invoke_method_ref(method, this_arg_ref, buffer, exceptionRoot.address, resultRoot.address);
-    return _handle_exception_and_produce_result_for_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer, is_result_marshaled);
+    return _handle_exception_and_produce_result_for_call(converter, token, buffer, resultRoot, exceptionRoot, sp, is_result_marshaled);
 }
 
 export function call_static_method(fqn: string, args: any[], signature: string/*ArgsMarshalString*/): any {

--- a/src/mono/wasm/runtime/method-calls.ts
+++ b/src/mono/wasm/runtime/method-calls.ts
@@ -44,7 +44,11 @@ export function _get_buffer_for_method_call(converter: Converter, token: BoundMe
     if (!converter)
         return VoidPtrNull;
 
-    const result = Module.stackAlloc(converter.size + 64);
+    // worst case length
+    const bufferSizeBytes = converter.size + ((converter.args_marshal || "").length * 4);
+    const result = Module.stackAlloc(bufferSizeBytes);
+    // debug fill pattern
+    Module.HEAPU8.fill(0xCA, <any>result, bufferSizeBytes);
     return result;
 }
 


### PR DESCRIPTION
This works around the crash in issue #69681 and is an optimization versus how it currently works, assuming it doesn't introduce any new issues. We still need to identify the root cause of that issue but this should unblock us.