### PR TITLE
Bug fixes from dead code elimination

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -735,25 +735,26 @@ bool Compiler::fgRemoveDeadBlocks()
     do
     {
         changed = false;
-        fgRemoveUnreachableBlocks(isBlockRemovable);
-
-        // Check if we produced some more unreachable blocks and if yes, remove them as well.
-        // Note: We skip recalculating all the visited blocks and instead just remove them from
-        // the visited list because of two reasons - We won't have to recreate the visited list
-        // and it is rare to have a scenario.
-        //
-        // TODO-CQ: Ideally, we should have a PriorityQueue that sorts the blocks based on bbRefs
-        // and remove them as they become unreachable.
-        for (auto reachableBlock : visitedlist)
+        if (fgRemoveUnreachableBlocks(isBlockRemovable))
         {
-            if (reachableBlock->bbRefs == 0)
+            // If we produced more unreachable blocks, remove them as well.
+            // Note: We skip recalculating all the visited blocks and instead just remove them from
+            // the visited list because of two reasons - We won't have to recreate the visited list
+            // and it is rare scenario .
+            //
+            // TODO-CQ: Ideally, we should have a PriorityQueue that sorts the blocks based on bbRefs
+            // and remove them as they become unreachable.
+            for (auto reachableBlock : visitedlist)
             {
-                if (BlockSetOps::IsMember(this, visitedBlocks, reachableBlock->bbNum) &&
-                    ((reachableBlock->bbFlags & BBF_REMOVED) == 0))
+                if (reachableBlock->bbRefs == 0)
                 {
-                    changed = true;
-                    BlockSetOps::RemoveElemD(this, visitedBlocks, reachableBlock->bbNum);
-                    JITDUMP("Found a reachable block " FMT_BB " that now has zero refs\n", reachableBlock->bbNum);
+                    if (BlockSetOps::IsMember(this, visitedBlocks, reachableBlock->bbNum) &&
+                        ((reachableBlock->bbFlags & BBF_REMOVED) == 0))
+                    {
+                        changed = true;
+                        BlockSetOps::RemoveElemD(this, visitedBlocks, reachableBlock->bbNum);
+                        JITDUMP("Found a reachable block " FMT_BB " that now has zero refs\n", reachableBlock->bbNum);
+                    }
                 }
             }
         }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -723,7 +723,7 @@ bool Compiler::fgRemoveDeadBlocks()
     // A block is unreachable if no path was found from
     // any of the fgFirstBB, handler, filter or BBJ_ALWAYS (Arm) blocks.
     auto isBlockRemovable = [&](BasicBlock* block) -> bool {
-        bool isVisited = BlockSetOps::IsMember(this, visitedBlocks, block->bbNum);
+        bool isVisited   = BlockSetOps::IsMember(this, visitedBlocks, block->bbNum);
         bool isRemovable = (!isVisited || block->bbRefs == 0);
 
         hasUnreachableBlock |= isRemovable;

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -726,6 +726,10 @@ bool Compiler::fgRemoveDeadBlocks()
         bool isVisited   = BlockSetOps::IsMember(this, visitedBlocks, block->bbNum);
         bool isRemovable = (!isVisited || block->bbRefs == 0);
 
+#if defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
+        isRemovable &=
+            !block->isBBCallAlwaysPairTail(); // can't remove the BBJ_ALWAYS of a BBJ_CALLFINALLY / BBJ_ALWAYS pair
+#endif
         hasUnreachableBlock |= isRemovable;
 
         return isRemovable;

--- a/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_1.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_1.cs
@@ -1,5 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+//
+// In this issue, although we were not removing an unreachable block, we were removing all the code
+// inside it and as such should update the liveness information. Since we were not updating the liveness
+// information for such scenarios, we were hitting an assert during register allocation.
 public class Program
 {
     public static ulong[] s_14;

--- a/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_1.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_1.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+public class Program
+{
+    public static ulong[] s_14;
+    public static uint s_34;
+    public static int Main()
+    {
+        var vr2 = new ulong[][]{new ulong[]{0}};
+        M27(s_34, vr2);
+        return 100;
+    }
+
+    public static void M27(uint arg4, ulong[][] arg5)
+    {
+        arg5[0][0] = arg5[0][0];
+        for (int var7 = 0; var7 < 1; var7++)
+        {
+            return;
+        }
+
+        try
+        {
+            s_14 = arg5[0];
+        }
+        finally
+        {
+            arg4 = arg4;
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_1.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_1.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_2.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_2.cs
@@ -1,5 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+//
+// In this issue, we were not removing all the unreachable blocks and that led us to expect that
+// there should be an IG label for one of the unreachable block, but we were not creating it leading
+// to an assert failure.
 public class _65659_2
 {
     public static bool[][,] s_2;

--- a/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_2.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_2.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+public class _65659_2
+{
+    public static bool[][,] s_2;
+    public static short[,][] s_8;
+    public static bool[] s_10;
+    public static ushort[][] s_29;
+    public static int Main()
+    {
+        bool vr1 = M47();
+        return 100;
+    }
+
+    public static bool M47()
+    {
+        bool var0 = default(bool);
+        try
+        {
+            if (var0)
+            {
+                try
+                {
+                    if (s_10[0])
+                    {
+                        return s_2[0][0, 0];
+                    }
+                }
+                finally
+                {
+                    s_8[0, 0][0] = 0;
+                }
+            }
+        }
+        finally
+        {
+            s_29 = s_29;
+        }
+
+        return true;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_2.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_69659/GitHub_69659_2.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes 2 issues from the dead code elimination changes earlier.

> !foundDiff

This one was happening because we detect certain block is dead and remove the code inside it, but sometimes might decide to not delete the block itself. In those cases, we need to still make sure that we update liveness of variables. In https://github.com/dotnet/runtime/pull/69421, I was only updating the liveness if we deleted the actual blocks.

The fix is to take into account if any block was unreachable and if yes, update the liveness info.

> cookie != nullptr

This one was interesting. We have chain of try-finally that looks like this. During dead block elimination, we eliminate `BB08` and `BB09`. However, we fail to detect that `BB11` could be eliminated as well because the only block that reaches `BB11` is `BB09`. Going forward, we add labels to `genMarkLabelsForCodegen` and since no block is jumping to `BB11` , we do not add label to it, do not generate a dedicated IG for it and hence do not have `bbEmitCookie`.

```
BB08 [0016]  1  1    BB04                  1       [???..???)-> BB15 (callf ) T1                  i internal LIR 
BB09 [0017]  1  1    BB15                  1       [???..???)-> BB11 (ALWAYS) T1      }           i internal LIR KEEP 
BB10 [0021]  2       BB02,BB07             1       [033..03E)-> BB14 (always)                     keep i LIR cfb cfe 
BB11 [0018]  1       BB09                  1       [???..???)-> BB17 (callf )                     i internal LIR 
BB12 [0019]  1       BB17                  1       [???..???)-> BB13 (ALWAYS)                     i internal LIR KEEP 
```

The fix was to check if we made any reachable blocks dead and if yes, do another iteration. We would restrict the number of iterations to 3.

Fixes: #69659