### PR TITLE
Relax the address exposure condition in forward substitution

### DIFF
--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -628,15 +628,16 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
     // These conditions can be checked earlier in the final version to save some throughput.
     // Perhaps allowing for bypass with jit stress.
     //
-    // If fwdSubNode is an address-exposed local, forwarding it may lose optimizations.
-    // (maybe similar for dner?)
+    // If fwdSubNode is an address-exposed local, forwarding it may lose optimizations due
+    // to GLOB_REF "poisoning" the tree. CQ analysis shows this to not be a problem with
+    // structs.
     //
     if (fwdSubNode->OperIs(GT_LCL_VAR))
     {
         unsigned const   fwdLclNum = fwdSubNode->AsLclVarCommon()->GetLclNum();
         LclVarDsc* const fwdVarDsc = lvaGetDesc(fwdLclNum);
 
-        if (fwdVarDsc->IsAddressExposed())
+        if (!varTypeIsStruct(fwdVarDsc) && fwdVarDsc->IsAddressExposed())
         {
             JITDUMP(" V%02u is address exposed\n", fwdLclNum);
             return false;


### PR DESCRIPTION
The condition in question is a CQ heuristic -- this change refines it by not applying the block to structs.

The motivation here is that I will be enabling folding of implicit byref parameters in `LocalAddressVisitor` soon and need this change to avoid some substitution-induced regressions.

Deleting this check entirely requires more work (and results in actual regressions) and so is out of scope (for now).

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1791275&view=ms.vss-build-web.run-extensions-tab): nice diffs overall; all regressions I've checked were RA / copy propagation - related.