### PR TITLE
Enable MsQuicTests.ConnectWithClientCertificate on Windows

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -393,7 +393,6 @@ namespace System.Net.Quic.Tests
         [InlineData(false, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/64944", TestPlatforms.Windows)]
         public async Task ConnectWithClientCertificate(bool sendCertificate, bool useClientSelectionCallback)
         {
             if (PlatformDetection.IsWindows10Version20348OrLower)


### PR DESCRIPTION
Fixes #64944.

Newer MsQuic version is now being consumed since #69127 was merged, so reenabling the test should be okay.

Context: https://github.com/dotnet/runtime/pull/69843#issuecomment-1138523394

CC: @wfurt.