### PR TITLE
JIT: Faster long->int overflow checks

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3943,9 +3943,7 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
         case GenIntCastDesc::CHECK_INT_RANGE:
         {
             // Emit "if ((long)(int)x != x) goto OVERFLOW"
-            const regNumber tempReg = cast->GetSingleTempReg();
-            GetEmitter()->emitIns_Mov(INS_sxtw, EA_8BYTE, tempReg, reg, true);
-            GetEmitter()->emitIns_R_R(INS_cmp, EA_8BYTE, reg, tempReg);
+            GetEmitter()->emitIns_R_R(INS_cmp, EA_8BYTE, reg, reg, INS_OPTS_SXTW);
             genJumpToThrowHlpBlk(EJ_ne, SCK_OVERFLOW);
         }
         break;
@@ -3957,26 +3955,38 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
             const int castMaxValue = desc.CheckSmallIntMax();
             const int castMinValue = desc.CheckSmallIntMin();
 
-            // Values greater than 255 cannot be encoded in the immediate operand of CMP.
-            // Replace (x > max) with (x >= max + 1) where max + 1 (a power of 2) can be
-            // encoded. We could do this for all max values but on ARM32 "cmp r0, 255"
-            // is better than "cmp r0, 256" because it has a shorter encoding.
-            if (castMaxValue > 255)
+            if ((castMaxValue == UINT16_MAX) || (castMaxValue == UINT8_MAX))
             {
-                assert((castMaxValue == 32767) || (castMaxValue == 65535));
+                assert(castMinValue == 0);
                 GetEmitter()->emitIns_R_I(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, castMaxValue + 1);
                 genJumpToThrowHlpBlk((castMinValue == 0) ? EJ_hs : EJ_ge, SCK_OVERFLOW);
             }
-            else
+            else if (castMaxValue == INT16_MAX)
             {
+                assert(castMinValue == INT16_MIN);
+#ifdef TARGET_64BIT
+                GetEmitter()->emitIns_R_R(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, reg, INS_OPTS_SXTH);
+                genJumpToThrowHlpBlk(EJ_ne, SCK_OVERFLOW);
+#else
                 GetEmitter()->emitIns_R_I(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, castMaxValue);
                 genJumpToThrowHlpBlk((castMinValue == 0) ? EJ_hi : EJ_gt, SCK_OVERFLOW);
-            }
-
-            if (castMinValue != 0)
-            {
                 GetEmitter()->emitIns_R_I(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, castMinValue);
                 genJumpToThrowHlpBlk(EJ_lt, SCK_OVERFLOW);
+#endif
+            }
+            else
+            {
+                assert(castMaxValue == INT8_MAX);
+                assert(castMinValue == INT8_MIN);
+#ifdef TARGET_64BIT
+                GetEmitter()->emitIns_R_R(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, reg, INS_OPTS_SXTB);
+                genJumpToThrowHlpBlk(EJ_ne, SCK_OVERFLOW);
+#else
+                GetEmitter()->emitIns_R_I(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, castMaxValue);
+                genJumpToThrowHlpBlk((castMinValue == 0) ? EJ_hi : EJ_gt, SCK_OVERFLOW);
+                GetEmitter()->emitIns_R_I(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, castMinValue);
+                genJumpToThrowHlpBlk(EJ_lt, SCK_OVERFLOW);
+#endif
             }
         }
         break;

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3942,14 +3942,11 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
 
         case GenIntCastDesc::CHECK_INT_RANGE:
         {
+            // Emit "if ((long)(int)x != x) goto OVERFLOW"
             const regNumber tempReg = cast->GetSingleTempReg();
-            assert(tempReg != reg);
-            instGen_Set_Reg_To_Imm(EA_8BYTE, tempReg, INT32_MAX);
+            GetEmitter()->emitIns_Mov(INS_sxtw, EA_8BYTE, tempReg, reg, true);
             GetEmitter()->emitIns_R_R(INS_cmp, EA_8BYTE, reg, tempReg);
-            genJumpToThrowHlpBlk(EJ_gt, SCK_OVERFLOW);
-            instGen_Set_Reg_To_Imm(EA_8BYTE, tempReg, INT32_MIN);
-            GetEmitter()->emitIns_R_R(INS_cmp, EA_8BYTE, reg, tempReg);
-            genJumpToThrowHlpBlk(EJ_lt, SCK_OVERFLOW);
+            genJumpToThrowHlpBlk(EJ_ne, SCK_OVERFLOW);
         }
         break;
 #endif

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3957,13 +3957,11 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
 
             if ((castMaxValue == UINT16_MAX) || (castMaxValue == UINT8_MAX))
             {
-                assert(castMinValue == 0);
                 GetEmitter()->emitIns_R_I(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, castMaxValue + 1);
                 genJumpToThrowHlpBlk((castMinValue == 0) ? EJ_hs : EJ_ge, SCK_OVERFLOW);
             }
             else if (castMaxValue == INT16_MAX)
             {
-                assert(castMinValue == INT16_MIN);
 #ifdef TARGET_64BIT
                 GetEmitter()->emitIns_R_R(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, reg, INS_OPTS_SXTH);
                 genJumpToThrowHlpBlk(EJ_ne, SCK_OVERFLOW);
@@ -3977,7 +3975,6 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
             else
             {
                 assert(castMaxValue == INT8_MAX);
-                assert(castMinValue == INT8_MIN);
 #ifdef TARGET_64BIT
                 GetEmitter()->emitIns_R_R(INS_cmp, EA_SIZE(desc.CheckSrcSize()), reg, reg, INS_OPTS_SXTB);
                 genJumpToThrowHlpBlk(EJ_ne, SCK_OVERFLOW);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6648,11 +6648,14 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
             break;
 
         case GenIntCastDesc::CHECK_INT_RANGE:
-            GetEmitter()->emitIns_R_I(INS_cmp, EA_8BYTE, reg, INT32_MAX);
-            genJumpToThrowHlpBlk(EJ_jg, SCK_OVERFLOW);
-            GetEmitter()->emitIns_R_I(INS_cmp, EA_8BYTE, reg, INT32_MIN);
-            genJumpToThrowHlpBlk(EJ_jl, SCK_OVERFLOW);
-            break;
+        {
+            // Emit "if ((long)(int)x != x) goto OVERFLOW"
+            const regNumber regTmp = cast->GetSingleTempReg();
+            GetEmitter()->emitIns_Mov(INS_movsxd, EA_8BYTE, regTmp, reg, true);
+            GetEmitter()->emitIns_R_R(INS_cmp, EA_8BYTE, reg, regTmp);
+            genJumpToThrowHlpBlk(EJ_jne, SCK_OVERFLOW);
+        }
+        break;
 #endif
 
         default:

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -4503,12 +4503,14 @@ void emitter::emitIns_R_R(
         case INS_str:
         case INS_strb:
         case INS_strh:
-
-        case INS_cmp:
         case INS_cmn:
         case INS_tst:
             assert(insOptsNone(opt));
             emitIns_R_R_I(ins, attr, reg1, reg2, 0, INS_OPTS_NONE);
+            return;
+
+        case INS_cmp:
+            emitIns_R_R_I(ins, attr, reg1, reg2, 0, opt);
             return;
 
         case INS_staddb:

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -820,13 +820,6 @@ int LinearScan::BuildCast(GenTreeCast* cast)
         buildInternalFloatRegisterDefForNode(cast, RBM_ALLFLOAT);
         setInternalRegsDelayFree = true;
     }
-#else
-    // Overflow checking cast from TYP_LONG to TYP_INT requires a temporary register to
-    // store the min and max immediate values that cannot be encoded in the CMP instruction.
-    if (cast->gtOverflow() && varTypeIsLong(srcType) && !cast->IsUnsigned() && (castType == TYP_INT))
-    {
-        buildInternalIntRegisterDefForNode(cast);
-    }
 #endif
 
     int srcCount = BuildOperandUses(src);

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -2480,9 +2480,9 @@ int LinearScan::BuildCast(GenTreeCast* cast)
 
     assert(!varTypeIsLong(srcType) || (src->OperIs(GT_LONG) && src->isContained()));
 #else
-    // Overflow checking cast from TYP_(U)LONG to TYP_UINT requires a temporary
+    // Overflow checking cast from TYP_(U)LONG to TYP_(U)INT requires a temporary
     // register to extract the upper 32 bits of the 64 bit source register.
-    if (cast->gtOverflow() && varTypeIsLong(srcType) && (castType == TYP_UINT))
+    if (cast->gtOverflow() && varTypeIsLong(srcType) && varTypeIsInt(castType))
     {
         // Here we don't need internal register to be different from targetReg,
         // rather require it to be different from operand's reg.


### PR DESCRIPTION
Use `(long)(int)x != x` instead of `x > int.MaxValue && x < int.MinValue` to detect overflow during long->int checked casts.

```csharp
int Test(long a) => checked((int)a);
```
```diff
; Method ConsoleApp23.Program:Test(long):int
G_M63833_IG01:              ;; offset=0000H
        A9BF7BFD          stp     fp, lr, [sp,#-16]!
        910003FD          mov     fp, sp

G_M63833_IG02:
-       B2407BE1          mov     x1, #0x7fffffff
-       EB01001F          cmp     x0, x1
-       540000CC          bgt     G_M63833_IG04
-       B26183E1          mov     x1, #-0x80000000
-       EB01001F          cmp     x0, x1
-       5400006B          blt     G_M63833_IG04
+       93407C01          sxtw    x1, w0
+       EB01001F          cmp     x0, x1
+       54000061          bne     G_M63833_IG04

G_M63833_IG03:
        A8C17BFD          ldp     fp, lr, [sp],#16
        D65F03C0          ret     lr

G_M63833_IG04:
        94000000          bl      CORINFO_HELP_OVERFLOW
        D43E0000          brk_windows #0
-; Total bytes of code: 48
+; Total bytes of code: 36
```
(same trick on x64)

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1791445&view=ms.vss-build-web.run-extensions-tab)