### PR TITLE
Fix Stream.ReadAtLeast perf regression in DataContractSerializer

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContextSerializer.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContextSerializer.cs
@@ -84,17 +84,20 @@ namespace System.ComponentModel.Design
 
             public override void Flush() => _stream.Flush();
 
-            public override int Read(byte[] buffer, int offset, int count)
+            public override int Read(byte[] buffer, int offset, int count) =>
+                Read(new Span<byte>(buffer, offset, count));
+
+            public override int Read(Span<byte> buffer)
             {
                 Debug.Assert(_stream.Position != 0, "Expected the first byte to be read first");
                 if (_stream.Position == 1)
                 {
                     Debug.Assert(_readFirstByte == true);
                     // Add the first byte read by ReadByte into buffer here
-                    buffer[offset] = _firstByte;
-                    return _stream.Read(buffer, offset + 1, count - 1) + 1;
+                    buffer[0] = _firstByte;
+                    return _stream.Read(buffer.Slice(1)) + 1;
                 }
-                return _stream.Read(buffer, offset, count);
+                return _stream.Read(buffer);
             }
 
             public override long Seek(long offset, SeekOrigin origin) => _stream.Seek(offset, origin);

--- a/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SqlXml.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SqlXml.cs
@@ -424,6 +424,22 @@ namespace System.Data.SqlTypes
             return iBytesRead;
         }
 
+        // Duplicate the Read(byte[]) logic here instead of refactoring both to use Spans
+        // in case the backing _stream doesn't override Read(Span).
+        public override int Read(Span<byte> buffer)
+        {
+            ThrowIfStreamClosed(nameof(Read));
+            ThrowIfStreamCannotRead(nameof(Read));
+
+            if (_stream.CanSeek && _stream.Position != _lPosition)
+                _stream.Seek(_lPosition, SeekOrigin.Begin);
+
+            int iBytesRead = _stream.Read(buffer);
+            _lPosition += iBytesRead;
+
+            return iBytesRead;
+        }
+
         public override void Write(byte[] buffer, int offset, int count)
         {
             ThrowIfStreamClosed(nameof(Write));

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipWrappingStream.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipWrappingStream.cs
@@ -67,6 +67,22 @@ namespace System.IO.Packaging
             return _baseStream.Read(buffer, offset, count);
         }
 
+#if NETCOREAPP
+        public override void Write(
+            ReadOnlySpan<byte> buffer
+        )
+        {
+            _baseStream.Write(buffer);
+        }
+
+        public override int Read(
+            Span<byte> buffer
+        )
+        {
+            return _baseStream.Read(buffer);
+        }
+#endif
+
         public override void SetLength(
             long value
         )

--- a/src/libraries/System.Net.Requests/src/System/Net/FtpDataStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpDataStream.cs
@@ -193,12 +193,47 @@ namespace System.Net
             return readBytes;
         }
 
+        public override int Read(Span<byte> buffer)
+        {
+            CheckError();
+            int readBytes;
+            try
+            {
+                readBytes = _networkStream.Read(buffer);
+            }
+            catch
+            {
+                CheckError();
+                throw;
+            }
+            if (readBytes == 0)
+            {
+                _isFullyRead = true;
+                Close();
+            }
+            return readBytes;
+        }
+
         public override void Write(byte[] buffer, int offset, int size)
         {
             CheckError();
             try
             {
                 _networkStream.Write(buffer, offset, size);
+            }
+            catch
+            {
+                CheckError();
+                throw;
+            }
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            CheckError();
+            try
+            {
+                _networkStream.Write(buffer);
             }
             catch
             {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
@@ -174,7 +174,10 @@ namespace System.Runtime.Serialization.Json
             _stream.Flush();
         }
 
-        public override int Read(byte[] buffer, int offset, int count)
+        public override int Read(byte[] buffer, int offset, int count) =>
+            Read(new Span<byte>(buffer, offset, count));
+
+        public override int Read(Span<byte> buffer)
         {
             try
             {
@@ -182,7 +185,7 @@ namespace System.Runtime.Serialization.Json
                 {
                     if (_encodingCode == SupportedEncoding.UTF8)
                     {
-                        return _stream.Read(buffer, offset, count);
+                        return _stream.Read(buffer);
                     }
 
                     Debug.Assert(_bytes != null);
@@ -206,11 +209,13 @@ namespace System.Runtime.Serialization.Json
                 }
 
                 // Give them bytes
+                int count = buffer.Length;
                 if (_byteCount < count)
                 {
                     count = _byteCount;
                 }
-                Buffer.BlockCopy(_bytes!, _byteOffset, buffer, offset, count);
+
+                _bytes.AsSpan(_byteOffset, count).CopyTo(buffer);
                 _byteOffset += count;
                 _byteCount -= count;
                 return count;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
@@ -593,14 +593,17 @@ namespace System.Xml
             return _byteBuffer[0];
         }
 
-        public override int Read(byte[] buffer, int offset, int count)
+        public override int Read(byte[] buffer, int offset, int count) =>
+            Read(new Span<byte>(buffer, offset, count));
+
+        public override int Read(Span<byte> buffer)
         {
             try
             {
                 if (_byteCount == 0)
                 {
                     if (_encodingCode == SupportedEncoding.UTF8)
-                        return _stream.Read(buffer, offset, count);
+                        return _stream.Read(buffer);
 
                     Debug.Assert(_bytes != null);
                     Debug.Assert(_chars != null);
@@ -622,9 +625,11 @@ namespace System.Xml
                 }
 
                 // Give them bytes
+                int count = buffer.Length;
                 if (_byteCount < count)
                     count = _byteCount;
-                Buffer.BlockCopy(_bytes!, _byteOffset, buffer, offset, count);
+
+                _bytes.AsSpan(_byteOffset, count).CopyTo(buffer);
                 _byteOffset += count;
                 _byteCount -= count;
                 return count;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ImmutableMemoryStream.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ImmutableMemoryStream.cs
@@ -72,6 +72,18 @@ namespace System.Reflection.Internal
             return result;
         }
 
+#if NETCOREAPP
+        // Duplicate the Read(byte[]) logic here instead of refactoring both to use Spans
+        // so we don't affect perf on .NET Framework.
+        public override int Read(Span<byte> buffer)
+        {
+            int result = Math.Min(buffer.Length, _array.Length - _position);
+            _array.AsSpan(_position, result).CopyTo(buffer);
+            _position += result;
+            return result;
+        }
+#endif
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             long target;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ReadOnlyUnmanagedMemoryStream.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ReadOnlyUnmanagedMemoryStream.cs
@@ -36,6 +36,18 @@ namespace System.Reflection.Internal
             return bytesRead;
         }
 
+#if NETCOREAPP
+        // Duplicate the Read(byte[]) logic here instead of refactoring both to use Spans
+        // so we don't affect perf on .NET Framework.
+        public override int Read(Span<byte> buffer)
+        {
+            int bytesRead = Math.Min(buffer.Length, _length - _position);
+            new Span<byte>(_data + _position, bytesRead).CopyTo(buffer);
+            _position += bytesRead;
+            return bytesRead;
+        }
+#endif
+
         public override void Flush()
         {
         }


### PR DESCRIPTION
#69272 changed DCS to no longer call Stream.Read inside a loop, but instead call the new ReadAtLeast method. ReadAtLeast only takes a `Span<byte>`, and not a `byte[]`. This caused a regression because the internal encoding stream wrapper classes don't override `Read(Span<byte>)`, so the base implementation is used. The base implementation is slower because it needs to rent a `byte[]` from the pool, and do 2 copies.

Overriding `Read(Span<byte>)` on the internal encoding stream wrapper classes allows ReadAtLeast to be just as fast.

Fix #69730