### PR TITLE
Pin char when UTF-16 marshalling is specified and runtime marshalling is disabled

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -323,7 +323,6 @@ namespace Microsoft.Interop
 
         private static MarshallingGeneratorFactoryKey<(TargetFramework, Version, LibraryImportGeneratorOptions)> CreateGeneratorFactory(StubEnvironment env, LibraryImportGeneratorOptions options)
         {
-            InteropGenerationOptions interopGenerationOptions = new(options.UseMarshalType);
             IMarshallingGeneratorFactory generatorFactory;
 
             if (options.GenerateForwarders)
@@ -343,7 +342,6 @@ namespace Microsoft.Interop
                     generatorFactory = new UnsupportedMarshallingFactory();
                 }
 
-                generatorFactory = new MarshalAsMarshallingGeneratorFactory(interopGenerationOptions, generatorFactory);
 
                 // The presence of System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute is tied to TFM,
                 // so we use TFM in the generator factory key instead of the Compilation as the compilation changes on every keystroke.
@@ -351,6 +349,9 @@ namespace Microsoft.Interop
                 ITypeSymbol? disabledRuntimeMarshallingAttributeType = coreLibraryAssembly.GetTypeByMetadataName(TypeNames.System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute);
                 bool runtimeMarshallingDisabled = disabledRuntimeMarshallingAttributeType is not null
                     && env.Compilation.Assembly.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, disabledRuntimeMarshallingAttributeType));
+
+                InteropGenerationOptions interopGenerationOptions = new(options.UseMarshalType, runtimeMarshallingDisabled);
+                generatorFactory = new MarshalAsMarshallingGeneratorFactory(interopGenerationOptions, generatorFactory);
 
                 IMarshallingGeneratorFactory elementFactory = new AttributedMarshallingModelGeneratorFactory(generatorFactory, new AttributedMarshallingModelOptions(runtimeMarshallingDisabled));
                 // We don't need to include the later generator factories for collection elements

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/InteropGenerationOptions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/InteropGenerationOptions.cs
@@ -7,5 +7,5 @@ using System.Text;
 
 namespace Microsoft.Interop
 {
-    public readonly record struct InteropGenerationOptions(bool UseMarshalType);
+    public readonly record struct InteropGenerationOptions(bool UseMarshalType, bool RuntimeMarshallingDisabled);
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
@@ -339,7 +339,7 @@ namespace Microsoft.Interop
             {
                 return new ArrayMarshaller(
                     new CustomNativeTypeMarshallingGenerator(marshallingStrategy, enableByValueContentsMarshalling: true),
-                    collectionInfo.ElementType.Syntax,
+                    elementInfo,
                     enableArrayPinning);
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshalAsMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshalAsMarshallingGeneratorFactory.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Interop
                     return s_safeHandle;
 
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Char } }:
-                    return CreateCharMarshaller(info, context);
+                    return CreateCharMarshaller(info, context, Options);
 
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_String } }:
                     return ReportStringMarshallingNotSupported(info, context);
@@ -122,7 +122,7 @@ namespace Microsoft.Interop
             }
         }
 
-        private static IMarshallingGenerator CreateCharMarshaller(TypePositionInfo info, StubCodeContext context)
+        private static IMarshallingGenerator CreateCharMarshaller(TypePositionInfo info, StubCodeContext context, InteropGenerationOptions options)
         {
             MarshallingInfo marshalInfo = info.MarshallingAttributeInfo;
             if (marshalInfo is NoMarshallingInfo)
@@ -141,7 +141,8 @@ namespace Microsoft.Interop
                 {
                     case UnmanagedType.I2:
                     case UnmanagedType.U2:
-                        return s_utf16Char;
+                        // If runtime marshalling is disabled, we treat UTF-16 char as blittable
+                        return options.RuntimeMarshallingDisabled ? s_blittable : s_utf16Char;
                 }
             }
             else if (marshalInfo is MarshallingInfoStringSupport marshalStringInfo)
@@ -149,7 +150,8 @@ namespace Microsoft.Interop
                 switch (marshalStringInfo.CharEncoding)
                 {
                     case CharEncoding.Utf16:
-                        return s_utf16Char;
+                        // If runtime marshalling is disabled, we treat UTF-16 char as blittable
+                        return options.RuntimeMarshallingDisabled ? s_blittable : s_utf16Char;
                     case CharEncoding.Utf8:
                         throw new MarshallingNotSupportedException(info, context) // [Compat] UTF-8 is not supported for char
                         {

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
@@ -32,10 +32,10 @@ namespace LibraryImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<bool>(), 5, 0 };
 
             // Unsupported StringMarshalling configuration
-            yield return new object[] { CodeSnippets.BasicParametersAndModifiersWithStringMarshalling<char>(StringMarshalling.Utf8), 6, 0 };
-            yield return new object[] { CodeSnippets.BasicParametersAndModifiersWithStringMarshalling<char>(StringMarshalling.Custom), 7, 0 };
-            yield return new object[] { CodeSnippets.BasicParametersAndModifiersWithStringMarshalling<string>(StringMarshalling.Custom), 7, 0 };
-            yield return new object[] { CodeSnippets.CustomStringMarshallingParametersAndModifiers<char>(), 6, 0 };
+            yield return new object[] { CodeSnippets.BasicParametersAndModifiersWithStringMarshalling<char>(StringMarshalling.Utf8), 5, 0 };
+            yield return new object[] { CodeSnippets.BasicParametersAndModifiersWithStringMarshalling<char>(StringMarshalling.Custom), 6, 0 };
+            yield return new object[] { CodeSnippets.BasicParametersAndModifiersWithStringMarshalling<string>(StringMarshalling.Custom), 6, 0 };
+            yield return new object[] { CodeSnippets.CustomStringMarshallingParametersAndModifiers<char>(), 5, 0 };
 
             // Unsupported UnmanagedType
             yield return new object[] { CodeSnippets.MarshalAsParametersAndModifiers<char>(UnmanagedType.I1), 5, 0 };


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/69809: item (2)

When `DisableRuntimeMarshalling` is used and marshalling info (`StringMarshalling.Utf16` or `UnmanagedType.U2/I2`) is specified for `char`, we were treating it as if runtime marshalling was not disabled, so we wouldn't pin.

```csharp
[assembly: DisableRuntimeMarshalling]

[LibraryImport("lib", StringMarshalling = StringMarshalling.Utf16)]
public static partial void CharArray(char[] c);
```
Old generated code:
```csharp
byte* __c_native = default;
// Setup - Perform required setup.
global::System.Runtime.InteropServices.Marshalling.ArrayMarshaller<char> __c_native__marshaller = default;
try
{
    // Marshal - Convert managed data to native data.
    byte* __c_native__marshaller__stackptr = stackalloc byte[512];
    __c_native__marshaller = new(c, new System.Span<byte>(__c_native__marshaller__stackptr, 512), sizeof(ushort));
    __c_native__marshaller.GetManagedValuesSource().CopyTo(System.Runtime.InteropServices.MemoryMarshal.Cast<byte, char>(__c_native__marshaller.GetNativeValuesDestination()));
    // Pin - Pin data in preparation for calling the P/Invoke.
    fixed (void* __c_native__ignored = __c_native__marshaller)
    {
        __c_native = __c_native__marshaller.ToNativeValue();
        __PInvoke(__c_native);
    }
}
finally
{
    // Cleanup - Perform required cleanup.
    __c_native__marshaller.FreeNative();
}
```
New generated code:
```csharp
// Marshal - Convert managed data to native data.
ref char __byref_c = ref (c == null ? ref *(char*)0 : ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(c));
// Pin - Pin data in preparation for calling the P/Invoke.
fixed (byte* __c_native = &System.Runtime.CompilerServices.Unsafe.As<char, byte>(ref __byref_c))
{
    __PInvoke(__c_native);
}
```