### PR TITLE
Add issue cleanup documentation and update automation

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1307,7 +1307,7 @@
         {
           "name": "addReply",
           "parameters": {
-            "comment": "Due to lack of recent activity, this issue has been marked as a candidate for backlog cleanup.  It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will undo this process.\n\nThis process is part of the experimental [issue cleanup initiative](https://github.com/dotnet/runtime/issues/60288) we are currently trialing. Please share any feedback you might have in the linked issue."
+            "comment": "Due to lack of recent activity, this issue has been marked as a candidate for backlog cleanup.  It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will undo this process.\n\nThis process is part of our [issue cleanup automation](https://github.com/dotnet/runtime/blob/main/docs/issue-cleanup.md)."
           }
         },
         {
@@ -1422,16 +1422,16 @@
       "taskName": "Automated Issue cleanup",
       "actions": [
         {
-          "name": "addLabel",
+          "name": "addReply",
           "parameters": {
-            "label": "backlog-cleanup-candidate"
+            "comment": "Due to lack of recent activity, this issue has been marked as a candidate for backlog cleanup.  It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will undo this process.\n\nThis process is part of our [issue cleanup automation](https://github.com/dotnet/runtime/blob/main/docs/issue-cleanup.md)."
           }
         },
         {
-          "name": "addReply",
-          "parameters": {
-            "comment": "Due to lack of recent activity, this issue has been marked as a candidate for backlog cleanup.  It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will undo this process.\n\nThis process is part of the experimental [issue cleanup initiative](https://github.com/dotnet/runtime/issues/60288) we are currently trialing. Please share any feedback you might have in the linked issue."
-          }
+            "name": "addLabel",
+            "parameters": {
+              "label": "backlog-cleanup-candidate"
+            }
         },
         {
           "name": "addLabel",
@@ -2346,6 +2346,12 @@
           "parameters": {
             "label": "no-recent-activity"
           }
+        },
+        {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "backlog-cleanup-candidate"
+            }
         }
       ],
       "eventType": "issue",
@@ -2401,6 +2407,12 @@
           "parameters": {
             "label": "no-recent-activity"
           }
+        },
+        {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "backlog-cleanup-candidate"
+            }
         }
       ],
       "eventType": "issue",

--- a/docs/issue-cleanup.md
+++ b/docs/issue-cleanup.md
@@ -1,0 +1,7 @@
+## Automated Issue Cleanup
+
+dotnet/runtime is very popular repository, with tens of issues being filed by the community every day. While we generally do try to respond to and resolve issues as quickly as possible, it is still likely that some issues can be left to stagnate in the backlog. Currently, dotnet/runtime contains hundreds of issues that have not seen any activity in over three years.
+
+In our attempt to create leaner and more focused backlogs, we have implemented automation that identifies stale issues and marks them for closure. This uses a two-phase process: stale issues are [given a notification](https://github.com/dotnet/runtime/issues/7780#issuecomment-1093721931) and marked with the [`backlog-cleanup-candidate`](https://github.com/dotnet/runtime/labels/backlog-cleanup-candidate) label; if this prompts any feedback [the process is undone](https://github.com/dotnet/runtime/issues/7780#event-6400706926), otherwise it gets [closed if no further activity occurs within 14 days](https://github.com/dotnet/runtime/issues/8050#issuecomment-1137995415).
+
+This approach is intended to trigger re-evaluation of older issues both by maintainers and by the community: an issue could get reprioritized or it could be closed as already resolved or obsolete.


### PR DESCRIPTION
Adds documentation describing issue cleanup automation and updates automation so that

1. Messages point to the new doc instead of #60288.
2. Tweak documentation so that new activity also removes the `backlog-cleanup-candidate` label.

Fix #60288.