### PR TITLE
[Mono] Fix test skipping for mobile device runtime tests

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
+++ b/src/tests/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Coreclr.TestWrapper\CoreclrTestWrapperLib.cs" Link="CoreclrTestWrapperLib.cs" />
+    <Compile Include="..\Coreclr.TestWrapper\MobileAppHandler.cs" Link="MobileAppHandler.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -14,6 +14,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
+using MobileTestLib;
 
 namespace CoreclrTestLib
 {
@@ -342,10 +343,10 @@ namespace CoreclrTestLib
                         // Process completed. Check process.ExitCode here.
                         exitCode = process.ExitCode;
 
-                        var retriableCodes = CoreclrTestLib.MobileAppHandler.GetKnownExitCodes();
+                        var retriableCodes = MobileAppHandler.GetKnownExitCodes();
                         if (retriableCodes.Contains(exitCode))
                         {
-                            CoreclrTestLib.MobileAppHandler.CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
+                            MobileAppHandler.CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
                             outputWriter.WriteLine("\nInfra issue was detected and a work item retry was requested");
                         }
 

--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -307,8 +307,7 @@ namespace CoreclrTestLib
             {
                 if (File.Exists($"{testBinaryBase}/.retry"))
                 {
-                    // We have requested a work item retry because of an infra issue - no point executing further tests
-                    outputWriter.WriteLine("\nretry file was found, quit testing...");
+                    outputWriter.WriteLine("\nWork item retry had been requested earlier - skipping test...");
                 }
                 else
                 {

--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -291,12 +291,6 @@ namespace CoreclrTestLib
 
             int exitCode = -100;
 
-            if (File.Exists($"{testBinaryBase}/.retry"))
-            {
-                // We have requested a work item retry because of an infra issue - no point executing further tests
-                return exitCode;
-            }
-
             // If a timeout was given to us by an environment variable, use it instead of the default
             // timeout.
             string environmentVar = Environment.GetEnvironmentVariable(TIMEOUT_ENVIRONMENT_VAR);
@@ -311,92 +305,99 @@ namespace CoreclrTestLib
             using (var errorWriter = new StreamWriter(errorStream))
             using (Process process = new Process())
             {
-                // Windows can run the executable implicitly
-                if (OperatingSystem.IsWindows())
+                if (File.Exists($"{testBinaryBase}/.retry"))
                 {
-                    process.StartInfo.FileName = executable;
-                }
-                // Non-windows needs to be told explicitly to run through /bin/bash shell
-                else
-                {
-                    process.StartInfo.FileName = "/bin/bash";
-                    process.StartInfo.Arguments = executable;
-                }
-
-                process.StartInfo.UseShellExecute = false;
-                process.StartInfo.RedirectStandardOutput = true;
-                process.StartInfo.RedirectStandardError = true;
-                process.StartInfo.EnvironmentVariables.Add("__Category", category);
-                process.StartInfo.EnvironmentVariables.Add("__TestBinaryBase", testBinaryBase);
-                process.StartInfo.EnvironmentVariables.Add("__OutputDir", outputDir);
-
-                DateTime startTime = DateTime.Now;
-                process.Start();
-
-                var cts = new CancellationTokenSource();
-                Task copyOutput = process.StandardOutput.BaseStream.CopyToAsync(outputStream, 4096, cts.Token);
-                Task copyError = process.StandardError.BaseStream.CopyToAsync(errorStream, 4096, cts.Token);
-
-                if (process.WaitForExit(timeout))
-                {
-                    // Process completed. Check process.ExitCode here.
-                    exitCode = process.ExitCode;
-
-                    var retriableCodes = MobileAppHandler.GetKnownExitCodes();
-                    if (retriableCodes.Contains(exitCode))
-                    {
-                        MobileAppHandler.CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
-                    }
-
-                    Task.WaitAll(copyOutput, copyError);
+                    // We have requested a work item retry because of an infra issue - no point executing further tests
+                    outputWriter.WriteLine("\nretry file was found, quit testing...");
                 }
                 else
                 {
-                    // Timed out.
-
-                    DateTime endTime = DateTime.Now;
-
-                    try
+                    // Windows can run the executable implicitly
+                    if (OperatingSystem.IsWindows())
                     {
-                        cts.Cancel();
+                        process.StartInfo.FileName = executable;
                     }
-                    catch {}
-
-                    outputWriter.WriteLine("\ncmdLine:{0} Timed Out (timeout in milliseconds: {1}{2}{3}, start: {4}, end: {5})",
-                            executable, timeout, (environmentVar != null) ? " from variable " : "", (environmentVar != null) ? TIMEOUT_ENVIRONMENT_VAR : "",
-                            startTime.ToString(), endTime.ToString());
-                    errorWriter.WriteLine("\ncmdLine:{0} Timed Out (timeout in milliseconds: {1}{2}{3}, start: {4}, end: {5})",
-                            executable, timeout, (environmentVar != null) ? " from variable " : "", (environmentVar != null) ? TIMEOUT_ENVIRONMENT_VAR : "",
-                            startTime.ToString(), endTime.ToString());
-
-                    if (collectCrashDumps)
+                    // Non-windows needs to be told explicitly to run through /bin/bash shell
+                    else
                     {
-                        if (crashDumpFolder != null)
+                        process.StartInfo.FileName = "/bin/bash";
+                        process.StartInfo.Arguments = executable;
+                    }
+
+                    process.StartInfo.UseShellExecute = false;
+                    process.StartInfo.RedirectStandardOutput = true;
+                    process.StartInfo.RedirectStandardError = true;
+                    process.StartInfo.EnvironmentVariables.Add("__Category", category);
+                    process.StartInfo.EnvironmentVariables.Add("__TestBinaryBase", testBinaryBase);
+                    process.StartInfo.EnvironmentVariables.Add("__OutputDir", outputDir);
+
+                    DateTime startTime = DateTime.Now;
+                    process.Start();
+
+                    var cts = new CancellationTokenSource();
+                    Task copyOutput = process.StandardOutput.BaseStream.CopyToAsync(outputStream, 4096, cts.Token);
+                    Task copyError = process.StandardError.BaseStream.CopyToAsync(errorStream, 4096, cts.Token);
+
+                    if (process.WaitForExit(timeout))
+                    {
+                        // Process completed. Check process.ExitCode here.
+                        exitCode = process.ExitCode;
+
+                        var retriableCodes = CoreclrTestLib.MobileAppHandler.GetKnownExitCodes();
+                        if (retriableCodes.Contains(exitCode))
                         {
-                            foreach (var child in FindChildProcessesByName(process, "corerun"))
+                            CoreclrTestLib.MobileAppHandler.CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
+                            outputWriter.WriteLine("\nretry file has been created.");
+                        }
+
+                        Task.WaitAll(copyOutput, copyError);
+                    }
+                    else
+                    {
+                        // Timed out.
+                        DateTime endTime = DateTime.Now;
+
+                        try
+                        {
+                            cts.Cancel();
+                        }
+                        catch {}
+
+                        outputWriter.WriteLine("\ncmdLine:{0} Timed Out (timeout in milliseconds: {1}{2}{3}, start: {4}, end: {5})",
+                                executable, timeout, (environmentVar != null) ? " from variable " : "", (environmentVar != null) ? TIMEOUT_ENVIRONMENT_VAR : "",
+                                startTime.ToString(), endTime.ToString());
+                        errorWriter.WriteLine("\ncmdLine:{0} Timed Out (timeout in milliseconds: {1}{2}{3}, start: {4}, end: {5})",
+                                executable, timeout, (environmentVar != null) ? " from variable " : "", (environmentVar != null) ? TIMEOUT_ENVIRONMENT_VAR : "",
+                                startTime.ToString(), endTime.ToString());
+
+                        if (collectCrashDumps)
+                        {
+                            if (crashDumpFolder != null)
                             {
-                                string crashDumpPath = Path.Combine(Path.GetFullPath(crashDumpFolder), string.Format("crashdump_{0}.dmp", child.Id));
-                                Console.WriteLine($"Attempting to collect crash dump: {crashDumpPath}");
-                                if (CollectCrashDump(child, crashDumpPath))
+                                foreach (var child in FindChildProcessesByName(process, "corerun"))
                                 {
-                                    Console.WriteLine("Collected crash dump: {0}", crashDumpPath);
-                                }
-                                else
-                                {
-                                    Console.WriteLine("Failed to collect crash dump");
+                                    string crashDumpPath = Path.Combine(Path.GetFullPath(crashDumpFolder), string.Format("crashdump_{0}.dmp", child.Id));
+                                    Console.WriteLine($"Attempting to collect crash dump: {crashDumpPath}");
+                                    if (CollectCrashDump(child, crashDumpPath))
+                                    {
+                                        Console.WriteLine("Collected crash dump: {0}", crashDumpPath);
+                                    }
+                                    else
+                                    {
+                                        Console.WriteLine("Failed to collect crash dump");
+                                    }
                                 }
                             }
                         }
-                    }
 
-                    // kill the timed out processes after we've collected dumps
-                    process.Kill(entireProcessTree: true);
+                        // kill the timed out processes after we've collected dumps
+                        process.Kill(entireProcessTree: true);
+                    }
                 }
 
-               outputWriter.WriteLine("Test Harness Exitcode is : " + exitCode.ToString());
-               outputWriter.Flush();
-
-               errorWriter.Flush();
+                outputWriter.WriteLine("Test Harness Exitcode is : " + exitCode.ToString());
+                outputWriter.Flush();
+                errorWriter.Flush();
             }
 
             return exitCode;

--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -342,19 +342,10 @@ namespace CoreclrTestLib
                     // Process completed. Check process.ExitCode here.
                     exitCode = process.ExitCode;
 
-                    // See https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
-                    // 78 - PACKAGE_INSTALLATION_FAILURE
-                    // 81 - DEVICE_NOT_FOUND
-                    // 85 - ADB_DEVICE_ENUMERATION_FAILURE
-                    // 86 - PACKAGE_INSTALLATION_TIMEOUT
-                    // 88 - SIMULATOR_FAILURE
-                    // 89 - DEVICE_FAILURE
-                    // 90 - APP_LAUNCH_TIMEOUT
-                    // 91 - ADB_FAILURE
-                    var retriableCodes = new[] { 78, 81, 85, 86, 88, 89, 90, 91 };
+                    var retriableCodes = MobileAppHandler.GetKnownExitCodes();
                     if (retriableCodes.Contains(exitCode))
                     {
-                        CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
+                        MobileAppHandler.CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
                     }
 
                     Task.WaitAll(copyOutput, copyError);

--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -14,7 +14,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
-using MobileTestLib;
 
 namespace CoreclrTestLib
 {
@@ -306,7 +305,7 @@ namespace CoreclrTestLib
             using (var errorWriter = new StreamWriter(errorStream))
             using (Process process = new Process())
             {
-                if (File.Exists($"{testBinaryBase}/.retry"))
+                if (MobileAppHandler.IsRetryRequested(testBinaryBase))
                 {
                     outputWriter.WriteLine("\nWork item retry had been requested earlier - skipping test...");
                 }
@@ -342,14 +341,7 @@ namespace CoreclrTestLib
                     {
                         // Process completed. Check process.ExitCode here.
                         exitCode = process.ExitCode;
-
-                        var retriableCodes = MobileAppHandler.GetKnownExitCodes();
-                        if (retriableCodes.Contains(exitCode))
-                        {
-                            MobileAppHandler.CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
-                            outputWriter.WriteLine("\nInfra issue was detected and a work item retry was requested");
-                        }
-
+                        MobileAppHandler.CheckExitCode(exitCode, testBinaryBase, category, outputWriter);
                         Task.WaitAll(copyOutput, copyError);
                     }
                     else

--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -346,7 +346,7 @@ namespace CoreclrTestLib
                         if (retriableCodes.Contains(exitCode))
                         {
                             CoreclrTestLib.MobileAppHandler.CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
-                            outputWriter.WriteLine("\nretry file has been created.");
+                            outputWriter.WriteLine("\nInfra issue was detected and a work item retry was requested");
                         }
 
                         Task.WaitAll(copyOutput, copyError);

--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -190,13 +190,15 @@ namespace CoreclrTestLib
             // See https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
             // 78 - PACKAGE_INSTALLATION_FAILURE
             // 81 - DEVICE_NOT_FOUND
-            // 85 - ADB_DEVICE_ENUMERATION_FAILURE
+            // 82 - RETURN_CODE_NOT_SET
+            // 83 - APP_LAUNCH_FAILURE
+            // 84 - DEVICE_FILE_COPY_FAILURE
             // 86 - PACKAGE_INSTALLATION_TIMEOUT
             // 88 - SIMULATOR_FAILURE
             // 89 - DEVICE_FAILURE
             // 90 - APP_LAUNCH_TIMEOUT
             // 91 - ADB_FAILURE
-            return new[] { 78, 81, 85, 86, 88, 89, 90, 91 };
+            return new[] { 78, 81, 82, 83, 84, 86, 88, 89, 90, 91 };
         }
     }
 }

--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -9,6 +9,19 @@ namespace CoreclrTestLib
 {
     public class MobileAppHandler
     {
+        // See https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
+        // 78 - PACKAGE_INSTALLATION_FAILURE
+        // 81 - DEVICE_NOT_FOUND
+        // 82 - RETURN_CODE_NOT_SET
+        // 83 - APP_LAUNCH_FAILURE
+        // 84 - DEVICE_FILE_COPY_FAILURE
+        // 86 - PACKAGE_INSTALLATION_TIMEOUT
+        // 88 - SIMULATOR_FAILURE
+        // 89 - DEVICE_FAILURE
+        // 90 - APP_LAUNCH_TIMEOUT
+        // 91 - ADB_FAILURE
+        private static readonly int[] _knownExitCodes = new int[] { 78, 81, 82, 83, 84, 86, 88, 89, 90, 91 };
+
         public int InstallMobileApp(string platform, string category, string testBinaryBase, string reportBase)
         {
             return HandleMobileApp("install", platform, category, testBinaryBase, reportBase);
@@ -170,26 +183,9 @@ namespace CoreclrTestLib
             }
         }
 
-        private static int[] GetKnownExitCodes()
-        {
-            // See https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
-            // 78 - PACKAGE_INSTALLATION_FAILURE
-            // 81 - DEVICE_NOT_FOUND
-            // 82 - RETURN_CODE_NOT_SET
-            // 83 - APP_LAUNCH_FAILURE
-            // 84 - DEVICE_FILE_COPY_FAILURE
-            // 86 - PACKAGE_INSTALLATION_TIMEOUT
-            // 88 - SIMULATOR_FAILURE
-            // 89 - DEVICE_FAILURE
-            // 90 - APP_LAUNCH_TIMEOUT
-            // 91 - ADB_FAILURE
-            return new[] { 78, 81, 82, 83, 84, 86, 88, 89, 90, 91 };
-        }
-
         public static void CheckExitCode(int exitCode, string testBinaryBase, string category, StreamWriter outputWriter)
         {
-            var retriableCodes = GetKnownExitCodes();
-            if (retriableCodes.Contains(exitCode))
+            if (_knownExitCodes.Contains(exitCode))
             {
                 CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
                 outputWriter.WriteLine("\nInfra issue was detected and a work item retry was requested");

--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace CoreclrTestLib
+namespace MobileTestLib
 {
     public class MobileAppHandler
     {

--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -133,7 +133,6 @@ namespace CoreclrTestLib
                             if (retriableCodes.Contains(exitCode))
                             {
                                 CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
-                                return exitCode;
                             }
 
                             Task.WaitAll(copyOutput, copyError);

--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -23,12 +23,6 @@ namespace CoreclrTestLib
         {
             int exitCode = -100;
 
-            if (File.Exists($"{testBinaryBase}/.retry"))
-            {
-                // We have requested a work item retry because of an infra issue - no point executing further tests
-                return exitCode;
-            }
-
             string outputFile = Path.Combine(reportBase, action, $"{category}_{action}.output.txt");
             string errorFile = Path.Combine(reportBase, action, $"{category}_{action}.error.txt");
             bool platformValueFlag = true;
@@ -41,111 +35,119 @@ namespace CoreclrTestLib
             using (var outputWriter = new StreamWriter(outputStream))
             using (var errorWriter = new StreamWriter(errorStream))
             {
-                if ((platform != "android") && (platform != "apple"))
+                if (File.Exists($"{testBinaryBase}/.retry"))
                 {
-                    outputWriter.WriteLine($"Incorrect value of platform. Provided {platform}. Valid strings are android and apple.");
-                    platformValueFlag = false;
+                    outputWriter.WriteLine("\nretry file was found, quit mobile app installation/uninstallation...");
                 }
-
-                if ((action != "install") && (action != "uninstall"))
+                else
                 {
-                    outputWriter.WriteLine($"Incorrect value of action. Provided {action}. Valid strings are install and uninstall.");
-                    actionValueFlag = false;
-                }
-
-                if (platformValueFlag && actionValueFlag)
-                {
-                    int timeout = 240000; // Set timeout to 4 mins, because the installation on Android arm64/32 devices could take up to 10 mins on CI
-                    string dotnetCmd_raw = System.Environment.GetEnvironmentVariable("__TestDotNetCmd");
-                    string xharnessCmd_raw = System.Environment.GetEnvironmentVariable("XHARNESS_CLI_PATH");
-                    string dotnetCmd = string.IsNullOrEmpty(dotnetCmd_raw) ? "dotnet" : dotnetCmd_raw;
-                    string xharnessCmd = string.IsNullOrEmpty(xharnessCmd_raw) ? "xharness" : $"exec {xharnessCmd_raw}";
-                    string appExtension = platform == "android" ? "apk" : "app";
-
-                    string cmdStr = $"{dotnetCmd} {xharnessCmd} {platform} {action}";
-
-                    if (platform == "android")
+                    if ((platform != "android") && (platform != "apple"))
                     {
-                        cmdStr += $" --package-name=net.dot.{category}";
+                        outputWriter.WriteLine($"Incorrect value of platform. Provided {platform}. Valid strings are android and apple.");
+                        platformValueFlag = false;
+                    }
+
+                    if ((action != "install") && (action != "uninstall"))
+                    {
+                        outputWriter.WriteLine($"Incorrect value of action. Provided {action}. Valid strings are install and uninstall.");
+                        actionValueFlag = false;
+                    }
+
+                    if (platformValueFlag && actionValueFlag)
+                    {
+                        int timeout = 240000; // Set timeout to 4 mins, because the installation on Android arm64/32 devices could take up to 10 mins on CI
+                        string dotnetCmd_raw = System.Environment.GetEnvironmentVariable("__TestDotNetCmd");
+                        string xharnessCmd_raw = System.Environment.GetEnvironmentVariable("XHARNESS_CLI_PATH");
+                        string dotnetCmd = string.IsNullOrEmpty(dotnetCmd_raw) ? "dotnet" : dotnetCmd_raw;
+                        string xharnessCmd = string.IsNullOrEmpty(xharnessCmd_raw) ? "xharness" : $"exec {xharnessCmd_raw}";
+                        string appExtension = platform == "android" ? "apk" : "app";
+
+                        string cmdStr = $"{dotnetCmd} {xharnessCmd} {platform} {action}";
+
+                        if (platform == "android")
+                        {
+                            cmdStr += $" --package-name=net.dot.{category}";
+
+                            if (action == "install")
+                            {
+                                cmdStr += $" --app={testBinaryBase}/{category}.{appExtension} --output-directory={reportBase}/{action}";
+                            }
+                        }
+                        else // platform is apple
+                        {
+                            cmdStr += $" --output-directory={reportBase}/{action} --target=ios-simulator-64"; //To Do: target should be either emulator or device
+
+                            if (action == "install")
+                            {
+                                cmdStr += $" --app={testBinaryBase}/{category}.{appExtension}";
+                            }
+                            else // action is uninstall
+                            {
+                                cmdStr += $" --app=net.dot.{category}";
+                            }
+                        }
 
                         if (action == "install")
                         {
-                            cmdStr += $" --app={testBinaryBase}/{category}.{appExtension} --output-directory={reportBase}/{action}";
-                        }
-                    }
-                    else // platform is apple
-                    {
-                        cmdStr += $" --output-directory={reportBase}/{action} --target=ios-simulator-64"; //To Do: target should be either emulator or device
-
-                        if (action == "install")
-                        {
-                            cmdStr += $" --app={testBinaryBase}/{category}.{appExtension}";
-                        }
-                        else // action is uninstall
-                        {
-                            cmdStr += $" --app=net.dot.{category}";
-                        }
-                    }
-
-                    if (action == "install")
-                    {
-                        cmdStr += " --timeout 00:02:30";
-                    }
-
-                    using (Process process = new Process())
-                    {
-                        if (OperatingSystem.IsWindows())
-                        {
-                            process.StartInfo.FileName = "cmd.exe";
-                        }
-                        else
-                        {
-                            process.StartInfo.FileName = "/bin/bash";
+                            cmdStr += " --timeout 00:02:30";
                         }
 
-                        process.StartInfo.Arguments = ConvertCmd2Arg(cmdStr);
-                        process.StartInfo.UseShellExecute = false;
-                        process.StartInfo.RedirectStandardOutput = true;
-                        process.StartInfo.RedirectStandardError = true;
-
-                        DateTime startTime = DateTime.Now;
-                        process.Start();
-
-                        var cts = new CancellationTokenSource();
-                        Task copyOutput = process.StandardOutput.BaseStream.CopyToAsync(outputStream, 4096, cts.Token);
-                        Task copyError = process.StandardError.BaseStream.CopyToAsync(errorStream, 4096, cts.Token);
-
-                        if (process.WaitForExit(timeout))
+                        using (Process process = new Process())
                         {
-                            // Process completed.
-                            exitCode = process.ExitCode;
-
-                            
-                            var retriableCodes = GetKnownExitCodes();
-                            if (retriableCodes.Contains(exitCode))
+                            if (OperatingSystem.IsWindows())
                             {
-                                CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
+                                process.StartInfo.FileName = "cmd.exe";
+                            }
+                            else
+                            {
+                                process.StartInfo.FileName = "/bin/bash";
                             }
 
-                            Task.WaitAll(copyOutput, copyError);
-                        }
-                        else
-                        {
-                            //Time out.
-                            DateTime endTime = DateTime.Now;
+                            process.StartInfo.Arguments = ConvertCmd2Arg(cmdStr);
+                            process.StartInfo.UseShellExecute = false;
+                            process.StartInfo.RedirectStandardOutput = true;
+                            process.StartInfo.RedirectStandardError = true;
 
-                            try
+                            DateTime startTime = DateTime.Now;
+                            process.Start();
+
+                            var cts = new CancellationTokenSource();
+                            Task copyOutput = process.StandardOutput.BaseStream.CopyToAsync(outputStream, 4096, cts.Token);
+                            Task copyError = process.StandardError.BaseStream.CopyToAsync(errorStream, 4096, cts.Token);
+
+                            if (process.WaitForExit(timeout))
                             {
-                                cts.Cancel();
+                                // Process completed.
+                                exitCode = process.ExitCode;
+
+                                
+                                var retriableCodes = GetKnownExitCodes();
+                                if (retriableCodes.Contains(exitCode))
+                                {
+                                    CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
+                                    outputWriter.WriteLine("\nretry file has been created.");
+                                }
+
+                                Task.WaitAll(copyOutput, copyError);
                             }
-                            catch {}
+                            else
+                            {
+                                //Time out.
+                                DateTime endTime = DateTime.Now;
 
-                            outputWriter.WriteLine("\ncmdLine:{0} Timed Out (timeout in milliseconds: {1}, start: {2}, end: {3})",
-                                    cmdStr, timeout, startTime.ToString(), endTime.ToString());
-                            errorWriter.WriteLine("\ncmdLine:{0} Timed Out (timeout in milliseconds: {1}, start: {2}, end: {3})",
-                                    cmdStr, timeout, startTime.ToString(), endTime.ToString());
+                                try
+                                {
+                                    cts.Cancel();
+                                }
+                                catch {}
 
-                            process.Kill(entireProcessTree: true);
+                                outputWriter.WriteLine("\ncmdLine:{0} Timed Out (timeout in milliseconds: {1}, start: {2}, end: {3})",
+                                        cmdStr, timeout, startTime.ToString(), endTime.ToString());
+                                errorWriter.WriteLine("\ncmdLine:{0} Timed Out (timeout in milliseconds: {1}, start: {2}, end: {3})",
+                                        cmdStr, timeout, startTime.ToString(), endTime.ToString());
+
+                                process.Kill(entireProcessTree: true);
+                            }
                         }
                     }
                 }

--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -120,16 +120,8 @@ namespace CoreclrTestLib
                             // Process completed.
                             exitCode = process.ExitCode;
 
-                            // See https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
-                            // 78 - PACKAGE_INSTALLATION_FAILURE
-                            // 81 - DEVICE_NOT_FOUND
-                            // 85 - ADB_DEVICE_ENUMERATION_FAILURE
-                            // 86 - PACKAGE_INSTALLATION_TIMEOUT
-                            // 88 - SIMULATOR_FAILURE
-                            // 89 - DEVICE_FAILURE
-                            // 90 - APP_LAUNCH_TIMEOUT
-                            // 91 - ADB_FAILURE
-                            var retriableCodes = new[] { 78, 81, 85, 86, 88, 89, 90, 91 };
+                            
+                            var retriableCodes = GetKnownExitCodes();
                             if (retriableCodes.Contains(exitCode))
                             {
                                 CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
@@ -183,12 +175,26 @@ namespace CoreclrTestLib
             return $"{cmdPrefix} \"{cmd}\"";
         }
 
-        private static void CreateRetryFile(string fileName, int exitCode, string appName)
+        public static void CreateRetryFile(string fileName, int exitCode, string appName)
         {
             using (StreamWriter writer = new StreamWriter(fileName))  
             {
                 writer.WriteLine($"appName: {appName}; exitCode: {exitCode}"); 
             }
+        }
+
+        public static int[] GetKnownExitCodes()
+        {
+            // See https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
+            // 78 - PACKAGE_INSTALLATION_FAILURE
+            // 81 - DEVICE_NOT_FOUND
+            // 85 - ADB_DEVICE_ENUMERATION_FAILURE
+            // 86 - PACKAGE_INSTALLATION_TIMEOUT
+            // 88 - SIMULATOR_FAILURE
+            // 89 - DEVICE_FAILURE
+            // 90 - APP_LAUNCH_TIMEOUT
+            // 91 - ADB_FAILURE
+            return new[] { 78, 81, 85, 86, 88, 89, 90, 91 };
         }
     }
 }


### PR DESCRIPTION
To avoid repeated trying to access the emulator when it should be caught at first seen. The symptom could be observed at this test run https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-heads-main-327ebaf1458b4a1d91/JIT.1/1/console.351c6516.log?helixlogtype=result