### PR TITLE
Redisable timouting MsQuic tests

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -342,6 +342,7 @@ namespace System.Net.Quic.Tests
         [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/64944", TestPlatforms.Windows)]
         public async Task ConnectWithClientCertificate(bool sendCertificate)
         {
             if (PlatformDetection.IsWindows10Version20348OrLower)


### PR DESCRIPTION
Contributes to #64944.

The test is still flaky and sometimes causes timeout for the entire test suite.

cc: @wfurt