### PR TITLE
Add hot/cold splitting test job to jit-runtime-experimental

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -572,6 +572,7 @@ jobs:
           - jitosr_stress
           - jitosr_pgo
           - jitosr_stress_random
+          - jit_stress_splitting
           - jitpartialcompilation
           - jitpartialcompilation_osr
           - jitpartialcompilation_osr_pgo

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7966,6 +7966,10 @@ private:
     void unwindReserveFuncHelper(FuncInfoDsc* func, bool isHotCode);
     void unwindEmitFuncHelper(FuncInfoDsc* func, void* pHotCode, void* pColdCode, bool isHotCode);
 
+#ifdef DEBUG
+    void fakeUnwindEmitFuncHelper(FuncInfoDsc* func, void* pHotCode);
+#endif // DEBUG
+
 #endif // TARGET_AMD64 || (TARGET_X86 && FEATURE_EH_FUNCLETS)
 
     UNATIVE_OFFSET unwindGetCurrentOffset(FuncInfoDsc* func);

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -1125,14 +1125,13 @@ void Compiler::eeDispLineInfos()
 void Compiler::eeAllocMem(AllocMemArgs* args)
 {
 #ifdef DEBUG
-    // Fake splitting implementation: hot section = hot code + 4K buffer + cold code
-    const UNATIVE_OFFSET hotSizeRequest      = args->hotCodeSize;
-    const UNATIVE_OFFSET coldSizeRequest     = args->coldCodeSize;
-    const UNATIVE_OFFSET fakeSplittingBuffer = 4096;
+    const UNATIVE_OFFSET hotSizeRequest  = args->hotCodeSize;
+    const UNATIVE_OFFSET coldSizeRequest = args->coldCodeSize;
 
+    // Fake splitting implementation: place hot/cold code in contiguous section
     if (JitConfig.JitFakeProcedureSplitting() && (coldSizeRequest > 0))
     {
-        args->hotCodeSize  = hotSizeRequest + fakeSplittingBuffer + coldSizeRequest;
+        args->hotCodeSize  = hotSizeRequest + coldSizeRequest;
         args->coldCodeSize = 0;
     }
 #endif
@@ -1143,8 +1142,8 @@ void Compiler::eeAllocMem(AllocMemArgs* args)
     if (JitConfig.JitFakeProcedureSplitting() && (coldSizeRequest > 0))
     {
         // Fix up hot/cold code pointers
-        args->coldCodeBlock   = ((BYTE*)args->hotCodeBlock) + hotSizeRequest + fakeSplittingBuffer;
-        args->coldCodeBlockRW = ((BYTE*)args->hotCodeBlockRW) + hotSizeRequest + fakeSplittingBuffer;
+        args->coldCodeBlock   = ((BYTE*)args->hotCodeBlock) + hotSizeRequest;
+        args->coldCodeBlockRW = ((BYTE*)args->hotCodeBlockRW) + hotSizeRequest;
 
         // Reset args' hot/cold code sizes in case caller reads them later
         args->hotCodeSize  = hotSizeRequest;
@@ -1160,13 +1159,6 @@ void Compiler::eeReserveUnwindInfo(bool isFunclet, bool isColdCode, ULONG unwind
     {
         printf("reserveUnwindInfo(isFunclet=%s, isColdCode=%s, unwindSize=0x%x)\n", isFunclet ? "true" : "false",
                isColdCode ? "true" : "false", unwindSize);
-    }
-
-    // Fake splitting currently does not handle unwind info for cold code
-    if (isColdCode && JitConfig.JitFakeProcedureSplitting())
-    {
-        JITDUMP("reserveUnwindInfo for cold code with JitFakeProcedureSplitting enabled: ignoring cold unwind info\n");
-        return;
     }
 #endif // DEBUG
 
@@ -1206,13 +1198,6 @@ void Compiler::eeAllocUnwindInfo(BYTE*          pHotCode,
                 break;
         }
         printf(")\n");
-    }
-
-    // Fake splitting currently does not handle unwind info for cold code
-    if (pColdCode && JitConfig.JitFakeProcedureSplitting())
-    {
-        JITDUMP("allocUnwindInfo for cold code with JitFakeProcedureSplitting enabled: ignoring cold unwind info\n");
-        return;
     }
 #endif // DEBUG
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6637,10 +6637,13 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             {
                 // The allocated chunk is bigger than used, fill in unused space in it.
                 unsigned unusedSize = allocatedHotCodeSize - emitCurCodeOffs(cp);
+                BYTE*    cpRW       = cp + writeableOffset;
                 for (unsigned i = 0; i < unusedSize; ++i)
                 {
-                    *cp++ = DEFAULT_CODE_BUFFER_INIT;
+                    *cpRW++ = DEFAULT_CODE_BUFFER_INIT;
                 }
+
+                cp = cpRW - writeableOffset;
                 assert(allocatedHotCodeSize == emitCurCodeOffs(cp));
             }
         }

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -196,11 +196,6 @@ CONFIG_INTEGER(JitDumpInlinePhases, W("JitDumpInlinePhases"), 1) // Dump inline 
 CONFIG_METHODSET(JitEHDump, W("JitEHDump")) // Dump the EH table for the method, as reported to the VM
 CONFIG_METHODSET(JitExclude, W("JitExclude"))
 CONFIG_INTEGER(JitFakeProcedureSplitting, W("JitFakeProcedureSplitting"), 0) // Do code splitting independent of VM.
-                                                                             // For now, this disables unwind info for
-                                                                             // cold sections, breaking stack walks.
-                                                                             // Set COMPlus_GCgen0size=1000000 to avoid
-                                                                             // running the GC, which requires
-                                                                             // stack-walking.
 CONFIG_METHODSET(JitForceProcedureSplitting, W("JitForceProcedureSplitting"))
 CONFIG_METHODSET(JitGCDump, W("JitGCDump"))
 CONFIG_METHODSET(JitDebugDump, W("JitDebugDump"))

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -42,7 +42,9 @@
       COMPlus_HeapVerify;
       COMPlus_JITMinOpts;
       COMPlus_JitELTHookEnabled;
+      COMPlus_JitFakeProcedureSplitting;
       COMPlus_JitStress;
+      COMPlus_JitStressProcedureSplitting;
       COMPlus_JitStressRegs;
       COMPlus_TailcallStress;
       COMPlus_ReadyToRun;
@@ -188,6 +190,7 @@
     <TestEnvironment Include="jitosr" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TieredCompilation="1" />
     <TestEnvironment Include="jitosr_stress" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TC_OnStackReplacement_InitialCounter="1" OSR_HitLimit="1" TieredCompilation="1" />
     <TestEnvironment Include="jitosr_stress_random" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TC_OnStackReplacement_InitialCounter="1" OSR_HitLimit="2" TieredCompilation="1" JitRandomOnStackReplacement="15"/>
+    <TestEnvironment Include="jit_stress_splitting" JitFakeProcedureSplitting="1" JitStressProcedureSplitting="1" />
     <TestEnvironment Include="jitosr_pgo" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" />
     <TestEnvironment Include="jitpartialcompilation" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" />
     <TestEnvironment Include="jitpartialcompilation_pgo" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" />


### PR DESCRIPTION
Adding a new rolling test job to `JIT-runtime-experimental` can help ensure the [new](https://github.com/dotnet/runtime/pull/69763) fake- and stress-splitting modes in the JIT do not regress. The proposed test, titled `jitosr_stress_splitting`, runs a Checked build of the JIT on OS- and platform-specific test suites with the following environment:

- COMPlus_GCgen0size=1000000
- COMPlus_JitFakeProcedureSplitting=1
- COMPlus_JitStressprocedureSplitting=1

This environment forces the JIT to fake-split every method after its first basic block, assuming the method consists of more than one block. `COMPlus_GCgen0size=1000000` sets a large memory allocation threshold before the GC runs; recall that `COMPlus_JitFakeProcedureSplitting` currently doesn't generate unwind information for cold code, thus breaking the GC's stack walks. `COMPlus_GCgen0size` provides a patchwork fix for this limitation in cases where memory usage is not excessive (i.e. `>= 0x1000000 B`).

In my local testing, all of the x64 tests in `src/tests/` pass with this environment.