### PR TITLE
[mono][interp] Fix invocation of finally clauses with tiering enabled

### DIFF
--- a/src/mono/mono/mini/ee.h
+++ b/src/mono/mono/mini/ee.h
@@ -36,7 +36,7 @@ typedef gpointer MonoInterpFrameHandle;
 	MONO_EE_CALLBACK (void, delegate_ctor, (MonoObjectHandle this_obj, MonoObjectHandle target, gpointer addr, MonoError *error)) \
 	MONO_EE_CALLBACK (void, set_resume_state, (MonoJitTlsData *jit_tls, MonoObject *ex, MonoJitExceptionInfo *ei, MonoInterpFrameHandle interp_frame, gpointer handler_ip)) \
 	MONO_EE_CALLBACK (void, get_resume_state, (const MonoJitTlsData *jit_tls, gboolean *has_resume_state, MonoInterpFrameHandle *interp_frame, gpointer *handler_ip)) \
-	MONO_EE_CALLBACK (gboolean, run_finally, (StackFrameInfo *frame, int clause_index, gpointer handler_ip, gpointer handler_ip_end)) \
+	MONO_EE_CALLBACK (gboolean, run_finally, (StackFrameInfo *frame, int clause_index)) \
 	MONO_EE_CALLBACK (gboolean, run_filter, (StackFrameInfo *frame, MonoException *ex, int clause_index, gpointer handler_ip, gpointer handler_ip_end)) \
 	MONO_EE_CALLBACK (gboolean, run_clause_with_il_state, (gpointer il_state, int clause_index, MonoObject *ex, gboolean *filtered)) \
 	MONO_EE_CALLBACK (void, frame_iter_init, (MonoInterpStackIter *iter, gpointer interp_exit_data)) \

--- a/src/mono/mono/mini/interp-stubs.c
+++ b/src/mono/mono/mini/interp-stubs.c
@@ -102,7 +102,7 @@ stub_get_resume_state (const MonoJitTlsData *jit_tls, gboolean *has_resume_state
 }
 
 static gboolean
-stub_run_finally (StackFrameInfo *frame, int clause_index, gpointer handler_ip, gpointer handler_ip_end)
+stub_run_finally (StackFrameInfo *frame, int clause_index)
 {
 	g_assert_not_reached ();
 }

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7390,16 +7390,17 @@ interp_get_resume_state (const MonoJitTlsData *jit_tls, gboolean *has_resume_sta
  * Return TRUE if the finally clause threw an exception.
  */
 static gboolean
-interp_run_finally (StackFrameInfo *frame, int clause_index, gpointer handler_ip, gpointer handler_ip_end)
+interp_run_finally (StackFrameInfo *frame, int clause_index)
 {
 	InterpFrame *iframe = (InterpFrame*)frame->interp_frame;
+	MonoJitExceptionInfo *ei = &iframe->imethod->jinfo->clauses [clause_index];
 	ThreadContext *context = get_context ();
 	FrameClauseArgs clause_args;
 	const guint16 *state_ip;
 
 	memset (&clause_args, 0, sizeof (FrameClauseArgs));
-	clause_args.start_with_ip = (const guint16*)handler_ip;
-	clause_args.end_at_ip = (const guint16*)handler_ip_end;
+	clause_args.start_with_ip = (const guint16*)ei->handler_start;
+	clause_args.end_at_ip = (const guint16*)ei->data.handler_end;
 	clause_args.exec_frame = iframe;
 
 	state_ip = iframe->state.ip;

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2576,7 +2576,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 								g_print ("EXCEPTION: finally/fault clause found in AOTed code, running it with the interpreter.\n");
 							mini_get_interp_callbacks ()->run_clause_with_il_state (frame.il_state, i, NULL, NULL);
 						} else if (in_interp) {
-							gboolean has_ex = mini_get_interp_callbacks ()->run_finally (&frame, i, ei->handler_start, ei->data.handler_end);
+							gboolean has_ex = mini_get_interp_callbacks ()->run_finally (&frame, i);
 							if (has_ex) {
 								/*
 								 * If run_finally didn't resume to a context, it means that the handler frame


### PR DESCRIPTION
When unwinding the stack during EH, we first populate a StackFrameInfo with various data, like native_offset and jinfo. Let's assume this data is for an untiered method. If this frame has multiple finally clauses that need to be invoked, a finally invocation could tier up the InterpFrame that it is executing. The future finally invocations would use the IPs from the previously resolved untiered method. This change makes the interpreter receive only the clause index (in interp_run_finally) so we correctly resolve the native offsets of the handler.

Fixes https://github.com/dotnet/runtime/issues/69868,  maybe also https://github.com/dotnet/runtime/issues/69864