### PR TITLE
Skip `COMMA`s when creating non-null assertions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1323,6 +1323,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
         //
         // Set op1 to the instance pointer of the indirection
         //
+        op1 = op1->gtEffectiveVal(/* commaOnly */ true);
 
         ssize_t offset = 0;
         while ((op1->gtOper == GT_ADD) && (op1->gtType == TYP_BYREF))


### PR DESCRIPTION
It has been noticed that the compiler can sometimes generate `COMMA(..., LCL_VAR)` under an indirection (as part of CSE, say), but then fail to take advantage of the introduced precision in conservative VNs when creating assertions.

This change fixes that by skipping `COMMA`s when creating non-null assertions.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1787132&view=results).