### PR TITLE
Change dispenser policy for RuntimeAssembly to ReuseAlways

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DefaultDispenserPolicy.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DefaultDispenserPolicy.cs
@@ -29,7 +29,7 @@ namespace System.Reflection.Runtime.Dispensers
 
                 // Scope definition handle to RuntimeAssembly
                 case DispenserScenario.Scope_Assembly:
-                    return DispenserAlgorithm.ReuseAsLongAsValueIsAlive;
+                    return DispenserAlgorithm.ReuseAlways; // Match policy used for runtime Assembly instances in other runtime flavors.
 
                 default:
                     return DispenserAlgorithm.CreateAlways;


### PR DESCRIPTION
This matches the policy used by all other runtime flavors.

Fixes #69743