### PR TITLE
Fix build issues after enabling TRACE_GC

### DIFF
--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -43,9 +43,10 @@
 #define STRESS_LOG
 #ifdef STRESS_LOG
 /*  STRESS_LOG_VA was added to allow sending GC trace output to the stress log. msg must be enclosed
-    in ()'s and contain a format string. The arguments must be numbers or string literals.
-    This was done because GC Trace uses dprintf which dosen't contain info on how many arguments are
-    getting passed in and using va_args would require parsing the format string during the GC
+    in ()'s and contain a format string followed by 0 to 12 arguments. The arguments must be numbers
+     or string literals. This was done because GC Trace uses dprintf which dosen't contain info on 
+    how many arguments are getting passed in and using va_args would require parsing the format 
+    string during the GC
 */
 #define STRESS_LOG_VA(level, msg) do {                                        \
             if (StressLog::LogOn(LF_GC, LL_ALWAYS))                           \

--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -42,11 +42,10 @@
 
 #define STRESS_LOG
 #ifdef STRESS_LOG
-/*  STRESS_LOG_VA was added to allow sendign GC trace output to the stress log. msg must be enclosed
-      in ()'s and contain a format string followed by 0 - 4 arguments.  The arguments must be numbers or
-      string literals.  LogMsgOL is overloaded so that all of the possible sets of parameters are covered.
-      This was done becasue GC Trace uses dprintf which dosen't contain info on how many arguments are
-      getting passed in and using va_args would require parsing the format string during the GC
+/*  STRESS_LOG_VA was added to allow sending GC trace output to the stress log. msg must be enclosed
+    in ()'s and contain a format string. The arguments must be numbers or string literals.
+    This was done because GC Trace uses dprintf which dosen't contain info on how many arguments are
+    getting passed in and using va_args would require parsing the format string during the GC
 */
 #define STRESS_LOG_VA(level, msg) do {                                        \
             if (StressLog::LogOn(LF_GC, LL_ALWAYS))                           \

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -30810,7 +30810,7 @@ void gc_heap::sweep_region_in_plan (heap_segment* region,
     size_t region_index = get_basic_region_index_for_address (heap_segment_mem (region));
     dprintf (REGIONS_LOG, ("region #%d %Ix survived %Id, %s recorded %Id",
         region_index, heap_segment_mem (region), survived,
-        ((survived == heap_segment_survived (region)) ? "same as" : "diff from"),
+        ((survived == (size_t)heap_segment_survived (region)) ? "same as" : "diff from"),
         heap_segment_survived (region)));
 #ifdef MULTIPLE_HEAPS
     assert (survived <= (size_t)heap_segment_survived (region));

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -137,7 +137,7 @@ inline void FATAL_GC_ERROR()
 #define MAX_LONGPATH 1024
 #endif // MAX_LONGPATH
 
-//#define TRACE_GC
+#define TRACE_GC
 //#define SIMPLE_DPRINTF
 
 //#define JOIN_STATS         //amount of time spent in the join

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -137,7 +137,9 @@ inline void FATAL_GC_ERROR()
 #define MAX_LONGPATH 1024
 #endif // MAX_LONGPATH
 
+#ifdef HOST_64BIT
 #define TRACE_GC
+#endif // HOST_64BIT
 //#define SIMPLE_DPRINTF
 
 //#define JOIN_STATS         //amount of time spent in the join
@@ -257,12 +259,11 @@ const int policy_expand  = 2;
 void GCLog (const char *fmt, ... );
 #define dprintf(l,x) {if ((l == 1) || (l == GTC_LOG)) {GCLog x;}}
 #else //SIMPLE_DPRINTF
-// Nobody used the logging mechanism that used to be here. If we find ourselves
-// wanting to inspect GC logs on unmodified builds, we can use this define here
-// to do so.
-//#define dprintf(l, x)
+#ifdef HOST_64BIT
 #define dprintf(l,x) STRESS_LOG_VA(l,x);
-
+#else
+#error Logging dprintf to stress log on 32 bits platforms is not supported.
+#endif
 #endif //SIMPLE_DPRINTF
 
 #else //TRACE_GC

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -137,9 +137,7 @@ inline void FATAL_GC_ERROR()
 #define MAX_LONGPATH 1024
 #endif // MAX_LONGPATH
 
-#ifdef HOST_64BIT
-#define TRACE_GC
-#endif // HOST_64BIT
+//#define TRACE_GC
 //#define SIMPLE_DPRINTF
 
 //#define JOIN_STATS         //amount of time spent in the join

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -59,11 +59,10 @@
             %pK     // The pointer is a code address (used for stack track)
 */
 
-/*  STRESS_LOG_VA was added to allow sendign GC trace output to the stress log. msg must be enclosed
-      in ()'s and contain a format string followed by 0 - 4 arguments.  The arguments must be numbers or
-      string literals.  LogMsgOL is overloaded so that all of the possible sets of parameters are covered.
-      This was done becasue GC Trace uses dprintf which dosen't contain info on how many arguments are
-      getting passed in and using va_args would require parsing the format string during the GC
+/*  STRESS_LOG_VA was added to allow sending GC trace output to the stress log. msg must be enclosed
+    in ()'s and contain a format string. The arguments must be numbers or string literals.
+    This was done because GC Trace uses dprintf which dosen't contain info on how many arguments are
+    getting passed in and using va_args would require parsing the format string during the GC
 */
 #define STRESS_LOG_VA(dprintfLevel,msg) do {                                                        \
             if (StressLog::LogOn(LF_GC, LL_ALWAYS))                                                 \

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -60,9 +60,10 @@
 */
 
 /*  STRESS_LOG_VA was added to allow sending GC trace output to the stress log. msg must be enclosed
-    in ()'s and contain a format string. The arguments must be numbers or string literals.
-    This was done because GC Trace uses dprintf which dosen't contain info on how many arguments are
-    getting passed in and using va_args would require parsing the format string during the GC
+    in ()'s and contain a format string followed by 0 to 12 arguments. The arguments must be numbers
+     or string literals. This was done because GC Trace uses dprintf which dosen't contain info on 
+    how many arguments are getting passed in and using va_args would require parsing the format 
+    string during the GC
 */
 #define STRESS_LOG_VA(dprintfLevel,msg) do {                                                        \
             if (StressLog::LogOn(LF_GC, LL_ALWAYS))                                                 \

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -105,8 +105,8 @@ enum LogFacilitiesEnum: unsigned int {
 #define _Args(...) __VA_ARGS__
 
 #define STRESS_LOG_VA(dprintfLevel,msg) do {                                                 \
-            if (StressLog::StressLogOn(LF_GC, LL_ALWAYS))                                    \
-                StressLog::LogMsg(LF_ALWAYS|(dprintfLevel<<16)|LF_GC, LL_ALWAYS, _Args msg); \
+            if (StressLog::StressLogOn(LF_ALWAYS|(dprintfLevel<<16)|LF_GC, LL_ALWAYS))       \
+                StressLog::LogMsgOL(_Args msg); \
             } WHILE_0
 
 #define STRESS_LOG0(facility, level, msg) do {                                      \
@@ -425,6 +425,41 @@ public:
     {
         C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*));
         LogMsg(LF_GC, 7, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7);
+    }
+
+    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8 >
+    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8)
+    {
+        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*));
+        LogMsg(LF_GC, 8, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8);
+    }
+
+    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9 >
+    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9)
+    {
+        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*));
+        LogMsg(LF_GC, 9, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9);
+    }
+
+    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10 >
+    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10)
+    {
+        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*));
+        LogMsg(LF_GC, 10, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10);
+    }
+
+    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11 >
+    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11)
+    {
+        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*));
+        LogMsg(LF_GC, 11, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10, (void*)(size_t)data11);
+    }
+
+    template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12 >
+    static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7, T8 data8, T9 data9, T10 data10, T11 data11, T12 data12)
+    {
+        C_ASSERT(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*) && sizeof(T8) <= sizeof(void*) && sizeof(T9) <= sizeof(void*) && sizeof(T10) <= sizeof(void*) && sizeof(T11) <= sizeof(void*) && sizeof(T12) <= sizeof(void*));
+        LogMsg(LF_GC, 12, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7, (void*)(size_t)data8, (void*)(size_t)data9, (void*)(size_t)data10, (void*)(size_t)data11, (void*)(size_t)data12);
     }
 
     #ifdef _MSC_VER

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -460,10 +460,12 @@ public:
 // space on 32-bit platforms
 //
 struct StressMsg {
+    static const size_t formatOffsetBits = 26;
     union {
         struct {
             uint32_t numberOfArgs  : 3;   // at most 7 arguments
-            uint32_t formatOffset  : 29;  // offset of string in mscorwks
+            uint32_t formatOffset  : formatOffsetBits;    // offset of string in mscorwks
+            uint32_t numberOfArgsX : 3;                   // extend number of args in a backward compat way
         };
         uint32_t fmtOffsCArgs;            // for optimized access
     };
@@ -471,8 +473,8 @@ struct StressMsg {
     unsigned __int64 timeStamp;         // time when mssg was logged
     void*     args[0];                  // size given by numberOfArgs
 
-    static const size_t maxArgCnt = 7;
-    static const size_t maxOffset = 0x20000000;
+    static const size_t maxArgCnt = 63;
+    static const size_t maxOffset = 1 << formatOffsetBits;
     static size_t maxMsgSize ()
     { return sizeof(StressMsg) + maxArgCnt*sizeof(void*); }
 

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -97,16 +97,16 @@ enum LogFacilitiesEnum: unsigned int {
 //
 
 /*  STRESS_LOG_VA was added to allow sending GC trace output to the stress log. msg must be enclosed
-    in ()'s and contain a format string. The arguments must be numbers or string literals.
-    This was done because GC Trace uses dprintf which dosen't contain info on how many arguments are
-    getting passed in and using va_args would require parsing the format string during the GC
+    in ()'s and contain a format string followed by 0 to 12 arguments. The arguments must be numbers
+     or string literals. This was done because GC Trace uses dprintf which dosen't contain info on 
+    how many arguments are getting passed in and using va_args would require parsing the format 
+    string during the GC
 */
-
 #define _Args(...) __VA_ARGS__
 
 #define STRESS_LOG_VA(dprintfLevel,msg) do {                                                 \
             if (StressLog::StressLogOn(LF_ALWAYS|(dprintfLevel<<16)|LF_GC, LL_ALWAYS))       \
-                StressLog::LogMsgOL(_Args msg); \
+                StressLog::LogMsgOL(_Args msg);                                              \
             } WHILE_0
 
 #define STRESS_LOG0(facility, level, msg) do {                                      \

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -93,13 +93,6 @@ static bool InitDLL(HANDLE hPalInstance)
 
     InitializeYieldProcessorNormalizedCrst();
 
-    STARTUP_TIMELINE_EVENT(NONGC_INIT_COMPLETE);
-
-    if (!RedhawkGCInterface::InitializeSubsystems())
-        return false;
-
-    STARTUP_TIMELINE_EVENT(GC_INIT_COMPLETE);
-
 #ifdef STRESS_LOG
     uint32_t dwTotalStressLogSize = g_pRhConfig->GetTotalStressLogSize();
     uint32_t dwStressLogLevel = g_pRhConfig->GetStressLogLevel();
@@ -113,6 +106,13 @@ static bool InitDLL(HANDLE hPalInstance)
                               (unsigned)dwTotalStressLogSize, hPalInstance);
     }
 #endif // STRESS_LOG
+
+    STARTUP_TIMELINE_EVENT(NONGC_INIT_COMPLETE);
+
+    if (!RedhawkGCInterface::InitializeSubsystems())
+        return false;
+
+    STARTUP_TIMELINE_EVENT(GC_INIT_COMPLETE);
 
 #ifndef USE_PORTABLE_HELPERS
     if (!DetectCPUFeatures())

--- a/src/coreclr/nativeaot/Runtime/stressLog.cpp
+++ b/src/coreclr/nativeaot/Runtime/stressLog.cpp
@@ -263,7 +263,7 @@ void StressLog::ThreadDetach(ThreadStressLog *msgs) {
 
 bool StressLog::AllowNewChunk (long numChunksInCurThread)
 {
-    Thread* pCurrentThread = ThreadStore::GetCurrentThread();
+    Thread* pCurrentThread = ThreadStore::RawGetCurrentThread();
     if (pCurrentThread->IsInCantAllocStressLogRegion())
     {
         return FALSE;
@@ -368,7 +368,6 @@ void ThreadStressLog::Activate (Thread * pThread)
     curPtr = (StressMsg *)curWriteChunk->EndPtr ();
     writeHasWrapped = FALSE;
     this->pThread = pThread;
-    ASSERT(pThread->IsCurrentThread());
 }
 
 /* static */
@@ -379,7 +378,7 @@ void StressLog::LogMsg (unsigned facility, int cArgs, const char* format, ... )
     va_list Args;
     va_start(Args, format);
 
-    Thread *pThread = ThreadStore::GetCurrentThread();
+    Thread *pThread = ThreadStore::RawGetCurrentThread();
     if (pThread == NULL)
         return;
 

--- a/src/coreclr/nativeaot/Runtime/stressLog.cpp
+++ b/src/coreclr/nativeaot/Runtime/stressLog.cpp
@@ -345,7 +345,8 @@ void ThreadStressLog::LogMsg ( uint32_t facility, int cArgs, const char* format,
     msg->timeStamp = getTimeStamp();
     msg->facility = facility;
     msg->formatOffset = offs;
-    msg->numberOfArgs = cArgs;
+    msg->numberOfArgs = cArgs & 0x7;
+    msg->numberOfArgsX = cArgs >> 3;
 
     for ( int i = 0; i < cArgs; ++i )
     {

--- a/src/coreclr/vm/commtmemberinfomap.cpp
+++ b/src/coreclr/vm/commtmemberinfomap.cpp
@@ -336,7 +336,7 @@ void ComMTMemberInfoMap::SetupPropsForIClassX(size_t sizeOfPtr)
             m_MethodProps[i].pName = reinterpret_cast<WCHAR*>(m_sNames.Alloc(cchpName * sizeof(WCHAR)));
 
             m_MethodProps[i].pMeth = (MethodDesc*)pFieldMeth;
-            // It's safe to do the following case becasue that FieldSemanticOffset is 100, msSetter = 1, msGetter = 2
+            // It's safe to do the following case because that FieldSemanticOffset is 100, msSetter = 1, msGetter = 2
             m_MethodProps[i].semantic = static_cast<USHORT>(FieldSemanticOffset + (pFieldMeth->IsFieldGetter() ? msGetter : msSetter));
             m_MethodProps[i].property = mdPropertyNil;
             wcscpy_s(m_MethodProps[i].pName, cchpName, rName.Ptr());
@@ -348,7 +348,7 @@ void ComMTMemberInfoMap::SetupPropsForIClassX(size_t sizeOfPtr)
             ++i;
             pFieldMeth = pCMT->GetFieldCallMethodDescForSlot(i);
             m_MethodProps[i].pMeth = (MethodDesc*)pFieldMeth;
-            // It's safe to do the following case becasue that FieldSemanticOffset is 100, msSetter = 1, msGetter = 2
+            // It's safe to do the following case because that FieldSemanticOffset is 100, msSetter = 1, msGetter = 2
             m_MethodProps[i].semantic = static_cast<USHORT>(FieldSemanticOffset + (pFieldMeth->IsFieldGetter() ? msGetter : msSetter));
             m_MethodProps[i].property = i - 1;
             m_MethodProps[i].dispid = dispid;


### PR DESCRIPTION
- [x] In various places, we are logging 64-bit numbers, this fails on 32-bit architectures as it is larger than pointer size.
- [x] There is a signed vs unsigned comparison in `gc_heap::sweep_region_in_plan` and is failing gcc build.
- [x] Ensure NativeAOT implementation of StressLog support more parameters.
- [x] Fixing CI failures