### PR TITLE
Fix DELETE URL in backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,16 +23,13 @@ jobs:
     - name: Delete old workflow runs
       run: |
         _UrlPath="/repos/$GITHUB_REPOSITORY/actions/workflows"
-
         _CurrentWorkflowID="$(gh api -X GET "$_UrlPath" | jq '.workflows[] | select(.name == '\""$GITHUB_WORKFLOW"\"') | .id')"
-
-        _UrlPath="$_UrlPath/$_CurrentWorkflowID/runs"
 
         # delete workitems which are 'completed'. (other candidate values of status field are: 'queued' and 'in_progress')
 
-        gh api -X GET "$_UrlPath" --paginate \
+        gh api -X GET "$_UrlPath/$_CurrentWorkflowID/runs" --paginate \
           | jq '.workflow_runs[] | select(.status == "completed") | .id' \
-          | xargs -I{} gh api -X DELETE "$_UrlPath"/{}
+          | xargs -I{} gh api -X DELETE "/repos/$GITHUB_REPOSITORY/actions/runs"/{}
 
   backport:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/backport to')


### PR DESCRIPTION
In previous update, I forgot that `DELETE` endpoint has a different URL.