### PR TITLE
Don't use top level statements in the repro app

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/repro/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/repro/Program.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 
 class Program

--- a/src/coreclr/tools/aot/ILCompiler/repro/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/repro/Program.cs
@@ -1,3 +1,9 @@
 using System;
 
-Console.WriteLine("Hello world");
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine("Hello world");
+    }
+}


### PR DESCRIPTION
I'm finding myself adding `class Program` too often. Top level statements are not helpful here.