### PR TITLE
Fix CI jobs regression to *not* default to `shouldContinueOnError: true`

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -15,7 +15,7 @@ parameters:
 jobs:
 - template: ${{ coalesce(parameters.helixQueuesTemplate, parameters.jobTemplate) }}
   parameters:
-    shouldContinueOnError: ${{ or(parameters.shouldContinueOnError, and(endsWith(variables['Build.DefinitionName'], 'staging'), eq(variables['Build.Reason'], 'PullRequest'))) }}
+    shouldContinueOnError: ${{ or(eq(parameters.shouldContinueOnError, true), and(endsWith(variables['Build.DefinitionName'], 'staging'), eq(variables['Build.Reason'], 'PullRequest'))) }}
 
     # keep in sync with /eng/pipelines/common/variables.yml
     dependOnEvaluatePaths: ${{ and(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.DefinitionName'], 'runtime', 'runtime-staging', 'runtime-community', 'runtime-extra-platforms')) }}


### PR DESCRIPTION
My change in https://github.com/radical/runtime/commit/110b4cfaa627deed4b06b864b06128267d0a64c2, changed
xplat-setup.yml to have:

`shouldContinueOnError: ${{ or(parameters.shouldContinueOnError, ..`

but IIUC, yml is treating this as a string, and not a bool, and so is
evaluating that to `true` if the string is not empty, which would be the
case even if the string has `false`.
(`To Boolean: '' (the empty string) → False, any other string → True`[1]).

This patch changes the condition to match how it is done in other files:

`shouldContinueOnError: ${{ or(eq(parameters.shouldContinueOnError, true),`

To confirm this, I added:
```diff
+      - name: foo_orig
+        value: ${{ parameters.shouldContinueOnError }}
+      - name: foo_true
+        value: ${{ eq(parameters.shouldContinueOnError, true) }}
+      - name: foo_false
+        value: ${{ eq(parameters.shouldContinueOnError, false) }}
+      - name: foo_true_x
+        value: ${{ eq(parameters.shouldContinueOnError, True) }}
+      - name: foo_false_x
+        value: ${{ eq(parameters.shouldContinueOnError, False) }}
+      - name: foo_bar
+        value: ${{ or(parameters.shouldContinueOnError, False) }}
```

.. and the resulting values in the expanded yml were:
```yml
    - name: foo_orig
      value: false
    - name: foo_true
      value: False
    - name: foo_false
      value: True
    - name: foo_true_x
      value: False
    - name: foo_false_x
      value: True
    - name: foo_bar
      value: True
```

So, if we have a parameter `shouldContinueOnError: false` (note the lower case),
then it is a string. And using it in
`or(parameters.shouldContinueOnError, false)` becomes `or(True, false)`
since `false` is a non-empty string. And using
`eq(parameters.shouldContinueOnError, true)` correctly "converts" that
to a boolean.

--

1. https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops