### PR TITLE
[wasm][debugger] Added Default Interface Method tests.

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -820,7 +820,7 @@ namespace DebuggerTests
             );
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(RunningOnChrome))]
         [InlineData("IDefaultInterface", "DefaultMethod", "Evaluate", 1070, 1001, 999, 1003)]
         [InlineData("IExtendIDefaultInterface", "IDefaultInterface.DefaultMethodToOverride", "Evaluate", 1071, 1030, 1028, 1032)]
         [InlineData("IDefaultInterface", "DefaultMethodAsync", "EvaluateAsync", 37, 1014, 1012, 1016, true, "Start<IDefaultInterface/<DefaultMethodAsync>d__2>")]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -1221,33 +1221,21 @@ namespace DebuggerTests
                 await CheckProps(props, expected_props, "props#2");
              });
 
-        [Fact]
-        public async Task EvaluateDefaultInterfaceMethod() =>  
-            await CheckInspectLocalsAtBreakpointSite(
-            "DefaultInterfaceMethod", "Evaluate", 7, "Evaluate",
-            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DefaultInterfaceMethod:Evaluate'); })",
-            wait_for_event_fn: async (pause_location) =>
-            {
-                var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
-
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("defaultFromIDefault", TString("DefaultMethod() from IDefaultInterface")),
-                    ("defaultFromIOverride", TString("DefaultMethod() from IDefaultInterface")),
-                    ("default2FromIOverride", TString("DefaultMethod2() from IOverrideDefaultInterface"))
-                );
-            });
-
         [Theory]
-        [InlineData("DefaultMethod", "IDefaultInterface")]
-        [InlineData("DefaultMethod2", "IOverrideDefaultInterface")]
-        public async Task EvaluateLocalsInDefaultInterfaceMethod(string pauseMethod, string methodInterface) =>  
+        [InlineData("DefaultMethod", "IDefaultInterface", "Evaluate")]
+        [InlineData("DefaultMethod2", "IExtendIDefaultInterface", "Evaluate")]
+        [InlineData("DefaultMethodAsync", "IDefaultInterface", "EvaluateAsync", true)]
+        public async Task EvaluateLocalsInDefaultInterfaceMethod(string pauseMethod, string methodInterface, string entryMethod, bool isAsync = false) =>
             await CheckInspectLocalsAtBreakpointSite(
-            methodInterface, pauseMethod, 2, pauseMethod,
-            $"window.setTimeout(function() {{ invoke_static_method ('[debugger-test] DefaultInterfaceMethod:Evaluate'); }})",
+            methodInterface, pauseMethod, 2, isAsync ? "MoveNext" : pauseMethod,
+            $"window.setTimeout(function() {{ invoke_static_method ('[debugger-test] DefaultInterfaceMethod:{entryMethod}'); }})",
             wait_for_event_fn: async (pause_location) =>
             {
                 var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
-                await EvaluateOnCallFrameAndCheck(id, ("localString", TString($"{pauseMethod}()")));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("localString", TString($"{pauseMethod}()")),
+                    ("this", TObject("DIMClass")),
+                    ("this.dimClassMember", TNumber(123)));
             });
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -999,16 +999,37 @@ public interface IDefaultInterface
     string DefaultMethod()
     {
         string localString = "DefaultMethod()";
+        DefaultInterfaceMethod.MethodForCallingFromDIM();
         return $"{localString} from IDefaultInterface";
+    }
+    
+    int DefaultMethodToOverride()
+    {
+        int retValue = 10;
+        return retValue;
+    }
+
+    async System.Threading.Tasks.Task DefaultMethodAsync()
+    {
+        string localString = "DefaultMethodAsync()";
+        DefaultInterfaceMethod.MethodForCallingFromDIM();
+        await System.Threading.Tasks.Task.FromResult(0);
     }
 }
 
-public interface IOverrideDefaultInterface : IDefaultInterface
+public interface IExtendIDefaultInterface : IDefaultInterface
 {
     void DefaultMethod2(out string t)
     {
         string localString = "DefaultMethod2()";
-        t = $"{localString} from IOverrideDefaultInterface";
+        t = $"{localString} from IExtendIDefaultInterface";
+    }
+
+    int IDefaultInterface.DefaultMethodToOverride()
+    {
+        int retValue = 110;
+        DefaultInterfaceMethod.MethodForCallingFromDIM();
+        return retValue;
     }
 
     [System.Diagnostics.DebuggerHidden]
@@ -1037,22 +1058,54 @@ public interface IOverrideDefaultInterface : IDefaultInterface
     }
 }
 
-public class DIMClass : IOverrideDefaultInterface { }
+public class DIMClass : IExtendIDefaultInterface
+{
+    public int dimClassMember = 123;
+}
 
 public static class DefaultInterfaceMethod
 {
     public static void Evaluate()
     {
+        IExtendIDefaultInterface extendDefaultInter = new DIMClass();
+        string defaultFromIDefault = extendDefaultInter.DefaultMethod();
+        int overrideFromIExtend = extendDefaultInter.DefaultMethodToOverride();
+        extendDefaultInter.DefaultMethod2(out string default2FromIExtend);
+    }
+    
+    public static async void EvaluateAsync()
+    {
         IDefaultInterface defaultInter = new DIMClass();
-        IOverrideDefaultInterface overrideDefaultInter = new DIMClass();
+        await defaultInter.DefaultMethodAsync();
+    }
 
-        string defaultFromIDefault = defaultInter.DefaultMethod();
-        string defaultFromIOverride = overrideDefaultInter.DefaultMethod();
-        overrideDefaultInter.DefaultMethod2(out string default2FromIOverride);
-        overrideDefaultInter.StepThroughDefaultMethod();
-        overrideDefaultInter.NonUserCodeDefaultMethod();
-        overrideDefaultInter.HiddenDefaultMethod();
-        overrideDefaultInter.NonUserCodeDefaultMethod(overrideDefaultInter.BoundaryBp);
+    public static void EvaluateHiddenAttr()
+    {
+        IExtendIDefaultInterface extendDefaultInter = new DIMClass();
+        extendDefaultInter.HiddenDefaultMethod();
+    }
+
+    public static void EvaluateStepThroughAttr()
+    {
+        IExtendIDefaultInterface extendDefaultInter = new DIMClass();
+        extendDefaultInter.StepThroughDefaultMethod();
+    }
+
+    public static void EvaluateNonUserCodeAttr()
+    {
+        IExtendIDefaultInterface extendDefaultInter = new DIMClass();
+        extendDefaultInter.NonUserCodeDefaultMethod();
+    }
+
+    public static void EvaluateStepperBoundaryAttr()
+    {
+        IExtendIDefaultInterface extendDefaultInter = new DIMClass();
+        extendDefaultInter.NonUserCodeDefaultMethod(extendDefaultInter.BoundaryBp);
+    }
+
+    public static void MethodForCallingFromDIM()
+    {
+        string text = "a place for pausing and inspecting DIM";
     }
 }
 #endregion

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -992,3 +992,67 @@ public class TestHotReloadUsingSDB {
             myMethod.Invoke(null, null);
         }
 }
+
+#region Default Interface Method
+public interface IDefaultInterface
+{
+    string DefaultMethod()
+    {
+        string localString = "DefaultMethod()";
+        return $"{localString} from IDefaultInterface";
+    }
+}
+
+public interface IOverrideDefaultInterface : IDefaultInterface
+{
+    void DefaultMethod2(out string t)
+    {
+        string localString = "DefaultMethod2()";
+        t = $"{localString} from IOverrideDefaultInterface";
+    }
+
+    [System.Diagnostics.DebuggerHidden]
+    void HiddenDefaultMethod()
+    {
+        var a = 9;
+    }
+
+    [System.Diagnostics.DebuggerStepThroughAttribute]
+    void StepThroughDefaultMethod()
+    {
+        var a = 0;
+    }
+
+    [System.Diagnostics.DebuggerNonUserCode]
+    void NonUserCodeDefaultMethod(Action boundaryTestFun = null)
+    {
+        if (boundaryTestFun != null)
+            boundaryTestFun();
+    }
+
+    [System.Diagnostics.DebuggerStepperBoundary]
+    void BoundaryBp()
+    {
+        var a = 15;
+    }
+}
+
+public class DIMClass : IOverrideDefaultInterface { }
+
+public static class DefaultInterfaceMethod
+{
+    public static void Evaluate()
+    {
+        IDefaultInterface defaultInter = new DIMClass();
+        IOverrideDefaultInterface overrideDefaultInter = new DIMClass();
+
+        string defaultFromIDefault = defaultInter.DefaultMethod();
+        string defaultFromIOverride = overrideDefaultInter.DefaultMethod();
+        overrideDefaultInter.DefaultMethod2(out string default2FromIOverride);
+        overrideDefaultInter.StepThroughDefaultMethod();
+        overrideDefaultInter.NonUserCodeDefaultMethod();
+        overrideDefaultInter.HiddenDefaultMethod();
+        overrideDefaultInter.NonUserCodeDefaultMethod(overrideDefaultInter.BoundaryBp);
+    }
+}
+#endregion


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/69747.
Adds test of Default Interface Method checking if:
- We can access local variables, this and this's members on pause in DIM and async DIM (EvaluateLocalsInDefaultInterfaceMethod);
- We can set and hit a breakpoint in DIM and async DIM and resume it (BreakInDefaultInterfaceMethod) - here we are checking previous frame from DIM and then we call a method in DIM to check from there the previous frame that belongs to DIM;
- Method attributes are accessible and working: hidden attribute (CheckDefaultInterfaceMethodHiddenAttribute), step through and non-user code (StepThroughOrNonUserCodeAttributeStepInNoBp), stepper boundary (StepperBoundary).