### PR TITLE
Fix ICorDebugFunction2::GetVersionNumber for arm32.

### DIFF
--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1518,6 +1518,9 @@ DebuggerJitInfo * DebuggerMethodInfo::FindJitInfo(MethodDesc * pMD,
     }
     CONTRACTL_END;
 
+#ifdef TARGET_ARM
+    addrNativeStartAddr = addrNativeStartAddr|THUMB_CODE;
+#endif
 
     DebuggerJitInfo * pCheck = m_latestJitInfo;
     while (pCheck != NULL)


### PR DESCRIPTION
We are implementing Hot Reload feature support during debug session in our debugger (https://github.com/Samsung/netcoredbg) for Tizen devices. We have Linux/Tizen arm32/arm64/amd64 devices with custom built runtime, that have `FEATURE_ENC_SUPPORTED` defined in order to make deltas apply debugger API part work.

During netcoredbg functional testing, I found, that for Linux arm32  `ICorDebugFunction2::GetVersionNumber` return wrong code version (it return `1` all times), but execute proper (updated by deltas) code in the same time.
This happens for `IcorDebugFunction` received from current frame, that received from provided by callback ICorDebugThread (`IcorDebugManagedCallback::Breakpoint`, `IcorDebugManagedCallback::StepComplete`, …).

I found, that point of issue for Linux arm32 is wrong `DebuggerMethodInfo::FindJitInfo` work, that not return proper `DebuggerJitInfo` (with proper method's code version), since can’t find it due to 
https://github.com/dotnet/runtime/blob/ecb4e6c178b98aec29fbf3e7a70a820240c1dd0b/src/coreclr/debug/ee/functioninfo.cpp#L1526
comparation, that all times produce `false`. In case no `DebuggerJitInfo` was found by `DebuggerMethodInfo::FindJitInfo`, `1` version (initial code version) are used.

During investigation, I found that `m_addrOfCode` in `DebuggerJitInfo` have a THUMB code bit set unconditionally all the time:
https://github.com/dotnet/runtime/blob/ecb4e6c178b98aec29fbf3e7a70a820240c1dd0b/src/coreclr/debug/ee/debugger.cpp#L2498-L2500
In the same time, `addrNativeStartAddr` THUMB code bit at `DebuggerMethodInfo::FindJitInfo` call is not defined and in case of our issue, have assertion and even unconditionally remove it from address (since this required by other code logic) before `DebuggerMethodInfo::FindJitInfo` (`DacDbiInterfaceImpl::LookupEnCVersions`-> `DebuggerMethodInfo::FindJitInfo` ) call:
https://github.com/dotnet/runtime/blob/ecb4e6c178b98aec29fbf3e7a70a820240c1dd0b/src/coreclr/debug/daccess/dacdbiimpl.cpp#L1417-L1421

Looks like in `./src/coreclr/debug/ee/debugger.cpp` and `./src/coreclr/debug/ee/functioninfo.cpp` we calls `DebuggerMethodInfo::FindJitInfo` in proper way (with proper addresses in `addrNativeStartAddr` argument) and even have assertion about  THUMB code bit before call:
https://github.com/dotnet/runtime/blob/ecb4e6c178b98aec29fbf3e7a70a820240c1dd0b/src/coreclr/debug/ee/functioninfo.cpp#L1593-L1594
but other sources call `DebuggerMethodInfo::FindJitInfo` without care about THUMB code bit. In this commit I propose fix `DebuggerMethodInfo::FindJitInfo` itself in order to care about THUMB code bit right before compare addresses.

I tested this changes with our debugger on Linux arm32 and can confirm, this fix arm32 issue in `ICorDebugFunction2::GetVersionNumber`.

CC @alpencolt 