### PR TITLE
[NativeAot] Null ref return is wrapped in TargetInvocationException

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -127,5 +127,10 @@ namespace Internal.Runtime.CompilerHelpers
         {
             throw new ArgumentOutOfRangeException();
         }
+
+        public static void ThrowInvokeNullRefReturned()
+        {
+            throw new NullReferenceException(SR.NullReference_InvokeNullRefReturned);
+        }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -427,9 +427,6 @@ namespace System
                     }
                 }
 
-                if (result == NullByRefValueSentinel)
-                    throw new NullReferenceException(SR.NullReference_InvokeNullRefReturned);
-
                 return result;
             }
         }
@@ -669,19 +666,6 @@ namespace System
                         }
                     }
                 }
-            }
-        }
-
-        private static volatile object _nullByRefValueSentinel;
-        public static object NullByRefValueSentinel
-        {
-            get
-            {
-                if (_nullByRefValueSentinel == null)
-                {
-                    Interlocked.CompareExchange(ref _nullByRefValueSentinel, new object(), null);
-                }
-                return _nullByRefValueSentinel;
             }
         }
     }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.cs
@@ -1119,13 +1119,11 @@ namespace Internal.Runtime.TypeLoader
                         RuntimeTypeHandle returnTypeRuntimeTypeHandle = thRetType.GetRuntimeTypeHandle();
 
                         // Need to box value type before returning it
-                        object returnValue;
+                        object returnValue = null;
                         if (returnType == CorElementType.ELEMENT_TYPE_BYREF && returnValueToCopy == null)
                         {
                             // This is a byref return and dereferencing it would result in a NullReferenceException.
-                            // Set the return value to a sentinel that InvokeUtils will recognize.
-                            // Can't throw from here or we would wrap this in a TargetInvocationException.
-                            returnValue = InvokeUtils.NullByRefValueSentinel;
+                            CompilerHelpers.ThrowHelpers.ThrowInvokeNullRefReturned();
                         }
                         else if (RuntimeAugments.IsUnmanagedPointerType(returnTypeRuntimeTypeHandle))
                         {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.cs
@@ -1119,11 +1119,13 @@ namespace Internal.Runtime.TypeLoader
                         RuntimeTypeHandle returnTypeRuntimeTypeHandle = thRetType.GetRuntimeTypeHandle();
 
                         // Need to box value type before returning it
-                        object returnValue = null;
+                        object returnValue;
                         if (returnType == CorElementType.ELEMENT_TYPE_BYREF && returnValueToCopy == null)
                         {
                             // This is a byref return and dereferencing it would result in a NullReferenceException.
                             CompilerHelpers.ThrowHelpers.ThrowInvokeNullRefReturned();
+                            // Unreachable
+                            returnValue = null;
                         }
                         else if (RuntimeAugments.IsUnmanagedPointerType(returnTypeRuntimeTypeHandle))
                         {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
@@ -388,9 +388,7 @@ namespace Internal.IL.Stubs
             //
             // !if (ReturnType is ByRef)
             //   ByRefNull:
-            //   pop
-            //   call InvokeUtils.get_NullByRefValueSentinel
-            //   ret
+            //   throw NullReferenceException
 
             ILCodeLabel lStaticCall = emitter.NewCodeLabel();
             ILCodeLabel lProcessReturn = emitter.NewCodeLabel();
@@ -512,9 +510,8 @@ namespace Internal.IL.Stubs
             if (lByRefReturnNull != null)
             {
                 returnCodeStream.EmitLabel(lByRefReturnNull);
-                returnCodeStream.Emit(ILOpcode.pop);
-                returnCodeStream.Emit(ILOpcode.call, emitter.NewToken(InvokeUtilsType.GetKnownMethod("get_NullByRefValueSentinel", null)));
-                returnCodeStream.Emit(ILOpcode.ret);
+                MethodDesc nullReferencedExceptionHelper = Context.GetHelperEntryPoint("ThrowHelpers", "ThrowInvokeNullRefReturned");
+                returnCodeStream.EmitCallThrowHelper(emitter, nullReferencedExceptionHelper);                
             }
 
             return emitter.Link(this);

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -1216,7 +1216,6 @@ internal class ReflectionTest
             PropertyInfo p = typeof(TestClassIntPointer).GetProperty(nameof(TestClassIntPointer.NullRefReturningProp));
             Assert.NotNull(p);
             Assert.Throws<TargetInvocationException>(() => p.GetValue(tc));
-            Assert.IsType<NullReferenceException>(ex.InnerException);
         }
 
         public static unsafe void TestByRefLikeRefReturn()

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -1215,7 +1215,8 @@ internal class ReflectionTest
 
             PropertyInfo p = typeof(TestClassIntPointer).GetProperty(nameof(TestClassIntPointer.NullRefReturningProp));
             Assert.NotNull(p);
-            Assert.Throws<NullReferenceException>(() => p.GetValue(tc));
+            Assert.Throws<TargetInvocationException>(() => p.GetValue(tc));
+            Assert.IsType<NullReferenceException>(ex.InnerException);
         }
 
         public static unsafe void TestByRefLikeRefReturn()


### PR DESCRIPTION
When a null ref return method is invoked. Fixes #69755