### PR TITLE
Speed up ValueType.Equals

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
@@ -64,11 +64,7 @@ namespace System
 
                 // Compare the memory
                 int valueTypeSize = (int)this.GetEETypePtr().ValueTypeSize;
-                for (int i = 0; i < valueTypeSize; i++)
-                {
-                    if (Unsafe.Add(ref thisRawData, i) != Unsafe.Add(ref thatRawData, i))
-                        return false;
-                }
+                return SpanHelpers.SequenceEqual(ref thisRawData, ref thatRawData, valueTypeSize);
             }
             else
             {


### PR DESCRIPTION
Inspired by #69723 

`SpanHelpers` didn't exist when this part of NativeAOT was written (https://github.com/dotnet/corert/pull/5436#discussion_r170412863).