### PR TITLE
PoC: support custom X509ChainPolicy in SslStream

### DIFF
--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -139,6 +139,7 @@ namespace System.Net.Security
         public bool AllowRenegotiation { get { throw null; } set { } }
         public System.Collections.Generic.List<System.Net.Security.SslApplicationProtocol>? ApplicationProtocols { get { throw null; } set { } }
         public System.Security.Cryptography.X509Certificates.X509RevocationMode CertificateRevocationCheckMode { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509ChainPolicy? ChainPolicy { get { throw null; } set { } }
         public System.Net.Security.CipherSuitesPolicy? CipherSuitesPolicy { get { throw null; } set { } }
         public System.Security.Cryptography.X509Certificates.X509CertificateCollection? ClientCertificates { get { throw null; } set { } }
         public System.Security.Authentication.SslProtocols EnabledSslProtocols { get { throw null; } set { } }
@@ -160,6 +161,7 @@ namespace System.Net.Security
         public bool AllowRenegotiation { get { throw null; } set { } }
         public System.Collections.Generic.List<System.Net.Security.SslApplicationProtocol>? ApplicationProtocols { get { throw null; } set { } }
         public System.Security.Cryptography.X509Certificates.X509RevocationMode CertificateRevocationCheckMode { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509ChainPolicy? ChainPolicy { get { throw null; } set { } }
         public System.Net.Security.CipherSuitesPolicy? CipherSuitesPolicy { get { throw null; } set { } }
         public bool ClientCertificateRequired { get { throw null; } set { } }
         public System.Security.Authentication.SslProtocols EnabledSslProtocols { get { throw null; } set { } }

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
@@ -44,7 +44,8 @@ namespace System.Net
         private static X509Certificate2? GetRemoteCertificate(
             SafeDeleteContext securityContext,
             bool retrieveChainCertificates,
-            ref X509Chain? chain)
+            ref X509Chain? chain,
+            X509ChainPolicy? chainPolicy)
         {
             SafeSslHandle sslContext = ((SafeDeleteSslContext)securityContext).SslContext;
             if (sslContext == null)
@@ -64,7 +65,15 @@ namespace System.Net
             }
             else
             {
-                chain ??= new X509Chain();
+                if (chain == null)
+                {
+                    chain = new X509Chain();
+                    if (chainPolicy != null)
+                    {
+                        chain.ChainPolicy = chainPolicy;
+                    }
+                }
+
                 IntPtr[]? ptrs = Interop.AndroidCrypto.SSLStreamGetPeerCertificates(sslContext);
                 if (ptrs != null && ptrs.Length > 0)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
@@ -50,7 +50,8 @@ namespace System.Net
         private static X509Certificate2? GetRemoteCertificate(
             SafeDeleteContext securityContext,
             bool retrieveChainCertificates,
-            ref X509Chain? chain)
+            ref X509Chain? chain,
+            X509ChainPolicy? chainPolicy)
         {
             if (securityContext == null)
             {
@@ -72,7 +73,14 @@ namespace System.Net
 
                 if (retrieveChainCertificates)
                 {
-                    chain ??= new X509Chain();
+                    if (chain == null)
+                    {
+                        chain = new X509Chain();
+                        if (chainPolicy != null)
+                        {
+                            chain.ChainPolicy = chainPolicy;
+                        }
+                    }
 
                     for (int i = 0; i < chainSize; i++)
                     {

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -24,7 +24,7 @@ namespace System.Net
         //
         // Extracts a remote certificate upon request.
         //
-        private static X509Certificate2? GetRemoteCertificate(SafeDeleteContext? securityContext, bool retrieveChainCertificates, ref X509Chain? chain)
+        private static X509Certificate2? GetRemoteCertificate(SafeDeleteContext? securityContext, bool retrieveChainCertificates, ref X509Chain? chain, X509ChainPolicy? chainPolicy)
         {
             bool gotReference = false;
 
@@ -47,7 +47,14 @@ namespace System.Net
 
                 if (retrieveChainCertificates)
                 {
-                    chain ??= new X509Chain();
+                    if (chain == null)
+                    {
+                        chain = new X509Chain();
+                        if (chainPolicy != null)
+                        {
+                            chain.ChainPolicy = chainPolicy;
+                        }
+                    }
 
                     using (SafeSharedX509StackHandle chainStack =
                         Interop.OpenSsl.GetPeerCertificateChain(((SafeDeleteSslContext)securityContext).SslContext))

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -29,7 +29,7 @@ namespace System.Net
         //
 
         private static X509Certificate2? GetRemoteCertificate(
-            SafeDeleteContext? securityContext, bool retrieveChainCertificates, ref X509Chain? chain)
+            SafeDeleteContext? securityContext, bool retrieveChainCertificates, ref X509Chain? chain, X509ChainPolicy? chainPolicy)
         {
             if (securityContext == null)
             {
@@ -66,7 +66,14 @@ namespace System.Net
                 {
                     if (retrieveChainCertificates)
                     {
-                        chain ??= new X509Chain();
+                        if (chain == null)
+                        {
+                            chain = new X509Chain();
+                            if (chainPolicy != null)
+                            {
+                                chain.ChainPolicy = chainPolicy;
+                            }
+                        }
 
                         UnmanagedCertificateContext.GetRemoteCertificatesFromStoreContext(remoteContext, chain.ChainPolicy.ExtraStore);
                     }

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
@@ -19,10 +19,10 @@ namespace System.Net
         private static X509Chain? s_chain;
 
         internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext securityContext) =>
-            GetRemoteCertificate(securityContext, retrieveChainCertificates: false, ref s_chain);
+            GetRemoteCertificate(securityContext, retrieveChainCertificates: false, ref s_chain, null);
 
-        internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext securityContext, ref X509Chain? chain) =>
-            GetRemoteCertificate(securityContext, retrieveChainCertificates: true, ref chain);
+        internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext securityContext, ref X509Chain? chain, X509ChainPolicy? chainPolicy) =>
+            GetRemoteCertificate(securityContext, retrieveChainCertificates: true, ref chain, chainPolicy);
 
         static partial void CheckSupportsStore(StoreLocation storeLocation, ref bool hasSupport);
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -55,6 +55,11 @@ namespace System.Net.Security
             CertificateRevocationCheckMode = sslClientAuthenticationOptions.CertificateRevocationCheckMode;
             ClientCertificates = sslClientAuthenticationOptions.ClientCertificates;
             CipherSuitesPolicy = sslClientAuthenticationOptions.CipherSuitesPolicy;
+
+            if (sslClientAuthenticationOptions.ChainPolicy != null)
+            {
+                ChainPolicy = (X509ChainPolicy)sslClientAuthenticationOptions.ChainPolicy.Duplicate();
+            }
         }
 
         internal void UpdateOptions(ServerOptionsSelectionCallback optionCallback, object? state)
@@ -106,6 +111,12 @@ namespace System.Net.Security
             if (sslServerAuthenticationOptions.ServerCertificateContext != null)
             {
                 CertificateContext = sslServerAuthenticationOptions.ServerCertificateContext;
+
+                if (CertificateContext.Trust != null && sslServerAuthenticationOptions.ChainPolicy != null &&
+                    sslServerAuthenticationOptions.ChainPolicy.TrustMode != X509ChainTrustMode.CustomRootTrust)
+                {
+                    throw new InvalidOperationException("Unable to use custom trust without custom root"); ;
+                }
             }
             else if (sslServerAuthenticationOptions.ServerCertificate != null)
             {
@@ -169,5 +180,6 @@ namespace System.Net.Security
         internal CipherSuitesPolicy? CipherSuitesPolicy { get; set; }
         internal object? UserState { get; set; }
         internal ServerOptionsSelectionCallback? ServerOptionDelegate { get; set; }
+        internal X509ChainPolicy? ChainPolicy { get; set; }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
@@ -73,5 +73,11 @@ namespace System.Net.Security
         /// Use extreme caution when changing this setting.
         /// </summary>
         public CipherSuitesPolicy? CipherSuitesPolicy { get; set; }
+
+        /// <summary>
+        /// Sepcifies specific policy for verifying remote cretrificate.
+        /// </summary>
+        public X509ChainPolicy? ChainPolicy { get; set; }
+
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
@@ -74,5 +74,10 @@ namespace System.Net.Security
         /// Use extreme caution when changing this setting.
         /// </summary>
         public CipherSuitesPolicy? CipherSuitesPolicy { get; set; }
+
+        /// <summary>
+        /// Sepcifies specific policy for verifying remote cretrificate.
+        /// </summary>
+        public X509ChainPolicy? ChainPolicy { get; set; }
     }
 }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -2908,6 +2908,7 @@ namespace System.Security.Cryptography.X509Certificates
         public System.TimeSpan UrlRetrievalTimeout { get { throw null; } set { } }
         public System.Security.Cryptography.X509Certificates.X509VerificationFlags VerificationFlags { get { throw null; } set { } }
         public System.DateTime VerificationTime { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509ChainPolicy Duplicate() { throw null; }
         public void Reset() { }
     }
     public partial struct X509ChainStatus

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.X509Certificates
         private X509RevocationFlag _revocationFlag;
         private X509VerificationFlags _verificationFlags;
         private X509ChainTrustMode _trustMode;
+        private DateTime _verificationTime;
         internal OidCollection? _applicationPolicy;
         internal OidCollection? _certificatePolicy;
         internal X509Certificate2Collection? _extraStore;
@@ -94,9 +95,31 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        public DateTime VerificationTime { get; set; }
+        public DateTime VerificationTime
+        {
+            get
+            {
+                return _verificationTime.Equals(default(DateTime)) ? DateTime.Now : _verificationTime;
+            }
+            set
+            {
+                _verificationTime = value;
+            }
+        }
 
         public TimeSpan UrlRetrievalTimeout { get; set; }
+
+        public X509ChainPolicy Duplicate()
+        {
+            var dup = (X509ChainPolicy)this.MemberwiseClone();
+            if (_extraStore?.Count > 0)
+            {
+                // copy collection as TLS handshake may modify content.
+                dup._extraStore = new X509Certificate2Collection(_extraStore);
+            }
+
+            return dup;
+        }
 
         public void Reset()
         {
@@ -109,7 +132,7 @@ namespace System.Security.Cryptography.X509Certificates
             _revocationFlag = X509RevocationFlag.ExcludeRoot;
             _verificationFlags = X509VerificationFlags.NoFlag;
             _trustMode = X509ChainTrustMode.System;
-            VerificationTime = DateTime.Now;
+            _verificationTime = default;
             UrlRetrievalTimeout = TimeSpan.Zero; // default timeout
         }
     }


### PR DESCRIPTION
Related to #59979.
Allowing users  to provide custom policy give option to disable AIA or influence other aspects of validation. 

- we would copy provided policy when we capture other properties in `SslAuthenticationOptions` when AuthenticateAs*() is called. 
- Unless `VerificationTime` was set, it would resolve to `DateTime.Now` e.g. same behavior as now.
- If custom policy is set, `SslStream` would ignore `X509RevocationMode` and `Trust` e.g. complete policy takes precedence. (similar how we prioritize `SslStreamCertificateContext` over `X509Certificate`) Then X509ChainPolicy is not provided, we would construct it same way as now from the bits.
- If `ApplicationPolicy` is not set, we would always create it and set EKU. This one deviates from above. The may goal is to preserve right behavior for cases when only custom trust is desired, like:
```c#
X509ChainPolicy policy = new X509ChainPolicy();

policy.CustomTrustMode = CustomRootTrust;

policy.TrustStore.Add(s_ourPrivateRoot);

// whatever else they want to set.



SslStreamClientOptions clientOpts = ...;

clientOpts.ChainPolicy = policy;



SslStreamServerOptions serverOpts = ...;

serverOpts.ChainPolicy = policy;
```
If `ApplicationPolicy` is set, we would preserve it, assuming it is what caller really wants. 

The `Duplicate` creates copy of `_extraStore` because this is place where certificates from the TLS session go e.g. may be unique for each TLS session.  I was wondering about the `CustomTrustStore` but I felt we don't need extra copy and allocations. 

Please comment as you see fit. This is mostly to illustrate the intention and behavior. 