### PR TITLE
Delete an old quirk from `gtSetEvalOrder`

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4927,20 +4927,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                         {
                             doAddrMode = false;
                         }
-                        else if (varTypeIsStruct(tree))
-                        {
-                            // This is a heuristic attempting to match prior behavior when indirections
-                            // under a struct assignment would not be considered for addressing modes.
-                            if (compCurStmt != nullptr)
-                            {
-                                GenTree* expr = compCurStmt->GetRootNode();
-                                if ((expr->OperGet() == GT_ASG) &&
-                                    ((expr->gtGetOp1() == tree) || (expr->gtGetOp2() == tree)))
-                                {
-                                    doAddrMode = false;
-                                }
-                            }
-                        }
+
 #ifdef TARGET_ARM64
                         if (tree->gtFlags & GTF_IND_VOLATILE)
                         {


### PR DESCRIPTION
The quirk prevented us from marking address modes for SIMD types as `NO_CSE`, which in most cases is not good for CQ.

Thus, deleting the quirk yields mostly positive diffs, with some small regressions in ARM64 where `genCreateAddrMode` is not  perfect in its understanding of which address modes are legal.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1793004&view=ms.vss-build-web.run-extensions-tab).