### PR TITLE
Allow ToCryptographicException to create serializable exceptions

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/CryptoThrowHelper.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CryptoThrowHelper.Windows.cs
@@ -2,8 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Security.Cryptography;
+
+#if !NETCOREAPP3_1_OR_GREATER
+using System.Diagnostics;
+using System.Runtime.Serialization;
+#endif
 
 namespace Internal.Cryptography
 {
@@ -13,19 +17,54 @@ namespace Internal.Cryptography
         {
             string message = Interop.Kernel32.GetMessage(hr);
 
-            if ((hr & 0x80000000) != 0x80000000)
+            // If the incoming value is non-negative, it's a Win32 error instead of an
+            // HRESULT. We'll convert it to an HRESULT now (subsystem = 0x0007 [win32]).
+            if (hr >= 0)
+            {
                 hr = (hr & 0x0000FFFF) | unchecked((int)0x80070000);
+            }
+
+#if NETCOREAPP3_1_OR_GREATER
+            return new CryptographicException(message)
+            {
+                HResult = hr
+            };
+#else
+            // Prior to .NET Core 3.1, the Exception.HResult property was not publicly
+            // settable, and CryptographicException did not have a ctor which allowed
+            // setting both the message and the HRESULT. We use a subclassed helper
+            // type to allow flowing both pieces of data to receivers.
 
             return new WindowsCryptographicException(hr, message);
+#endif
         }
 
+#if !NETCOREAPP3_1_OR_GREATER
+        [Serializable]
         private sealed class WindowsCryptographicException : CryptographicException
         {
+            private WindowsCryptographicException(SerializationInfo info, StreamingContext context)
+            {
+                Debug.Fail("This should never be called; we swap the active type during serialization.");
+                throw new NotImplementedException();
+            }
+
             public WindowsCryptographicException(int hr, string message)
                 : base(message)
             {
                 HResult = hr;
             }
+
+            public override void GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                // This exception shouldn't be serialized since it's a private implementation
+                // detail potentially copied across multiple different assemblies. We'll
+                // instead ask the serializer to pretend that we're a normal CryptographicException.
+
+                info.SetType(typeof(CryptographicException));
+                base.GetObjectData(info, context);
+            }
         }
+#endif
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/69704.

## Problem description

Our helper wants to throw a `CryptographicException` with a custom error message and HRESULT. However, on runtimes prior to .NET Core 3.1, there was no way to do this using publicly available APIs on `CryptographicException`, so we created our own subclassed type `WindowsCryptographicException` to allow this.

However, `WindowsCryptographicException` is not marked `[Serializable]`. This prevents its use in remoting scenarios which rely on _ISerializable_-style serialization compatibility. And even if it were marked as such, the type is a private implementation detail copied (in source) across multiple different projects, which means that it's not stable enough to be marked `[Serializable]`.

## Solution

When targeting .NET Core 3.1+, we forego our custom exception type in favor of the public APIs on `CryptographicException` and `Exception`. Those types are already marked serializable and are understood by serializers.

When targeting other runtimes, we mark our custom exception type `[Serializable]`, but we override its _GetObjectData_ method to say "when writing me to the wire, you should write me out as `CryptographicException` instead of `WindowsCryptographicException`." When deserializing, the formatter will not ever bother looking for `WindowsCryptographicException`, creating an instance of `CryptographicException` instead.

## Testing

I manually built the assembly both with and without the ifdef, wrote a console app which used reflection to call the helper routine, and round-tripped the result through `BinaryFormatter`. The exception instance successfully round-tripped _as `CryptographicException`_ in both cases.