### PR TITLE
Avoid try/catch when generating type forwarder metadata

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
@@ -254,21 +254,19 @@ namespace ILCompiler
 
             public bool GeneratesMetadata(EcmaModule module, ExportedTypeHandle exportedTypeHandle)
             {
-                try
-                {
-                    // We'll possibly need to do something else here if we ever use this MetadataManager
-                    // with compilation modes that generate multiple metadata blobs.
-                    // (Multi-module or .NET Native style shared library.)
-                    // We are currently missing type forwarders pointing to the other blobs.
-                    var targetType = (MetadataType)module.GetObject(exportedTypeHandle);
-                    return GeneratesMetadata(targetType);
-                }
-                catch (TypeSystemException)
+                // We'll possibly need to do something else here if we ever use this MetadataManager
+                // with compilation modes that generate multiple metadata blobs.
+                // (Multi-module or .NET Native style shared library.)
+                // We are currently missing type forwarders pointing to the other blobs.
+                var targetType = (MetadataType)module.GetObject(exportedTypeHandle, NotFoundBehavior.ReturnNull);
+                if (targetType == null)
                 {
                     // No harm in generating a forwarder that didn't resolve.
                     // We'll get matching behavior at runtime.
                     return true;
                 }
+
+                return GeneratesMetadata(targetType);
             }
 
             public bool IsBlocked(MetadataType typeDef)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -885,19 +885,16 @@ namespace ILCompiler
 
             public bool GeneratesMetadata(EcmaModule module, ExportedTypeHandle exportedTypeHandle)
             {
-                try
-                {
-                    // Generate the forwarder only if we generated the target type.
-                    // If the target type is in a different compilation group, assume we generated it there.
-                    var targetType = (MetadataType)module.GetObject(exportedTypeHandle);
-                    return GeneratesMetadata(targetType) || !_factory.CompilationModuleGroup.ContainsType(targetType);
-                }
-                catch (TypeSystemException)
+                // Generate the forwarder only if we generated the target type.
+                // If the target type is in a different compilation group, assume we generated it there.
+                var targetType = (MetadataType)module.GetObject(exportedTypeHandle, NotFoundBehavior.ReturnNull);
+                if (targetType == null)
                 {
                     // No harm in generating a forwarder that didn't resolve.
                     // We'll get matching behavior at runtime.
                     return true;
                 }
+                return GeneratesMetadata(targetType) || !_factory.CompilationModuleGroup.ContainsType(targetType);
             }
 
             public bool IsBlocked(MetadataType typeDef)


### PR DESCRIPTION
The code was written before we introduced the concept of `NotFoundBehavior`. This avoids hitting first-chance exceptions when mscorlib becomes part of the closure for whatever reason. First chance exceptions are annoying.

For context, NativeAOT currently generates type forwarder metadata for everything that had a definition generated (e.g. if System.Object is generated and mscorlib and System.Runtime is generated, we generate the forwarders for System.Object in both S.Runtime and mscorlib).

We'll want to eventually model type forwarders in the dependency graph and only generate them when needed (e.g. only if `Type.GetType("System.Object, mscorlib")` is present). It's what IL Linker now does. It's a possible future size optimization.