### PR TITLE
Improve string.Format / {Value}StringBuilder.AppendFormat parsing throughput

### DIFF
--- a/src/libraries/Common/tests/Tests/System/StringTests.cs
+++ b/src/libraries/Common/tests/Tests/System/StringTests.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
+using static System.Text.Tests.StringBuilderTests;
 
 #pragma warning disable xUnit2009 // these are the tests for String and so should be using the explicit methods on String
 
@@ -2623,15 +2624,116 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentException>("comparisonType", () => "a".Equals("b", comparisonType));
         }
 
-        [Fact]
-        public static void Format()
+        public static IEnumerable<object[]> Format_Valid_TestData()
         {
-            string s = string.Format(null, "0 = {0} 1 = {1} 2 = {2} 3 = {3} 4 = {4}", "zero", "one", "two", "three", "four");
-            Assert.Equal("0 = zero 1 = one 2 = two 3 = three 4 = four", s);
+            yield return new object[] { null, "", new object[0], "" };
+            yield return new object[] { null, ", ", new object[0], ", " };
 
-            var testFormatter = new TestFormatter();
-            s = string.Format(testFormatter, "0 = {0} 1 = {1} 2 = {2} 3 = {3} 4 = {4}", "zero", "one", "two", "three", "four");
-            Assert.Equal("0 = Test: : zero 1 = Test: : one 2 = Test: : two 3 = Test: : three 4 = Test: : four", s);
+            yield return new object[] { null, ", Foo {0  }", new object[] { "Bar" }, ", Foo Bar" }; // Ignores whitespace
+
+            yield return new object[] { null, "Foo {0}", new object[] { "Bar" }, "Foo Bar" };
+            yield return new object[] { null, "Foo {0} Baz {1}", new object[] { "Bar", "Foo" }, "Foo Bar Baz Foo" };
+            yield return new object[] { null, "Foo {0} Baz {1} Bar {2}", new object[] { "Bar", "Foo", "Baz" }, "Foo Bar Baz Foo Bar Baz" };
+            yield return new object[] { null, "Foo {0} Baz {1} Bar {2} Foo {3}", new object[] { "Bar", "Foo", "Baz", "Bar" }, "Foo Bar Baz Foo Bar Baz Foo Bar" };
+
+            // Length is positive
+            yield return new object[] { null, "Foo {0,2}", new object[] { "Bar" }, "Foo Bar" }; // MiValue's length > minimum length (so don't prepend whitespace)
+            yield return new object[] { null, "Foo {0,3}", new object[] { "B" }, "Foo   B" }; // Value's length < minimum length (so prepend whitespace)
+            yield return new object[] { null, "Foo {0,     3}", new object[] { "B" }, "Foo   B" }; // Same as above, but verify AppendFormat ignores whitespace
+            yield return new object[] { null, "Foo {0,0}", new object[] { "Bar" }, "Foo Bar" }; // Minimum length is 0
+            yield return new object[] { null, "Foo {0,  2 }", new object[] { "Bar" }, "Foo Bar" }; // whitespace before and after length
+
+            // Length is negative
+            yield return new object[] { null, "Foo {0,-2}", new object[] { "Bar" }, "Foo Bar" }; // Value's length > |minimum length| (so don't prepend whitespace)
+            yield return new object[] { null, "Foo {0,-3}", new object[] { "B" }, "Foo B  " }; // Value's length < |minimum length| (so append whitespace)
+            yield return new object[] { null, "Foo {0,     -3}", new object[] { "B" }, "Foo B  " }; // Same as above, but verify AppendFormat ignores whitespace
+            yield return new object[] { null, "Foo {0,0}", new object[] { "Bar" }, "Foo Bar" }; // Minimum length is 0
+            yield return new object[] { null, "Foo {0, -2  }", new object[] { "Bar" }, "Foo Bar" }; // whitespace before and after length
+
+            yield return new object[] { null, "Foo {0:D6}", new object[] { 1 }, "Foo 000001" }; // Custom format
+            yield return new object[] { null, "Foo {0     :D6}", new object[] { 1 }, "Foo 000001" }; // Custom format with ignored whitespace
+            yield return new object[] { null, "Foo {0:}", new object[] { 1 }, "Foo 1" }; // Missing custom format
+
+            yield return new object[] { null, "Foo {0,9:D6}", new object[] { 1 }, "Foo    000001" }; // Positive minimum length and custom format
+            yield return new object[] { null, "Foo {0,-9:D6}", new object[] { 1 }, "Foo 000001   " }; // Negative length and custom format
+
+            yield return new object[] { null, "Foo {{{0}", new object[] { 1 }, "Foo {1" }; // Escaped open curly braces
+            yield return new object[] { null, "Foo }}{0}", new object[] { 1 }, "Foo }1" }; // Escaped closed curly braces
+            yield return new object[] { null, "Foo {0} {{0}}", new object[] { 1 }, "Foo 1 {0}" }; // Escaped placeholder
+
+
+            yield return new object[] { null, "Foo {0}", new object[] { null }, "Foo " }; // Values has null only
+            yield return new object[] { null, "Foo {0} {1} {2}", new object[] { "Bar", null, "Baz" }, "Foo Bar  Baz" }; // Values has null
+
+            yield return new object[] { CultureInfo.InvariantCulture, "Foo {0,9:D6}", new object[] { 1 }, "Foo    000001" }; // Positive minimum length, custom format and custom format provider
+
+            yield return new object[] { new CustomFormatter(), "{0}", new object[] { 1.2 }, "abc" }; // Custom format provider
+            yield return new object[] { new CustomFormatter(), "{0:0}", new object[] { 1.2 }, "abc" }; // Custom format provider
+
+            // Longer inputs
+            yield return new object[] { null, "0 = {0} 1 = {1} 2 = {2} 3 = {3} 4 = {4}", new object[] { "zero", "one", "two", "three", "four" }, "0 = zero 1 = one 2 = two 3 = three 4 = four" };
+            yield return new object[] { new TestFormatter(), "0 = {0} 1 = {1} 2 = {2} 3 = {3} 4 = {4}", new object[] { "zero", "one", "two", "three", "four" }, "0 = Test: : zero 1 = Test: : one 2 = Test: : two 3 = Test: : three 4 = Test: : four" };
+
+            // ISpanFormattable inputs: simple validation of known types that implement the interface
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (byte)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { 'A' }, "A" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0:r}", new object[] { DateTime.ParseExact("2021-03-15T14:52:51.5058563Z", "o", null, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal) }, "Mon, 15 Mar 2021 14:52:51 GMT" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0:r}", new object[] { DateTimeOffset.ParseExact("2021-03-15T14:52:51.5058563Z", "o", null, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal) }, "Mon, 15 Mar 2021 14:52:51 GMT" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (decimal)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (double)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { Guid.Parse("68d9cfaf-feab-4d5b-96d8-a3fd889ae89f") }, "68d9cfaf-feab-4d5b-96d8-a3fd889ae89f" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (Half)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (short)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (int)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (long)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (IntPtr)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { new Rune('A') }, "A" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (sbyte)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (float)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { TimeSpan.FromSeconds(42) }, "00:00:42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (ushort)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (uint)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (ulong)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { (UIntPtr)42 }, "42" };
+            yield return new object[] { CultureInfo.InvariantCulture, "{0}", new object[] { new Version(1, 2, 3, 4) }, "1.2.3.4" };
+        }
+
+        [Theory]
+        [MemberData(nameof(Format_Valid_TestData))]
+        public static void Format_Valid(IFormatProvider provider, string format, object[] values, string expected)
+        {
+            Assert.Equal(expected, string.Format(provider, format, values));
+            if (provider is null)
+            {
+                Assert.Equal(expected, string.Format(format, values));
+            }
+
+            switch (values.Length)
+            {
+                case 1:
+                    Assert.Equal(expected, string.Format(provider, format, values[0]));
+                    if (provider is null)
+                    {
+                        Assert.Equal(expected, string.Format(format, values[0]));
+                    }
+                    break;
+
+                case 2:
+                    Assert.Equal(expected, string.Format(provider, format, values[0], values[1]));
+                    if (provider is null)
+                    {
+                        Assert.Equal(expected, string.Format(format, values[0], values[1]));
+                    }
+                    break;
+
+                case 3:
+                    Assert.Equal(expected, string.Format(provider, format, values[0], values[1], values[2]));
+                    if (provider is null)
+                    {
+                        Assert.Equal(expected, string.Format(format, values[0], values[1], values[2]));
+                    }
+                    break;
+            }
         }
 
         [Fact]
@@ -2661,26 +2763,54 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentNullException>("format", () => string.Format(null, (object[])null));
             AssertExtensions.Throws<ArgumentNullException>("format", () => string.Format(formatter, null, null));
 
-            // Format has value < 0
-            Assert.Throws<FormatException>(() => string.Format("{-1}", obj1));
-            Assert.Throws<FormatException>(() => string.Format("{-1}", obj1, obj2));
-            Assert.Throws<FormatException>(() => string.Format("{-1}", obj1, obj2, obj3));
-            Assert.Throws<FormatException>(() => string.Format("{-1}", obj1, obj2, obj3, obj4));
-            Assert.Throws<FormatException>(() => string.Format(formatter, "{-1}", obj1));
-            Assert.Throws<FormatException>(() => string.Format(formatter, "{-1}", obj1, obj2));
-            Assert.Throws<FormatException>(() => string.Format(formatter, "{-1}", obj1, obj2, obj3));
-            Assert.Throws<FormatException>(() => string.Format(formatter, "{-1}", obj1, obj2, obj3, obj4));
-#pragma warning disable IDE0043 // Format string contains invalid placeholder - the purpose of this is to test the functions
-            // Format has out of range value
-            Assert.Throws<FormatException>(() => string.Format("{1}", obj1));
-            Assert.Throws<FormatException>(() => string.Format("{2}", obj1, obj2));
-            Assert.Throws<FormatException>(() => string.Format("{3}", obj1, obj2, obj3));
-            Assert.Throws<FormatException>(() => string.Format("{4}", obj1, obj2, obj3, obj4));
-            Assert.Throws<FormatException>(() => string.Format(formatter, "{1}", obj1));
-            Assert.Throws<FormatException>(() => string.Format(formatter, "{2}", obj1, obj2));
-            Assert.Throws<FormatException>(() => string.Format(formatter, "{3}", obj1, obj2, obj3));
-            Assert.Throws<FormatException>(() => string.Format(formatter, "{4}", obj1, obj2, obj3, obj4));
-#pragma warning restore IDE0043 // Format string contains invalid placeholder
+            Assert.Throws<FormatException>(() => string.Format("{-1}", obj1)); // Format has value < 0
+            Assert.Throws<FormatException>(() => string.Format("{-1}", obj1, obj2)); // Format has value < 0
+            Assert.Throws<FormatException>(() => string.Format("{-1}", obj1, obj2, obj3)); // Format has value < 0
+            Assert.Throws<FormatException>(() => string.Format("{-1}", obj1, obj2, obj3, obj4)); // Format has value < 0
+            Assert.Throws<FormatException>(() => string.Format(formatter, "{-1}", obj1)); // Format has value < 0
+            Assert.Throws<FormatException>(() => string.Format(formatter, "{-1}", obj1, obj2)); // Format has value < 0
+            Assert.Throws<FormatException>(() => string.Format(formatter, "{-1}", obj1, obj2, obj3)); // Format has value < 0
+            Assert.Throws<FormatException>(() => string.Format(formatter, "{-1}", obj1, obj2, obj3, obj4)); // Format has value < 0
+
+            Assert.Throws<FormatException>(() => string.Format("{1}", obj1)); // Format has value >= 1
+            Assert.Throws<FormatException>(() => string.Format("{2}", obj1, obj2)); // Format has value >= 2
+            Assert.Throws<FormatException>(() => string.Format("{3}", obj1, obj2, obj3)); // Format has value >= 3
+            Assert.Throws<FormatException>(() => string.Format("{4}", obj1, obj2, obj3, obj4)); // Format has value >= 4
+            Assert.Throws<FormatException>(() => string.Format(formatter, "{1}", obj1)); // Format has value >= 1
+            Assert.Throws<FormatException>(() => string.Format(formatter, "{2}", obj1, obj2)); // Format has value >= 2
+            Assert.Throws<FormatException>(() => string.Format(formatter, "{3}", obj1, obj2, obj3)); // Format has value >= 3
+            Assert.Throws<FormatException>(() => string.Format(formatter, "{4}", obj1, obj2, obj3, obj4)); // Format has value >= 4
+
+            Assert.Throws<FormatException>(() => string.Format("{", "")); // Format has unescaped {
+            Assert.Throws<FormatException>(() => string.Format("{a", "")); // Format has unescaped {
+
+            Assert.Throws<FormatException>(() => string.Format("}", "")); // Format has unescaped }
+            Assert.Throws<FormatException>(() => string.Format("}a", "")); // Format has unescaped }
+            Assert.Throws<FormatException>(() => string.Format("{0:}}", "")); // Format has unescaped }
+
+            Assert.Throws<FormatException>(() => string.Format("{\0", "")); // Format has invalid character after {
+            Assert.Throws<FormatException>(() => string.Format("{a", "")); // Format has invalid character after {
+
+            Assert.Throws<FormatException>(() => string.Format("{0     ", "")); // Format with index and spaces is not closed
+
+            Assert.Throws<FormatException>(() => string.Format("{1000000", new string[10])); // Format index is too long
+            Assert.Throws<FormatException>(() => string.Format("{10000000}", new string[10])); // Format index is too long
+
+            Assert.Throws<FormatException>(() => string.Format("{0,", "")); // Format with comma is not closed
+            Assert.Throws<FormatException>(() => string.Format("{0,   ", "")); // Format with comma and spaces is not closed
+            Assert.Throws<FormatException>(() => string.Format("{0,-", "")); // Format with comma and minus sign is not closed
+
+            Assert.Throws<FormatException>(() => string.Format("{0,-\0", "")); // Format has invalid character after minus sign
+            Assert.Throws<FormatException>(() => string.Format("{0,-a", "")); // Format has invalid character after minus sign
+
+            Assert.Throws<FormatException>(() => string.Format("{0,1000000", new string[10])); // Format length is too long
+            Assert.Throws<FormatException>(() => string.Format("{0,10000000}", new string[10])); // Format length is too long
+
+            Assert.Throws<FormatException>(() => string.Format("{0:", new string[10])); // Format with colon is not closed
+            Assert.Throws<FormatException>(() => string.Format("{0:    ", new string[10])); // Format with colon and spaces is not closed
+
+            Assert.Throws<FormatException>(() => string.Format("{0:{", new string[10])); // Format with custom format contains unescaped {
+            Assert.Throws<FormatException>(() => string.Format("{0:{}", new string[10])); // Format with custom format contains unescaped {
         }
 
         [ConditionalTheory]

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
@@ -505,7 +505,7 @@ namespace System.IO
             }
         }
 
-        private void WriteFormatHelper(string format, ParamsArray args, bool appendNewLine)
+        private void WriteFormatHelper(string format, ReadOnlySpan<object?> args, bool appendNewLine)
         {
             int estimatedLength = (format?.Length ?? 0) + args.Length * 8;
             var vsb = estimatedLength <= 256 ?
@@ -523,7 +523,7 @@ namespace System.IO
         {
             if (GetType() == typeof(StreamWriter))
             {
-                WriteFormatHelper(format, new ParamsArray(arg0), appendNewLine: false);
+                WriteFormatHelper(format, new ReadOnlySpan<object?>(in arg0), appendNewLine: false);
             }
             else
             {
@@ -535,7 +535,8 @@ namespace System.IO
         {
             if (GetType() == typeof(StreamWriter))
             {
-                WriteFormatHelper(format, new ParamsArray(arg0, arg1), appendNewLine: false);
+                TwoObjects two = new TwoObjects(arg0, arg1);
+                WriteFormatHelper(format, MemoryMarshal.CreateReadOnlySpan(ref two.Arg0, 2), appendNewLine: false);
             }
             else
             {
@@ -547,7 +548,8 @@ namespace System.IO
         {
             if (GetType() == typeof(StreamWriter))
             {
-                WriteFormatHelper(format, new ParamsArray(arg0, arg1, arg2), appendNewLine: false);
+                ThreeObjects three = new ThreeObjects(arg0, arg1, arg2);
+                WriteFormatHelper(format, MemoryMarshal.CreateReadOnlySpan(ref three.Arg0, 3), appendNewLine: false);
             }
             else
             {
@@ -563,7 +565,7 @@ namespace System.IO
                 {
                     ArgumentNullException.Throw(format is null ? nameof(format) : nameof(arg)); // same as base logic
                 }
-                WriteFormatHelper(format, new ParamsArray(arg), appendNewLine: false);
+                WriteFormatHelper(format, arg, appendNewLine: false);
             }
             else
             {
@@ -575,7 +577,7 @@ namespace System.IO
         {
             if (GetType() == typeof(StreamWriter))
             {
-                WriteFormatHelper(format, new ParamsArray(arg0), appendNewLine: true);
+                WriteFormatHelper(format, new ReadOnlySpan<object?>(in arg0), appendNewLine: true);
             }
             else
             {
@@ -587,7 +589,8 @@ namespace System.IO
         {
             if (GetType() == typeof(StreamWriter))
             {
-                WriteFormatHelper(format, new ParamsArray(arg0, arg1), appendNewLine: true);
+                TwoObjects two = new TwoObjects(arg0, arg1);
+                WriteFormatHelper(format, MemoryMarshal.CreateReadOnlySpan(ref two.Arg0, 2), appendNewLine: true);
             }
             else
             {
@@ -599,7 +602,8 @@ namespace System.IO
         {
             if (GetType() == typeof(StreamWriter))
             {
-                WriteFormatHelper(format, new ParamsArray(arg0, arg1, arg2), appendNewLine: true);
+                ThreeObjects three = new ThreeObjects(arg0, arg1, arg2);
+                WriteFormatHelper(format, MemoryMarshal.CreateReadOnlySpan(ref three.Arg0, 3), appendNewLine: true);
             }
             else
             {
@@ -612,7 +616,7 @@ namespace System.IO
             if (GetType() == typeof(StreamWriter))
             {
                 ArgumentNullException.ThrowIfNull(arg);
-                WriteFormatHelper(format, new ParamsArray(arg), appendNewLine: true);
+                WriteFormatHelper(format, arg, appendNewLine: true);
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/ParamsArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ParamsArray.cs
@@ -1,75 +1,39 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// These types are temporary workarounds for an inability to stackalloc object references.
+// Once we're able to do `stackalloc object[n]`, these can be removed.
+
+// Suppress warnings for unused private fields
+#pragma warning disable CS0169
+#pragma warning disable CA1823
+#pragma warning disable IDE0051
+
 namespace System
 {
-    internal readonly struct ParamsArray
+    internal struct TwoObjects
     {
-        // Sentinel fixed-length arrays eliminate the need for a "count" field keeping this
-        // struct down to just 4 fields. These are only used for their "Length" property,
-        // that is, their elements are never set or referenced.
-        private static readonly object?[] s_oneArgArray = new object?[1];
-        private static readonly object?[] s_twoArgArray = new object?[2];
-        private static readonly object?[] s_threeArgArray = new object?[3];
+        internal object? Arg0;
+        private object? _arg1;
 
-        private readonly object? _arg0;
-        private readonly object? _arg1;
-        private readonly object? _arg2;
-
-        // After construction, the first three elements of this array will never be accessed
-        // because the indexer will retrieve those values from arg0, arg1, and arg2.
-        private readonly object?[] _args;
-
-        public ParamsArray(object? arg0)
+        public TwoObjects(object? arg0, object? arg1)
         {
-            _arg0 = arg0;
-            _arg1 = null;
-            _arg2 = null;
-
-            // Always assign this.args to make use of its "Length" property
-            _args = s_oneArgArray;
-        }
-
-        public ParamsArray(object? arg0, object? arg1)
-        {
-            _arg0 = arg0;
+            Arg0 = arg0;
             _arg1 = arg1;
-            _arg2 = null;
-
-            // Always assign this.args to make use of its "Length" property
-            _args = s_twoArgArray;
         }
+    }
 
-        public ParamsArray(object? arg0, object? arg1, object? arg2)
+    internal struct ThreeObjects
+    {
+        internal object? Arg0;
+        private object? _arg1;
+        private object? _arg2;
+
+        public ThreeObjects(object? arg0, object? arg1, object? arg2)
         {
-            _arg0 = arg0;
+            Arg0 = arg0;
             _arg1 = arg1;
             _arg2 = arg2;
-
-            // Always assign this.args to make use of its "Length" property
-            _args = s_threeArgArray;
-        }
-
-        public ParamsArray(object?[] args)
-        {
-            int len = args.Length;
-            _arg0 = len > 0 ? args[0] : null;
-            _arg1 = len > 1 ? args[1] : null;
-            _arg2 = len > 2 ? args[2] : null;
-            _args = args;
-        }
-
-        public int Length => _args.Length;
-
-        public object? this[int index] => index == 0 ? _arg0 : GetAtSlow(index);
-
-        private object? GetAtSlow(int index)
-        {
-            if (index == 1)
-                return _arg1;
-            if (index == 2)
-                return _arg2;
-            return _args[index];
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -436,17 +436,19 @@ namespace System
 
         public static string Format([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0)
         {
-            return FormatHelper(null, format, new ParamsArray(arg0));
+            return FormatHelper(null, format, new ReadOnlySpan<object?>(in arg0));
         }
 
         public static string Format([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1)
         {
-            return FormatHelper(null, format, new ParamsArray(arg0, arg1));
+            TwoObjects two = new TwoObjects(arg0, arg1);
+            return FormatHelper(null, format, MemoryMarshal.CreateReadOnlySpan(ref two.Arg0, 2));
         }
 
         public static string Format([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1, object? arg2)
         {
-            return FormatHelper(null, format, new ParamsArray(arg0, arg1, arg2));
+            ThreeObjects three = new ThreeObjects(arg0, arg1, arg2);
+            return FormatHelper(null, format, MemoryMarshal.CreateReadOnlySpan(ref three.Arg0, 3));
         }
 
         public static string Format([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, params object?[] args)
@@ -458,22 +460,24 @@ namespace System
                 ArgumentNullException.Throw(format is null ? nameof(format) : nameof(args));
             }
 
-            return FormatHelper(null, format, new ParamsArray(args));
+            return FormatHelper(null, format, args);
         }
 
         public static string Format(IFormatProvider? provider, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0)
         {
-            return FormatHelper(provider, format, new ParamsArray(arg0));
+            return FormatHelper(provider, format, new ReadOnlySpan<object?>(in arg0));
         }
 
         public static string Format(IFormatProvider? provider, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1)
         {
-            return FormatHelper(provider, format, new ParamsArray(arg0, arg1));
+            TwoObjects two = new TwoObjects(arg0, arg1);
+            return FormatHelper(provider, format, MemoryMarshal.CreateReadOnlySpan(ref two.Arg0, 2));
         }
 
         public static string Format(IFormatProvider? provider, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1, object? arg2)
         {
-            return FormatHelper(provider, format, new ParamsArray(arg0, arg1, arg2));
+            ThreeObjects three = new ThreeObjects(arg0, arg1, arg2);
+            return FormatHelper(provider, format, MemoryMarshal.CreateReadOnlySpan(ref three.Arg0, 3));
         }
 
         public static string Format(IFormatProvider? provider, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, params object?[] args)
@@ -485,10 +489,10 @@ namespace System
                 ArgumentNullException.Throw(format is null ? nameof(format) : nameof(args));
             }
 
-            return FormatHelper(provider, format, new ParamsArray(args));
+            return FormatHelper(provider, format, args);
         }
 
-        private static string FormatHelper(IFormatProvider? provider, string format, ParamsArray args)
+        private static string FormatHelper(IFormatProvider? provider, string format, ReadOnlySpan<object?> args)
         {
             ArgumentNullException.ThrowIfNull(format);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1410,11 +1410,22 @@ namespace System.Text
             return Insert(index, value.ToString(), 1);
         }
 
-        public StringBuilder AppendFormat([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0) => AppendFormatHelper(null, format, new ParamsArray(arg0));
+        public StringBuilder AppendFormat([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0)
+        {
+            return AppendFormatHelper(null, format, new ReadOnlySpan<object?>(in arg0));
+        }
 
-        public StringBuilder AppendFormat([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1) => AppendFormatHelper(null, format, new ParamsArray(arg0, arg1));
+        public StringBuilder AppendFormat([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1)
+        {
+            TwoObjects two = new TwoObjects(arg0, arg1);
+            return AppendFormatHelper(null, format, MemoryMarshal.CreateReadOnlySpan(ref two.Arg0, 2));
+        }
 
-        public StringBuilder AppendFormat([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1, object? arg2) => AppendFormatHelper(null, format, new ParamsArray(arg0, arg1, arg2));
+        public StringBuilder AppendFormat([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1, object? arg2)
+        {
+            ThreeObjects three = new ThreeObjects(arg0, arg1, arg2);
+            return AppendFormatHelper(null, format, MemoryMarshal.CreateReadOnlySpan(ref three.Arg0, 3));
+        }
 
         public StringBuilder AppendFormat([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, params object?[] args)
         {
@@ -1425,14 +1436,25 @@ namespace System.Text
                 ArgumentNullException.Throw(format is null ? nameof(format) : nameof(args));
             }
 
-            return AppendFormatHelper(null, format, new ParamsArray(args));
+            return AppendFormatHelper(null, format, args);
         }
 
-        public StringBuilder AppendFormat(IFormatProvider? provider, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0) => AppendFormatHelper(provider, format, new ParamsArray(arg0));
+        public StringBuilder AppendFormat(IFormatProvider? provider, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0)
+        {
+            return AppendFormatHelper(provider, format, new ReadOnlySpan<object?>(in arg0));
+        }
 
-        public StringBuilder AppendFormat(IFormatProvider? provider, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1) => AppendFormatHelper(provider, format, new ParamsArray(arg0, arg1));
+        public StringBuilder AppendFormat(IFormatProvider? provider, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1)
+        {
+            TwoObjects two = new TwoObjects(arg0, arg1);
+            return AppendFormatHelper(provider, format, MemoryMarshal.CreateReadOnlySpan(ref two.Arg0, 2));
+        }
 
-        public StringBuilder AppendFormat(IFormatProvider? provider, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1, object? arg2) => AppendFormatHelper(provider, format, new ParamsArray(arg0, arg1, arg2));
+        public StringBuilder AppendFormat(IFormatProvider? provider, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, object? arg0, object? arg1, object? arg2)
+        {
+            ThreeObjects three = new ThreeObjects(arg0, arg1, arg2);
+            return AppendFormatHelper(provider, format, MemoryMarshal.CreateReadOnlySpan(ref three.Arg0, 3));
+        }
 
         public StringBuilder AppendFormat(IFormatProvider? provider, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, params object?[] args)
         {
@@ -1443,231 +1465,202 @@ namespace System.Text
                 ArgumentNullException.Throw(format is null ? nameof(format) : nameof(args));
             }
 
-            return AppendFormatHelper(provider, format, new ParamsArray(args));
+            return AppendFormatHelper(provider, format, args);
         }
 
-        private static void FormatError()
-        {
-            throw new FormatException(SR.Format_InvalidString);
-        }
-
-        // Undocumented exclusive limits on the range for Argument Hole Index and Argument Hole Alignment.
-        private const int IndexLimit = 1000000; // Note:            0 <= ArgIndex < IndexLimit
-        private const int WidthLimit = 1000000; // Note:  -WidthLimit <  ArgAlign < WidthLimit
-
-        internal StringBuilder AppendFormatHelper(IFormatProvider? provider, string format, ParamsArray args)
+        internal StringBuilder AppendFormatHelper(IFormatProvider? provider, string format, ReadOnlySpan<object?> args)
         {
             ArgumentNullException.ThrowIfNull(format);
 
+            // Undocumented exclusive limits on the range for Argument Hole Index and Argument Hole Alignment.
+            const int IndexLimit = 1_000_000; // Note:            0 <= ArgIndex < IndexLimit
+            const int WidthLimit = 1_000_000; // Note:  -WidthLimit <  ArgAlign < WidthLimit
+
+            // Query the provider (if one was supplied) for an ICustomFormatter.  If there is one,
+            // it needs to be used to transform all arguments.
+            ICustomFormatter? cf = (ICustomFormatter?)provider?.GetFormat(typeof(ICustomFormatter));
+
+            // Repeatedly find the next hole and process it.
             int pos = 0;
-            int len = format.Length;
-            char ch = '\x0';
-
-            ICustomFormatter? cf = null;
-            if (provider != null)
-            {
-                cf = (ICustomFormatter?)provider.GetFormat(typeof(ICustomFormatter));
-            }
-
+            char ch;
             while (true)
             {
-                while (pos < len)
+                // Skip until either the end of the input or the first unescaped opening brace, whichever comes first.
+                // Along the way we need to also unescape escaped closing braces.
+                while (true)
                 {
-                    ch = format[pos];
-
-                    pos++;
-                    // Is it a closing brace?
-                    if (ch == '}')
+                    // Find the next brace.  If there isn't one, the remainder of the input is text to be appended, and we're done.
+                    if ((uint)pos >= (uint)format.Length)
                     {
-                        // Check next character (if there is one) to see if it is escaped. eg }}
-                        if (pos < len && format[pos] == '}')
-                        {
-                            pos++;
-                        }
-                        else
-                        {
-                            // Otherwise treat it as an error (Mismatched closing brace)
-                            FormatError();
-                        }
+                        return this;
                     }
-                    // Is it an opening brace?
-                    else if (ch == '{')
-                    {
-                        // Check next character (if there is one) to see if it is escaped. eg {{
-                        if (pos < len && format[pos] == '{')
-                        {
-                            pos++;
-                        }
-                        else
-                        {
-                            // Otherwise treat it as the opening brace of an Argument Hole.
-                            pos--;
-                            break;
-                        }
-                    }
-                    // If it's neither then treat the character as just text.
-                    Append(ch);
-                }
 
-                //
-                // Start of parsing of Argument Hole.
-                // Argument Hole ::= { Index (, WS* Alignment WS*)? (: Formatting)? }
-                //
-                if (pos == len)
-                {
+                    ReadOnlySpan<char> remainder = format.AsSpan(pos);
+                    int countUntilNextBrace = remainder.IndexOfAny('{', '}');
+                    if (countUntilNextBrace < 0)
+                    {
+                        Append(remainder);
+                        return this;
+                    }
+
+                    // Append the text until the brace.
+                    Append(remainder.Slice(0, countUntilNextBrace));
+                    pos += countUntilNextBrace;
+
+                    // Get the brace.  It must be followed by another character, either a copy of itself in the case of being
+                    // escaped, or an arbitrary character that's part of the hole in the case of an opening brace.
+                    char brace = format[pos];
+                    ch = MoveNext(format, ref pos);
+                    if (brace == ch)
+                    {
+                        Append(ch);
+                        pos++;
+                        continue;
+                    }
+
+                    // This wasn't an escape, so it must be an opening brace.
+                    if (brace != '{')
+                    {
+                        ThrowHelper.ThrowFormatInvalidString();
+                    }
+
+                    // Proceed to parse the hole.
                     break;
                 }
 
-                //
-                //  Start of parsing required Index parameter.
-                //  Index ::= ('0'-'9')+ WS*
-                //
-                pos++;
-                // If reached end of text then error (Unexpected end of text)
-                // or character is not a digit then error (Unexpected Character)
-                if (pos == len || !char.IsAsciiDigit(ch = format[pos])) FormatError();
-                int index = 0;
-                do
-                {
-                    index = index * 10 + ch - '0';
-                    pos++;
-                    // If reached end of text then error (Unexpected end of text)
-                    if (pos == len)
-                    {
-                        FormatError();
-                    }
-                    ch = format[pos];
-                    // so long as character is digit and value of the index is less than 1000000 ( index limit )
-                }
-                while (char.IsAsciiDigit(ch) && index < IndexLimit);
-
-                // If value of index is not within the range of the arguments passed in then error (Index out of range)
-                if (index >= args.Length)
-                {
-                    throw new FormatException(SR.Format_IndexOutOfRange);
-                }
-
-                // Consume optional whitespace.
-                while (pos < len && (ch = format[pos]) == ' ') pos++;
-                // End of parsing index parameter.
-
-                //
-                //  Start of parsing of optional Alignment
-                //  Alignment ::= comma WS* minus? ('0'-'9')+ WS*
-                //
-                bool leftJustify = false;
+                // We're now positioned just after the opening brace of an argument hole, which consists of
+                // an opening brace, an index, an optional width preceded by a comma, and an optional format
+                // preceded by a colon, with arbitrary amounts of spaces throughout.
                 int width = 0;
-                // Is the character a comma, which indicates the start of alignment parameter.
-                if (ch == ',')
-                {
-                    pos++;
-
-                    // Consume Optional whitespace
-                    while (pos < len && format[pos] == ' ') pos++;
-
-                    // If reached the end of the text then error (Unexpected end of text)
-                    if (pos == len)
-                    {
-                        FormatError();
-                    }
-
-                    // Is there a minus sign?
-                    ch = format[pos];
-                    if (ch == '-')
-                    {
-                        // Yes, then alignment is left justified.
-                        leftJustify = true;
-                        pos++;
-                        // If reached end of text then error (Unexpected end of text)
-                        if (pos == len)
-                        {
-                            FormatError();
-                        }
-                        ch = format[pos];
-                    }
-
-                    // If current character is not a digit then error (Unexpected character)
-                    if (!char.IsAsciiDigit(ch))
-                    {
-                        FormatError();
-                    }
-                    // Parse alignment digits.
-                    do
-                    {
-                        width = width * 10 + ch - '0';
-                        pos++;
-                        // If reached end of text then error. (Unexpected end of text)
-                        if (pos == len)
-                        {
-                            FormatError();
-                        }
-                        ch = format[pos];
-                        // So long a current character is a digit and the value of width is less than 100000 ( width limit )
-                    }
-                    while (char.IsAsciiDigit(ch) && width < WidthLimit);
-                    // end of parsing Argument Alignment
-                }
-
-                // Consume optional whitespace
-                while (pos < len && (ch = format[pos]) == ' ') pos++;
-
-                //
-                // Start of parsing of optional formatting parameter.
-                //
-                object? arg = args[index];
-
+                bool leftJustify = false;
                 ReadOnlySpan<char> itemFormatSpan = default; // used if itemFormat is null
-                // Is current character a colon? which indicates start of formatting parameter.
-                if (ch == ':')
+
+                // First up is the index parameter, which is of the form:
+                //     at least on digit
+                //     optional any number of spaces
+                // We've already read the first digit into ch.
+                Debug.Assert(format[pos - 1] == '{');
+                Debug.Assert(ch != '{');
+                int index = ch - '0';
+                if ((uint)index >= 10u)
                 {
-                    pos++;
-                    int startPos = pos;
-
-                    while (true)
-                    {
-                        // If reached end of text then error. (Unexpected end of text)
-                        if (pos == len)
-                        {
-                            FormatError();
-                        }
-                        ch = format[pos];
-
-                        if (ch == '}')
-                        {
-                            // Argument hole closed
-                            break;
-                        }
-                        else if (ch == '{')
-                        {
-                            // Braces inside the argument hole are not supported
-                            FormatError();
-                        }
-
-                        pos++;
-                    }
-
-                    if (pos > startPos)
-                    {
-                        itemFormatSpan = format.AsSpan(startPos, pos - startPos);
-                    }
+                    ThrowHelper.ThrowFormatInvalidString();
                 }
-                else if (ch != '}')
+
+                // Common case is a single digit index followed by a closing brace.  If it's not a closing brace,
+                // proceed to finish parsing the full hole format.
+                ch = MoveNext(format, ref pos);
+                if (ch != '}')
                 {
-                    // Unexpected character
-                    FormatError();
+                    // Continue consuming optional additional digits.
+                    while (char.IsAsciiDigit(ch) && index < IndexLimit)
+                    {
+                        index = index * 10 + ch - '0';
+                        ch = MoveNext(format, ref pos);
+                    }
+
+                    // Consume optional whitespace.
+                    while (ch == ' ')
+                    {
+                        ch = MoveNext(format, ref pos);
+                    }
+
+                    // Parse the optional alignment, which is of the form:
+                    //     comma
+                    //     optional any number of spaces
+                    //     optional -
+                    //     at least one digit
+                    //     optional any number of spaces
+                    if (ch == ',')
+                    {
+                        // Consume optional whitespace.
+                        do
+                        {
+                            ch = MoveNext(format, ref pos);
+                        }
+                        while (ch == ' ');
+
+                        // Consume an optional minus sign indicating left alignment.
+                        if (ch == '-')
+                        {
+                            leftJustify = true;
+                            ch = MoveNext(format, ref pos);
+                        }
+
+                        // Parse alignment digits. The read character must be a digit.
+                        width = ch - '0';
+                        if ((uint)width >= 10u)
+                        {
+                            ThrowHelper.ThrowFormatInvalidString();
+                        }
+                        ch = MoveNext(format, ref pos);
+                        while (char.IsAsciiDigit(ch) && width < WidthLimit)
+                        {
+                            width = width * 10 + ch - '0';
+                            ch = MoveNext(format, ref pos);
+                        }
+
+                        // Consume optional whitespace
+                        while (ch == ' ')
+                        {
+                            ch = MoveNext(format, ref pos);
+                        }
+                    }
+
+                    // The next character needs to either be a closing brace for the end of the hole,
+                    // or a colon indicating the start of the format.
+                    if (ch != '}')
+                    {
+                        if (ch != ':')
+                        {
+                            // Unexpected character
+                            ThrowHelper.ThrowFormatInvalidString();
+                        }
+
+                        // Search for the closing brace; everything in between is the format,
+                        // but opening braces aren't allowed.
+                        int startingPos = pos;
+                        while (true)
+                        {
+                            ch = MoveNext(format, ref pos);
+
+                            if (ch == '}')
+                            {
+                                // Argument hole closed
+                                break;
+                            }
+
+                            if (ch == '{')
+                            {
+                                // Braces inside the argument hole are not supported
+                                ThrowHelper.ThrowFormatInvalidString();
+                            }
+                        }
+
+                        startingPos++;
+                        itemFormatSpan = format.AsSpan(startingPos, pos - startingPos);
+                    }
                 }
 
                 // Construct the output for this arg hole.
+                Debug.Assert(format[pos] == '}');
                 pos++;
                 string? s = null;
                 string? itemFormat = null;
 
+                if ((uint)index >= (uint)args.Length)
+                {
+                    throw new FormatException(SR.Format_IndexOutOfRange);
+                }
+                object? arg = args[index];
+
                 if (cf != null)
                 {
-                    if (itemFormatSpan.Length != 0)
+                    if (!itemFormatSpan.IsEmpty)
                     {
                         itemFormat = new string(itemFormatSpan);
                     }
+
                     s = cf.Format(itemFormat, arg, provider);
                 }
 
@@ -1684,16 +1677,15 @@ namespace System.Text
                             // Untrusted ISpanFormattable implementations might return an erroneous charsWritten value,
                             // and m_ChunkLength might end up being used in Unsafe code, so fail if we get back an
                             // out-of-range charsWritten value.
-                            FormatError();
+                            ThrowHelper.ThrowFormatInvalidString();
                         }
 
                         m_ChunkLength += charsWritten;
 
                         // Pad the end, if needed.
-                        int padding = width - charsWritten;
-                        if (leftJustify && padding > 0)
+                        if (leftJustify && width > charsWritten)
                         {
-                            Append(' ', padding);
+                            Append(' ', width - charsWritten);
                         }
 
                         // Continue to parse other characters.
@@ -1709,30 +1701,43 @@ namespace System.Text
                         }
                         s = formattableArg.ToString(itemFormat, provider);
                     }
-                    else if (arg != null)
+                    else
                     {
-                        s = arg.ToString();
+                        s = arg?.ToString();
                     }
-                }
-                // Append it to the final output of the Format String.
-                if (s == null)
-                {
-                    s = string.Empty;
-                }
-                int pad = width - s.Length;
-                if (!leftJustify && pad > 0)
-                {
-                    Append(' ', pad);
+
+                    s ??= string.Empty;
                 }
 
-                Append(s);
-                if (leftJustify && pad > 0)
+                // Append it to the final output of the Format String.
+                if (width <= s.Length)
                 {
-                    Append(' ', pad);
+                    Append(s);
                 }
-                // Continue to parse other characters.
+                else if (leftJustify)
+                {
+                    Append(s);
+                    Append(' ', width - s.Length);
+                }
+                else
+                {
+                    Append(' ', width - s.Length);
+                    Append(s);
+                }
+
+                // Continue parsing the rest of the format string.
             }
-            return this;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static char MoveNext(string format, ref int pos)
+            {
+                pos++;
+                if ((uint)pos >= (uint)format.Length)
+                {
+                    ThrowHelper.ThrowFormatInvalidString();
+                }
+                return format[pos];
+            }
         }
 
         /// <summary>
@@ -2633,7 +2638,7 @@ namespace System.Text
                             {
                                 // Protect against faulty ISpanFormattable implementations returning invalid charsWritten values.
                                 // Other code in _stringBuilder uses Unsafe manipulation, and we want to ensure m_ChunkLength remains safe.
-                                FormatError();
+                                ThrowHelper.ThrowFormatInvalidString();
                             }
 
                             _stringBuilder.m_ChunkLength += charsWritten;
@@ -2686,7 +2691,7 @@ namespace System.Text
                             {
                                 // Protect against faulty ISpanFormattable implementations returning invalid charsWritten values.
                                 // Other code in _stringBuilder uses Unsafe manipulation, and we want to ensure m_ChunkLength remains safe.
-                                FormatError();
+                                ThrowHelper.ThrowFormatInvalidString();
                             }
 
                             _stringBuilder.m_ChunkLength += charsWritten;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ValueStringBuilder.AppendFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ValueStringBuilder.AppendFormat.cs
@@ -1,260 +1,209 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 namespace System.Text
 {
     internal ref partial struct ValueStringBuilder
     {
-        public void AppendFormat(string format, object? arg0) => AppendFormatHelper(null, format, new ParamsArray(arg0));
-
-        public void AppendFormat(string format, object? arg0, object? arg1) => AppendFormatHelper(null, format, new ParamsArray(arg0, arg1));
-
-        public void AppendFormat(string format, object? arg0, object? arg1, object? arg2) => AppendFormatHelper(null, format, new ParamsArray(arg0, arg1, arg2));
-
-        public void AppendFormat(string format, params object?[] args)
-        {
-            if (args is null)
-            {
-                // To preserve the original exception behavior, throw an exception about format if both
-                // args and format are null. The actual null check for format is in AppendFormatHelper.
-                ArgumentNullException.Throw(format is null ? nameof(format) : nameof(args));
-            }
-
-            AppendFormatHelper(null, format, new ParamsArray(args));
-        }
-
-        public void AppendFormat(IFormatProvider? provider, string format, object? arg0) => AppendFormatHelper(provider, format, new ParamsArray(arg0));
-
-        public void AppendFormat(IFormatProvider? provider, string format, object? arg0, object? arg1) => AppendFormatHelper(provider, format, new ParamsArray(arg0, arg1));
-
-        public void AppendFormat(IFormatProvider? provider, string format, object? arg0, object? arg1, object? arg2) => AppendFormatHelper(provider, format, new ParamsArray(arg0, arg1, arg2));
-
-        public void AppendFormat(IFormatProvider? provider, string format, params object?[] args)
-        {
-            if (args is null)
-            {
-                // To preserve the original exception behavior, throw an exception about format if both
-                // args and format are null. The actual null check for format is in AppendFormatHelper.
-                ArgumentNullException.Throw(format is null ? nameof(format) : nameof(args));
-            }
-
-            AppendFormatHelper(provider, format, new ParamsArray(args));
-        }
-
         // Copied from StringBuilder, can't be done via generic extension
         // as ValueStringBuilder is a ref struct and cannot be used in a generic.
-        internal void AppendFormatHelper(IFormatProvider? provider, string format, ParamsArray args)
+        internal void AppendFormatHelper(IFormatProvider? provider, string format, ReadOnlySpan<object?> args)
         {
             ArgumentNullException.ThrowIfNull(format);
 
             // Undocumented exclusive limits on the range for Argument Hole Index and Argument Hole Alignment.
-            const int IndexLimit = 1000000; // Note:            0 <= ArgIndex < IndexLimit
-            const int WidthLimit = 1000000; // Note:  -WidthLimit <  ArgAlign < WidthLimit
+            const int IndexLimit = 1_000_000; // Note:            0 <= ArgIndex < IndexLimit
+            const int WidthLimit = 1_000_000; // Note:  -WidthLimit <  ArgAlign < WidthLimit
 
-            int pos = 0;
-            int len = format.Length;
-            char ch = '\0';
+            // Query the provider (if one was supplied) for an ICustomFormatter.  If there is one,
+            // it needs to be used to transform all arguments.
             ICustomFormatter? cf = (ICustomFormatter?)provider?.GetFormat(typeof(ICustomFormatter));
 
+            // Repeatedly find the next hole and process it.
+            int pos = 0;
+            char ch;
             while (true)
             {
-                while (pos < len)
+                // Skip until either the end of the input or the first unescaped opening brace, whichever comes first.
+                // Along the way we need to also unescape escaped closing braces.
+                while (true)
                 {
-                    ch = format[pos];
-
-                    pos++;
-                    // Is it a closing brace?
-                    if (ch == '}')
+                    // Find the next brace.  If there isn't one, the remainder of the input is text to be appended, and we're done.
+                    if ((uint)pos >= (uint)format.Length)
                     {
-                        // Check next character (if there is one) to see if it is escaped. eg }}
-                        if (pos < len && format[pos] == '}')
-                        {
-                            pos++;
-                        }
-                        else
-                        {
-                            // Otherwise treat it as an error (Mismatched closing brace)
-                            ThrowFormatError();
-                        }
+                        return;
                     }
-                    // Is it a opening brace?
-                    else if (ch == '{')
-                    {
-                        // Check next character (if there is one) to see if it is escaped. eg {{
-                        if (pos < len && format[pos] == '{')
-                        {
-                            pos++;
-                        }
-                        else
-                        {
-                            // Otherwise treat it as the opening brace of an Argument Hole.
-                            pos--;
-                            break;
-                        }
-                    }
-                    // If it's neither then treat the character as just text.
-                    Append(ch);
-                }
 
-                //
-                // Start of parsing of Argument Hole.
-                // Argument Hole ::= { Index (, WS* Alignment WS*)? (: Formatting)? }
-                //
-                if (pos == len)
-                {
+                    ReadOnlySpan<char> remainder = format.AsSpan(pos);
+                    int countUntilNextBrace = remainder.IndexOfAny('{', '}');
+                    if (countUntilNextBrace < 0)
+                    {
+                        Append(remainder);
+                        return;
+                    }
+
+                    // Append the text until the brace.
+                    Append(remainder.Slice(0, countUntilNextBrace));
+                    pos += countUntilNextBrace;
+
+                    // Get the brace.  It must be followed by another character, either a copy of itself in the case of being
+                    // escaped, or an arbitrary character that's part of the hole in the case of an opening brace.
+                    char brace = format[pos];
+                    ch = MoveNext(format, ref pos);
+                    if (brace == ch)
+                    {
+                        Append(ch);
+                        pos++;
+                        continue;
+                    }
+
+                    // This wasn't an escape, so it must be an opening brace.
+                    if (brace != '{')
+                    {
+                        ThrowFormatInvalidString();
+                    }
+
+                    // Proceed to parse the hole.
                     break;
                 }
 
-                //
-                //  Start of parsing required Index parameter.
-                //  Index ::= ('0'-'9')+ WS*
-                //
-                pos++;
-                // If reached end of text then error (Unexpected end of text)
-                // or character is not a digit then error (Unexpected Character)
-                if (pos == len || !char.IsAsciiDigit(ch = format[pos])) ThrowFormatError();
-                int index = 0;
-                do
-                {
-                    index = index * 10 + ch - '0';
-                    pos++;
-                    // If reached end of text then error (Unexpected end of text)
-                    if (pos == len)
-                    {
-                        ThrowFormatError();
-                    }
-                    ch = format[pos];
-                    // so long as character is digit and value of the index is less than 1000000 ( index limit )
-                }
-                while (char.IsAsciiDigit(ch) && index < IndexLimit);
-
-                // If value of index is not within the range of the arguments passed in then error (Index out of range)
-                if (index >= args.Length)
-                {
-                    throw new FormatException(SR.Format_IndexOutOfRange);
-                }
-
-                // Consume optional whitespace.
-                while (pos < len && (ch = format[pos]) == ' ') pos++;
-                // End of parsing index parameter.
-
-                //
-                //  Start of parsing of optional Alignment
-                //  Alignment ::= comma WS* minus? ('0'-'9')+ WS*
-                //
-                bool leftJustify = false;
+                // We're now positioned just after the opening brace of an argument hole, which consists of
+                // an opening brace, an index, an optional width preceded by a comma, and an optional format
+                // preceded by a colon, with arbitrary amounts of spaces throughout.
                 int width = 0;
-                // Is the character a comma, which indicates the start of alignment parameter.
-                if (ch == ',')
-                {
-                    pos++;
-
-                    // Consume Optional whitespace
-                    while (pos < len && format[pos] == ' ') pos++;
-
-                    // If reached the end of the text then error (Unexpected end of text)
-                    if (pos == len)
-                    {
-                        ThrowFormatError();
-                    }
-
-                    // Is there a minus sign?
-                    ch = format[pos];
-                    if (ch == '-')
-                    {
-                        // Yes, then alignment is left justified.
-                        leftJustify = true;
-                        pos++;
-                        // If reached end of text then error (Unexpected end of text)
-                        if (pos == len)
-                        {
-                            ThrowFormatError();
-                        }
-                        ch = format[pos];
-                    }
-
-                    // If current character is not a digit then error (Unexpected character)
-                    if (!char.IsAsciiDigit(ch))
-                    {
-                        ThrowFormatError();
-                    }
-                    // Parse alignment digits.
-                    do
-                    {
-                        width = width * 10 + ch - '0';
-                        pos++;
-                        // If reached end of text then error. (Unexpected end of text)
-                        if (pos == len)
-                        {
-                            ThrowFormatError();
-                        }
-                        ch = format[pos];
-                        // So long a current character is a digit and the value of width is less than 100000 ( width limit )
-                    }
-                    while (char.IsAsciiDigit(ch) && width < WidthLimit);
-                    // end of parsing Argument Alignment
-                }
-
-                // Consume optional whitespace
-                while (pos < len && (ch = format[pos]) == ' ') pos++;
-
-                //
-                // Start of parsing of optional formatting parameter.
-                //
-                object? arg = args[index];
-
+                bool leftJustify = false;
                 ReadOnlySpan<char> itemFormatSpan = default; // used if itemFormat is null
-                // Is current character a colon? which indicates start of formatting parameter.
-                if (ch == ':')
+
+                // First up is the index parameter, which is of the form:
+                //     at least on digit
+                //     optional any number of spaces
+                // We've already read the first digit into ch.
+                Debug.Assert(format[pos - 1] == '{');
+                Debug.Assert(ch != '{');
+                int index = ch - '0';
+                if ((uint)index >= 10u)
                 {
-                    pos++;
-                    int startPos = pos;
-
-                    while (true)
-                    {
-                        // If reached end of text then error. (Unexpected end of text)
-                        if (pos == len)
-                        {
-                            ThrowFormatError();
-                        }
-                        ch = format[pos];
-
-                        if (ch == '}')
-                        {
-                            // Argument hole closed
-                            break;
-                        }
-                        else if (ch == '{')
-                        {
-                            // Braces inside the argument hole are not supported
-                            ThrowFormatError();
-                        }
-
-                        pos++;
-                    }
-
-                    if (pos > startPos)
-                    {
-                        itemFormatSpan = format.AsSpan(startPos, pos - startPos);
-                    }
+                    ThrowFormatInvalidString();
                 }
-                else if (ch != '}')
+
+                // Common case is a single digit index followed by a closing brace.  If it's not a closing brace,
+                // proceed to finish parsing the full hole format.
+                ch = MoveNext(format, ref pos);
+                if (ch != '}')
                 {
-                    // Unexpected character
-                    ThrowFormatError();
+                    // Continue consuming optional additional digits.
+                    while (char.IsAsciiDigit(ch) && index < IndexLimit)
+                    {
+                        index = index * 10 + ch - '0';
+                        ch = MoveNext(format, ref pos);
+                    }
+
+                    // Consume optional whitespace.
+                    while (ch == ' ')
+                    {
+                        ch = MoveNext(format, ref pos);
+                    }
+
+                    // Parse the optional alignment, which is of the form:
+                    //     comma
+                    //     optional any number of spaces
+                    //     optional -
+                    //     at least one digit
+                    //     optional any number of spaces
+                    if (ch == ',')
+                    {
+                        // Consume optional whitespace.
+                        do
+                        {
+                            ch = MoveNext(format, ref pos);
+                        }
+                        while (ch == ' ');
+
+                        // Consume an optional minus sign indicating left alignment.
+                        if (ch == '-')
+                        {
+                            leftJustify = true;
+                            ch = MoveNext(format, ref pos);
+                        }
+
+                        // Parse alignment digits. The read character must be a digit.
+                        width = ch - '0';
+                        if ((uint)width >= 10u)
+                        {
+                            ThrowFormatInvalidString();
+                        }
+                        ch = MoveNext(format, ref pos);
+                        while (char.IsAsciiDigit(ch) && width < WidthLimit)
+                        {
+                            width = width * 10 + ch - '0';
+                            ch = MoveNext(format, ref pos);
+                        }
+
+                        // Consume optional whitespace
+                        while (ch == ' ')
+                        {
+                            ch = MoveNext(format, ref pos);
+                        }
+                    }
+
+                    // The next character needs to either be a closing brace for the end of the hole,
+                    // or a colon indicating the start of the format.
+                    if (ch != '}')
+                    {
+                        if (ch != ':')
+                        {
+                            // Unexpected character
+                            ThrowFormatInvalidString();
+                        }
+
+                        // Search for the closing brace; everything in between is the format,
+                        // but opening braces aren't allowed.
+                        int startingPos = pos;
+                        while (true)
+                        {
+                            ch = MoveNext(format, ref pos);
+
+                            if (ch == '}')
+                            {
+                                // Argument hole closed
+                                break;
+                            }
+
+                            if (ch == '{')
+                            {
+                                // Braces inside the argument hole are not supported
+                                ThrowFormatInvalidString();
+                            }
+                        }
+
+                        startingPos++;
+                        itemFormatSpan = format.AsSpan(startingPos, pos - startingPos);
+                    }
                 }
 
                 // Construct the output for this arg hole.
+                Debug.Assert(format[pos] == '}');
                 pos++;
                 string? s = null;
                 string? itemFormat = null;
 
+                if ((uint)index >= (uint)args.Length)
+                {
+                    throw new FormatException(SR.Format_IndexOutOfRange);
+                }
+                object? arg = args[index];
+
                 if (cf != null)
                 {
-                    if (itemFormatSpan.Length != 0)
+                    if (!itemFormatSpan.IsEmpty)
                     {
                         itemFormat = new string(itemFormatSpan);
                     }
+
                     s = cf.Format(itemFormat, arg, provider);
                 }
 
@@ -269,10 +218,9 @@ namespace System.Text
                         _pos += charsWritten;
 
                         // Pad the end, if needed.
-                        int padding = width - charsWritten;
-                        if (leftJustify && padding > 0)
+                        if (leftJustify && width > charsWritten)
                         {
-                            Append(' ', padding);
+                            Append(' ', width - charsWritten);
                         }
 
                         // Continue to parse other characters.
@@ -288,34 +236,45 @@ namespace System.Text
                         }
                         s = formattableArg.ToString(itemFormat, provider);
                     }
-                    else if (arg != null)
+                    else
                     {
-                        s = arg.ToString();
+                        s = arg?.ToString();
                     }
-                }
-                // Append it to the final output of the Format String.
-                if (s == null)
-                {
-                    s = string.Empty;
-                }
-                int pad = width - s.Length;
-                if (!leftJustify && pad > 0)
-                {
-                    Append(' ', pad);
+
+                    s ??= string.Empty;
                 }
 
-                Append(s);
-                if (leftJustify && pad > 0)
+                // Append it to the final output of the Format String.
+                if (width <= s.Length)
                 {
-                    Append(' ', pad);
+                    Append(s);
                 }
-                // Continue to parse other characters.
+                else if (leftJustify)
+                {
+                    Append(s);
+                    Append(' ', width - s.Length);
+                }
+                else
+                {
+                    Append(' ', width - s.Length);
+                    Append(s);
+                }
+
+                // Continue parsing the rest of the format string.
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static char MoveNext(string format, ref int pos)
+            {
+                pos++;
+                if ((uint)pos >= (uint)format.Length)
+                {
+                    ThrowFormatInvalidString();
+                }
+                return format[pos];
             }
         }
 
-        private static void ThrowFormatError()
-        {
-            throw new FormatException(SR.Format_InvalidString);
-        }
+        private static void ThrowFormatInvalidString() => throw new FormatException(SR.Format_InvalidString);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -556,6 +556,12 @@ namespace System
             throw ex;
         }
 
+        [DoesNotReturn]
+        internal static void ThrowFormatInvalidString()
+        {
+            throw new FormatException(SR.Format_InvalidString);
+        }
+
         private static Exception GetArraySegmentCtorValidationFailedException(Array? array, int offset, int count)
         {
             if (array == null)


### PR DESCRIPTION
The primary purpose of this change was to use IndexOfAny as part of parsing a composite string format in order to look for the next brace in the string: for longer composite formats with fewer holes, this can significantly speed up the parsing.

However, for very small strings filled with formats, the overhead of the IndexOfAny is unnecessary and resulted in regressions in some benchmarks, so I ended up overhauling the implementation to gain back the losses for those shorter cases, e.g. by avoiding bounds checking, by favoring expected cases, etc., and also generally cleaned up the implementation.  As part of this, I also deleted the internal ParamsArray helper struct and replaced it with use of `ReadOnlySpan<object?>`.

|                      Method |         Toolchain |      Mean | Ratio |
|---------------------------- |------------------ |----------:|------:|
|  AppendFormat_Small_Strings | \main\corerun.exe |  51.18 ns |  1.00 |
|  AppendFormat_Small_Strings |   \pr\corerun.exe |  50.33 ns |  0.98 |
|                             |                   |           |       |
| AppendFormat_Medium_Strings | \main\corerun.exe |  65.40 ns |  1.00 |
| AppendFormat_Medium_Strings |   \pr\corerun.exe |  54.49 ns |  0.83 |
|                             |                   |           |       |
|  AppendFormat_Large_Strings | \main\corerun.exe | 193.19 ns |  1.00 |
|  AppendFormat_Large_Strings |   \pr\corerun.exe |  88.38 ns |  0.46 |
|                             |                   |           |       |
|        AppendFormat_Varying | \main\corerun.exe | 188.89 ns |  1.00 |
|        AppendFormat_Varying |   \pr\corerun.exe | 180.35 ns |  0.96 |
|                             |                   |           |       |
|        Format_Small_Strings | \main\corerun.exe |  66.31 ns |  1.00 |
|        Format_Small_Strings |   \pr\corerun.exe |  64.82 ns |  0.98 |
|                             |                   |           |       |
|       Format_Medium_Strings | \main\corerun.exe |  86.25 ns |  1.00 |
|       Format_Medium_Strings |   \pr\corerun.exe |  68.47 ns |  0.79 |
|                             |                   |           |       |
|        Format_Large_Strings | \main\corerun.exe | 237.92 ns |  1.00 |
|        Format_Large_Strings |   \pr\corerun.exe | 113.92 ns |  0.48 |
|                             |                   |           |       |
|              Format_Varying | \main\corerun.exe | 201.46 ns |  1.00 |
|              Format_Varying |   \pr\corerun.exe | 197.43 ns |  0.98 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Runtime.CompilerServices;
using System.Text;

public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private StringBuilder _sb = new StringBuilder();
    private object _int = 12345;

    [Benchmark]
    public void AppendFormat_Small_Strings()
    {
        _sb.Clear();
        _sb.AppendFormat("{0}: {1}", "key", "value");
    }

    [Benchmark]
    public void AppendFormat_Medium_Strings()
    {
        _sb.Clear();
        _sb.AppendFormat("Key: {0}, Value: {1}", "key", "value");
    }

    [Benchmark]
    public void AppendFormat_Large_Strings()
    {
        _sb.Clear();
        _sb.AppendFormat("This is a test to see what happens when there's more text {0} the individual {1} that need to be {2} in.", "between", "arguments", "filled");
    }

    [Benchmark]
    public void AppendFormat_Varying()
    {
        _sb.Clear();
        _sb.AppendFormat("{0:X}.{1,10:X4}.{2,-4}.{3:d10}", _int, _int, _int, _int);
    }

    [Benchmark]
    public string Format_Small_Strings()
    {
        return string.Format("{0}: {1}", "key", "value");
    }

    [Benchmark]
    public string Format_Medium_Strings()
    {
        return string.Format("Key: {0}, Value: {1}", "key", "value");
    }

    [Benchmark]
    public string Format_Large_Strings()
    {
        return string.Format("This is a test to see what happens when there's more text {0} the individual {1} that need to be {2} in.", "between", "arguments", "filled");
    }

    [Benchmark]
    public string Format_Varying()
    {
        return string.Format("{0:X}.{1,10:X4}.{2,-4}.{3:d10}", _int, _int, _int, _int);
    }
}
```