### PR TITLE
Fix StreamReader EOF handling and improve perf

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -1226,20 +1226,12 @@ namespace System.IO
                         _charPos = 0;
                         if (readToUserBuffer)
                         {
-                            n += _decoder.GetChars(new ReadOnlySpan<byte>(tmpByteBuffer, 0, _byteLen), buffer.Span.Slice(charsRead), flush: false);
-
-                            // Why did the bytes yield no chars?
-                            Debug.Assert(n > 0);
-
+                            n = _decoder.GetChars(new ReadOnlySpan<byte>(tmpByteBuffer, 0, _byteLen), buffer.Span.Slice(charsRead), flush: false);
                             _charLen = 0;  // StreamReader's buffer is empty.
                         }
                         else
                         {
                             n = _decoder.GetChars(tmpByteBuffer, 0, _byteLen, _charBuffer, 0);
-
-                            // Why did the bytes yield no chars?
-                            Debug.Assert(n > 0);
-
                             _charLen += n;  // Number of chars in StreamReader's buffer.
                         }
                     } while (n == 0);


### PR DESCRIPTION
This fixes a bug in `StreamReader` where it doesn't properly pass _flush: true_ to the backing `Decoder` instance when EOF is reached. This could result in cases where partial data in the decoder buffer is never processed.

For a concrete example, consider the below sample.

```cs
using System.IO;
using System.Text;

var reader = new StreamReader(
    new MemoryStream(new byte[] { 0xF0 }),
    new UTF8Encoding(
        encoderShouldEmitUTF8Identifier: false,
        throwOnInvalidBytes: true));
Console.WriteLine(reader.ReadToEnd());
```

This prints an empty string to the console, even though it should throw `DecoderFallbackException` since the caller explicitly requested that they want to reject invalid data.

I also took this opportunity to tighten the `ReadLine` and `ReadLineAsync` methods, including using `StringBuilderCache`. This shouldn't blow the cache because we expect lines to be 80 - 100 chars at the high end, which is well within what `StringBuilderCache` can handle.

This results in an approx. __50% throughput increase__ in _ReadLine_ and _ReadLineAsync_, as shown in the below benchmarks. The benchmarks also show a decrease in overall `StringBuilder` allocations.

|            Method |        Job | Toolchain |     Mean |    Error |   StdDev | Ratio | RatioSD |    Gen 0 | Allocated |
|------------------ |----------- |---------- |---------:|---------:|---------:|------:|--------:|---------:|----------:|
|      GetLineCount | Job-QTEUMB |      main | 404.5 μs |  4.27 μs |  4.19 μs |  1.00 |    0.00 | 105.4688 |    431 KB |
|      GetLineCount | Job-OSITYF |        sr | 263.5 μs |  5.15 μs |  7.70 μs |  0.66 |    0.02 |  93.7500 |    384 KB |
|                   |            |           |          |          |          |       |         |          |           |
| GetLineCountAsync | Job-QTEUMB |      main | 645.5 μs | 12.58 μs | 11.15 μs |  1.00 |    0.00 | 169.9219 |    694 KB |
| GetLineCountAsync | Job-OSITYF |        sr | 421.6 μs |  8.35 μs | 12.24 μs |  0.66 |    0.02 | 158.2031 |    647 KB |

```cs
// In the below benchmarks, _ms is a MemoryStream whose contents have been initialized from:
// https://www.gutenberg.org/files/11/11-0.txt

[Benchmark]
public int GetLineCount()
{
    _ms.Position = 0;
    StreamReader reader = new StreamReader(_ms);

    int lineCount = 0;
    while (reader.ReadLine() != null) { lineCount++; }
    return lineCount;
}

[Benchmark]
public int GetLineCountAsync()
{
    _ms.Position = 0;
    StreamReader reader = new StreamReader(_ms);

    int lineCount = 0;
    while (reader.ReadLineAsync().GetAwaiter().GetResult() != null) { lineCount++; }
    return lineCount;
}
```

/cc @dotnet/area-system-io