### PR TITLE
[wasm] Fix runtime test failing due to the app running in debug mode

### DIFF
--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -186,7 +186,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
-    <CLRTestMSBuildArgs>/p:MSBuildEnableWorkloadResolver=false</CLRTestMSBuildArgs>
+    <CLRTestMSBuildArgs>/p:MSBuildEnableWorkloadResolver=false /p:Configuration=$(Configuration)</CLRTestMSBuildArgs>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestsCommonProject)' != 'true'">

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3285,13 +3285,6 @@
 
 
     <ItemGroup Condition=" '$(TargetArchitecture)' == 'wasm' " >
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/tailcall/**">
-            <Issue>https://github.com/dotnet/runtime/issues/69517</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/IL/Tailcall/ExplicitTailCallNoSO/*">
-            <Issue>https://github.com/dotnet/runtime/issues/69517</Issue>
-        </ExcludeList>
-
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Intrinsics/TypeIntrinsics_r/**">
             <Issue>https://github.com/dotnet/runtime/issues/54867</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes #69517

- Recent [wasm-app-host commit](6b3ea40) changed `WasmApp.targets` so
  `WasmDebugLevel` would be set to enable debugging if
  `Configuration==Debug`.
    - this broke some runtime tests which depend on tail call
    optimizations, which get disabled when debugging is enabled in the
    runtime.

- And the wasm apps for the runtime tests are being built with no
  configuration set, which defaults to `Debug`. Instead, propogate the
  config for the build to the wasm proxy (`WasmTestRunner`) projects too.