### PR TITLE
Implement LoadLibraryErrorTracker

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -258,6 +258,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeThreadPoolIOHandle.cs" />
+    <Compile Include="System\Runtime\InteropServices\NativeLibrary.NativeAot.Windows.cs" />
     <Compile Include="System\Runtime\InteropServices\PInvokeMarshal.Windows.cs" />
     <Compile Include="$(CommonPath)\System\Runtime\InteropServices\Variant.cs">
       <Link>System\Runtime\InteropServices\Variant.cs</Link>
@@ -317,6 +318,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
     <Compile Include="System\Environment.NativeAot.Unix.cs" />
+    <Compile Include="System\Runtime\InteropServices\NativeLibrary.NativeAot.Unix.cs" />
     <Compile Include="System\Runtime\InteropServices\PInvokeMarshal.Unix.cs" />
     <Compile Include="System\Threading\LowLevelLifoSemaphore.Unix.cs" />
     <Compile Include="System\Threading\Thread.NativeAot.Unix.cs" />

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Unix.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Unix.cs
@@ -7,6 +7,8 @@ namespace System.Runtime.InteropServices
 {
     public static partial class NativeLibrary
     {
+        private const int LoadWithAlteredSearchPathFlag = 0;
+
         private static IntPtr LoadLibraryHelper(string libraryName, int flags, ref LoadLibErrorTracker errorTracker)
         {
             // do the Dos/Unix conversion

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Unix.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Unix.cs
@@ -9,7 +9,9 @@ namespace System.Runtime.InteropServices
     {
         private static IntPtr LoadLibraryHelper(string libraryName, int flags, ref LoadLibErrorTracker errorTracker)
         {
-            // TODO: FileDosToUnixPathA
+            // do the Dos/Unix conversion
+            libraryName = libraryName.Replace('\\', '/');
+
             IntPtr ret = Interop.Sys.LoadLibrary(libraryName);
             if (ret == IntPtr.Zero)
             {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Unix.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Unix.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace System.Runtime.InteropServices
+{
+    public static partial class NativeLibrary
+    {
+        private static IntPtr LoadLibraryHelper(string libraryName, int flags, ref LoadLibErrorTracker errorTracker)
+        {
+            // TODO: FileDosToUnixPathA
+            IntPtr ret = Interop.Sys.LoadLibrary(libraryName);
+            if (ret == IntPtr.Zero)
+            {
+                string? message = Marshal.PtrToStringAnsi(Interop.Sys.GetLoadLibraryError());
+                errorTracker.TrackErrorMessage(message);
+            }
+
+            return ret;
+        }
+
+        private static void FreeLib(IntPtr handle)
+        {
+            Debug.Assert(handle != IntPtr.Zero);
+
+            Interop.Sys.FreeLibrary(handle);
+        }
+
+        private static unsafe IntPtr GetSymbolOrNull(IntPtr handle, string symbolName)
+        {
+            return Interop.Sys.GetProcAddress(handle, symbolName);
+        }
+
+        internal struct LoadLibErrorTracker
+        {
+            private string? _errorMessage;
+
+            public void Throw(string libraryName)
+            {
+#if TARGET_OSX
+                throw new DllNotFoundException(SR.Format(SR.DllNotFound_Mac, libraryName, _errorMessage));
+#else
+                throw new DllNotFoundException(SR.Format(SR.DllNotFound_Linux, libraryName, _errorMessage));
+#endif
+            }
+
+            public void TrackErrorMessage(string? message)
+            {
+                _errorMessage = message;
+            }
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Windows.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Windows.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Text;
+
+namespace System.Runtime.InteropServices
+{
+    public static partial class NativeLibrary
+    {
+        private static IntPtr LoadLibraryHelper(string libraryName, int flags, ref LoadLibErrorTracker errorTracker)
+        {
+            IntPtr ret = Interop.Kernel32.LoadLibraryEx(libraryName, IntPtr.Zero, flags);
+            if (ret != IntPtr.Zero)
+            {
+                return ret;
+            }
+
+            int lastError = Marshal.GetLastWin32Error();
+            if (lastError != Interop.Errors.ERROR_INVALID_PARAMETER)
+            {
+                errorTracker.TrackErrorCode(lastError);
+            }
+
+            return ret;
+        }
+
+        private static void FreeLib(IntPtr handle)
+        {
+            Debug.Assert(handle != IntPtr.Zero);
+
+            bool result = Interop.Kernel32.FreeLibrary(handle);
+            if (!result)
+                throw new InvalidOperationException();
+        }
+
+        private static unsafe IntPtr GetSymbolOrNull(IntPtr handle, string symbolName)
+        {
+            var symbolBytes = new byte[Encoding.UTF8.GetByteCount(symbolName) + 1];
+            Encoding.UTF8.GetBytes(symbolName, symbolBytes);
+            fixed (byte* pSymbolBytes = symbolBytes)
+            {
+                return Interop.Kernel32.GetProcAddress(handle, pSymbolBytes);
+            }
+        }
+
+        // Preserving good error info from DllImport-driven LoadLibrary is tricky because we keep loading from different places
+        // if earlier loads fail and those later loads obliterate error codes.
+        //
+        // This tracker object will keep track of the error code in accordance to priority:
+        //
+        //   low-priority:      unknown error code (should never happen)
+        //   medium-priority:   dll not found
+        //   high-priority:     dll found but error during loading
+        //
+        // We will overwrite the previous load's error code only if the new error code is higher priority.
+        internal struct LoadLibErrorTracker
+        {
+            private int _errorCode;
+            private int _priority;
+
+            private const int PriorityNotFound = 10;
+            private const int PriorityAccessDenied = 20;
+            private const int PriorityCouldNotLoad = 99999;
+
+            public void Throw(string libraryName)
+            {
+                if (_errorCode == Interop.Errors.ERROR_BAD_EXE_FORMAT)
+                {
+                    throw new BadImageFormatException();
+                }
+
+                string message = Interop.Kernel32.GetMessage(_errorCode);
+                throw new DllNotFoundException(SR.Format(SR.DllNotFound_Windows, libraryName, message));
+            }
+
+            public void TrackErrorCode(int errorCode)
+            {
+                int priority = errorCode switch
+                {
+                    Interop.Errors.ERROR_FILE_NOT_FOUND or
+                    Interop.Errors.ERROR_PATH_NOT_FOUND or
+                    Interop.Errors.ERROR_MOD_NOT_FOUND or
+                    Interop.Errors.ERROR_DLL_NOT_FOUND => PriorityNotFound,
+
+                    // If we can't access a location, we can't know if the dll's there or if it's good.
+                    // Still, this is probably more unusual (and thus of more interest) than a dll-not-found
+                    // so give it an intermediate priority.
+                    Interop.Errors.ERROR_ACCESS_DENIED => PriorityAccessDenied,
+
+                    // Assume all others are "dll found but couldn't load."
+                    _ => PriorityCouldNotLoad,
+                };
+
+                if (priority > _priority)
+                {
+                    _errorCode = errorCode;
+                    _priority = priority;
+                }
+            }
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
@@ -58,7 +58,7 @@ namespace System.Runtime.InteropServices
         {
             IntPtr ret;
 
-            int loadWithAlteredPathFlags = 0;
+            int loadWithAlteredPathFlags = LoadWithAlteredSearchPathFlag;
             bool libNameIsRelativePath = !Path.IsPathFullyQualified(libraryName);
 
             // P/Invokes are often declared with variations on the actual library name.
@@ -105,7 +105,7 @@ namespace System.Runtime.InteropServices
         private static IntPtr LoadFromPath(string libraryName, bool throwOnError)
         {
             LoadLibErrorTracker errorTracker = default;
-            IntPtr ret = LoadLibraryHelper(libraryName, 0, ref errorTracker);
+            IntPtr ret = LoadLibraryHelper(libraryName, LoadWithAlteredSearchPathFlag, ref errorTracker);
             if (throwOnError && ret == IntPtr.Zero)
             {
                 errorTracker.Throw(libraryName);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
@@ -1,10 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using System.Text;
 
 using LibraryNameVariation = System.Runtime.Loader.LibraryNameVariation;
 
@@ -116,141 +114,13 @@ namespace System.Runtime.InteropServices
             return ret;
         }
 
-        private static IntPtr LoadLibraryHelper(string libraryName, int flags, ref LoadLibErrorTracker errorTracker)
-        {
-#if TARGET_WINDOWS
-            IntPtr ret = Interop.Kernel32.LoadLibraryEx(libraryName, IntPtr.Zero, flags);
-            if (ret != IntPtr.Zero)
-            {
-                return ret;
-            }
-
-            int lastError = Marshal.GetLastWin32Error();
-            if (lastError != Interop.Errors.ERROR_INVALID_PARAMETER)
-            {
-                errorTracker.TrackErrorCode(lastError);
-            }
-
-            return ret;
-#else
-            // TODO: FileDosToUnixPathA
-            IntPtr ret = Interop.Sys.LoadLibrary(libraryName);
-            if (ret == IntPtr.Zero)
-            {
-                string? message = Marshal.PtrToStringAnsi(Interop.Sys.GetLoadLibraryError());
-                errorTracker.TrackErrorMessage(message);
-            }
-
-            return ret;
-#endif
-        }
-
-        private static void FreeLib(IntPtr handle)
-        {
-            Debug.Assert(handle != IntPtr.Zero);
-
-#if !TARGET_UNIX
-            bool result = Interop.Kernel32.FreeLibrary(handle);
-            if (!result)
-                throw new InvalidOperationException();
-#else
-            Interop.Sys.FreeLibrary(handle);
-#endif
-        }
-
         private static unsafe IntPtr GetSymbol(IntPtr handle, string symbolName, bool throwOnError)
         {
-            IntPtr ret;
-#if !TARGET_UNIX
-            var symbolBytes = new byte[Encoding.UTF8.GetByteCount(symbolName) + 1];
-            Encoding.UTF8.GetBytes(symbolName, symbolBytes);
-            fixed (byte* pSymbolBytes = symbolBytes)
-            {
-                ret = Interop.Kernel32.GetProcAddress(handle, pSymbolBytes);
-            }
-#else
-            ret = Interop.Sys.GetProcAddress(handle, symbolName);
-#endif
+            IntPtr ret = GetSymbolOrNull(handle, symbolName);
             if (throwOnError && ret == IntPtr.Zero)
                 throw new EntryPointNotFoundException(SR.Format(SR.Arg_EntryPointNotFoundExceptionParameterizedNoLibrary, symbolName));
 
             return ret;
-        }
-
-        // Preserving good error info from DllImport-driven LoadLibrary is tricky because we keep loading from different places
-        // if earlier loads fail and those later loads obliterate error codes.
-        //
-        // This tracker object will keep track of the error code in accordance to priority:
-        //
-        //   low-priority:      unknown error code (should never happen)
-        //   medium-priority:   dll not found
-        //   high-priority:     dll found but error during loading
-        //
-        // We will overwrite the previous load's error code only if the new error code is higher priority.
-        internal struct LoadLibErrorTracker
-        {
-#if TARGET_WINDOWS
-            private int _errorCode;
-            private int _priority;
-
-            private const int PriorityNotFound = 10;
-            private const int PriorityAccessDenied = 20;
-            private const int PriorityCouldNotLoad = 99999;
-
-            public void Throw(string libraryName)
-            {
-                if (_errorCode == Interop.Errors.ERROR_BAD_EXE_FORMAT)
-                {
-                    throw new BadImageFormatException();
-                }
-
-                string message = Interop.Kernel32.GetMessage(_errorCode);
-                throw new DllNotFoundException(SR.Format(SR.DllNotFound_Windows, libraryName, message));
-            }
-
-            public void TrackErrorCode(int errorCode)
-            {
-                int priority = errorCode switch
-                {
-                    Interop.Errors.ERROR_FILE_NOT_FOUND or
-                    Interop.Errors.ERROR_PATH_NOT_FOUND or
-                    Interop.Errors.ERROR_MOD_NOT_FOUND or
-                    Interop.Errors.ERROR_DLL_NOT_FOUND => PriorityNotFound,
-
-                    // If we can't access a location, we can't know if the dll's there or if it's good.
-                    // Still, this is probably more unusual (and thus of more interest) than a dll-not-found
-                    // so give it an intermediate priority.
-                    Interop.Errors.ERROR_ACCESS_DENIED => PriorityAccessDenied,
-
-                    // Assume all others are "dll found but couldn't load."
-                    _ => PriorityCouldNotLoad,
-                };
-
-                if (priority > _priority)
-                {
-                    _errorCode = errorCode;
-                    _priority = priority;
-                }
-            }
-#else
-            // On Unix systems we don't have detailed programatic information on why load failed
-            // so there's no priorities.
-            private string? _errorMessage;
-
-            public void Throw(string libraryName)
-            {
-#if TARGET_OSX
-                throw new DllNotFoundException(SR.Format(SR.DllNotFound_Mac, libraryName, _errorMessage));
-#else
-                throw new DllNotFoundException(SR.Format(SR.DllNotFound_Linux, libraryName, _errorMessage));
-#endif
-            }
-
-            public void TrackErrorMessage(string? message)
-            {
-                _errorMessage = message;
-            }
-#endif
         }
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.DynamicLoad.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.DynamicLoad.cs
@@ -11,6 +11,9 @@ internal static partial class Interop
         [LibraryImport(Interop.Libraries.SystemNative, EntryPoint = "SystemNative_LoadLibrary", StringMarshalling = StringMarshalling.Utf8)]
         internal static partial IntPtr LoadLibrary(string filename);
 
+        [LibraryImport(Interop.Libraries.SystemNative, EntryPoint = "SystemNative_GetLoadLibraryError")]
+        internal static partial IntPtr GetLoadLibraryError();
+
         [LibraryImport(Interop.Libraries.SystemNative, EntryPoint = "SystemNative_GetProcAddress")]
         internal static partial IntPtr GetProcAddress(IntPtr handle, byte* symbol);
 

--- a/src/libraries/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.Errors.cs
@@ -34,6 +34,7 @@ internal static partial class Interop
         internal const int ERROR_CALL_NOT_IMPLEMENTED = 0x78;
         internal const int ERROR_INSUFFICIENT_BUFFER = 0x7A;
         internal const int ERROR_INVALID_NAME = 0x7B;
+        internal const int ERROR_MOD_NOT_FOUND = 0x7E;
         internal const int ERROR_NEGATIVE_SEEK = 0x83;
         internal const int ERROR_DIR_NOT_EMPTY = 0x91;
         internal const int ERROR_BAD_PATHNAME = 0xA1;

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DynamicLoad.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DynamicLoad.cs
@@ -12,5 +12,8 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Kernel32)]
         internal static partial IntPtr GetProcAddress(IntPtr hModule, byte* lpProcName);
+
+        [LibraryImport(Libraries.Kernel32, StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3910,8 +3910,14 @@
   <data name="Arg_EntryPointNotFoundExceptionParameterizedNoLibrary" xml:space="preserve">
     <value>Unable to find an entry point named '{0}' in native library.</value>
   </data>
-  <data name="Arg_DllNotFoundExceptionParameterized" xml:space="preserve">
-    <value>Unable to load native library '{0}' or one of its dependencies.</value>
+  <data name="DllNotFound_Windows" xml:space="preserve">
+    <value>Unable to load DLL '{0}' or one of its dependencies: {1}</value>
+  </data>
+  <data name="DllNotFound_Linux" xml:space="preserve">
+    <value>Unable to load shared library '{0}' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable: {1}</value>
+  </data>
+  <data name="DllNotFound_Mac" xml:space="preserve">
+    <value>Unable to load shared library '{0}' or one of its dependencies. In order to help diagnose loading problems, consider setting the DYLD_PRINT_LIBRARIES environment variable: {1}</value>
   </data>
   <data name="InvalidOperation_ComInteropRequireComWrapperInstance" xml:space="preserve">
     <value>COM Interop requires ComWrapper instance registered for marshalling.</value>

--- a/src/native/libs/System.Native/entrypoints.c
+++ b/src/native/libs/System.Native/entrypoints.c
@@ -234,6 +234,7 @@ static const Entry s_sysNative[] =
     DllImportEntry(SystemNative_LowLevelMonitor_TimedWait)
     DllImportEntry(SystemNative_LowLevelMonitor_Signal_Release)
     DllImportEntry(SystemNative_LoadLibrary)
+    DllImportEntry(SystemNative_GetLoadLibraryError)
     DllImportEntry(SystemNative_GetProcAddress)
     DllImportEntry(SystemNative_FreeLibrary)
     DllImportEntry(SystemNative_GetDefaultSearchOrderPseudoHandle)

--- a/src/native/libs/System.Native/pal_dynamicload.c
+++ b/src/native/libs/System.Native/pal_dynamicload.c
@@ -38,6 +38,11 @@ void* SystemNative_LoadLibrary(const char* filename)
     return dlopen(filename, RTLD_LAZY);
 }
 
+void* SystemNative_GetLoadLibraryError(void)
+{
+    return dlerror();
+}
+
 void* SystemNative_GetProcAddress(void* handle, const char* symbol)
 {
     // We're not trying to disambiguate between "symbol was not found" and "symbol found, but

--- a/src/native/libs/System.Native/pal_dynamicload.h
+++ b/src/native/libs/System.Native/pal_dynamicload.h
@@ -8,6 +8,8 @@
 
 PALEXPORT void* SystemNative_LoadLibrary(const char* filename);
 
+PALEXPORT void* SystemNative_GetLoadLibraryError(void);
+
 PALEXPORT void* SystemNative_GetProcAddress(void* handle, const char* symbol);
 
 PALEXPORT void SystemNative_FreeLibrary(void* handle);


### PR DESCRIPTION
Finishes the LoadLibraryErrorTracker port from CoreCLR VM to C#.

This allows us to report more details about the reason of `DllImport` resolution failures at runtime.

The logic matches CoreCLR. There might be a slight behavior difference for empty string literal `DllImport`/`NativeLibrary.Load` on Unix-like systems. Not sure we care enough (I couldn't discern what the CoreCLR behavior is - I think we report an arbitrary old message from the last load attempt since we never even try to `dlopen` the empty string).

Instead of:

```
System.DllNotFoundException: Unable to load native library 'bruh' or one of its dependencies.
```

We can now do:

```
System.DllNotFoundException: Unable to load DLL 'bruh' or one of its dependencies: The process cannot access the file because it is being used by another process.
```

Contributes to #69743.

Cc @dotnet/ilc-contrib 