### PR TITLE
Use the signature's struct handle for making outgoing arg copies

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5616,7 +5616,7 @@ private:
     GenTreeFieldList* fgMorphLclArgToFieldlist(GenTreeLclVarCommon* lcl);
     GenTreeCall* fgMorphArgs(GenTreeCall* call);
 
-    void fgMakeOutgoingStructArgCopy(GenTreeCall* call, CallArg* arg, CORINFO_CLASS_HANDLE copyBlkClass);
+    void fgMakeOutgoingStructArgCopy(GenTreeCall* call, CallArg* arg);
 
     GenTree* fgMorphLocalVar(GenTree* tree, bool forceRemorph);
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_69965/Runtime_69965.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_69965/Runtime_69965.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+public unsafe class Runtime_69965
+{
+    public static int Main()
+    {
+        const int Value = 10;
+        var vtor = Vector128.Create(Value, Value, Value, Value);
+        var vtors = new StructWithOverlappedVtor128[] { new StructWithOverlappedVtor128 { Vtor = vtor } };
+
+        return Problem(vtors) != Value ? 101 : 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Problem(StructWithOverlappedVtor128[] a)
+    {
+        static Vector128<int> Tunnel(StructWithOverlappedVtor128[] a) => a[0].Vtor;
+
+        return CallForVtor(Tunnel(a));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int CallForVtor(Vector128<int> value) => value.GetElement(0);
+
+    [StructLayout(LayoutKind.Explicit)]
+    struct StructWithOverlappedVtor128
+    {
+        [FieldOffset(16)]
+        public Vector128<int> Vtor;
+        [FieldOffset(16)]
+        public Vector128<uint> AnotherVtor;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_69965/Runtime_69965.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_69965/Runtime_69965.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1795809&view=ms.vss-build-web.run-extensions-tab) as expected.

Fixes #69965.