### PR TITLE
Fix `--fulllog` in ILC/crossgen2

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/FirstMarkLogStrategy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/FirstMarkLogStrategy.cs
@@ -85,10 +85,9 @@ namespace ILCompiler.DependencyAnalysisFramework
                     {
                         var combinedNode = new Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>>(markData.Reason1, markData.Reason2);
 
-                        if (!combinedNodesReported.Contains(combinedNode))
+                        if (combinedNodesReported.Add(combinedNode))
                         {
                             logNodeVisitor.VisitCombinedNode(combinedNode);
-                            combinedNodesReported.Add(combinedNode);
                         }
                     }
                 }

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/FullGraphLogStrategy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/FullGraphLogStrategy.cs
@@ -157,10 +157,9 @@ namespace ILCompiler.DependencyAnalysisFramework
                         {
                             var combinedNode = new Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>>(markData.Reason1, markData.Reason2);
 
-                            if (!combinedNodesReported.Contains(combinedNode))
+                            if (combinedNodesReported.Add(combinedNode))
                             {
                                 logNodeVisitor.VisitCombinedNode(combinedNode);
-                                combinedNodesReported.Add(combinedNode);
                             }
                         }
                     }

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/FullGraphLogStrategy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/FullGraphLogStrategy.cs
@@ -160,6 +160,7 @@ namespace ILCompiler.DependencyAnalysisFramework
                             if (!combinedNodesReported.Contains(combinedNode))
                             {
                                 logNodeVisitor.VisitCombinedNode(combinedNode);
+                                combinedNodesReported.Add(combinedNode);
                             }
                         }
                     }


### PR DESCRIPTION
Fixes issue reported in https://github.com/dotnet/runtime/issues/66716#issuecomment-1069310326.

We create a hashset for the purpose of avoiding this problem, check it, but never add to it.

Cc @dotnet/ilc-contrib @dotnet/crossgen-contrib 