### PR TITLE
Fix incorrect BigInteger multiply result for -a * a

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2693,7 +2693,7 @@ namespace System.Numerics
                                 : bitsFromPool = ArrayPool<uint>.Shared.Rent(size)).Slice(0, size);
 
                 BigIntegerCalculator.Square(left, bits);
-                result = new BigInteger(bits, negative: false);
+                result = new BigInteger(bits, (leftSign < 0) ^ (rightSign < 0));
             }
             else if (left.Length < right.Length)
             {

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/multiply.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/multiply.cs
@@ -204,6 +204,30 @@ namespace System.Numerics.Tests
             VerifyMultiplyString(Math.Pow(2, 33) + " 2 bMultiply");
         }
 
+        [Fact]
+        public static void RunMultiply_OnePositiveOneNegative()
+        {
+            Random random = new Random(s_seed);
+            byte[] tempByteArray1 = new byte[0];
+
+            // Multiply Method - One positive and one negative BigIntegers
+            for (int i = 0; i < s_samples; i++)
+            {
+                try
+                {
+                    tempByteArray1 = GetRandomByteArray(random);
+                    string randBigInt = Print(tempByteArray1);
+                    VerifyMultiplyString(randBigInt + randBigInt + "uNegate bMultiply");
+
+                }
+                catch (IndexOutOfRangeException)
+                {
+                    Console.WriteLine("Array1: " + Print(tempByteArray1));
+                    throw;
+                }
+            }
+        }
+
         private static void VerifyMultiplyString(string opstring)
         {
             StackCalc sc = new StackCalc(opstring);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/69970

Regression from https://github.com/dotnet/runtime/pull/35565
