### PR TITLE
Improve Encoding.UTF8.GetMaxByte/CharCount perf

### DIFF
--- a/src/libraries/Common/src/System/Text/ValueUtf8Converter.cs
+++ b/src/libraries/Common/src/System/Text/ValueUtf8Converter.cs
@@ -23,7 +23,7 @@ namespace System.Text
 
         public Span<byte> ConvertAndTerminateString(ReadOnlySpan<char> value)
         {
-            int maxSize = Encoding.UTF8.GetMaxByteCount(value.Length) + 1;
+            int maxSize = checked(Encoding.UTF8.GetMaxByteCount(value.Length) + 1);
             if (_bytes.Length < maxSize)
             {
                 Dispose();

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -993,7 +993,7 @@ namespace System.Runtime.InteropServices
 
             int nb = Encoding.UTF8.GetMaxByteCount(s.Length);
 
-            IntPtr ptr = AllocHGlobal(nb + 1);
+            IntPtr ptr = AllocHGlobal(checked(nb + 1));
 
             int nbWritten;
             byte* pbMem = (byte*)ptr;
@@ -1040,7 +1040,7 @@ namespace System.Runtime.InteropServices
 
             int nb = Encoding.UTF8.GetMaxByteCount(s.Length);
 
-            IntPtr ptr = AllocCoTaskMem(nb + 1);
+            IntPtr ptr = AllocCoTaskMem(checked(nb + 1));
 
             int nbWritten;
             byte* pbMem = (byte*)ptr;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
@@ -761,8 +761,20 @@ namespace System.Text
                 throw new ArgumentOutOfRangeException(nameof(charCount),
                      SR.ArgumentOutOfRange_NeedNonNegNum);
 
-            // Characters would be # of characters + 1 in case left over high surrogate is ? * max fallback
-            long byteCount = (long)charCount + 1;
+            // GetMaxByteCount assumes that the caller might have a stateful Encoder instance. If the
+            // Encoder instance already has a captured high surrogate, then one of two things will
+            // happen:
+            //
+            // - The next char is a low surrogate, at which point the two chars together result in 4
+            //   UTF-8 bytes in the output; or
+            // - The next char is not a low surrogate (or the input reaches EOF), at which point the
+            //   standalone captured surrogate will go through the fallback routine.
+            //
+            // The second case is the worst-case scenario for expansion, so it's what we use for any
+            // pessimistic "max byte count" calculation: assume there's a captured surrogate and that
+            // it must fall back.
+
+            long byteCount = (long)charCount + 1; // +1 to account for captured surrogate, per above
 
             if (EncoderFallback.MaxCharCount > 1)
                 byteCount *= EncoderFallback.MaxCharCount;
@@ -781,9 +793,24 @@ namespace System.Text
             if (byteCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(byteCount),
                      SR.ArgumentOutOfRange_NeedNonNegNum);
+            
+            // GetMaxCharCount assumes that the caller might have a stateful Decoder instance. If the
+            // Decoder instance already has a captured partial UTF-8 subsequence, then one of two
+            // thngs will happen:
+            //
+            // - The next byte(s) won't complete the subsequence but will instead be consumed into
+            //   the Decoder's internal state, resulting in no character output; or
+            // - The next byte(s) will complete the subsequence, and the previously captured
+            //   subsequence and the next byte(s) will result in 1 - 2 chars output; or
+            // - The captured subsequence will be treated as a singular ill-formed subsequence, at
+            //   which point the captured subsequence will go through the fallback routine.
+            //   (See The Unicode Standard, Sec. 3.9 for more information on this.)
+            //
+            // The third case is the worst-case scenario for expansion, since it means 0 bytes of
+            // new input could cause any existing captured state to expand via fallback. So it's
+            // what we'll use for any pessimistic "max char count" calculation.
 
-            // Figure out our length, 1 char per input byte + 1 char if 1st byte is last byte of 4 byte surrogate pair
-            long charCount = ((long)byteCount + 1);
+            long charCount = ((long)byteCount + 1); // +1 to account for captured subsequence, as above
 
             // Non-shortest form would fall back, so get max count from fallback.
             // So would 11... followed by 11..., so you could fall back every byte

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
@@ -793,7 +793,7 @@ namespace System.Text
             if (byteCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(byteCount),
                      SR.ArgumentOutOfRange_NeedNonNegNum);
-            
+
             // GetMaxCharCount assumes that the caller might have a stateful Decoder instance. If the
             // Decoder instance already has a captured partial UTF-8 subsequence, then one of two
             // thngs will happen:

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/SequentialOutput.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/SequentialOutput.cs
@@ -72,6 +72,7 @@ namespace System.Xml.Xsl.XsltOld
 
         // Uri Escaping:
         private byte[]? _byteBuffer;
+        private Encoding? _utf8Encoding;
 
         [MemberNotNull(nameof(_output))]
         private void CacheOuptutProps(XsltOutput output)
@@ -606,8 +607,12 @@ namespace System.Xml.Xsl.XsltOld
                     default:
                         if (127 < ch)
                         {
-                            _byteBuffer = new byte[Encoding.UTF8.GetMaxByteCount(1)];
-                            int bytes = Encoding.UTF8.GetBytes(value, i - 1, 1, _byteBuffer!, 0);
+                            if (_utf8Encoding == null)
+                            {
+                                _utf8Encoding = Encoding.UTF8;
+                                _byteBuffer = new byte[_utf8Encoding.GetMaxByteCount(1)];
+                            }
+                            int bytes = _utf8Encoding.GetBytes(value, i - 1, 1, _byteBuffer!, 0);
                             for (int j = 0; j < bytes; j++)
                             {
                                 Write("%");

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/SequentialOutput.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/SequentialOutput.cs
@@ -72,7 +72,6 @@ namespace System.Xml.Xsl.XsltOld
 
         // Uri Escaping:
         private byte[]? _byteBuffer;
-        private Encoding? _utf8Encoding;
 
         [MemberNotNull(nameof(_output))]
         private void CacheOuptutProps(XsltOutput output)
@@ -607,12 +606,8 @@ namespace System.Xml.Xsl.XsltOld
                     default:
                         if (127 < ch)
                         {
-                            if (_utf8Encoding == null)
-                            {
-                                _utf8Encoding = Encoding.UTF8;
-                                _byteBuffer = new byte[_utf8Encoding.GetMaxByteCount(1)];
-                            }
-                            int bytes = _utf8Encoding.GetBytes(value, i - 1, 1, _byteBuffer!, 0);
+                            _byteBuffer = new byte[Encoding.UTF8.GetMaxByteCount(1)];
+                            int bytes = Encoding.UTF8.GetBytes(value, i - 1, 1, _byteBuffer!, 0);
                             for (int j = 0; j < bytes; j++)
                             {
                                 Write("%");

--- a/src/libraries/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetMaxByteCount.cs
+++ b/src/libraries/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetMaxByteCount.cs
@@ -15,10 +15,24 @@ namespace System.Text.Tests
         public void GetMaxByteCount(int charCount)
         {
             int expected = (charCount + 1) * 3;
+            Assert.Equal(expected, Encoding.UTF8.GetMaxByteCount(charCount));
             Assert.Equal(expected, new UTF8Encoding(true, true).GetMaxByteCount(charCount));
             Assert.Equal(expected, new UTF8Encoding(true, false).GetMaxByteCount(charCount));
             Assert.Equal(expected, new UTF8Encoding(false, true).GetMaxByteCount(charCount));
             Assert.Equal(expected, new UTF8Encoding(false, false).GetMaxByteCount(charCount));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(int.MinValue)]
+        [InlineData(-1_000_000_000)]
+        [InlineData(-1_300_000_000)] // yields positive result when *3
+        [InlineData(int.MaxValue / 3)]
+        [InlineData(int.MaxValue)]
+        public void GetMaxByteCount_NegativeTests(int charCount)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(nameof(charCount), () => Encoding.UTF8.GetMaxByteCount(charCount));
+            Assert.Throws<ArgumentOutOfRangeException>(nameof(charCount), () => new UTF8Encoding().GetMaxByteCount(charCount));
         }
     }
 }

--- a/src/libraries/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetMaxCharCount.cs
+++ b/src/libraries/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingGetMaxCharCount.cs
@@ -15,10 +15,22 @@ namespace System.Text.Tests
         public void GetMaxCharCount(int byteCount)
         {
             int expected = byteCount + 1;
+            Assert.Equal(expected, Encoding.UTF8.GetMaxCharCount(byteCount));
             Assert.Equal(expected, new UTF8Encoding(true, true).GetMaxCharCount(byteCount));
             Assert.Equal(expected, new UTF8Encoding(true, false).GetMaxCharCount(byteCount));
             Assert.Equal(expected, new UTF8Encoding(false, true).GetMaxCharCount(byteCount));
             Assert.Equal(expected, new UTF8Encoding(false, false).GetMaxCharCount(byteCount));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(int.MinValue)]
+        [InlineData(-1_000_000_000)]
+        [InlineData(int.MaxValue)]
+        public void GetMaxCharCount_NegativeTests(int byteCount)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(nameof(byteCount), () => Encoding.UTF8.GetMaxCharCount(byteCount));
+            Assert.Throws<ArgumentOutOfRangeException>(nameof(byteCount), () => new UTF8Encoding().GetMaxCharCount(byteCount));
         }
     }
 }


### PR DESCRIPTION
Mostly a very small perf improvement to `GetMaxByteCount` and `GetMaxCharCount`. It's now small enough to inline into callers when using the `Encoding.UTF8` accelerator.

Also addresses:
* Adds integer overflow protection to some unmanaged callers.
* Improves unit test coverage.
* Cleans up some XML usage.

|             Method |        Job | Toolchain |  input |     Mean |    Error |   StdDev | Ratio | RatioSD |
|------------------- |----------- |---------- |------- |---------:|---------:|---------:|------:|--------:|
| GetTranscodedLenth | Job-LLVNSR |  baseline | Hello! | 15.27 ns | 0.383 ns | 1.123 ns |  1.00 |    0.00 |
| GetTranscodedLenth | Job-DMFSKR |   compare | Hello! | 13.51 ns | 0.306 ns | 0.340 ns |  0.87 |    0.06 |

```cs
[Benchmark]
[Arguments("Hello!")]
public int GetTranscodedLenth(string input)
{
    const int MaxStackLength = 64;
    byte[] rentedArray = null;
    int maxByteCount = Encoding.UTF8.GetMaxByteCount(input.Length);
    Span<byte> scratch = ((uint)maxByteCount <= MaxStackLength)
        ? stackalloc byte[MaxStackLength]
        : (rentedArray = ArrayPool<byte>.Shared.Rent(maxByteCount));

    try
    {
        return Encoding.UTF8.GetBytes(input, scratch);
    }
    finally
    {
        if (rentedArray != null)
        {
            ArrayPool<byte>.Shared.Return(rentedArray);
        }
    }
}
```