### PR TITLE
Reflection.Metadata.Tests: make tests pass when rsa+sha1 signing is not supported.

### DIFF
--- a/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEBuilderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEBuilderTests.cs
@@ -135,7 +135,7 @@ namespace System.Reflection.PortableExecutable.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SigningUtilities), nameof(SigningUtilities.SupportsSigning))]
         [SkipOnPlatform(TestPlatforms.Browser, "System.Security.Cryptography isn't supported on browser")]
         public void BasicValidationSigned()
         {
@@ -748,7 +748,7 @@ namespace System.Reflection.PortableExecutable.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SigningUtilities), nameof(SigningUtilities.SupportsSigning))]
         [SkipOnPlatform(TestPlatforms.Browser, "System.Security.Cryptography isn't supported on browser")]
         public void Checksum()
         {

--- a/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -9,6 +9,8 @@
     <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\SignatureSupport.cs"
+             Link="CommonTest\System\Security\Cryptography\SignatureSupport.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs"
              Link="Common\Interop\Windows\Interop.Libraries.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs"

--- a/src/libraries/System.Reflection.Metadata/tests/TestUtilities/SigningUtilities.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/TestUtilities/SigningUtilities.cs
@@ -11,31 +11,8 @@ namespace System.Reflection.PortableExecutable.Tests
 {
     internal static class SigningUtilities
     {
-        private static int _supportsSigning = 0;
-
-        public static bool SupportsSigning
-        {
-            get
-            {
-                if (_supportsSigning == 0)
-                {
-                    bool supported;
-                    try
-                    {
-                        using var rsa = RSA.Create();
-                        rsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
-                        supported = true;
-                    }
-                    catch (CryptographicException)
-                    {
-                        supported = false;
-                    }
-
-                    _supportsSigning = supported ? 1 : -1;
-                }
-                return _supportsSigning == 1;
-            }
-        }
+        public static bool SupportsSigning { get; } =
+            System.Security.Cryptography.Tests.SignatureSupport.CanProduceSha1Signature(RSA.Create());
 
         public static byte[] CalculateRsaSignature(IEnumerable<Blob> content, byte[] privateKey)
         {

--- a/src/libraries/System.Reflection.Metadata/tests/TestUtilities/SigningUtilities.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/TestUtilities/SigningUtilities.cs
@@ -11,6 +11,32 @@ namespace System.Reflection.PortableExecutable.Tests
 {
     internal static class SigningUtilities
     {
+        private static int _supportsSigning = 0;
+
+        public static bool SupportsSigning
+        {
+            get
+            {
+                if (_supportsSigning == 0)
+                {
+                    bool supported;
+                    try
+                    {
+                        using var rsa = RSA.Create();
+                        rsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
+                        supported = true;
+                    }
+                    catch (CryptographicException)
+                    {
+                        supported = false;
+                    }
+
+                    _supportsSigning = supported ? 1 : -1;
+                }
+                return _supportsSigning == 1;
+            }
+        }
+
         public static byte[] CalculateRsaSignature(IEnumerable<Blob> content, byte[] privateKey)
         {
             var hash = CalculateSha1(content);


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/65874.

@bartonjs @vcsjones ptal.