### PR TITLE
Remove CORCOMPILE_IMPORT_SECTION

### DIFF
--- a/src/coreclr/inc/corcompile.h
+++ b/src/coreclr/inc/corcompile.h
@@ -36,14 +36,14 @@ typedef DPTR(struct CORCOMPILE_EXTERNAL_METHOD_DATA_ENTRY)
 typedef DPTR(struct READYTORUN_IMPORT_SECTION)
     PTR_READYTORUN_IMPORT_SECTION;
 
-constexpr ReadyToRunImportSectionFlags operator |( const ReadyToRunImportSectionFlags left, const ReadyToRunImportSectionFlags right)
+inline ReadyToRunImportSectionFlags operator |( const ReadyToRunImportSectionFlags left, const ReadyToRunImportSectionFlags right)
 {
-    return (ReadyToRunImportSectionFlags)(uint16_t(left) | uint16_t(right));
+    return static_cast<ReadyToRunImportSectionFlags>(static_cast<uint16_t>(left) | static_cast<uint16_t>(right));
 }
 
-constexpr ReadyToRunImportSectionFlags operator &( const ReadyToRunImportSectionFlags left, const ReadyToRunImportSectionFlags right)
+inline ReadyToRunImportSectionFlags operator &( const ReadyToRunImportSectionFlags left, const ReadyToRunImportSectionFlags right)
 {
-    return (ReadyToRunImportSectionFlags)(uint16_t(left) & uint16_t(right));
+    return static_cast<ReadyToRunImportSectionFlags>(static_cast<uint16_t>(left) & static_cast<uint16_t>(right));
 }
 
 #ifdef TARGET_X86

--- a/src/coreclr/inc/corcompile.h
+++ b/src/coreclr/inc/corcompile.h
@@ -23,6 +23,7 @@
 #include <shash.h>
 #include <daccess.h>
 #include <clrtypes.h>
+#include <readytorun.h>
 
 typedef DPTR(struct CORCOMPILE_EXCEPTION_LOOKUP_TABLE)
     PTR_CORCOMPILE_EXCEPTION_LOOKUP_TABLE;
@@ -32,8 +33,18 @@ typedef DPTR(struct CORCOMPILE_EXCEPTION_CLAUSE)
    PTR_CORCOMPILE_EXCEPTION_CLAUSE;
 typedef DPTR(struct CORCOMPILE_EXTERNAL_METHOD_DATA_ENTRY)
     PTR_CORCOMPILE_EXTERNAL_METHOD_DATA_ENTRY;
-typedef DPTR(struct CORCOMPILE_IMPORT_SECTION)
-    PTR_CORCOMPILE_IMPORT_SECTION;
+typedef DPTR(struct READYTORUN_IMPORT_SECTION)
+    PTR_READYTORUN_IMPORT_SECTION;
+
+constexpr ReadyToRunImportSectionFlags operator |( const ReadyToRunImportSectionFlags left, const ReadyToRunImportSectionFlags right)
+{
+    return (ReadyToRunImportSectionFlags)(uint16_t(left) | uint16_t(right));
+}
+
+constexpr ReadyToRunImportSectionFlags operator &( const ReadyToRunImportSectionFlags left, const ReadyToRunImportSectionFlags right)
+{
+    return (ReadyToRunImportSectionFlags)(uint16_t(left) & uint16_t(right));
+}
 
 #ifdef TARGET_X86
 
@@ -55,81 +66,6 @@ typedef DPTR(RUNTIME_FUNCTION) PTR_RUNTIME_FUNCTION;
 typedef DPTR(struct CORCOMPILE_RUNTIME_DLL_INFO)
     PTR_CORCOMPILE_RUNTIME_DLL_INFO;
 typedef DPTR(struct COR_ILMETHOD) PTR_COR_ILMETHOD;
-
-//
-// CORCOMPILE_IMPORT_SECTION describes image range with references to other assemblies or runtime data structures
-//
-// There is number of different types of these ranges: eagerly initialized at image load vs. lazily initialized at method entry
-// vs. lazily initialized on first use; hot vs. cold, handles vs. code pointers, etc.
-//
-struct CORCOMPILE_IMPORT_SECTION
-{
-    IMAGE_DATA_DIRECTORY    Section;            // Section containing values to be fixed up
-    USHORT                  Flags;              // One or more of CorCompileImportFlags
-    BYTE                    Type;               // One of CorCompileImportType
-    BYTE                    EntrySize;
-    DWORD                   Signatures;         // RVA of optional signature descriptors
-    DWORD                   AuxiliaryData;      // RVA of optional auxiliary data (typically GC info)
-};
-
-enum CorCompileImportType
-{
-    CORCOMPILE_IMPORT_TYPE_UNKNOWN          = 0,
-    CORCOMPILE_IMPORT_TYPE_EXTERNAL_METHOD  = 1,
-    CORCOMPILE_IMPORT_TYPE_STUB_DISPATCH    = 2,
-    CORCOMPILE_IMPORT_TYPE_STRING_HANDLE    = 3,
-    CORCOMPILE_IMPORT_TYPE_TYPE_HANDLE      = 4,
-    CORCOMPILE_IMPORT_TYPE_METHOD_HANDLE    = 5,
-    CORCOMPILE_IMPORT_TYPE_VIRTUAL_METHOD   = 6,
-};
-
-enum CorCompileImportFlags
-{
-    CORCOMPILE_IMPORT_FLAGS_EAGER           = 0x0001,   // Section at module load time.
-    CORCOMPILE_IMPORT_FLAGS_CODE            = 0x0002,   // Section contains code.
-    CORCOMPILE_IMPORT_FLAGS_PCODE           = 0x0004,   // Section contains pointers to code.
-};
-
-// ================================================================================
-// Portable tagged union of a pointer field with a 30 bit scalar value
-// ================================================================================
-
-// The lowest bit of the tag will be set for tagged pointers. We also set the highest bit for convenience.
-// It makes dereferences of tagged pointers to crash under normal circumstances.
-// The highest bit of the tag will be set for tagged indexes (e.g. classid).
-
-#define CORCOMPILE_TOKEN_TAG 0x80000001
-
-// These two macros are mostly used just for debug-only checks to ensure that we have either tagged pointer (lowest bit is set)
-// or tagged index (highest bit is set).
-#define CORCOMPILE_IS_POINTER_TAGGED(token)     ((((SIZE_T)(token)) & 0x00000001) != 0)
-#define CORCOMPILE_IS_INDEX_TAGGED(token)       ((((SIZE_T)(token)) & 0x80000000) != 0)
-
-// The token (RVA of the fixup in most cases) is stored in the mid 30 bits of DWORD
-#define CORCOMPILE_TAG_TOKEN(token)             ((SIZE_T)(((token)<<1)|CORCOMPILE_TOKEN_TAG))
-#define CORCOMPILE_UNTAG_TOKEN(token)           ((((SIZE_T)(token))&~CORCOMPILE_TOKEN_TAG)>>1)
-
-#ifdef TARGET_ARM
-// Tagging of code pointers on ARM uses inverse logic because of the thumb bit.
-#define CORCOMPILE_IS_PCODE_TAGGED(token)       ((((SIZE_T)(token)) & 0x00000001) == 0x00000000)
-#define CORCOMPILE_TAG_PCODE(token)             ((SIZE_T)(((token)<<1)|0x80000000))
-#else
-#define CORCOMPILE_IS_PCODE_TAGGED(token)       CORCOMPILE_IS_POINTER_TAGGED(token)
-#define CORCOMPILE_TAG_PCODE(token)             CORCOMPILE_TAG_TOKEN(token)
-#endif
-
-inline BOOL CORCOMPILE_IS_FIXUP_TAGGED(SIZE_T fixup, PTR_CORCOMPILE_IMPORT_SECTION pSection)
-{
-#ifdef TARGET_ARM
-    // Tagging of code pointers on ARM has to use inverse logic because of the thumb bit
-    if (pSection->Flags & CORCOMPILE_IMPORT_FLAGS_PCODE)
-    {
-        return CORCOMPILE_IS_PCODE_TAGGED(fixup);
-    }
-#endif
-
-    return ((((SIZE_T)(fixup)) & CORCOMPILE_TOKEN_TAG) == CORCOMPILE_TOKEN_TAG);
-}
 
 //
 // GCRefMap blob starts with DWORDs lookup index of relative offsets into the blob. This lookup index is used to limit amount

--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -97,6 +97,20 @@ struct READYTORUN_SECTION
     IMAGE_DATA_DIRECTORY    Section;
 };
 
+enum class ReadyToRunImportSectionType : uint8_t
+{
+    Unknown   = 0,
+    StubDispatch = 2,
+    StringHandle = 3,
+};
+
+enum class ReadyToRunImportSectionFlags : uint16_t
+{
+    None     = 0x0000,
+    Eager    = 0x0001, // Section at module load time.
+    PCode    = 0x0004, // Section contains pointers to code
+};
+
 //
 // READYTORUN_IMPORT_SECTION describes image range with references to code or runtime data structures
 //
@@ -105,22 +119,12 @@ struct READYTORUN_SECTION
 //
 struct READYTORUN_IMPORT_SECTION
 {
-    IMAGE_DATA_DIRECTORY    Section;            // Section containing values to be fixed up
-    USHORT                  Flags;              // One or more of ReadyToRunImportSectionFlags
-    BYTE                    Type;               // One of ReadyToRunImportSectionType
-    BYTE                    EntrySize;
-    DWORD                   Signatures;         // RVA of optional signature descriptors
-    DWORD                   AuxiliaryData;      // RVA of optional auxiliary data (typically GC info)
-};
-
-enum ReadyToRunImportSectionType
-{
-    READYTORUN_IMPORT_SECTION_TYPE_UNKNOWN   = 0,
-};
-
-enum ReadyToRunImportSectionFlags
-{
-    READYTORUN_IMPORT_SECTION_FLAGS_EAGER    = 0x0001,
+    IMAGE_DATA_DIRECTORY         Section;            // Section containing values to be fixed up
+    ReadyToRunImportSectionFlags Flags;              // One or more of ReadyToRunImportSectionFlags
+    ReadyToRunImportSectionType  Type;               // One of ReadyToRunImportSectionType
+    BYTE                         EntrySize;
+    DWORD                        Signatures;         // RVA of optional signature descriptors
+    DWORD                        AuxiliaryData;      // RVA of optional auxiliary data (typically GC info)
 };
 
 //

--- a/src/coreclr/tools/Common/Internal/Runtime/CorConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/CorConstants.cs
@@ -5,31 +5,6 @@ using System;
 
 namespace Internal.CorConstants
 {
-    /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/corcompile.h">src/inc/corcompile.h</a> CorCompileImportType
-    /// </summary>
-    public enum CorCompileImportType
-    {
-        CORCOMPILE_IMPORT_TYPE_UNKNOWN = 0,
-        CORCOMPILE_IMPORT_TYPE_EXTERNAL_METHOD = 1,
-        CORCOMPILE_IMPORT_TYPE_STUB_DISPATCH = 2,
-        CORCOMPILE_IMPORT_TYPE_STRING_HANDLE = 3,
-        CORCOMPILE_IMPORT_TYPE_TYPE_HANDLE = 4,
-        CORCOMPILE_IMPORT_TYPE_METHOD_HANDLE = 5,
-        CORCOMPILE_IMPORT_TYPE_VIRTUAL_METHOD = 6,
-    };
-
-    /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/corcompile.h">src/inc/corcompile.h</a> CorCompileImportFlags
-    /// </summary>
-    public enum CorCompileImportFlags
-    {
-        CORCOMPILE_IMPORT_FLAGS_UNKNOWN = 0x0000,
-        CORCOMPILE_IMPORT_FLAGS_EAGER = 0x0001,     // Section at module load time.
-        CORCOMPILE_IMPORT_FLAGS_CODE = 0x0002,      // Section contains code.
-        CORCOMPILE_IMPORT_FLAGS_PCODE = 0x0004,     // Section contains pointers to code.
-    };
-
     public enum CorElementType : byte
     {
         Invalid = 0,

--- a/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -19,6 +19,21 @@ namespace Internal.ReadyToRunConstants
         READYTORUN_FLAG_Component = 0x00000020,                 // This is the header describing a component assembly of composite R2R
     }
 
+    public enum ReadyToRunImportSectionType : byte
+    {
+        Unknown      = 0,
+        StubDispatch = 2,
+        StringHandle = 3,
+    }
+
+    [Flags]
+    public enum ReadyToRunImportSectionFlags : ushort
+    {
+        None     = 0x0000,
+        Eager    = 0x0001, // Section at module load time.
+        PCode    = 0x0004, // Section contains pointers to code
+    }
+
     /// <summary>
     /// Constants for method and field encoding
     /// </summary>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-using Internal.CorConstants;
+using Internal.ReadyToRunConstants;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
@@ -26,8 +26,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private readonly List<Signature> _signatureList;
         private readonly GCRefMapNode _gcRefMap;
 
-        private readonly CorCompileImportType _type;
-        private readonly CorCompileImportFlags _flags;
+        private readonly ReadyToRunImportSectionType _type;
+        private readonly ReadyToRunImportSectionFlags _flags;
         private readonly byte _entrySize;
         private readonly string _name;
         private readonly bool _emitPrecode;
@@ -35,7 +35,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private bool _materializedSignature;
 
-        public ImportSectionNode(string name, CorCompileImportType importType, CorCompileImportFlags flags, byte entrySize, bool emitPrecode, bool emitGCRefMap)
+        public ImportSectionNode(string name, ReadyToRunImportSectionType importType, ReadyToRunImportSectionFlags flags, byte entrySize, bool emitPrecode, bool emitGCRefMap)
         {
             _name = name;
             _type = importType;
@@ -87,7 +87,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public bool EmitPrecode => _emitPrecode;
 
-        public bool IsEager => (_flags & CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_EAGER) != 0;
+        public bool IsEager => (_flags & ReadyToRunImportSectionFlags.Eager) != 0;
 
         public override bool StaticDependenciesAreComputed => true;
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -678,8 +678,8 @@ namespace ILCompiler.DependencyAnalysis
 
             EagerImports = new ImportSectionNode(
                 "EagerImports",
-                CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN,
-                CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_EAGER,
+                ReadyToRunImportSectionType.Unknown,
+                ReadyToRunImportSectionFlags.Eager,
                 (byte)Target.PointerSize,
                 emitPrecode: false,
                 emitGCRefMap: false);
@@ -730,8 +730,8 @@ namespace ILCompiler.DependencyAnalysis
 
             MethodImports = new ImportSectionNode(
                 "MethodImports",
-                CorCompileImportType.CORCOMPILE_IMPORT_TYPE_STUB_DISPATCH,
-                CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
+                ReadyToRunImportSectionType.StubDispatch,
+                ReadyToRunImportSectionFlags.PCode,
                 (byte)Target.PointerSize,
                 emitPrecode: false,
                 emitGCRefMap: true);
@@ -739,8 +739,8 @@ namespace ILCompiler.DependencyAnalysis
 
             DispatchImports = new ImportSectionNode(
                 "DispatchImports",
-                CorCompileImportType.CORCOMPILE_IMPORT_TYPE_STUB_DISPATCH,
-                CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
+                ReadyToRunImportSectionType.StubDispatch,
+                ReadyToRunImportSectionFlags.PCode,
                 (byte)Target.PointerSize,
                 emitPrecode: false,
                 emitGCRefMap: true);
@@ -748,8 +748,8 @@ namespace ILCompiler.DependencyAnalysis
 
             HelperImports = new ImportSectionNode(
                 "HelperImports",
-                CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN,
-                CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
+                ReadyToRunImportSectionType.Unknown,
+                ReadyToRunImportSectionFlags.PCode,
                 (byte)Target.PointerSize,
                 emitPrecode: false,
                 emitGCRefMap: false);
@@ -757,8 +757,8 @@ namespace ILCompiler.DependencyAnalysis
 
             PrecodeImports = new ImportSectionNode(
                 "PrecodeImports",
-                CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN,
-                CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
+                ReadyToRunImportSectionType.Unknown,
+                ReadyToRunImportSectionFlags.PCode,
                 (byte)Target.PointerSize,
                 emitPrecode: true,
                 emitGCRefMap: false);
@@ -766,8 +766,8 @@ namespace ILCompiler.DependencyAnalysis
 
             StringImports = new ImportSectionNode(
                 "StringImports",
-                CorCompileImportType.CORCOMPILE_IMPORT_TYPE_STRING_HANDLE,
-                CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_UNKNOWN,
+                ReadyToRunImportSectionType.StringHandle,
+                ReadyToRunImportSectionFlags.None,
                 (byte)Target.PointerSize,
                 emitPrecode: true,
                 emitGCRefMap: false);

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunImportSection.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunImportSection.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection.PortableExecutable;
-using Internal.CorConstants;
+using Internal.ReadyToRunConstants;
 
 namespace ILCompiler.Reflection.ReadyToRun
 {
@@ -50,12 +50,12 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// One or more of ImportSectionFlags
         /// </summary>
-        public CorCompileImportFlags Flags { get; set; }
+        public ReadyToRunImportSectionFlags Flags { get; set; }
 
         /// <summary>
         /// One of ImportSectionType
         /// </summary>
-        public CorCompileImportType Type { get; set; }
+        public ReadyToRunImportSectionType Type { get; set; }
 
         /// <summary>
         ///
@@ -80,8 +80,8 @@ namespace ILCompiler.Reflection.ReadyToRun
             ReadyToRunReader reader,
             int rva,
             int size,
-            CorCompileImportFlags flags,
-            byte type,
+            ReadyToRunImportSectionFlags flags,
+            ReadyToRunImportSectionType type,
             byte entrySize,
             int signatureRVA,
             List<ImportSectionEntry> entries,
@@ -94,7 +94,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             SectionRVA = rva;
             SectionSize = size;
             Flags = flags;
-            Type = (CorCompileImportType)type;
+            Type = type;
             EntrySize = entrySize;
 
             SignatureRVA = signatureRVA;

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -13,9 +13,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
-using Internal.CorConstants;
-using Internal.Runtime;
 using Internal.ReadyToRunConstants;
+using Internal.Runtime;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -1253,8 +1252,8 @@ namespace ILCompiler.Reflection.ReadyToRun
                 int sectionOffset = GetOffset(rva);
                 int startOffset = sectionOffset;
                 int size = NativeReader.ReadInt32(Image, ref offset);
-                CorCompileImportFlags flags = (CorCompileImportFlags)NativeReader.ReadUInt16(Image, ref offset);
-                byte type = NativeReader.ReadByte(Image, ref offset);
+                ReadyToRunImportSectionFlags flags = (ReadyToRunImportSectionFlags)NativeReader.ReadUInt16(Image, ref offset);
+                ReadyToRunImportSectionType type = (ReadyToRunImportSectionType)NativeReader.ReadByte(Image, ref offset);
                 byte entrySize = NativeReader.ReadByte(Image, ref offset);
                 if (entrySize == 0)
                 {

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1452,9 +1452,9 @@ public:
 #endif
 
     PEImageLayout * GetReadyToRunImage();
-    PTR_CORCOMPILE_IMPORT_SECTION GetImportSections(COUNT_T *pCount);
-    PTR_CORCOMPILE_IMPORT_SECTION GetImportSectionFromIndex(COUNT_T index);
-    PTR_CORCOMPILE_IMPORT_SECTION GetImportSectionForRVA(RVA rva);
+    PTR_READYTORUN_IMPORT_SECTION GetImportSections(COUNT_T *pCount);
+    PTR_READYTORUN_IMPORT_SECTION GetImportSectionFromIndex(COUNT_T index);
+    PTR_READYTORUN_IMPORT_SECTION GetImportSectionForRVA(RVA rva);
 
     // These are overridden by reflection modules
     virtual TADDR GetIL(RVA il);
@@ -1509,7 +1509,7 @@ public:
     IMDInternalImport *GetNativeAssemblyImport(BOOL loadAllowed = TRUE);
     IMDInternalImport *GetNativeAssemblyImportIfLoaded();
 
-    BOOL FixupNativeEntry(CORCOMPILE_IMPORT_SECTION * pSection, SIZE_T fixupIndex, SIZE_T *fixup, BOOL mayUsePrecompiledNDirectMethods = TRUE);
+    BOOL FixupNativeEntry(READYTORUN_IMPORT_SECTION * pSection, SIZE_T fixupIndex, SIZE_T *fixup, BOOL mayUsePrecompiledNDirectMethods = TRUE);
 
     //this split exists to support new CLR Dump functionality in DAC.  The
     //template removes any indirections.
@@ -1518,7 +1518,7 @@ public:
     template<typename Ptr, typename FixupNativeEntryCallback>
     BOOL FixupDelayListAux(TADDR pFixupList,
                            Ptr pThis, FixupNativeEntryCallback pfnCB,
-                           PTR_CORCOMPILE_IMPORT_SECTION pImportSections, COUNT_T nImportSections,
+                           PTR_READYTORUN_IMPORT_SECTION pImportSections, COUNT_T nImportSections,
                            PEDecoder * pNativeImage, BOOL mayUsePrecompiledNDirectMethods = TRUE);
     void RunEagerFixups();
     void RunEagerFixupsUnlocked();

--- a/src/coreclr/vm/ceeload.inl
+++ b/src/coreclr/vm/ceeload.inl
@@ -332,7 +332,7 @@ FORCEINLINE BOOL Module::FixupDelayList(TADDR pFixupList, BOOL mayUsePrecompiled
     WRAPPER_NO_CONTRACT;
 
     COUNT_T nImportSections;
-    PTR_CORCOMPILE_IMPORT_SECTION pImportSections = GetImportSections(&nImportSections);
+    PTR_READYTORUN_IMPORT_SECTION pImportSections = GetImportSections(&nImportSections);
 
     return FixupDelayListAux(pFixupList, this, &Module::FixupNativeEntry, pImportSections, nImportSections, GetReadyToRunImage(), mayUsePrecompiledNDirectMethods);
 }
@@ -340,7 +340,7 @@ FORCEINLINE BOOL Module::FixupDelayList(TADDR pFixupList, BOOL mayUsePrecompiled
 template<typename Ptr, typename FixupNativeEntryCallback>
 BOOL Module::FixupDelayListAux(TADDR pFixupList,
                                Ptr pThis, FixupNativeEntryCallback pfnCB,
-                               PTR_CORCOMPILE_IMPORT_SECTION pImportSections, COUNT_T nImportSections,
+                               PTR_READYTORUN_IMPORT_SECTION pImportSections, COUNT_T nImportSections,
                                PEDecoder * pNativeImage, BOOL mayUsePrecompiledNDirectMethods)
 {
     CONTRACTL
@@ -419,7 +419,7 @@ BOOL Module::FixupDelayListAux(TADDR pFixupList,
         // Get the correct section to work with. This is stored in the first two nibbles (first byte)
 
         _ASSERTE(curTableIndex < nImportSections);
-        PTR_CORCOMPILE_IMPORT_SECTION pImportSection = pImportSections + curTableIndex;
+        PTR_READYTORUN_IMPORT_SECTION pImportSection = pImportSections + curTableIndex;
 
         COUNT_T cbData;
         TADDR pData = pNativeImage->GetDirectoryData(&pImportSection->Section, &cbData);

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -101,7 +101,6 @@ PTR_Module ClassLoader::ComputeLoaderModuleWorker(
     for (DWORD i = 0; i < classInst.GetNumArgs(); i++)
     {
         TypeHandle classArg = classInst[i];
-        _ASSERTE(!classArg.IsEncodedFixup());
         Module* pModule = classArg.GetLoaderModule();
         if (pModule->IsCollectible())
             goto ComputeCollectibleLoaderModule;
@@ -112,7 +111,6 @@ PTR_Module ClassLoader::ComputeLoaderModuleWorker(
     for (DWORD i = 0; i < methodInst.GetNumArgs(); i++)
     {
         TypeHandle methodArg = methodInst[i];
-        _ASSERTE(!methodArg.IsEncodedFixup());
         Module *pModule = methodArg.GetLoaderModule();
         if (pModule->IsCollectible())
             goto ComputeCollectibleLoaderModule;

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -618,7 +618,7 @@ static PTR_BYTE FindGCRefMap(PTR_Module pZapModule, TADDR ptr)
 
     RVA rva = pNativeImage->GetDataRva(ptr);
 
-    PTR_CORCOMPILE_IMPORT_SECTION pImportSection = pZapModule->GetImportSectionForRVA(rva);
+    PTR_READYTORUN_IMPORT_SECTION pImportSection = pZapModule->GetImportSectionForRVA(rva);
     if (pImportSection == NULL)
         return NULL;
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -13364,7 +13364,7 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
             {
                 CrstHolder ch(pInfoModule->GetFixupCrst());
 
-                if (!CORCOMPILE_IS_POINTER_TAGGED(*entry) && (*entry != NULL))
+                if (*entry != NULL)
                 {
                     // We lost the race, just return
                     return TRUE;
@@ -13463,19 +13463,6 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
 
         MethodEntry:
             result = pMD->GetMultiCallableAddrOfCode(CORINFO_ACCESS_ANY);
-
-        #ifndef TARGET_ARM
-            if (CORCOMPILE_IS_PCODE_TAGGED(result))
-            {
-                // There is a rare case where the function entrypoint may not be aligned. This could happen only for FCalls,
-                // only on x86 and only if we failed to hardbind the fcall (e.g. ngen image for CoreLib does not exist
-                // and /nodependencies flag for ngen was used). The function entrypoints should be aligned in all other cases.
-                //
-                // We will wrap the unaligned method entrypoint by funcptr stub with aligned entrypoint.
-                _ASSERTE(pMD->IsFCall());
-                result = pMD->GetLoaderAllocator()->GetFuncPtrStubs()->GetFuncPtrStub(pMD);
-            }
-        #endif
         }
         break;
 

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -285,7 +285,6 @@ BOOL LoaderAllocator::EnsureInstantiation(Module *pDefiningModule, Instantiation
     for (DWORD i = 0; i < inst.GetNumArgs(); i++)
     {
         TypeHandle arg = inst[i];
-        _ASSERTE(!arg.IsEncodedFixup());
         LoaderAllocator *pOtherLA = arg.GetLoaderModule()->GetLoaderAllocator();
 
         if (pOtherLA == this)

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -754,13 +754,9 @@ Module *MethodDesc::GetDefiningModuleForOpenMethod()
     Instantiation inst = GetMethodInstantiation();
     for (DWORD i = 0; i < inst.GetNumArgs(); i++)
     {
-        // Encoded types are never open
-        if (!inst[i].IsEncodedFixup())
-        {
-            pModule = inst[i].GetDefiningModuleForOpenType();
-            if (pModule != NULL)
-                return pModule;
-        }
+        pModule = inst[i].GetDefiningModuleForOpenType();
+        if (pModule != NULL)
+            return pModule;
     }
 
     return NULL;

--- a/src/coreclr/vm/methoditer.cpp
+++ b/src/coreclr/vm/methoditer.cpp
@@ -93,8 +93,6 @@ ADVANCE_TYPE:
     {
         if (!GetCurrentModule()->GetAvailableParamTypes()->FindNext(&m_typeIterator, &m_typeIteratorEntry))
             goto ADVANCE_ASSEMBLY;
-        if (CORCOMPILE_IS_POINTER_TAGGED(m_typeIteratorEntry->GetTypeHandle().AsTAddr()))
-            goto ADVANCE_TYPE;
 
         //if (m_typeIteratorEntry->data != TypeHandle(m_mainMD->GetMethodTable()))
         //    goto ADVANCE_TYPE;
@@ -104,9 +102,6 @@ ADVANCE_TYPE:
         // Similar logic occurs in the Lookup function for that table.  We will clean this
         // up in Whidbey Beta2.
         TypeHandle th = m_typeIteratorEntry->GetTypeHandle();
-
-        if (th.IsEncodedFixup())
-            goto ADVANCE_TYPE;
 
         if (th.IsTypeDesc())
             goto ADVANCE_TYPE;
@@ -147,8 +142,6 @@ ADVANCE_METHOD:
     {
         if (!GetCurrentModule()->GetInstMethodHashTable()->FindNext(&m_methodIterator, &m_methodIteratorEntry))
             goto ADVANCE_TYPE;
-        if (CORCOMPILE_IS_POINTER_TAGGED(dac_cast<TADDR>(m_methodIteratorEntry->GetMethod())))
-            goto ADVANCE_METHOD;
         if (m_methodIteratorEntry->GetMethod()->GetModule() != m_module)
             goto ADVANCE_METHOD;
         if (m_methodIteratorEntry->GetMethod()->GetMemberDef() != m_md)

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -7767,7 +7767,6 @@ BOOL MethodTable::ContainsGenericMethodVariables()
     Instantiation inst = GetInstantiation();
     for (DWORD i = 0; i < inst.GetNumArgs(); i++)
     {
-        CONSISTENCY_CHECK(!inst[i].IsEncodedFixup());
         if (inst[i].ContainsGenericVariables(TRUE))
             return TRUE;
     }
@@ -7793,13 +7792,9 @@ Module *MethodTable::GetDefiningModuleForOpenType()
         Instantiation inst = GetInstantiation();
         for (DWORD i = 0; i < inst.GetNumArgs(); i++)
         {
-            // Encoded fixups are never open types
-            if (!inst[i].IsEncodedFixup())
-            {
-                Module *pModule = inst[i].GetDefiningModuleForOpenType();
-                if (pModule != NULL)
-                    RETURN pModule;
-            }
+            Module *pModule = inst[i].GetDefiningModuleForOpenType();
+            if (pModule != NULL)
+                RETURN pModule;
         }
     }
 

--- a/src/coreclr/vm/pgo.cpp
+++ b/src/coreclr/vm/pgo.cpp
@@ -976,7 +976,7 @@ public:
                     if (importSection != 0xF)
                     {
                         COUNT_T countImportSections;
-                        PTR_CORCOMPILE_IMPORT_SECTION pImportSections = m_pReadyToRunInfo->GetImportSections(&countImportSections);
+                        PTR_READYTORUN_IMPORT_SECTION pImportSections = m_pReadyToRunInfo->GetImportSections(&countImportSections);
 
                         if (importSection >= countImportSections)
                         {
@@ -984,7 +984,7 @@ public:
                             return false;
                         }
 
-                        PTR_CORCOMPILE_IMPORT_SECTION pImportSection = &pImportSections[importSection];
+                        PTR_READYTORUN_IMPORT_SECTION pImportSection = &pImportSections[importSection];
                         COUNT_T cbData;
                         TADDR pData = m_pNativeImage->GetDirectoryData(&pImportSection->Section, &cbData);
                         uint32_t fixupIndex = (uint32_t)typeIndex;

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2297,7 +2297,7 @@ PCODE TheVarargNDirectStub(BOOL hasRetBuffArg)
     }
 }
 
-static PCODE PatchNonVirtualExternalMethod(MethodDesc * pMD, PCODE pCode, PTR_CORCOMPILE_IMPORT_SECTION pImportSection, TADDR pIndirection)
+static PCODE PatchNonVirtualExternalMethod(MethodDesc * pMD, PCODE pCode, PTR_READYTORUN_IMPORT_SECTION pImportSection, TADDR pIndirection)
 {
     STANDARD_VM_CONTRACT;
 
@@ -2315,7 +2315,6 @@ static PCODE PatchNonVirtualExternalMethod(MethodDesc * pMD, PCODE pCode, PTR_CO
     }
 #endif //HAS_FIXUP_PRECODE
 
-    _ASSERTE((pImportSection->Flags & CORCOMPILE_IMPORT_FLAGS_CODE) == 0);
     *(TADDR *)pIndirection = pCode;
 
     return pCode;
@@ -2409,7 +2408,7 @@ EXTERN_C PCODE STDCALL ExternalMethodFixupWorker(TransitionBlock * pTransitionBl
 
         RVA rva = pNativeImage->GetDataRva(pIndirection);
 
-        PTR_CORCOMPILE_IMPORT_SECTION pImportSection;
+        PTR_READYTORUN_IMPORT_SECTION pImportSection;
         if (sectionIndex != (DWORD)-1)
         {
             pImportSection = pModule->GetImportSectionFromIndex(sectionIndex);
@@ -2421,7 +2420,6 @@ EXTERN_C PCODE STDCALL ExternalMethodFixupWorker(TransitionBlock * pTransitionBl
         }
         _ASSERTE(pImportSection != NULL);
 
-        _ASSERTE((pImportSection->Flags & CORCOMPILE_IMPORT_FLAGS_CODE) == 0);
         _ASSERTE(pImportSection->EntrySize == sizeof(TADDR));
         COUNT_T index = (rva - pImportSection->Section.VirtualAddress) / sizeof(TADDR);
 
@@ -2967,7 +2965,7 @@ PCODE DynamicHelperFixup(TransitionBlock * pTransitionBlock, TADDR * pCell, DWOR
 
     RVA rva = pNativeImage->GetDataRva((TADDR)pCell);
 
-    PTR_CORCOMPILE_IMPORT_SECTION pImportSection = pModule->GetImportSectionFromIndex(sectionIndex);
+    PTR_READYTORUN_IMPORT_SECTION pImportSection = pModule->GetImportSectionFromIndex(sectionIndex);
     _ASSERTE(pImportSection == pModule->GetImportSectionForRVA(rva));
 
     _ASSERTE(pImportSection->EntrySize == sizeof(TADDR));

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -464,7 +464,7 @@ static bool AcquireImage(Module * pModule, PEImageLayout * pLayout, READYTORUN_H
     for (READYTORUN_IMPORT_SECTION * pCurSection = pImportSections; pCurSection < pImportSectionsEnd; pCurSection++)
     {
         // The import for the module pointer is always in an eager fixup section, so skip delayed fixup sections.
-        if ((pCurSection->Flags & READYTORUN_IMPORT_SECTION_FLAGS_EAGER) == 0)
+        if ((pCurSection->Flags & ReadyToRunImportSectionFlags::Eager) != ReadyToRunImportSectionFlags::Eager)
             continue;
 
         // Found an eager fixup section. Check the signature of each fixup in this section.
@@ -649,8 +649,8 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, LoaderAllocator* pLoaderAllocat
     IMAGE_DATA_DIRECTORY * pImportSectionsDir = m_pComposite->FindSection(ReadyToRunSectionType::ImportSections);
     if (pImportSectionsDir != NULL)
     {
-        m_pImportSections = (CORCOMPILE_IMPORT_SECTION*)m_pComposite->GetLayout()->GetDirectoryData(pImportSectionsDir);
-        m_nImportSections = pImportSectionsDir->Size / sizeof(CORCOMPILE_IMPORT_SECTION);
+        m_pImportSections = (READYTORUN_IMPORT_SECTION*)m_pComposite->GetLayout()->GetDirectoryData(pImportSectionsDir);
+        m_nImportSections = pImportSectionsDir->Size / sizeof(READYTORUN_IMPORT_SECTION);
     }
     else
     {

--- a/src/coreclr/vm/readytoruninfo.h
+++ b/src/coreclr/vm/readytoruninfo.h
@@ -63,7 +63,7 @@ class ReadyToRunInfo
 
     PTR_IMAGE_DATA_DIRECTORY        m_pSectionDelayLoadMethodCallThunks;
 
-    PTR_CORCOMPILE_IMPORT_SECTION   m_pImportSections;
+    PTR_READYTORUN_IMPORT_SECTION   m_pImportSections;
     DWORD                           m_nImportSections;
 
     bool                            m_readyToRunCodeDisabled; // Is 
@@ -140,26 +140,26 @@ public:
         return m_pHeader->CoreHeader.Flags & READYTORUN_FLAG_NONSHARED_PINVOKE_STUBS;
     }
 
-    PTR_CORCOMPILE_IMPORT_SECTION GetImportSections(COUNT_T * pCount)
+    PTR_READYTORUN_IMPORT_SECTION GetImportSections(COUNT_T * pCount)
     {
         LIMITED_METHOD_CONTRACT;
         *pCount = m_nImportSections;
         return m_pImportSections;
     }
 
-    PTR_CORCOMPILE_IMPORT_SECTION GetImportSectionFromIndex(COUNT_T index)
+    PTR_READYTORUN_IMPORT_SECTION GetImportSectionFromIndex(COUNT_T index)
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(index < m_nImportSections);
         return m_pImportSections + index;
     }
 
-    PTR_CORCOMPILE_IMPORT_SECTION GetImportSectionForRVA(RVA rva)
+    PTR_READYTORUN_IMPORT_SECTION GetImportSectionForRVA(RVA rva)
     {
         LIMITED_METHOD_CONTRACT;
 
-        PTR_CORCOMPILE_IMPORT_SECTION pEnd = m_pImportSections + m_nImportSections;
-        for (PTR_CORCOMPILE_IMPORT_SECTION pSection = m_pImportSections; pSection < pEnd; pSection++)
+        PTR_READYTORUN_IMPORT_SECTION pEnd = m_pImportSections + m_nImportSections;
+        for (PTR_READYTORUN_IMPORT_SECTION pSection = m_pImportSections; pSection < pEnd; pSection++)
         {
             if (rva >= VAL32(pSection->Section.VirtualAddress) && rva < VAL32(pSection->Section.VirtualAddress) + VAL32(pSection->Section.Size))
                 return pSection;

--- a/src/coreclr/vm/typehandle.cpp
+++ b/src/coreclr/vm/typehandle.cpp
@@ -998,13 +998,6 @@ BOOL TypeHandle::IsRestored() const
     }
 }
 
-BOOL TypeHandle::IsEncodedFixup() const
-{
-    LIMITED_METHOD_DAC_CONTRACT;
-
-    return CORCOMPILE_IS_POINTER_TAGGED(m_asTAddr);
-}
-
 BOOL TypeHandle::HasUnrestoredTypeKey()  const
 {
     WRAPPER_NO_CONTRACT;
@@ -1022,7 +1015,6 @@ void TypeHandle::CheckRestore() const
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
-        PRECONDITION(!IsEncodedFixup());
     }
     CONTRACTL_END
 

--- a/src/coreclr/vm/typehandle.h
+++ b/src/coreclr/vm/typehandle.h
@@ -474,9 +474,6 @@ public:
     // Does this type have zap-encoded components (generic arguments, etc)?
     BOOL HasUnrestoredTypeKey() const;
 
-    // True if this type handle is a zap-encoded fixup
-    BOOL IsEncodedFixup() const;
-
     void DoRestoreTypeKey();
 
     void CheckRestore() const;

--- a/src/coreclr/vm/typehash.cpp
+++ b/src/coreclr/vm/typehash.cpp
@@ -206,7 +206,6 @@ static DWORD HashTypeHandle(TypeHandle t)
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(CheckPointer(t));
-        PRECONDITION(!t.IsEncodedFixup());
         SUPPORTS_DAC;
     }
     CONTRACTL_END;
@@ -528,7 +527,6 @@ VOID EETypeHashTable::InsertValue(TypeHandle data)
         INJECT_FAULT(COMPlusThrowOM(););
         PRECONDITION(IsUnsealed());          // If we are sealed then we should not be adding to this hashtable
         PRECONDITION(CheckPointer(data));
-        PRECONDITION(!data.IsEncodedFixup());
         PRECONDITION(!data.IsGenericTypeDefinition()); // Generic type defs live in typedef table (availableClasses)
         PRECONDITION(data.HasInstantiation() || data.HasTypeParam() || data.IsFnPtrType()); // It's an instantiated type or an array/ptr/byref type
         PRECONDITION(m_pModule == NULL || GetModule()->IsTenured()); // Destruct won't destruct m_pAvailableParamTypes for non-tenured modules - so make sure no one tries to insert one before the Module has been tenured

--- a/src/coreclr/vm/typestring.cpp
+++ b/src/coreclr/vm/typestring.cpp
@@ -715,12 +715,6 @@ void TypeString::AppendType(TypeNameBuilder& tnb, TypeHandle ty, Instantiation t
         tnb.AddName(W("(null)"));
     }
     else
-    // It's not restored yet!
-    if (ty.IsEncodedFixup())
-    {
-        tnb.AddName(W("(fixup)"));
-    }
-    else
 
     // It's an array, with format
     //   element_ty[] (1-d, SZARRAY)

--- a/src/coreclr/vm/zapsig.cpp
+++ b/src/coreclr/vm/zapsig.cpp
@@ -72,7 +72,7 @@ BOOL ZapSig::GetSignatureForTypeDesc(TypeDesc * desc, SigBuilder * pSigBuilder)
                 {
                     TypeHandle th = retAndArgTypes[i];
                     // This should be a consequence of the type key being restored
-                    CONSISTENCY_CHECK(!th.IsNull() && !th.IsEncodedFixup());
+                    CONSISTENCY_CHECK(!th.IsNull());
                     if (!this->GetSignatureForTypeHandle(th, pSigBuilder))
                         return FALSE;
                 }
@@ -246,7 +246,7 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
         for (DWORD i = 0; i < inst.GetNumArgs(); i++)
         {
             TypeHandle t = inst[i];
-            CONSISTENCY_CHECK(!t.IsNull() && !t.IsEncodedFixup());
+            CONSISTENCY_CHECK(!t.IsNull());
             if (!this->GetSignatureForTypeHandle(t, pSigBuilder))
                 return FALSE;
         }
@@ -548,7 +548,6 @@ BOOL ZapSig::CompareTypeHandleFieldToTypeHandle(TypeHandle *pTypeHnd, TypeHandle
         FORBID_FAULT;
         PRECONDITION(CheckPointer(pTypeHnd));
         PRECONDITION(CheckPointer(typeHnd2));
-        PRECONDITION(!CORCOMPILE_IS_POINTER_TAGGED((SIZE_T) typeHnd2.AsPtr()));
     }
     CONTRACTL_END
 


### PR DESCRIPTION
- Replace with direct use of ready to run data structures in runtime
- Remove pointer tagging that is not relevant in a R2R based world