### PR TITLE
Cleanup a few more allocations in X.509

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Apple.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Apple.cs
@@ -118,7 +118,7 @@ namespace System.Security.Cryptography.X509Certificates
 
         private SafeCreateHandle PreparePoliciesArray(bool checkRevocation)
         {
-            IntPtr[] policies = new IntPtr[checkRevocation ? 2 : 1];
+            Span<IntPtr> policies = checkRevocation ? stackalloc IntPtr[2] : stackalloc IntPtr[1];
 
             SafeHandle defaultPolicy = Interop.AppleCrypto.X509ChainCreateDefaultPolicy();
 
@@ -138,8 +138,7 @@ namespace System.Security.Cryptography.X509Certificates
                 policies[1] = revPolicy.DangerousGetHandle();
             }
 
-            SafeCreateHandle policiesArray =
-                Interop.CoreFoundation.CFArrayCreate(policies, (UIntPtr)policies.Length);
+            SafeCreateHandle policiesArray = Interop.CoreFoundation.CFArrayCreate(policies);
 
             _extraHandles.Push(policiesArray);
             return policiesArray;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -288,22 +288,12 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 ThrowIfInvalid();
 
-                X500DistinguishedName? issuerName = _lazyIssuerName;
-                if (issuerName == null)
-                    issuerName = _lazyIssuerName = Pal.IssuerName;
-                return issuerName;
+                return _lazyIssuerName ??= Pal.IssuerName;
             }
         }
 
-        public DateTime NotAfter
-        {
-            get { return GetNotAfter(); }
-        }
-
-        public DateTime NotBefore
-        {
-            get { return GetNotBefore(); }
-        }
+        public DateTime NotAfter => GetNotAfter();
+        public DateTime NotBefore => GetNotBefore();
 
         public PublicKey PublicKey
         {
@@ -312,14 +302,16 @@ namespace System.Security.Cryptography.X509Certificates
                 ThrowIfInvalid();
 
                 PublicKey? publicKey = _lazyPublicKey;
+
                 if (publicKey == null)
                 {
                     string keyAlgorithmOid = GetKeyAlgorithm();
-                    byte[] parameters = GetKeyAlgorithmParameters();
-                    byte[] keyValue = GetPublicKey();
+                    byte[] parameters = Pal.KeyAlgorithmParameters;
+                    byte[] keyValue = Pal.PublicKeyValue;
                     Oid oid = new Oid(keyAlgorithmOid);
                     publicKey = _lazyPublicKey = new PublicKey(oid, new AsnEncodedData(oid, parameters), new AsnEncodedData(oid, keyValue));
                 }
+
                 return publicKey;
             }
         }
@@ -343,13 +335,7 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        public string SerialNumber
-        {
-            get
-            {
-                return GetSerialNumberString();
-            }
-        }
+        public string SerialNumber => GetSerialNumberString();
 
         public Oid SignatureAlgorithm
         {
@@ -357,13 +343,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 ThrowIfInvalid();
 
-                Oid? signatureAlgorithm = _lazySignatureAlgorithm;
-                if (signatureAlgorithm == null)
-                {
-                    string oidValue = Pal.SignatureAlgorithm;
-                    signatureAlgorithm = _lazySignatureAlgorithm = new Oid(oidValue, null);
-                }
-                return signatureAlgorithm;
+                return _lazySignatureAlgorithm ??= new Oid(Pal.SignatureAlgorithm, null);
             }
         }
 
@@ -373,10 +353,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 ThrowIfInvalid();
 
-                X500DistinguishedName? subjectName = _lazySubjectName;
-                if (subjectName == null)
-                    subjectName = _lazySubjectName = Pal.SubjectName;
-                return subjectName;
+                return _lazySubjectName ??= Pal.SubjectName;
             }
         }
 
@@ -445,10 +422,7 @@ namespace System.Security.Cryptography.X509Certificates
             return Pal.GetNameInfo(nameType, forIssuer);
         }
 
-        public override string ToString()
-        {
-            return base.ToString(fVerbose: true);
-        }
+        public override string ToString() => base.ToString(fVerbose: true);
 
         public override string ToString(bool verbose)
         {


### PR DESCRIPTION
A few more small allocations that can be avoided, and a little bit of formatting cleanup in `X509Certificate2`.