### PR TITLE
JIT: allow pinvoke calli helper in TreatAsShouldHaveRetBufArg

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2097,14 +2097,14 @@ bool GenTreeCall::TreatAsShouldHaveRetBufArg(Compiler* compiler) const
         return true;
     }
 
-    // If we see a Jit helper call that returns a TYP_STRUCT we will
+    // If we see a Jit helper call that returns a TYP_STRUCT we may
     // transform it as if it has a Return Buffer Argument
     //
     if (IsHelperCall() && (gtReturnType == TYP_STRUCT))
     {
-        // There are two possible helper calls that use this path:
-        //  CORINFO_HELP_GETFIELDSTRUCT and CORINFO_HELP_UNBOX_NULLABLE
-        //
+        // There are three possible helper calls that use this path:
+        //  CORINFO_HELP_GETFIELDSTRUCT,  CORINFO_HELP_UNBOX_NULLABLE
+        //  CORINFO_HELP_PINVOKE_CALLI
         CorInfoHelpFunc helpFunc = compiler->eeGetHelperNum(gtCallMethHnd);
 
         if (helpFunc == CORINFO_HELP_GETFIELDSTRUCT)
@@ -2114,6 +2114,10 @@ bool GenTreeCall::TreatAsShouldHaveRetBufArg(Compiler* compiler) const
         else if (helpFunc == CORINFO_HELP_UNBOX_NULLABLE)
         {
             return true;
+        }
+        else if (helpFunc == CORINFO_HELP_PINVOKE_CALLI)
+        {
+            return false;
         }
         else
         {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_69612/Runtime_69612.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_69612/Runtime_69612.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+ref struct NewReference
+{
+    public IntPtr pointer;
+}
+
+static unsafe class Delegates
+{
+    static Delegates()
+    {
+        PyLong_FromLongLong = (delegate* unmanaged[Cdecl]<long, NewReference>)0xbadcab;
+        z = 100;
+    }
+
+    public static delegate* unmanaged[Cdecl]<long, NewReference> PyLong_FromLongLong { get; }
+    public static long z;
+}
+
+class Runtime_69612
+{
+    static NewReference ToPython(object value, Type type)
+    {
+        TypeCode tc = Type.GetTypeCode(type);
+        
+        switch (tc)
+        {
+            case TypeCode.Byte:
+                return PyInt_FromInt32((byte)value);
+            case TypeCode.Int16:
+                return PyInt_FromInt32((short)value);
+            case TypeCode.UInt16:
+                return PyInt_FromInt32((ushort)value);
+            case TypeCode.Int32:
+                return PyInt_FromInt32((int)value);
+            default:
+                return new NewReference();
+        }
+    }
+
+    static NewReference PyInt_FromInt32(int value) => PyLong_FromLongLong(value);
+
+    unsafe static NewReference PyLong_FromLongLong(long value) => Delegates.PyLong_FromLongLong(value);
+
+    [MethodImpl(MethodImplOptions.NoOptimization)]
+    static int Main()
+    {
+        for (int i = 0; i < 100; i++)
+        {
+            _ =  ToPython(Delegates.z, typeof(long));
+            Thread.Sleep(15);
+        }
+
+        Thread.Sleep(50);
+        _ = ToPython(Delegates.z, typeof(long));
+        return 100;
+
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_69612/Runtime_69612.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_69612/Runtime_69612.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_TieredCompilation=1
+set COMPlus_TieredPGO=1
+set COMPlus_TC_QuickJitForLoops=1
+set COMPlus_TC_OnStackReplacement=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_TieredCompilation=1
+export COMPlus_TieredPGO=1
+export COMPlus_TC_QuickJitForLoops=1
+export COMPlus_TC_OnStackReplacement=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
If we have multiple cold pinvokes in return positions that return
structs by value and we are merging returns, we will end up querying
these calls post-morph, and may see them using CORINFO_HELP_PINVOKE_CALLI.

Fixes #69612.