### PR TITLE
Revert MSVC changes for libunwind

### DIFF
--- a/src/native/external/libunwind-version.txt
+++ b/src/native/external/libunwind-version.txt
@@ -8,6 +8,7 @@ Apply https://github.com/libunwind/libunwind/pull/333
 Apply https://github.com/libunwind/libunwind/pull/342
 Apply https://github.com/libunwind/libunwind/pull/353
 Apply https://github.com/libunwind/libunwind/pull/358
+Apply https://github.com/libunwind/libunwind/commit/7cf6e84bb86ff5840896b4910ccc3865d4f00ffb
 
 For LoongArch64:
 Apply https://github.com/libunwind/libunwind/pull/316 and https://github.com/libunwind/libunwind/pull/322

--- a/src/native/external/libunwind/include/dwarf_i.h
+++ b/src/native/external/libunwind/include/dwarf_i.h
@@ -136,7 +136,7 @@ static inline int
 dwarf_readu8 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
               uint8_t *valp, void *arg)
 {
-  unw_word_t val, aligned_addr = UNW_ALIGN(*addr, sizeof (unw_word_t));
+  unw_word_t val, aligned_addr = *addr & (~sizeof (unw_word_t) + 1);
   unw_word_t off = *addr - aligned_addr;
   int ret;
 

--- a/src/native/external/libunwind/include/remote.h
+++ b/src/native/external/libunwind/include/remote.h
@@ -51,7 +51,7 @@ static inline int
 fetch8 (unw_addr_space_t as, unw_accessors_t *a,
         unw_word_t *addr, int8_t *valp, void *arg)
 {
-  unw_word_t val, aligned_addr = UNW_ALIGN(*addr, WSIZE), off = *addr - aligned_addr;
+  unw_word_t val, aligned_addr = *addr & (~WSIZE + 1), off = *addr - aligned_addr;
   int ret;
 
   *addr += 1;
@@ -71,7 +71,7 @@ static inline int
 fetch16 (unw_addr_space_t as, unw_accessors_t *a,
          unw_word_t *addr, int16_t *valp, void *arg)
 {
-  unw_word_t val, aligned_addr = UNW_ALIGN(*addr, WSIZE), off = *addr - aligned_addr;
+  unw_word_t val, aligned_addr = *addr & (~WSIZE + 1), off = *addr - aligned_addr;
   int ret;
 
   if ((off & 0x1) != 0)
@@ -94,7 +94,7 @@ static inline int
 fetch32 (unw_addr_space_t as, unw_accessors_t *a,
          unw_word_t *addr, int32_t *valp, void *arg)
 {
-  unw_word_t val, aligned_addr = UNW_ALIGN(*addr, WSIZE), off = *addr - aligned_addr;
+  unw_word_t val, aligned_addr = *addr & (~WSIZE + 1), off = *addr - aligned_addr;
   int ret;
 
   if ((off & 0x3) != 0)

--- a/src/native/external/libunwind/src/dwarf/Gexpr.c
+++ b/src/native/external/libunwind/src/dwarf/Gexpr.c
@@ -530,7 +530,7 @@ if (stackerror)                                 \
           Debug (15, "OP_abs\n");
           tmp1 = pop ();
           if (tmp1 & ((unw_word_t) 1 << (8 * dwarf_addr_size (as) - 1)))
-            tmp1 = (unw_word_t)(-(unw_sword_t)tmp1);
+            tmp1 = (~tmp1 + 1);
           push (tmp1);
           break;
 
@@ -578,7 +578,7 @@ if (stackerror)                                 \
 
         case DW_OP_neg:
           Debug (15, "OP_neg\n");
-          push (-(unw_sword_t)pop ());
+          push (~pop () + 1);
           break;
 
         case DW_OP_not:

--- a/src/native/external/libunwind/src/dwarf/Gparser.c
+++ b/src/native/external/libunwind/src/dwarf/Gparser.c
@@ -390,9 +390,9 @@ run_cfi_program (struct dwarf_cursor *c, dwarf_state_record_t *sr,
           if (((ret = read_regnum (as, a, addr, &regnum, arg)) < 0)
               || ((ret = dwarf_read_uleb128 (as, a, addr, &val, arg)) < 0))
             break;
-          set_reg (sr, regnum, DWARF_WHERE_CFAREL, (unw_word_t)(-(unw_sword_t)val));
+          set_reg (sr, regnum, DWARF_WHERE_CFAREL, ~(val * dci->data_align) + 1);
           Debug (15, "CFA_GNU_negative_offset_extended cfa+0x%lx\n",
-                 (long)(unw_word_t)(-(unw_sword_t)val));
+                 (long) (~(val * dci->data_align) + 1));
           break;
 
         case DW_CFA_GNU_window_save:


### PR DESCRIPTION
The changes made to libunwind for SDL requirements seem to have caused a regression in libunwind. This PR reverts them since they have been confirmed to cause regressions that we may not be observing but could be causing underlying issues.

See https://github.com/libunwind/libunwind/pull/333#issuecomment-1136277964 for the revert.

/cc @janvorli @am11 