### PR TITLE
Disable failing MsQuic tests on Windows

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -61,7 +61,7 @@ namespace System
 
         // Windows Server 2022
         public static bool IsWindows10Version20348OrGreater => IsWindowsVersionOrLater(10, 0, 20348);
-
+        public static bool IsWindows10Version20348OrLower => IsWindowsVersionOrEarlier(10, 0, 20348);
 
         // Windows 11 aka 21H2
         public static bool IsWindows10Version22000OrGreater => IsWindowsVersionOrLater(10, 0, 22000);
@@ -177,6 +177,11 @@ namespace System
         internal static bool IsWindowsVersionOrLater(int major, int minor, int build = -1)
         {
             return IsWindows && GetWindowsVersionObject() >= (build != -1 ? new Version(major, minor, build) : new Version(major, minor));
+        }
+
+        internal static bool IsWindowsVersionOrEarlier(int major, int minor, int build = -1)
+        {
+            return IsWindows && GetWindowsVersionObject() <= (build != -1 ? new Version(major, minor, build) : new Version(major, minor));
         }
 
         private static int s_isInAppContainer = -1;

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -105,10 +105,14 @@ namespace System.Net.Quic.Tests
             clientConnection.Dispose();
         }
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69792", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version20348OrGreater))]
+        [ConditionalFact]
         public async Task UntrustedClientCertificateFails()
         {
+            if (PlatformDetection.IsWindows10Version20348OrLower)
+            {
+                throw new SkipTestException("Client certificates are not supported on Windows Server 2022.");
+            }
+
             var listenerOptions = new QuicListenerOptions();
             listenerOptions.ListenEndPoint = new IPEndPoint(IPAddress.Loopback, 0);
             listenerOptions.ServerAuthenticationOptions = GetSslServerAuthenticationOptions();
@@ -335,12 +339,16 @@ namespace System.Net.Quic.Tests
             (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection(clientOptions, listenerOptions);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69792", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version20348OrGreater))]
         public async Task ConnectWithClientCertificate(bool sendCertificate)
         {
+            if (PlatformDetection.IsWindows10Version20348OrLower)
+            {
+                throw new SkipTestException("Client certificates are not supported on Windows Server 2022.");
+            }
+
             bool clientCertificateOK = false;
 
             var listenerOptions = new QuicListenerOptions();

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -106,6 +106,7 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/69792", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version20348OrGreater))]
         public async Task UntrustedClientCertificateFails()
         {
             var listenerOptions = new QuicListenerOptions();
@@ -337,6 +338,7 @@ namespace System.Net.Quic.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/69792", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version20348OrGreater))]
         public async Task ConnectWithClientCertificate(bool sendCertificate)
         {
             bool clientCertificateOK = false;


### PR DESCRIPTION
Contributes to #69792.

This PR disables newly failing tests. The failures seem to be confined to Windows 2022 Server.