### PR TITLE
[wasm] Process WebSocket connection errors on NodeJS

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -170,7 +170,6 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/63681", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJS))]
         public async Task ConnectAsync_PassNoSubProtocol_ServerRequires_ThrowsWebSocketException(Uri server)
         {
             const string AcceptedProtocol = "CustomProtocol";
@@ -257,7 +256,6 @@ namespace System.Net.WebSockets.Client.Tests
         }
 
         [ConditionalFact(nameof(WebSocketsSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/63672", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJS))]
         public async Task ConnectAsync_CancellationRequestedBeforeConnect_ThrowsOperationCanceledException()
         {
             using (var clientSocket = new ClientWebSocket())
@@ -270,7 +268,6 @@ namespace System.Net.WebSockets.Client.Tests
         }
 
         [ConditionalFact(nameof(WebSocketsSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/63672", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJS))]
         public async Task ConnectAsync_CancellationRequestedInflightConnect_ThrowsOperationCanceledException()
         {
             using (var clientSocket = new ClientWebSocket())
@@ -284,7 +281,6 @@ namespace System.Net.WebSockets.Client.Tests
 
         [ConditionalFact(nameof(WebSocketsSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/63671", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJS))]
         public async Task ConnectAsync_CancellationRequestedAfterConnect_ThrowsOperationCanceledException()
         {
             var releaseServer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/mono/wasm/runtime/web-socket.ts
+++ b/src/mono/wasm/runtime/web-socket.ts
@@ -88,10 +88,13 @@ export function mono_wasm_web_socket_open_ref(uri_address: MonoObjectRef, subPro
                 receive_promise_control.resolve(null);
             });
         };
+        const local_on_error = (ev: any) => {
+            open_promise_control.reject(ev.message);
+        };
         ws.addEventListener("message", local_on_message);
         ws.addEventListener("open", local_on_open, { once: true });
         ws.addEventListener("close", local_on_close, { once: true });
-
+        ws.addEventListener("error", local_on_error, { once: true });
         const ws_js_handle = mono_wasm_get_js_handle(ws);
         Module.setValue(web_socket_js_handle, <any>ws_js_handle, "i32");
 


### PR DESCRIPTION
Some of the errors produced during WebSocket connection are published as "error" event. 
Here we attach a listener to it and reject the open promise if the event is raised (which correctly produces an exception in managed code).

Fixes https://github.com/dotnet/runtime/issues/63671.
Fixes https://github.com/dotnet/runtime/issues/63681.