### PR TITLE
Cryptography.Pkcs.Tests: make tests pass when rsa+sha1 signing is not supported.

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/SignatureSupport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/SignatureSupport.cs
@@ -7,6 +7,10 @@ namespace System.Security.Cryptography.Tests
     {
         internal static bool CanProduceSha1Signature(AsymmetricAlgorithm algorithm)
         {
+#if NETFRAMEWORK
+            algorithm.Dispose();
+            return true;
+#else
             // We expect all non-Linux platforms to support SHA1 signatures, currently.
             if (!OperatingSystem.IsLinux())
             {
@@ -46,6 +50,7 @@ namespace System.Security.Cryptography.Tests
                 default:
                     throw new NotSupportedException($"Algorithm type {algorithm.GetType()} is not supported.");
             }
+#endif
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampRequestTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampRequestTests.cs
@@ -489,6 +489,12 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 nonce: nonce,
                 requestSignerCertificates: expectedStatus != Rfc3161RequestResponseStatus.UnexpectedCertificates);
 
+            if (!SignatureSupport.SupportsRsaSha1Signatures &&
+                expectedStatus != Rfc3161RequestResponseStatus.RequestFailed)
+            {
+                expectedStatus = Rfc3161RequestResponseStatus.DoesNotParse;
+            }
+
             ProcessResponse(expectedStatus, request, inputBytes, Padding.Length / 2);
         }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampTokenTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampTokenTests.cs
@@ -85,10 +85,20 @@ namespace System.Security.Cryptography.Pkcs.Tests
 
                 using (var signerCert = new X509Certificate2(testData.ExternalCertificateBytes))
                 {
-                    // Assert.NoThrow
-                    signedCms.CheckSignature(
-                        new X509Certificate2Collection(signerCert),
-                        true);
+                    if (!SignatureSupport.SupportsRsaSha1Signatures && signerCert.SignatureAlgorithm.FriendlyName == "sha512RSA")
+                    {
+                        Assert.ThrowsAny<CryptographicException>(() => signedCms.CheckSignature(
+                                                new X509Certificate2Collection(signerCert),
+                                                true));
+                        return;
+                    }
+                    else
+                    {
+                        // Assert.NoThrow
+                        signedCms.CheckSignature(
+                            new X509Certificate2Collection(signerCert),
+                            true);
+                    }
                 }
             }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampTokenTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampTokenTests.cs
@@ -85,11 +85,13 @@ namespace System.Security.Cryptography.Pkcs.Tests
 
                 using (var signerCert = new X509Certificate2(testData.ExternalCertificateBytes))
                 {
-                    if (!SignatureSupport.SupportsRsaSha1Signatures && signerCert.SignatureAlgorithm.FriendlyName == "sha512RSA")
+                    if (!SignatureSupport.SupportsRsaSha1Signatures &&
+                        signedCms.SignerInfos[0].SignatureAlgorithm.Value == Oids.Rsa &&
+                        signedCms.SignerInfos[0].DigestAlgorithm.Value == Oids.Sha1)
                     {
                         Assert.ThrowsAny<CryptographicException>(() => signedCms.CheckSignature(
-                                                new X509Certificate2Collection(signerCert),
-                                                true));
+                            new X509Certificate2Collection(signerCert),
+                            true));
                         return;
                     }
                     else

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignatureSupport.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignatureSupport.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml;
+using Xunit;
+
+namespace System.Security.Cryptography.Pkcs.Tests
+{
+    public class SignatureSupport
+    {
+        private static int _supportsRsaSha1Signatures = 0;
+
+        public static bool SupportsRsaSha1Signatures
+        {
+            get
+            {
+                if (_supportsRsaSha1Signatures == 0)
+                {
+                    bool supported;
+                    try
+                    {
+                        using var rsa = RSA.Create();
+                        rsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
+                        supported = true;
+                    }
+                    catch (CryptographicException)
+                    {
+                        supported = false;
+                    }
+
+                    _supportsRsaSha1Signatures = supported ? 1 : -1;
+                }
+                return _supportsRsaSha1Signatures == 1;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignatureSupport.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignatureSupport.cs
@@ -8,30 +8,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
 {
     public class SignatureSupport
     {
-        private static int _supportsRsaSha1Signatures = 0;
-
-        public static bool SupportsRsaSha1Signatures
-        {
-            get
-            {
-                if (_supportsRsaSha1Signatures == 0)
-                {
-                    bool supported;
-                    try
-                    {
-                        using var rsa = RSA.Create();
-                        rsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
-                        supported = true;
-                    }
-                    catch (CryptographicException)
-                    {
-                        supported = false;
-                    }
-
-                    _supportsRsaSha1Signatures = supported ? 1 : -1;
-                }
-                return _supportsRsaSha1Signatures == 1;
-            }
-        }
+        public static bool SupportsRsaSha1Signatures { get; } =
+            System.Security.Cryptography.Tests.SignatureSupport.CanProduceSha1Signature(RSA.Create());
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.cs
@@ -187,7 +187,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 () => new SignedCms(SubjectIdentifierType.SubjectKeyIdentifier, null, true));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void CheckSignature_ExtraStore_IsAdditional()
         {
             SignedCms cms = new SignedCms();
@@ -200,7 +200,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             cms.CheckSignature(new X509Certificate2Collection(), true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void Decode_IgnoresExtraData()
         {
             byte[] basis = SignedDocuments.RsaPkcs1OneSignerIssuerAndSerialNumber;
@@ -1132,7 +1132,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             cms.CheckSignature(true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void UntrustedCertFails_WhenTrustChecked()
         {
             SignedCms cms = new SignedCms();
@@ -1441,7 +1441,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             Assert.Equal(contentHex, signedCms.ContentInfo.Content.ByteArrayToHex());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void CheckSignedEncrypted_IssuerSerial_FromNetFx()
         {
             CheckSignedEncrypted(
@@ -1449,7 +1449,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 SubjectIdentifierType.IssuerAndSerialNumber);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void CheckSignedEncrypted_SKID_FromNetFx()
         {
             CheckSignedEncrypted(

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.netcoreapp.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.netcoreapp.cs
@@ -650,7 +650,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 CmsSigner cmsCounterSigner = new CmsSigner(SubjectIdentifierType.SubjectKeyIdentifier, counterSignerPubCert, counterSignerKey)
                 {
                     IncludeOption = X509IncludeOption.EndCertOnly,
-                    DigestAlgorithm = key is DSA ? new Oid(Oids.Sha1, Oids.Sha1) : new Oid(Oids.Sha256, Oids.Sha256)
+                    DigestAlgorithm = counterSignerKey is DSA ? new Oid(Oids.Sha1, Oids.Sha1) : new Oid(Oids.Sha256, Oids.Sha256)
                 };
 
                 cms.ComputeSignature(cmsSigner);

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.netcoreapp.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.netcoreapp.cs
@@ -59,7 +59,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             }
         }
 
-        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
+        [Fact]
         public static void SignCmsUsingExplicitRSAKey()
         {
             using (X509Certificate2 cert = Certificates.RSA2048SignatureOnly.TryGetCertificateWithPrivateKey())
@@ -100,7 +100,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             }
         }
 
-        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
+        [Fact]
         [SkipOnPlatform(PlatformSupport.MobileAppleCrypto, "DSA is not available")]
         public static void CounterSignCmsUsingExplicitRSAKeyForFirstSignerAndDSAForCounterSignature()
         {
@@ -126,7 +126,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             }
         }
 
-        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
+        [Fact]
         public static void CounterSignCmsUsingExplicitECDsaKeyForFirstSignerAndRSAForCounterSignature()
         {
             using (X509Certificate2 cert = Certificates.ECDsaP256Win.TryGetCertificateWithPrivateKey())
@@ -617,7 +617,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 CmsSigner signer = new CmsSigner(SubjectIdentifierType.SubjectKeyIdentifier, pubCert, key)
                 {
                     IncludeOption = X509IncludeOption.EndCertOnly,
-                    DigestAlgorithm = new Oid(Oids.Sha1, Oids.Sha1)
+                    DigestAlgorithm = key is DSA ? new Oid(Oids.Sha1, Oids.Sha1) : new Oid(Oids.Sha256, Oids.Sha256)
                 };
 
                 cms.ComputeSignature(signer);
@@ -644,13 +644,13 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 CmsSigner cmsSigner = new CmsSigner(SubjectIdentifierType.SubjectKeyIdentifier, pubCert, key)
                 {
                     IncludeOption = X509IncludeOption.EndCertOnly,
-                    DigestAlgorithm = new Oid(Oids.Sha1, Oids.Sha1)
+                    DigestAlgorithm = key is DSA ? new Oid(Oids.Sha1, Oids.Sha1) : new Oid(Oids.Sha256, Oids.Sha256)
                 };
 
                 CmsSigner cmsCounterSigner = new CmsSigner(SubjectIdentifierType.SubjectKeyIdentifier, counterSignerPubCert, counterSignerKey)
                 {
                     IncludeOption = X509IncludeOption.EndCertOnly,
-                    DigestAlgorithm = new Oid(Oids.Sha1, Oids.Sha1)
+                    DigestAlgorithm = key is DSA ? new Oid(Oids.Sha1, Oids.Sha1) : new Oid(Oids.Sha256, Oids.Sha256)
                 };
 
                 cms.ComputeSignature(cmsSigner);

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsWholeDocumentTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsWholeDocumentTests.cs
@@ -136,7 +136,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             Assert.Throws<CryptographicException>(() => cms.CheckSignature(true));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void ReadRsaPkcs1SimpleDocument()
         {
             SignedCms cms = new SignedCms();
@@ -204,7 +204,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             cms.CheckSignature(true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void ReadRsaPkcs1CounterSigned()
         {
             SignedCms cms = new SignedCms();
@@ -285,7 +285,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             cms.CheckHash();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void CheckNoSignatureDocument()
         {
             SignedCms cms = new SignedCms();
@@ -405,7 +405,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             Assert.Throws<CryptographicException>(() => cms.CheckSignature(true));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void NonEmbeddedCertificate()
         {
             SignedCms cms = new SignedCms();
@@ -518,7 +518,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void ReadRsaPkcs1DoubleCounterSigned()
         {
             SignedCms cms = new SignedCms();

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
@@ -183,7 +183,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 () => signer.CheckSignature(null, false));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void CheckSignature_ExtraStore_IsAdditional()
         {
             SignedCms cms = new SignedCms();
@@ -212,7 +212,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             signer.CheckSignature(true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void CheckSignature_SHA1WithRSA()
         {
             SignedCms cms = new SignedCms();
@@ -296,7 +296,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             signer.CheckSignature(true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFx bug in matching logic")]
         public static void RemoveCounterSignature_MatchesIssuerAndSerialNumber()
         {
@@ -327,7 +327,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             cms.CheckHash();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFx bug in matching logic")]
         public static void RemoveCounterSignature_MatchesSubjectKeyIdentifier()
         {
@@ -360,7 +360,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             cms.CheckHash();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFx bug in matching logic")]
         public static void RemoveCounterSignature_MatchesNoSignature()
         {
@@ -392,7 +392,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             cms.CheckSignature(true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFx bug in matching logic")]
         public static void RemoveCounterSignature_UsesLiveState()
         {
@@ -567,7 +567,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 () => signer.RemoveCounterSignature(0));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void AddCounterSigner_DuplicateCert_RSA()
         {
             SignedCms cms = new SignedCms();
@@ -613,7 +613,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             cms.CheckSignature(true);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         [InlineData(SubjectIdentifierType.IssuerAndSerialNumber)]
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier)]
         public static void AddCounterSigner_RSA(SubjectIdentifierType identifierType)
@@ -698,7 +698,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             cms.CheckSignature(true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         [SkipOnPlatform(PlatformSupport.MobileAppleCrypto, "DSA is not available")]
         public static void AddCounterSigner_DSA()
         {
@@ -758,7 +758,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             cms.CheckSignature(true);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [InlineData(SubjectIdentifierType.IssuerAndSerialNumber, Oids.Sha1)]
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier, Oids.Sha1)]
@@ -829,7 +829,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             cms.CheckSignature(true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void AddFirstCounterSigner_NoSignature_NoPrivateKey()
         {
             SignedCms cms = new SignedCms();
@@ -862,7 +862,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         public static void AddFirstCounterSigner_NoSignature()
         {
             SignedCms cms = new SignedCms();
@@ -912,7 +912,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         [InlineData(false)]
         [InlineData(true)]
         public static void AddSecondCounterSignature_NoSignature_WithCert(bool addExtraCert)
@@ -920,7 +920,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             AddSecondCounterSignature_NoSignature(withCertificate: true, addExtraCert);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(SignatureSupport), nameof(SignatureSupport.SupportsRsaSha1Signatures))]
         // On .NET Framework it will prompt for the counter-signer's certificate if it's null,
         // even if the signature type is NoSignature, so don't run the test there.
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
@@ -8,6 +8,8 @@
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs"
              Link="CommonTest\System\Security\Cryptography\PlatformSupport.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\SignatureSupport.cs"
+             Link="CommonTest\System\Security\Cryptography\SignatureSupport.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Certificates.cs" />
     <Compile Include="CertLoader.cs" />

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="Oids.cs" />
     <Compile Include="Pkcs9AttributeTests.cs" />
     <Compile Include="RecipientInfoCollectionTests.cs" />
+    <Compile Include="SignatureSupport.cs" />
     <Compile Include="SignedCms\CmsSignerTests.cs" />
     <Compile Include="SignedCms\CounterSigningDerOrder.cs" />
     <Compile Include="SignedCms\SignedCmsTests.cs" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/65874.

@bartonjs @vcsjones ptal.