### PR TITLE
Reenable GetHostAddressesTest_Cancellation on Unix

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -178,7 +178,6 @@ namespace System.Net.NameResolution.Tests
     public class GetHostAddressesTest_Cancellation
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
         public async Task DnsGetHostAddresses_PostCancelledToken_Throws()
         {
             using var cts = new CancellationTokenSource();
@@ -195,7 +194,6 @@ namespace System.Net.NameResolution.Tests
 
         // This is a regression test for https://github.com/dotnet/runtime/issues/63552
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
         public async Task DnsGetHostAddresses_ResolveParallelCancelOnFailure_AllCallsReturn()
         {
             string invalidAddress = TestSettings.UncachedHost;


### PR DESCRIPTION
The original issue (#33378) is marked as closed by (#34633).