### PR TITLE
[LibraryImportGenerator] Allow span copy for char arrays instead of manual copy loop

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
@@ -305,8 +305,6 @@ namespace Microsoft.Interop
             IMarshallingGenerator elementMarshaller = _elementMarshallingGenerator.Create(
                 elementInfo,
                 new LinearCollectionElementMarshallingCodeContext(StubCodeContext.Stage.Setup, string.Empty, string.Empty, context));
-            TypeSyntax elementType = elementMarshaller.AsNativeType(elementInfo);
-
 
             ExpressionSyntax numElementsExpression = LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0));
             if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In))
@@ -315,9 +313,9 @@ namespace Microsoft.Interop
                 numElementsExpression = GetNumElementsExpressionFromMarshallingInfo(info, collectionInfo.ElementCountInfo, context);
             }
 
-            bool isBlittable = elementMarshaller is BlittableMarshaller;
-
-            if (isBlittable)
+            bool enableArrayPinning = elementMarshaller is BlittableMarshaller;
+            bool treatAsBlittable = enableArrayPinning || elementMarshaller is Utf16CharMarshaller;
+            if (treatAsBlittable)
             {
                 marshallingStrategy = new LinearCollectionWithBlittableElementsMarshalling(marshallingStrategy, collectionInfo.ElementType.Syntax, numElementsExpression);
             }
@@ -332,16 +330,17 @@ namespace Microsoft.Interop
                 marshallingStrategy = DecorateWithTwoStageMarshallingStrategy(collectionInfo, marshallingStrategy);
             }
 
+            TypeSyntax nativeElementType = elementMarshaller.AsNativeType(elementInfo);
             marshallingStrategy = new SizeOfElementMarshalling(
                 marshallingStrategy,
-                SizeOfExpression(elementType));
+                SizeOfExpression(nativeElementType));
 
             if (collectionInfo.UseDefaultMarshalling && info.ManagedType is SzArrayType)
             {
                 return new ArrayMarshaller(
                     new CustomNativeTypeMarshallingGenerator(marshallingStrategy, enableByValueContentsMarshalling: true),
-                    elementType,
-                    isBlittable);
+                    collectionInfo.ElementType.Syntax,
+                    enableArrayPinning);
             }
 
             IMarshallingGenerator marshallingGenerator = new CustomNativeTypeMarshallingGenerator(marshallingStrategy, enableByValueContentsMarshalling: false);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -206,7 +206,8 @@ namespace Microsoft.Interop
         {
             var subContext = new CustomNativeTypeWithToFromNativeValueContext(context);
 
-            if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In))
+            if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In)
+                || (!info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out)))
             {
                 yield return GenerateFromNativeValueInvocation(info, context, subContext);
             }
@@ -526,7 +527,8 @@ namespace Microsoft.Interop
         {
             var subContext = new CustomNativeTypeWithToFromNativeValueContext(context);
 
-            if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In))
+            if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In)
+                || (!info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out)))
             {
                 // <marshalerIdentifier>.Value = <nativeIdentifier>;
                 yield return GenerateFromNativeValueInvocation(info, context, subContext);


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/69608: Performance item (1)

Marshal:
```csharp
// Old generated code
System.ReadOnlySpan<char> __c_native__marshaller__managedSpan = __c_native__marshaller.GetManagedValuesSource();
System.Span<ushort> __c_native__marshaller__nativeSpan = System.Runtime.InteropServices.MemoryMarshal.Cast<byte, ushort>(__c_native__marshaller.GetNativeValuesDestination());
for (int __i0 = 0; __i0 < __c_native__marshaller__managedSpan.Length; ++__i0)
{
    __c_native__marshaller__nativeSpan[__i0] = __c_native__marshaller__managedSpan[__i0];
}

// New generated code
__c_native__marshaller.GetManagedValuesSource().CopyTo(System.Runtime.InteropServices.MemoryMarshal.Cast<byte, char>(__c_native__marshaller.GetNativeValuesDestination()));
```
Unmarshal:
```csharp
// Old generated code
int __c_native__marshaller__numElements = __c_native__marshaller.GetManagedValuesSource().Length;
System.Span<char> __c_native__marshaller__managedSpan = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(ref System.Runtime.CompilerServices.Unsafe.AsRef(in __c_native__marshaller.GetManagedValuesSource().GetPinnableReference()), __c_native__marshaller__numElements);
System.Span<ushort> __c_native__marshaller__nativeSpan = System.Runtime.InteropServices.MemoryMarshal.Cast<byte, ushort>(__c_native__marshaller.GetNativeValuesDestination());
for (int __i0 = 0; __i0 < __c_native__marshaller__numElements; ++__i0)
{
    __c_native__marshaller__managedSpan[__i0] = (char)__c_native__marshaller__nativeSpan[__i0];
}

// New generated code
System.Runtime.InteropServices.MemoryMarshal.Cast<byte, char>(__c_native__marshaller.GetNativeValuesDestination()).CopyTo(System.Runtime.InteropServices.MemoryMarshal.CreateSpan(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(__c_native__marshaller.GetManagedValuesSource()), __c_native__marshaller.GetManagedValuesSource().Length));
```