### PR TITLE
Remove extraneous diagnostic

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -274,7 +274,6 @@ namespace Microsoft.Interop
 
             if (libraryImportData is null)
             {
-                generatorDiagnostics.ReportConfigurationNotSupported(generatedDllImportAttr!, "Invalid syntax");
                 libraryImportData = new LibraryImportData("INVALID_CSHARP_SYNTAX");
             }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
@@ -149,9 +149,9 @@ namespace LibraryImportGenerator.UnitTests
         {
             yield return new object[] { CodeSnippets.RecursiveImplicitlyBlittableStruct, 0, 1 };
             yield return new object[] { CodeSnippets.MutuallyRecursiveImplicitlyBlittableStruct, 0, 2 };
-            yield return new object[] { CodeSnippets.PartialPropertyName, 1, 2 };
-            yield return new object[] { CodeSnippets.InvalidConstantForModuleName, 1, 1 };
-            yield return new object[] { CodeSnippets.IncorrectAttributeFieldType, 1, 1 };
+            yield return new object[] { CodeSnippets.PartialPropertyName, 0, 2 };
+            yield return new object[] { CodeSnippets.InvalidConstantForModuleName, 0, 1 };
+            yield return new object[] { CodeSnippets.IncorrectAttributeFieldType, 0, 1 };
         }
 
         [Theory]


### PR DESCRIPTION
Remove the extra diagnostic we emit when the compiler failed to parse the attribute. The C# compiler will already fail so just let it emit its diagnostics.


Fixes #69827