### PR TITLE
[LibraryImportGenerator] Reduce unnecessary casting/locals in pinning path

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
@@ -30,10 +30,12 @@ namespace Microsoft.Interop
         /// The native type should match the managed type, including rehydrating marshalling attributes and by-ref syntax (pure forwarding).
         /// </summary>
         ManagedTypeAndAttributes,
+
         /// <summary>
         /// The native signature should be the type returned by <see cref="IMarshallingGenerator.AsNativeType(TypePositionInfo)"/> passed by value.
         /// </summary>
         NativeType,
+
         /// <summary>
         /// The native signature should be a pointer to the type returned by <see cref="IMarshallingGenerator.AsNativeType(TypePositionInfo)"/> passed by value.
         /// </summary>
@@ -49,14 +51,17 @@ namespace Microsoft.Interop
         /// The managed value should be passed as-is, including any managed by-ref syntax used in the managed declaration.
         /// </summary>
         ManagedIdentifier,
+
         /// <summary>
         /// The native identifier provided by <see cref="StubCodeContext.GetIdentifiers(TypePositionInfo)"/> should be passed by value.
         /// </summary>
         NativeIdentifier,
+
         /// <summary>
         /// The address of the native identifier provided by <see cref="StubCodeContext.GetIdentifiers(TypePositionInfo)"/> should be passed by value.
         /// </summary>
         AddressOfNativeIdentifier,
+
         /// <summary>
         /// The native identifier provided by <see cref="StubCodeContext.GetIdentifiers(TypePositionInfo)"/> should be cast to the native type.
         /// </summary>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
@@ -56,7 +56,11 @@ namespace Microsoft.Interop
         /// <summary>
         /// The address of the native identifier provided by <see cref="StubCodeContext.GetIdentifiers(TypePositionInfo)"/> should be passed by value.
         /// </summary>
-        AddressOfNativeIdentifier
+        AddressOfNativeIdentifier,
+        /// <summary>
+        /// The native identifier provided by <see cref="StubCodeContext.GetIdentifiers(TypePositionInfo)"/> should be cast to the native type.
+        /// </summary>
+        CastNativeIdentifier
     }
 
     /// <summary>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
@@ -96,7 +96,6 @@ namespace Microsoft.Interop
             return param;
         }
 
-
         private static bool TryRehydrateMarshalAsAttribute(TypePositionInfo info, out AttributeSyntax marshalAsAttribute)
         {
             marshalAsAttribute = null!;
@@ -203,6 +202,7 @@ namespace Microsoft.Interop
                 ValueBoundaryBehavior.ManagedIdentifier when info.IsByRef => Argument(IdentifierName(managedIdentifier)).WithRefKindKeyword(Token(info.RefKindSyntax)),
                 ValueBoundaryBehavior.NativeIdentifier => Argument(IdentifierName(nativeIdentifier)),
                 ValueBoundaryBehavior.AddressOfNativeIdentifier => Argument(PrefixUnaryExpression(SyntaxKind.AddressOfExpression, IdentifierName(nativeIdentifier))),
+                ValueBoundaryBehavior.CastNativeIdentifier => Argument(CastExpression(generator.AsParameter(info).Type, IdentifierName(nativeIdentifier))),
                 _ => throw new InvalidOperationException()
             };
         }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/69608: Style item (6)

UTF-16 `string`:
```csharp
[LibraryImport("lib", StringMarshalling = StringMarshalling.Utf16)]
internal static partial void ManyStrings(string s1, string s2, string s3, string s4, string s5);

// Generated
internal static partial void ManyStrings(string s1, string s2, string s3, string s4, string s5)
{
    // Pin - Pin data in preparation for calling the P/Invoke.
    fixed (void* __s1_native = s1)
        fixed (void* __s2_native = s2)
            fixed (void* __s3_native = s3)
                fixed (void* __s4_native = s4)
                    fixed (void* __s5_native = s5)
                    {
                        __PInvoke(__s1_native, __s2_native, __s3_native, __s4_native, __s5_native);
                    }

    // Local P/Invoke
    [System.Runtime.InteropServices.DllImportAttribute("lib", EntryPoint = "ManyStrings", ExactSpelling = true)]
    static extern unsafe void __PInvoke(void* s1, void* s2, void* s3, void* s4, void* s5);
}
```

User-defined: 
https://github.com/dotnet/runtime/blob/d143e18e1ac2894b47dad9fe062dbe1244e0f611/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/NonBlittable.cs#L98-L104
```csharp
[LibraryImport("lib")]
public static partial void UserDefinedPinnable(SharedTypes.IntWrapper i1, SharedTypes.IntWrapper i2);

// Generated
public static partial void UserDefinedPinnable(global::SharedTypes.IntWrapper i1, global::SharedTypes.IntWrapper i2)
{
    // Pin - Pin data in preparation for calling the P/Invoke.
    fixed (void* __i1_native = i1)
        fixed (void* __i2_native = i2)
        {
            __PInvoke((int*)__i1_native, (int*)__i2_native);
        }

    // Local P/Invoke
    [System.Runtime.InteropServices.DllImportAttribute("lib", EntryPoint = "UserDefinedPinnable", ExactSpelling = true)]
    static extern unsafe void __PInvoke(int* i1, int* i2);
}
```