### PR TITLE
Optimize better with maximum array length

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -39,13 +39,26 @@ bool IntegralRange::Contains(int64_t value) const
 //    value - the symbolic value in question
 //
 // Return Value:
-//    Integer correspoding to the symbolic value.
+//    Integer corresponding to the symbolic value.
 //
 /* static */ int64_t IntegralRange::SymbolicToRealValue(SymbolicIntegerValue value)
 {
-    static const int64_t SymbolicToRealMap[]{INT64_MIN, INT32_MIN,  INT16_MIN, INT8_MIN,  0,
-                                             1,         INT8_MAX,   UINT8_MAX, INT16_MAX, UINT16_MAX,
-                                             INT32_MAX, UINT32_MAX, INT64_MAX};
+    static const int64_t SymbolicToRealMap[]{
+        INT64_MIN,  // SymbolicIntegerValue::LongMin
+        INT32_MIN,  // SymbolicIntegerValue::IntMin
+        INT16_MIN,  // SymbolicIntegerValue::ShortMin
+        INT8_MIN,   // SymbolicIntegerValue::ByteMin
+        0,          // SymbolicIntegerValue::Zero
+        1,          // SymbolicIntegerValue::One
+        INT8_MAX,   // SymbolicIntegerValue::ByteMax
+        UINT8_MAX,  // SymbolicIntegerValue::UByteMax
+        INT16_MAX,  // SymbolicIntegerValue::ShortMax
+        UINT16_MAX, // SymbolicIntegerValue::UShortMax
+        ARRLEN_MAX, // SymbolicIntegerValue::ArrayLenMax
+        INT32_MAX,  // SymbolicIntegerValue::IntMax
+        UINT32_MAX, // SymbolicIntegerValue::UIntMax
+        INT64_MAX   // SymbolicIntegerValue::LongMax
+    };
 
     assert(sizeof(SymbolicIntegerValue) == sizeof(int32_t));
     assert(SymbolicToRealMap[static_cast<int32_t>(SymbolicIntegerValue::LongMin)] == INT64_MIN);
@@ -145,7 +158,7 @@ bool IntegralRange::Contains(int64_t value) const
             return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::One};
 
         case GT_ARR_LENGTH:
-            return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::IntMax};
+            return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::ArrayLenMax};
 
         case GT_CALL:
             if (node->AsCall()->NormalizesSmallTypesOnReturn())

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -44,20 +44,20 @@ bool IntegralRange::Contains(int64_t value) const
 /* static */ int64_t IntegralRange::SymbolicToRealValue(SymbolicIntegerValue value)
 {
     static const int64_t SymbolicToRealMap[]{
-        INT64_MIN,  // SymbolicIntegerValue::LongMin
-        INT32_MIN,  // SymbolicIntegerValue::IntMin
-        INT16_MIN,  // SymbolicIntegerValue::ShortMin
-        INT8_MIN,   // SymbolicIntegerValue::ByteMin
-        0,          // SymbolicIntegerValue::Zero
-        1,          // SymbolicIntegerValue::One
-        INT8_MAX,   // SymbolicIntegerValue::ByteMax
-        UINT8_MAX,  // SymbolicIntegerValue::UByteMax
-        INT16_MAX,  // SymbolicIntegerValue::ShortMax
-        UINT16_MAX, // SymbolicIntegerValue::UShortMax
-        ARRLEN_MAX, // SymbolicIntegerValue::ArrayLenMax
-        INT32_MAX,  // SymbolicIntegerValue::IntMax
-        UINT32_MAX, // SymbolicIntegerValue::UIntMax
-        INT64_MAX   // SymbolicIntegerValue::LongMax
+        INT64_MIN,               // SymbolicIntegerValue::LongMin
+        INT32_MIN,               // SymbolicIntegerValue::IntMin
+        INT16_MIN,               // SymbolicIntegerValue::ShortMin
+        INT8_MIN,                // SymbolicIntegerValue::ByteMin
+        0,                       // SymbolicIntegerValue::Zero
+        1,                       // SymbolicIntegerValue::One
+        INT8_MAX,                // SymbolicIntegerValue::ByteMax
+        UINT8_MAX,               // SymbolicIntegerValue::UByteMax
+        INT16_MAX,               // SymbolicIntegerValue::ShortMax
+        UINT16_MAX,              // SymbolicIntegerValue::UShortMax
+        CORINFO_Array_MaxLength, // SymbolicIntegerValue::ArrayLenMax
+        INT32_MAX,               // SymbolicIntegerValue::IntMax
+        UINT32_MAX,              // SymbolicIntegerValue::UIntMax
+        INT64_MAX                // SymbolicIntegerValue::LongMax
     };
 
     assert(sizeof(SymbolicIntegerValue) == sizeof(int32_t));

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1181,6 +1181,7 @@ enum class SymbolicIntegerValue : int32_t
     UByteMax,
     ShortMax,
     UShortMax,
+    ArrayLenMax,
     IntMax,
     UIntMax,
     LongMax,

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -852,5 +852,13 @@ extern "C" UINT32 WINAPI getLikelyClasses(LikelyClassRecord*                    
                                           int32_t                                ilOffset);
 
 /*****************************************************************************/
+
+// The maximum array length is defined to be slightly less than the maximum signed 32-bit integer.
+// See https://github.com/dotnet/runtime/pull/43301, https://msdn.microsoft.com/en-us/windows/apps/hh285054.aspx.
+// CLR throws IDS_EE_ARRAY_DIMENSIONS_EXCEEDED if array length is too large. The practical limit is likely smaller
+// due to memory fragmentation.
+#define ARRLEN_MAX (0x7FFFFFC7)
+
+/*****************************************************************************/
 #endif //_JIT_H_
 /*****************************************************************************/

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -852,13 +852,5 @@ extern "C" UINT32 WINAPI getLikelyClasses(LikelyClassRecord*                    
                                           int32_t                                ilOffset);
 
 /*****************************************************************************/
-
-// The maximum array length is defined to be slightly less than the maximum signed 32-bit integer.
-// See https://github.com/dotnet/runtime/pull/43301, https://msdn.microsoft.com/en-us/windows/apps/hh285054.aspx.
-// CLR throws IDS_EE_ARRAY_DIMENSIONS_EXCEEDED if array length is too large. The practical limit is likely smaller
-// due to memory fragmentation.
-#define ARRLEN_MAX (0x7FFFFFC7)
-
-/*****************************************************************************/
 #endif //_JIT_H_
 /*****************************************************************************/

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1056,12 +1056,6 @@ Range RangeCheck::ComputeRangeForLocalDef(BasicBlock*          block,
     return range;
 }
 
-// https://msdn.microsoft.com/en-us/windows/apps/hh285054.aspx
-// CLR throws IDS_EE_ARRAY_DIMENSIONS_EXCEEDED if array length is > INT_MAX.
-// new byte[INT_MAX]; still throws OutOfMemoryException on my system with 32 GB RAM.
-// I believe practical limits are still smaller than this number.
-#define ARRLEN_MAX (0x7FFFFFFF)
-
 // Get the limit's maximum possible value, treating array length to be ARRLEN_MAX.
 bool RangeCheck::GetLimitMax(Limit& limit, int* pMax)
 {

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1072,7 +1072,7 @@ bool RangeCheck::GetLimitMax(Limit& limit, int* pMax)
             if (tmp <= 0)
             {
                 // If we can't figure out the array length, use the maximum array length,
-                // CORINFO_Array_MaxLength (0x7FFFFFC7). However, we get here also when 
+                // CORINFO_Array_MaxLength (0x7FFFFFC7). However, we get here also when
                 // we can't find a Span/ReadOnlySpan bounds check length, and these have
                 // a maximum length of INT_MAX (0x7FFFFFFF). If limit.vn refers to a
                 // GT_ARR_LENGTH node, then it's an array length, otherwise use the INT_MAX value.
@@ -1084,7 +1084,7 @@ bool RangeCheck::GetLimitMax(Limit& limit, int* pMax)
                 else
                 {
                     const int MaxSpanLength = 0x7FFFFFFF;
-                    tmp = MaxSpanLength;
+                    tmp                     = MaxSpanLength;
                 }
             }
             if (IntAddOverflows(tmp, limit.GetConstant()))

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1056,7 +1056,7 @@ Range RangeCheck::ComputeRangeForLocalDef(BasicBlock*          block,
     return range;
 }
 
-// Get the limit's maximum possible value, treating array length to be ARRLEN_MAX.
+// Get the limit's maximum possible value, treating array length to be CORINFO_Array_MaxLength.
 bool RangeCheck::GetLimitMax(Limit& limit, int* pMax)
 {
     int& max1 = *pMax;
@@ -1071,7 +1071,7 @@ bool RangeCheck::GetLimitMax(Limit& limit, int* pMax)
             int tmp = GetArrLength(limit.vn);
             if (tmp <= 0)
             {
-                tmp = ARRLEN_MAX;
+                tmp = CORINFO_Array_MaxLength;
             }
             if (IntAddOverflows(tmp, limit.GetConstant()))
             {

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1056,7 +1056,7 @@ Range RangeCheck::ComputeRangeForLocalDef(BasicBlock*          block,
     return range;
 }
 
-// Get the limit's maximum possible value, treating array length to be CORINFO_Array_MaxLength.
+// Get the limit's maximum possible value.
 bool RangeCheck::GetLimitMax(Limit& limit, int* pMax)
 {
     int& max1 = *pMax;
@@ -1071,7 +1071,21 @@ bool RangeCheck::GetLimitMax(Limit& limit, int* pMax)
             int tmp = GetArrLength(limit.vn);
             if (tmp <= 0)
             {
-                tmp = CORINFO_Array_MaxLength;
+                // If we can't figure out the array length, use the maximum array length,
+                // CORINFO_Array_MaxLength (0x7FFFFFC7). However, we get here also when 
+                // we can't find a Span/ReadOnlySpan bounds check length, and these have
+                // a maximum length of INT_MAX (0x7FFFFFFF). If limit.vn refers to a
+                // GT_ARR_LENGTH node, then it's an array length, otherwise use the INT_MAX value.
+
+                if (m_pCompiler->vnStore->IsVNArrLen(limit.vn))
+                {
+                    tmp = CORINFO_Array_MaxLength;
+                }
+                else
+                {
+                    const int MaxSpanLength = 0x7FFFFFFF;
+                    tmp = MaxSpanLength;
+                }
             }
             if (IntAddOverflows(tmp, limit.GetConstant()))
             {

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -581,8 +581,8 @@ public:
     // Inspect the assertions about the current ValueNum to refine pRange
     void MergeEdgeAssertions(ValueNum num, ASSERT_VALARG_TP assertions, Range* pRange);
 
-    // The maximum possible value of the given "limit." If such a value could not be determined
-    // return "false." For example: ARRLEN_MAX for array length.
+    // The maximum possible value of the given "limit". If such a value could not be determined
+    // return "false". For example: CORINFO_Array_MaxLength for array length.
     bool GetLimitMax(Limit& limit, int* pMax);
 
     // Does the addition of the two limits overflow?

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -5749,7 +5749,7 @@ bool ValueNumStore::IsVNCheckedBound(ValueNum vn)
     if (m_checkedBoundVNs.TryGetValue(vn, &dummy))
     {
         // This VN appeared as the conservative VN of the length argument of some
-        // GT_ARR_BOUND node.
+        // GT_BOUNDS_CHECK node.
         return true;
     }
     if (IsVNArrLen(vn))


### PR DESCRIPTION
The maximum array length is 0x7FFFFFC7 (see
https://github.com/dotnet/runtime/pull/43301), which is slightly less than
the largest 32-bit signed integer. Use this value in range check and assertion
prop to optimize better. This is due do knowing that a value smaller than
the maximum array length plus a small constant will not overflow. This leads
to being able to remove some bounds checks.