### PR TITLE
[LoongArch64] Fixed the exception's dispatch by EPC.

### DIFF
--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -990,7 +990,7 @@ AdjustContextForVirtualStub(
 
     if (sk == VirtualCallStubManager::SK_DISPATCH)
     {
-        if (*PTR_DWORD(f_IP) != DISPATCH_STUB_FIRST_DWORD)
+        if (*PTR_DWORD(f_IP - 4) != DISPATCH_STUB_FIRST_DWORD)
         {
             _ASSERTE(!"AV in DispatchStub at unknown instruction");
             return FALSE;


### PR DESCRIPTION
For LongArch64, the `epc` is not the start address of the stub.