### PR TITLE
[release/6.0] Fix building with clang 14

### DIFF
--- a/src/libraries/Native/Unix/CMakeLists.txt
+++ b/src/libraries/Native/Unix/CMakeLists.txt
@@ -22,7 +22,7 @@ if(CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS
 endif()
 set(CMAKE_INSTALL_PREFIX $ENV{__CMakeBinDir})
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wno-declaration-after-statement")
 set(VERSION_FILE_PATH "${CMAKE_BINARY_DIR}/version.c")
 
 # We mark the function which needs exporting with PALEXPORT


### PR DESCRIPTION
Under clang 14, building runtime on Linux with a simple ./build.sh
fails with hundreds of errors that all look like this:

    runtime/src/libraries/Native/Unix/System.Native/pal_networking.c(2610,9):
    error GD58BE485: mixing declarations and code is incompatible with
    standards before C99 [-Wdeclaration-after-statement]
    [runtime/src/libraries/Native/build-native.proj]

This issue is not present in the main branch. It appears to have been
fixed by https://github.com/dotnet/runtime/pull/66410/ which turned off
that warning.

Tested with:

    $ clang --version
    clang version 14.0.0 (Fedora 14.0.0-1.fc36)
    Target: x86_64-redhat-linux-gnu
    Thread model: posix
    InstalledDir: /usr/bin