### PR TITLE
Add support for processing Unified TLS frames

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
@@ -24,6 +24,9 @@ namespace System.Net.Security
         private object _handshakeLock => _sslAuthenticationOptions;
         private volatile TaskCompletionSource<bool>? _handshakeWaiter;
 
+        //private const int HandshakeTypeOffsetSsl2 = 2;                       // Offset of HelloType in Sslv2 and Unified frames
+        //private const int HandshakeTypeOffsetTls = 5;                        // Offset of HelloType in Sslv3 and TLS frames
+
         private bool _receivedEOF;
 
         // Used by Telemetry to ensure we log connection close exactly once
@@ -973,6 +976,8 @@ namespace System.Net.Security
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, "invalid TLS frame size");
                 throw new AuthenticationException(SR.net_frame_read_size);
             }
+
+            Console.WriteLine("GetFrameSize = {0} on {1}", _lastFrame.Header.Length + TlsFrameHelper.HeaderSize, this.GetHashCode());
 
             return _lastFrame.Header.Length + TlsFrameHelper.HeaderSize;
         }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -1017,21 +1017,69 @@ namespace System.Net.Security.Tests
 
         }
 
-        [Fact]
-        public async Task SslStream_UnifiedHello_Ok()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public async Task SslStream_UnifiedHello_Ok(bool useOptionCallback)
         {
             (Stream client, Stream server) = TestHelper.GetConnectedTcpStreams();
             SslStream ssl = new SslStream(server);
 
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TestConfiguration.PassingTestTimeout);
+            bool callbackCalled = false;
+            Task serverTask;
 
-            var options = new SslServerAuthenticationOptions() { ServerCertificate = Configuration.Certificates.GetServerCertificate() };
-            Task t = ssl.AuthenticateAsServerAsync(options, cts.Token);
+            var options = new SslServerAuthenticationOptions();
+            if (useOptionCallback)
+            {
+                serverTask = ssl.AuthenticateAsServerAsync((ssl, info, o, ct) =>
+                {
+                    callbackCalled = true;
+                    options.ServerCertificate = Configuration.Certificates.GetServerCertificate();
+                    return new ValueTask<SslServerAuthenticationOptions>(options);
+                }, null, cts.Token);
 
-            await client.WriteAsync(TlsFrameHelperTests.s_UnifiedHello);
+            }
+            else
+            {
+                options.ServerCertificateSelectionCallback = (o, name) =>
+                {
+                    callbackCalled = true;
+                    return Configuration.Certificates.GetServerCertificate();
+                };
 
-            await t;
+                serverTask = ssl.AuthenticateAsServerAsync(options, cts.Token);
+            }
+
+            Task.WaitAny(client.WriteAsync(TlsFrameHelperTests.s_UnifiedHello).AsTask(), serverTask);
+            if (serverTask.IsCompleted)
+            {
+                // Something failed. Raise exception.
+                await serverTask;
+            }
+
+            byte[] buffer = new byte[1024];
+            Task<int> readTask = client.ReadAsync(buffer, cts.Token).AsTask();
+            Task.WaitAny(readTask, serverTask);
+            if (serverTask.IsCompleted)
+            {
+                // Something failed. Raise exception.
+                await serverTask;
+            }
+
+            int readLength = await readTask;
+            // We should get back ServerHello
+            Assert.True(readLength > 0);
+            Assert.True(callbackCalled);
+            Assert.Equal(22, buffer[0]); // Handshake Protocol
+            Assert.Equal(2, buffer[5]);  // ServerHello
+
+            // Handshake should not be finished at this point.
+            Assert.False(serverTask.IsCompleted);
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverTask);
         }
 
         private static bool ValidateServerCertificate(

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -1017,6 +1017,23 @@ namespace System.Net.Security.Tests
 
         }
 
+        [Fact]
+        public async Task SslStream_UnifiedHello_Ok()
+        {
+            (Stream client, Stream server) = TestHelper.GetConnectedTcpStreams();
+            SslStream ssl = new SslStream(server);
+
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(TestConfiguration.PassingTestTimeout);
+
+            var options = new SslServerAuthenticationOptions() { ServerCertificate = Configuration.Certificates.GetServerCertificate() };
+            Task t = ssl.AuthenticateAsServerAsync(options, cts.Token);
+
+            await client.WriteAsync(TlsFrameHelperTests.s_UnifiedHello);
+
+            await t;
+        }
+
         private static bool ValidateServerCertificate(
             object sender,
             X509Certificate retrievedServerPublicCertificate,

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
@@ -88,6 +88,37 @@ namespace System.Net.Security.Tests
             Assert.Equal(TlsFrameHelper.ApplicationProtocolInfo.Http2, info.ApplicationProtocols);
         }
 
+        [Fact]
+        public void TlsFrameHelper_UnifiedClientHello_Ok()
+        {
+            TlsFrameHelper.TlsFrameInfo info = default;
+            Assert.True(TlsFrameHelper.TryGetFrameHeader(s_UnifiedHello,  ref info.Header));
+            Assert.Equal(75, info.Header.Length);
+
+            Assert.True(TlsFrameHelper.TryGetFrameInfo(s_UnifiedHello, ref info));
+#pragma warning disable CS0618      // Ssl2 and Ssl3 are obsolete
+#pragma warning disable SYSLIB0039  // Tls is obsolete
+            Assert.Equal(SslProtocols.Ssl2, info.Header.Version);
+            Assert.Equal(SslProtocols.Ssl2 | SslProtocols.Tls, info.SupportedVersions);
+#pragma warning restore CS0618
+#pragma warning restore SYSLIB0039
+            Assert.Equal(TlsContentType.Handshake, info.Header.Type);
+            Assert.Equal(TlsFrameHelper.ApplicationProtocolInfo.None, info.ApplicationProtocols);
+            Assert.Equal(TlsHandshakeType.ClientHello, info.HandshakeType);
+        }
+
+        [Fact]
+        public void TlsFrameHelper_TlsClientHelloNoExtensions_Ok()
+        {
+            TlsFrameHelper.TlsFrameInfo info = default;
+            Assert.True(TlsFrameHelper.TryGetFrameInfo(s_TlsClientHelloNoExtensions, ref info));
+            Assert.Equal(SslProtocols.Tls12, info.Header.Version);
+            Assert.Equal(SslProtocols.Tls12, info.SupportedVersions);
+            Assert.Equal(TlsContentType.Handshake, info.Header.Type);
+            Assert.Equal(TlsFrameHelper.ApplicationProtocolInfo.None, info.ApplicationProtocols);
+            Assert.Equal(TlsHandshakeType.ClientHello, info.HandshakeType);
+        }
+
         public static IEnumerable<object[]> InvalidClientHelloData()
         {
             int id = 0;
@@ -379,6 +410,36 @@ namespace System.Net.Security.Tests
             0x00, 0x0B, 0x00, 0x02, 0x01, 0x00,
             // Extension.extension_type (application_level_Protocol)
             0x00, 0x10, 0x00, 0x05, 0x00, 0x03, 0x02, 0x68, 0x32,
+        };
+
+        internal static byte[] s_UnifiedHello = new byte[]
+        {
+            // Length
+            0x80, 0x49,
+            // ClientHello
+            0x01,
+            // Version
+            0x03, 0x01,
+            0x00, 0x30, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00,
+            0x2F, 0x00, 0x00, 0x35, 0x00, 0x00, 0x04, 0x00,
+            0x00, 0x05, 0x00, 0x00, 0x0A, 0x01, 0x00, 0x80,
+            0x07, 0x00, 0xC0, 0x03, 0x00, 0x80, 0x00, 0x00,
+            0x09, 0x06, 0x00, 0x40, 0x00, 0x00, 0x64, 0x00,
+            0x00, 0x62, 0x00, 0x00, 0x03, 0x00, 0x00, 0x06,
+            0x02, 0x00, 0x80, 0x04, 0x00, 0x80, 0x5B, 0x0B,
+            0xA1, 0xEB, 0xBF, 0x2D, 0x57, 0xF5, 0xD1, 0x0F,
+            0x52, 0x3B, 0x12, 0x9C, 0xF8, 0xD4,
+        };
+
+        private static byte[] s_TlsClientHelloNoExtensions = new byte[] {
+            0x16, 0x03, 0x03, 0x00, 0x39, 0x01, 0x00, 0x00,
+            0x35, 0x03, 0x03, 0x62, 0x5d, 0x50, 0x2a, 0x41,
+            0x2f, 0xd8, 0xc3, 0x65, 0x35, 0xea, 0x01, 0x70,
+            0x03, 0x7e, 0x7e, 0x2d, 0xd4, 0xfe, 0x93, 0x39,
+            0xa4, 0x04, 0x66, 0xbb, 0x46, 0x91, 0x41, 0xc3,
+            0x48, 0x87, 0x3d, 0x00, 0x00, 0x0e, 0x00, 0x3d,
+            0x00, 0x3c, 0x00, 0x0a, 0x00, 0x35, 0x00, 0x2f,
+            0x00, 0x05, 0x00, 0x04, 0x01, 0x00
         };
 
         private static IEnumerable<byte[]> InvalidClientHello()

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
@@ -46,7 +46,7 @@ namespace System.Net.Security.Tests
             Assert.True(TlsFrameHelper.TryGetFrameInfo(s_validClientHello, ref info));
 
             Assert.Equal(SslProtocols.Tls12, info.Header.Version);
-            Assert.Equal(203, info.Header.Length);
+            Assert.Equal(208, info.Header.Length);
             Assert.Equal(SslProtocols.Tls12, info.SupportedVersions);
             Assert.Equal(TlsFrameHelper.ApplicationProtocolInfo.None, info.ApplicationProtocols);
         }


### PR DESCRIPTION
This is mix of https://github.com/dotnet/runtime/pull/68425, https://github.com/microsoft/reverse-proxy/pull/1656 and reaction to https://github.com/dotnet/runtime/pull/64322.

Unified parsing works only on Windows as legacy and allows (old) clients to send TLS frame encoded in Ssl2 format.
All we really need is to process first frame. Server should respond back with "normal" TLS e.g. all the framing and processing removed in #64322 is really not needed. 

Since the header size is now variable, I changed `TlsFrameHelper` to return length of the TLS frame instead of just length of the inner payload.

Since we don't have good way how to generate real traffic, I added test that injects legacy ClientHello and verifies that we get back ServerHello instead of failure.  

fixes #68310