### PR TITLE
Make gcunsafe for cpblk if it has gc pointers

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -2801,11 +2801,6 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
     CopyBlockUnrollHelper helper(srcOffset, dstOffset, size);
     regNumber             srcReg = srcAddrBaseReg;
 
-#ifdef DEBUG
-    bool isSrcRegAddrAlignmentKnown = false;
-    bool isDstRegAddrAlignmentKnown = false;
-#endif
-
     if (srcLclNum != BAD_VAR_NUM)
     {
         bool      fpBased;
@@ -2813,10 +2808,6 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
         srcReg = fpBased ? REG_FPBASE : REG_SPBASE;
         helper.SetSrcOffset(baseAddr + srcOffset);
-
-#ifdef DEBUG
-        isSrcRegAddrAlignmentKnown = true;
-#endif
     }
 
     regNumber dstReg = dstAddrBaseReg;
@@ -2828,10 +2819,6 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
         dstReg = fpBased ? REG_FPBASE : REG_SPBASE;
         helper.SetDstOffset(baseAddr + dstOffset);
-
-#ifdef DEBUG
-        isDstRegAddrAlignmentKnown = true;
-#endif
     }
 
     bool canEncodeAllLoads  = true;
@@ -2945,8 +2932,8 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
     }
 #endif
 
-#ifndef JIT32_GCENCODER
-    if (!node->gtBlkOpGcUnsafe && ((srcOffsetAdjustment != 0) || (dstOffsetAdjustment != 0)))
+    if (!node->gtBlkOpGcUnsafe &&
+        ((srcOffsetAdjustment != 0) || (dstOffsetAdjustment != 0) || (node->GetLayout()->HasGCPtr())))
     {
         // If node is not already marked as non-interruptible, and if are about to generate code
         // that produce GC references in temporary registers not reported, then mark the block
@@ -2955,7 +2942,6 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
         node->gtBlkOpGcUnsafe = true;
         GetEmitter()->emitDisableGC();
     }
-#endif
 
     if ((srcOffsetAdjustment != 0) && (dstOffsetAdjustment != 0))
     {


### PR DESCRIPTION
While refactoring https://github.com/dotnet/runtime/pull/69202 I missed a case where we would not mark a region as GC unsafe for store block that might have GC pointers. 

Fixes: https://github.com/dotnet/runtime/issues/69657