### PR TITLE
Use correct holder for `ThreadLocalModule`.

### DIFF
--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -646,7 +646,7 @@ PTR_ThreadLocalModule ThreadStatics::AllocateAndInitTLM(ModuleIndex index, PTR_T
     _ASSERTE(pThreadLocalBlock != NULL);
     _ASSERTE(pModule != NULL);
 
-    NewArrayHolder<ThreadLocalModule> pThreadLocalModule = AllocateTLM(pModule);
+    NewHolder<ThreadLocalModule> pThreadLocalModule = AllocateTLM(pModule);
 
     pThreadLocalBlock->AllocateThreadStaticHandles(pModule, pThreadLocalModule);
 


### PR DESCRIPTION
The `ThreadLocalModule` allocation was temporarily using a `NewArrayHolder<>`, which is invalid for this type. The `ThreadLocalModule` overrides the `operator new()` and internally uses the global `operator new()`, so the `NewHolder<>` is the correct type to use.

https://github.com/dotnet/runtime/blob/bfbb78354e536ac616f2f9dabf3db2b8fa8b9f64/src/coreclr/vm/threadstatics.h#L457-L465

/cc @elinor-fung 