### PR TITLE
Add Linux Bionic to official build, for runtime packs

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -130,6 +130,8 @@ stages:
       - Linux_arm64
       - Linux_musl_x64
       - Browser_wasm
+      - Linux_bionic_arm64
+      - Linux_bionic_x64
       # - Linux_musl_arm
       # - Linux_musl_arm64
       - windows_x64


### PR DESCRIPTION
This is blocked on an official build, since runtime-official is only tested there