### PR TITLE
Disable TarWriter_WriteEntry_File_Tests.Add_File in Linux

### DIFF
--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
@@ -65,6 +65,7 @@ namespace System.Formats.Tar.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/69474", TestPlatforms.Linux)]
         [Theory]
         [InlineData(TarFormat.V7)]
         [InlineData(TarFormat.Ustar)]


### PR DESCRIPTION
Failing in Ubuntu and RedHat: https://github.com/dotnet/runtime/issues/69474#issuecomment-1141670255

Disabling to unblock PRs.