### PR TITLE
Optimize `System.Reflection.Metadata.ByteSequenceComparer`.

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/libraries/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -115,7 +115,7 @@ System.Collections.Immutable.ImmutableStack&lt;T&gt;</PackageDescription>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="System.Memory"  Version="$(SystemMemoryVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">

--- a/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -260,10 +260,15 @@ System.Reflection.PortableExecutable.ManagedPEBuilder</PackageDescription>
     <ProjectReference Include="$(LibrariesProjectRoot)System.Collections.Immutable\src\System.Collections.Immutable.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
     <Reference Include="System.Collections" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.MemoryMappedFiles" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Text.Encoding.Extensions" />

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ByteSequenceComparer.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ByteSequenceComparer.cs
@@ -18,71 +18,17 @@ namespace System.Reflection.Internal
 
         internal static bool Equals(ImmutableArray<byte> x, ImmutableArray<byte> y)
         {
-            if (x == y)
-            {
-                return true;
-            }
-
-            if (x.IsDefault || y.IsDefault || x.Length != y.Length)
-            {
-                return false;
-            }
-
-            for (var i = 0; i < x.Length; i++)
-            {
-                if (x[i] != y[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return x.AsSpan().SequenceEqual(y.AsSpan());
         }
 
         internal static bool Equals(byte[] left, int leftStart, byte[] right, int rightStart, int length)
         {
-            if (left == null || right == null)
-            {
-                return ReferenceEquals(left, right);
-            }
-
-            if (ReferenceEquals(left, right) && leftStart == rightStart)
-            {
-                return true;
-            }
-
-            for (var i = 0; i < length; i++)
-            {
-                if (left[leftStart + i] != right[rightStart + i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return left.AsSpan(leftStart, length).SequenceEqual(right.AsSpan(rightStart, length));
         }
 
         internal static bool Equals(byte[]? left, byte[]? right)
         {
-            if (ReferenceEquals(left, right))
-            {
-                return true;
-            }
-
-            if (left == null || right == null || left.Length != right.Length)
-            {
-                return false;
-            }
-
-            for (var i = 0; i < left.Length; i++)
-            {
-                if (left[i] != right[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return left.AsSpan().SequenceEqual(right.AsSpan());
         }
 
         // Both hash computations below use the FNV-1a algorithm (http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function).
@@ -96,7 +42,7 @@ namespace System.Reflection.Internal
         internal static int GetHashCode(ImmutableArray<byte> x)
         {
             Debug.Assert(!x.IsDefault);
-            return Hash.GetFNVHashCode(x);
+            return Hash.GetFNVHashCode(x.AsSpan());
         }
 
         bool IEqualityComparer<byte[]>.Equals(byte[]? x, byte[]? y)

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/Hash.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/Hash.cs
@@ -40,25 +40,7 @@ namespace System.Reflection.Internal
         /// </summary>
         /// <param name="data">The sequence of bytes</param>
         /// <returns>The FNV-1a hash of <paramref name="data"/></returns>
-        internal static int GetFNVHashCode(byte[] data)
-        {
-            int hashCode = Hash.FnvOffsetBias;
-
-            for (int i = 0; i < data.Length; i++)
-            {
-                hashCode = unchecked((hashCode ^ data[i]) * Hash.FnvPrime);
-            }
-
-            return hashCode;
-        }
-
-        /// <summary>
-        /// Compute the FNV-1a hash of a sequence of bytes
-        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
-        /// </summary>
-        /// <param name="data">The sequence of bytes</param>
-        /// <returns>The FNV-1a hash of <paramref name="data"/></returns>
-        internal static int GetFNVHashCode(ImmutableArray<byte> data)
+        internal static int GetFNVHashCode(ReadOnlySpan<byte> data)
         {
             int hashCode = Hash.FnvOffsetBias;
 

--- a/src/libraries/System.Reflection.Metadata/tests/Utilities/HashTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Utilities/HashTests.cs
@@ -18,7 +18,7 @@ namespace System.Reflection.Metadata.Tests
         [Fact]
         public void GetFNVHashCodeImmutableByteTest()
         {
-            Assert.Equal(-1088511923, Hash.GetFNVHashCode(ImmutableArray.Create((byte)0xFF, (byte)0xD1)));
+            Assert.Equal(-1088511923, Hash.GetFNVHashCode(ImmutableArray.Create((byte)0xFF, (byte)0xD1).AsSpan()));
         }
 
         [Fact]


### PR DESCRIPTION
This PR uses the optimized `MemoryExtensions.SequenceEqual` in place of simple `for` loops over the arrays~~, and also uses `System.HashCode.AddBytes` instead of the custom FNV hash implementation on frameworks that support it~~.

I benchmarked the hash code changes, it's slower on tiny arrays but it's getting better at lengths after around 100 bytes.

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1706 (21H2)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.100-preview.5.22267.11
  [Host]     : .NET 7.0.0 (7.0.22.26611), X64 RyuJIT
  DefaultJob : .NET 7.0.0 (7.0.22.26611), X64 RyuJIT


```
|   Method |    Size |              Mean |          Error |         StdDev |
|--------- |-------- |------------------:|---------------:|---------------:|
| **HashCode** |       **1** |         **7.2412 ns** |      **0.1760 ns** |      **0.1808 ns** |
|      Fnv |       1 |         0.1868 ns |      0.0419 ns |      0.0392 ns |
| **HashCode** |      **10** |        **15.8134 ns** |      **0.2868 ns** |      **0.2682 ns** |
|      Fnv |      10 |         4.6705 ns |      0.1316 ns |      0.1711 ns |
| **HashCode** |     **100** |        **75.6003 ns** |      **1.3908 ns** |      **1.2329 ns** |
|      Fnv |     100 |       102.0950 ns |      1.1608 ns |      1.0290 ns |
| **HashCode** |    **1000** |       **750.8242 ns** |     **12.9713 ns** |     **11.4987 ns** |
|      Fnv |    1000 |     1,219.6150 ns |      6.8126 ns |      5.6888 ns |
| **HashCode** |   **10000** |     **7,163.1200 ns** |    **138.3457 ns** |    **148.0284 ns** |
|      Fnv |   10000 |    12,338.7566 ns |    112.8478 ns |    100.0367 ns |
| **HashCode** |  **100000** |    **71,553.8933 ns** |  **1,400.4046 ns** |  **1,375.3846 ns** |
|      Fnv |  100000 |   124,787.2225 ns |  1,473.3178 ns |  1,378.1423 ns |
| **HashCode** | **1000000** |   **717,269.7070 ns** | **13,429.2555 ns** | **15,465.1506 ns** |
|      Fnv | 1000000 | 1,253,888.7630 ns | 10,577.0581 ns |  9,893.7867 ns |

Here's the benchmark source file:

``` csharp
using System.Security.Cryptography;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkRunner.Run<HashCodeBenchmark>();

public class HashCodeBenchmark
{
    private byte[] _bytes = null!;

    [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
    public int Size { get; set; }

    [GlobalSetup]
    public void Initialize()
    {
        _bytes = RandomNumberGenerator.GetBytes(Size);
    }

    [Benchmark]
    public int HashCode()
    {
        HashCode hc = default;
        hc.AddBytes(_bytes);
        return hc.ToHashCode();
    }

    [Benchmark]
    public int Fnv()
    {
        byte[] bytes = _bytes;
        int num = -2128831035;
        for (int i = 0; i < bytes.Length; i++)
        {
            num = (num ^ bytes[i]) * 16777619;
        }
        return num;
    }
}
```