### PR TITLE
[Release/6.0] Fix singlefile bundle alignment on OSX ARM64

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/TargetInfo.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/TargetInfo.cs
@@ -57,7 +57,7 @@ namespace Microsoft.NET.HostModel.Bundle
                 throw new ArgumentException($"Invalid input: Unsupported Target Framework Version {targetFrameworkVersion}");
             }
 
-            if (IsLinux && Arch == Architecture.Arm64)
+            if (Arch == Architecture.Arm64)
             {
                 // We align assemblies in the bundle at 4K so that we can use mmap on Linux without changing the page alignment of ARM64 R2R code.
                 // This is only necessary for R2R assemblies, but we do it for all assemblies for simplicity.


### PR DESCRIPTION
This is a small subset of #68845 that is relevant to 6.0 as well

For ARM64 we need to use the same 4K bundle alignment on OSX as on Linux. 
The reason for the alignment is not specific to OS, but specific to the instruction set. On ARM64 ADRP instruction works with 4K granularity. 
Since we do not perform any fixups for this at load time, we need to keep 4K alignment when placing files in a singlefile bundle. 

## Customer Impact

Depending on how files are placed in a bundle, we may see a crash when executing R2R code in a singlefile app on OSX.
Fixes: https://github.com/dotnet/runtime/issues/69923

## Testing
Regular test passes. 
Manually verified that replacing SDK version `Microsoft.NET.HostModel.dll` with a fixed version makes the crash described in #69923 disappear.

## Risk
Low. 
This is the same alignment strategy as used on ARM64 Linux for a very long time.
