### PR TITLE
limit retries of EPROTOTYPE on macOS

### DIFF
--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -1439,8 +1439,10 @@ int32_t SystemNative_Send(intptr_t socket, void* buffer, int32_t bufferLen, int3
 
     ssize_t res;
 #if defined(__APPLE__) && __APPLE__
-    int maxProtoRetry = 4;
     // possible OSX kernel bug: https://github.com/dotnet/runtime/issues/27221
+    // According to https://github.com/dotnet/runtime/issues/63291 the EPROTOTYPE may be
+    // permanent so we need to limit retries.
+    int maxProtoRetry = 4;
     while ((res = send(fd, buffer, (size_t)bufferLen, socketFlags)) < 0 && (errno == EINTR || (errno == EPROTOTYPE && --maxProtoRetry > 0)));
 #else
     while ((res = send(fd, buffer, (size_t)bufferLen, socketFlags)) < 0 && errno == EINTR);
@@ -1476,8 +1478,10 @@ int32_t SystemNative_SendMessage(intptr_t socket, MessageHeader* messageHeader, 
 
     ssize_t res;
 #if defined(__APPLE__) && __APPLE__
-    int maxProtoRetry = 4;
     // possible OSX kernel bug: https://github.com/dotnet/runtime/issues/27221
+    // According to https://github.com/dotnet/runtime/issues/63291 the EPROTOTYPE may be
+    // permanent so we need to limit retries.
+    int maxProtoRetry = 4;
     while ((res = sendmsg(fd, &header, socketFlags)) < 0 && (errno == EINTR || (errno == EPROTOTYPE && --maxProtoRetry > 0)));
 #else
     while ((res = sendmsg(fd, &header, socketFlags)) < 0 && errno == EINTR);

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -1439,8 +1439,9 @@ int32_t SystemNative_Send(intptr_t socket, void* buffer, int32_t bufferLen, int3
 
     ssize_t res;
 #if defined(__APPLE__) && __APPLE__
+    int maxProtoRetry = 4;
     // possible OSX kernel bug: https://github.com/dotnet/runtime/issues/27221
-    while ((res = send(fd, buffer, (size_t)bufferLen, socketFlags)) < 0 && (errno == EINTR || errno == EPROTOTYPE));
+    while ((res = send(fd, buffer, (size_t)bufferLen, socketFlags)) < 0 && (errno == EINTR || (errno == EPROTOTYPE && --maxProtoRetry > 0)));
 #else
     while ((res = send(fd, buffer, (size_t)bufferLen, socketFlags)) < 0 && errno == EINTR);
 #endif
@@ -1475,8 +1476,9 @@ int32_t SystemNative_SendMessage(intptr_t socket, MessageHeader* messageHeader, 
 
     ssize_t res;
 #if defined(__APPLE__) && __APPLE__
+    int maxProtoRetry = 4;
     // possible OSX kernel bug: https://github.com/dotnet/runtime/issues/27221
-    while ((res = sendmsg(fd, &header, socketFlags)) < 0 && (errno == EINTR || errno == EPROTOTYPE));
+    while ((res = sendmsg(fd, &header, socketFlags)) < 0 && (errno == EINTR || (errno == EPROTOTYPE && --maxProtoRetry > 0)));
 #else
     while ((res = sendmsg(fd, &header, socketFlags)) < 0 && errno == EINTR);
 #endif


### PR DESCRIPTION
#63291 suggest that the `EPROTOTYPE` condition may be permanent in certain configuration. 
That would lead to infinite loop. This change adds simple cap and we would surface the error afterwards. 

I was not able to reproduce it (nor the original condition when we tried to fix https://github.com/dotnet/runtime/issues/27221 in 3.0)

fixes https://github.com/dotnet/runtime/issues/63291