### PR TITLE
Set app context to null on thread detach

### DIFF
--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -389,6 +389,7 @@ void
 mono_domain_unset (void)
 {
 	SET_APPDOMAIN (NULL);
+	SET_APPCONTEXT(NULL);
 }
 
 void

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -389,7 +389,6 @@ void
 mono_domain_unset (void)
 {
 	SET_APPDOMAIN (NULL);
-	SET_APPCONTEXT(NULL);
 }
 
 void

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -1055,8 +1055,8 @@ mono_thread_detach_internal (MonoInternalThread *thread)
 	/* There is no more any guarantee that `thread` is alive */
 	mono_memory_barrier ();
 
+	mono_domain_unset();
 	SET_CURRENT_OBJECT (NULL);
-	mono_domain_unset ();
 
 	if (!mono_thread_info_try_get_internal_thread_gchandle (info, &gchandle))
 		g_error ("%s: failed to get gchandle, info = %p", __func__, info);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#21482,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When a domain is unloaded, it is possible that an InternalThread
has a reference to an app context from the unloaded domain.

