### PR TITLE
[mono] Enable -Werror=shorten-64-to-32

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -507,6 +507,7 @@ if(GCC)
 
   if (CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(WARNINGS "${WARNINGS} -Qunused-arguments -Wno-tautological-compare -Wno-parentheses-equality -Wno-self-assign -Wno-return-stack-address -Wno-constant-logical-operand -Wno-zero-length-array -Wno-asm-operand-widths")
+    append("-Werror=shorten-64-to-32 -Werror=implicit-int-conversion" WERROR)
   endif()
 
   check_c_compiler_flag("-Werror=incompatible-pointer-types" WERROR_INCOMPATIBLE_POINTER_TYPES)

--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -503,7 +503,7 @@ if(GCC)
   set(WARNINGS_C "-Wmissing-prototypes -Wstrict-prototypes -Wnested-externs")
 
   set(WERROR "-Werror=return-type")
-  set(WERROR_C "-Werror=implicit-function-declaration -Werror=implicit-int-conversion")
+  set(WERROR_C "-Werror=implicit-function-declaration")
 
   if (CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(WARNINGS "${WARNINGS} -Qunused-arguments -Wno-tautological-compare -Wno-parentheses-equality -Wno-self-assign -Wno-return-stack-address -Wno-constant-logical-operand -Wno-zero-length-array -Wno-asm-operand-widths")

--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -507,7 +507,6 @@ if(GCC)
 
   if (CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(WARNINGS "${WARNINGS} -Qunused-arguments -Wno-tautological-compare -Wno-parentheses-equality -Wno-self-assign -Wno-return-stack-address -Wno-constant-logical-operand -Wno-zero-length-array -Wno-asm-operand-widths")
-    set(WERROR "${WERROR} -Werror=shorten-64-to-32")
   endif()
 
   check_c_compiler_flag("-Werror=incompatible-pointer-types" WERROR_INCOMPATIBLE_POINTER_TYPES)

--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -502,12 +502,13 @@ if(GCC)
   set(WARNINGS "-Wall -Wunused -Wmissing-declarations -Wpointer-arith -Wno-cast-qual -Wwrite-strings -Wno-switch -Wno-switch-enum -Wno-unused-value -Wno-attributes -Wno-format-zero-length -Wno-unused-function")
   set(WARNINGS_C "-Wmissing-prototypes -Wstrict-prototypes -Wnested-externs")
 
+  set(WERROR "-Werror=return-type")
+  set(WERROR_C "-Werror=implicit-function-declaration -Werror=implicit-int-conversion")
+
   if (CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(WARNINGS "${WARNINGS} -Qunused-arguments -Wno-tautological-compare -Wno-parentheses-equality -Wno-self-assign -Wno-return-stack-address -Wno-constant-logical-operand -Wno-zero-length-array -Wno-asm-operand-widths")
+    set(WERROR "${WERROR} -Werror=shorten-64-to-32")
   endif()
-
-  set(WERROR "-Werror=return-type")
-  set(WERROR_C "-Werror=implicit-function-declaration")
 
   check_c_compiler_flag("-Werror=incompatible-pointer-types" WERROR_INCOMPATIBLE_POINTER_TYPES)
   if(WERROR_INCOMPATIBLE_POINTER_TYPES)

--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -10,7 +10,6 @@
 #pragma warning(disable:4152) // W4: nonstandard extension, function/data pointer conversion in expression
 #pragma warning(disable:4201) // W4: nonstandard extension used: nameless struct/union
 #pragma warning(disable:4210) // W4: nonstandard extension used: function given file scope
-#pragma warning(disable:4244) // W2: integer conversion, possible loss of data
 #pragma warning(disable:4245) // W4: signed/unsigned mismatch
 #pragma warning(disable:4389) // W4: signed/unsigned mismatch
 #pragma warning(disable:4505) // W4: unreferenced function with internal linkage has been removed

--- a/src/mono/dlls/dbgshim/CMakeLists.txt
+++ b/src/mono/dlls/dbgshim/CMakeLists.txt
@@ -30,6 +30,12 @@ include(${CLR_ENG_NATIVE_DIR}/configurecompiler.cmake)
 
 add_definitions(-D_WIN32_WINNT=0x0602)
 
+if (CLR_CMAKE_HOST_UNIX)
+  if (CMAKE_C_COMPILER_ID MATCHES "Clang")
+    append("-Wno-shorten-64-to-32 -Wno-implicit-int-conversion" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+  endif()
+endif()
+
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../../..
   ${PROJECT_SOURCE_DIR}/../../

--- a/src/mono/dlls/mscordbi/CMakeLists.txt
+++ b/src/mono/dlls/mscordbi/CMakeLists.txt
@@ -28,6 +28,12 @@ endif()
 
 add_definitions(-DDBI_COMPONENT_MONO)
 
+if (CLR_CMAKE_HOST_UNIX)
+  if (CMAKE_C_COMPILER_ID MATCHES "Clang")
+    append("-Wno-shorten-64-to-32 -Wno-implicit-int-conversion" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+  endif()
+endif()
+
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../../..
   ${PROJECT_SOURCE_DIR}/../../

--- a/src/mono/mono/arch/arm64/arm64-codegen.h
+++ b/src/mono/mono/arch/arm64/arm64-codegen.h
@@ -170,7 +170,7 @@ arm_is_bl_disp (void *code, void *target)
 static G_GNUC_UNUSED inline unsigned int
 arm_get_disp (void *p, void *target)
 {
-	unsigned int disp = ((char*)target - (char*)p) / 4;
+	unsigned int disp = (unsigned int) ((char*)target - (char*)p) / 4;
 
 	if (target)
 		g_assert (arm_is_bl_disp (p, target));
@@ -188,7 +188,7 @@ arm_get_disp (void *p, void *target)
 static G_GNUC_UNUSED inline gboolean
 arm_is_disp19 (void *code, void *target)
 {
-	gint64 disp = ((char*)(target) - (char*)(code)) / 4;
+	gint64 disp = (unsigned int) (((char*)(target) - (char*)(code)) / 4);
 
 	return (disp > -(1 << 18)) && (disp < (1 << 18));
 }
@@ -196,7 +196,7 @@ arm_is_disp19 (void *code, void *target)
 static G_GNUC_UNUSED inline unsigned int
 arm_get_disp19 (void *p, void *target)
 {
-	unsigned int disp = ((char*)target - (char*)p) / 4;
+	unsigned int disp = (unsigned int) (((char*)target - (char*)p) / 4);
 
 	if (target)
 		g_assert (arm_is_disp19 (p, target));
@@ -224,7 +224,7 @@ arm_get_disp19 (void *p, void *target)
 static G_GNUC_UNUSED inline unsigned int
 arm_get_disp15 (void *p, void *target)
 {
-	unsigned int disp = ((char*)target - (char*)p) / 4;
+	unsigned int disp = (unsigned int) (((char*)target - (char*)p) / 4);
 	return (disp & 0x7fff);
 }
 

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -3561,7 +3561,7 @@ process_event (EventKind event, gpointer arg, gint32 il_offset, MonoContext *ctx
 	buffer_add_int (&buf, nevents);
 
 	for (l = events; l; l = l->next) {
-		buffer_add_byte (&buf, event); // event kind
+		buffer_add_byte (&buf, GINT_TO_UINT8 (event)); // event kind
 		buffer_add_int (&buf, GPOINTER_TO_INT (l->data)); // request id
 
 		ecount ++;

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -931,7 +931,7 @@ socket_transport_recv (void *buf, int len)
 
 	do {
 	again:
-		res = recv (fd, (char *) buf + total, len - total, flags);
+		res = (int)recv (fd, (char *) buf + total, len - total, flags);
 		if (res > 0)
 			total += res;
 		if (agent_config.keepalive) {
@@ -997,7 +997,7 @@ socket_transport_send (void *data, int len)
 	MONO_REQ_GC_SAFE_MODE;
 
 	do {
-		res = send (conn_fd, (const char*)data, len, 0);
+		res = (int) send (conn_fd, (const char*)data, len, 0);
 	} while (res == SOCKET_ERROR && get_last_sock_error () == MONO_EINTR);
 
 	if (res != len)

--- a/src/mono/mono/eglib/gdir-unix.c
+++ b/src/mono/mono/eglib/gdir-unix.c
@@ -126,7 +126,7 @@ g_mkdir_with_parents (const gchar *pathname, int mode)
 		if (*d == '/' || *d == '\0') {
 		  char orig = *d;
 		  *d = '\0';
-		  rv = mkdir (path, mode);
+		  rv = mkdir (path, (mode_t)mode);
 		  if (rv == -1 && errno != EEXIST) {
 		  	g_free (path);
 			return -1;

--- a/src/mono/mono/eglib/gfile-posix.c
+++ b/src/mono/mono/eglib/gfile-posix.c
@@ -87,7 +87,7 @@ g_file_get_contents (const gchar *filename, gchar **contents, gsize *length, GEr
 	str = g_malloc (st.st_size + 1);
 	offset = 0;
 	do {
-		nread = read (fd, str + offset, st.st_size - offset);
+		nread = GSSIZE_TO_INT (read (fd, str + offset, st.st_size - offset));
 		if (nread > 0) {
 			offset += nread;
 		}

--- a/src/mono/mono/eglib/giconv.c
+++ b/src/mono/mono/eglib/giconv.c
@@ -158,8 +158,8 @@ static FORCE_INLINE (uint16_t)
 read_uint16_endian (unsigned char *inptr, unsigned endian)
 {
 	if (endian == G_LITTLE_ENDIAN)
-		return (inptr[1] << 8) | inptr[0];
-	return (inptr[0] << 8) | inptr[1];
+		return (uint16_t)((inptr[1] << 8) | inptr[0]);
+	return (uint16_t)((inptr[0] << 8) | inptr[1]);
 }
 
 static FORCE_INLINE (int)

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -199,6 +199,433 @@ typedef guint16 gunichar2;
 #endif
 typedef guint32 gunichar;
 
+G_END_DECLS
+
+// #define ENABLE_CHECKED_CASTS
+#ifdef ENABLE_CHECKED_CASTS
+
+#define __CAST_PTRTYPE_TO_STYPE(src,dest,min_v,max_v) \
+static inline dest \
+__cast_ptr_##src##_to_stype_##dest (src v) \
+{ \
+	if ((gssize)(v) < min_v) \
+		/* underflow */ \
+		; \
+	if ((gssize)(v) > max_v) \
+		/* overflow */ \
+		; \
+	return ((dest)(gssize)(v)); \
+}
+
+#define __CAST_PTRTYPE_TO_UTYPE(src,dest,max_v) \
+static inline dest \
+__cast_ptr_##src##_to_utype_##dest (src v) \
+{ \
+	if ((gsize)(v) > max_v) \
+		/* overflow */ \
+		; \
+	return ((dest)(gsize)(v)); \
+}
+
+#define __CAST_STYPE_TO_STYPE(src,dest,min_v,max_v) \
+static inline dest \
+__cast_##src##_to_##dest (src v) \
+{ \
+	if (v < min_v) \
+		/* underflow */ \
+		; \
+	if (v > max_v) \
+		/* overflow */ \
+		; \
+	return (dest)(v); \
+}
+
+#define __CAST_UTYPE_TO_UTYPE(src,dest,max_v) \
+static inline dest \
+__cast_##src##_to_##dest (src v) \
+{ \
+	if (v > max_v) \
+		/* overflow */ \
+		; \
+	return (dest)(v); \
+}
+
+#define __CAST_STYPE_TO_UTYPE(src,dest,max_v) \
+static inline dest \
+__cast_##src##_to_##dest (src v) \
+{ \
+	if (v < 0) \
+		/* underflow */ \
+		; \
+	if (v > max_v) \
+		/* overflow */ \
+		; \
+	return (dest)(v); \
+}
+
+#define __CAST_UTYPE_TO_STYPE(src,dest,min_v,max_v) \
+static inline dest \
+__cast_##src##_to_##dest (src v) \
+{ \
+	if (v > max_v) \
+		/* overflow */ \
+		; \
+	return (dest)(v); \
+}
+
+__CAST_PTRTYPE_TO_STYPE(gpointer, gint64, INT64_MIN, INT64_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gpointer, guint64, UINT64_MAX)
+__CAST_PTRTYPE_TO_STYPE(gpointer, gint32, INT32_MIN, INT32_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gpointer, guint32, UINT32_MAX)
+__CAST_PTRTYPE_TO_STYPE(gpointer, gint16, INT16_MIN, INT16_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gpointer, guint16, UINT16_MAX)
+__CAST_PTRTYPE_TO_STYPE(gpointer, gint8, INT8_MIN, INT8_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gpointer, guint8, UINT8_MAX)
+
+__CAST_PTRTYPE_TO_STYPE(gpointer, glong, LONG_MIN, LONG_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gpointer, gulong, ULONG_MAX)
+__CAST_PTRTYPE_TO_STYPE(gpointer, gint, INT_MIN, INT_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gpointer, guint, UINT_MAX)
+
+__CAST_PTRTYPE_TO_STYPE(gintptr, gint32, INT32_MIN, INT32_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gintptr, guint32, UINT32_MAX)
+__CAST_PTRTYPE_TO_STYPE(gintptr, gint16, INT16_MIN, INT16_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gintptr, guint16, UINT16_MAX)
+
+__CAST_PTRTYPE_TO_STYPE(gintptr, glong, LONG_MIN, LONG_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gintptr, gulong, ULONG_MAX)
+__CAST_PTRTYPE_TO_STYPE(gintptr, gint, INT_MIN, INT_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gintptr, guint, UINT_MAX)
+
+__CAST_PTRTYPE_TO_STYPE(guintptr, gint32, INT32_MIN, INT32_MAX)
+__CAST_PTRTYPE_TO_UTYPE(guintptr, guint32, UINT32_MAX)
+__CAST_PTRTYPE_TO_STYPE(guintptr, gint16, INT16_MIN, INT16_MAX)
+__CAST_PTRTYPE_TO_UTYPE(guintptr, guint16, UINT16_MAX)
+
+__CAST_PTRTYPE_TO_STYPE(guintptr, glong, LONG_MIN, LONG_MAX)
+__CAST_PTRTYPE_TO_UTYPE(guintptr, gulong, ULONG_MAX)
+__CAST_PTRTYPE_TO_STYPE(guintptr, gint, INT_MIN, INT_MAX)
+__CAST_PTRTYPE_TO_UTYPE(guintptr, guint, UINT_MAX)
+
+__CAST_PTRTYPE_TO_STYPE(gptrdiff, gint32, INT32_MIN, INT32_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint32, UINT32_MAX)
+__CAST_PTRTYPE_TO_STYPE(gptrdiff, gint16, INT16_MIN, INT16_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint16, UINT16_MAX)
+__CAST_PTRTYPE_TO_STYPE(gptrdiff, gint8, INT8_MIN, INT8_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint8, UINT8_MAX)
+
+__CAST_PTRTYPE_TO_STYPE(gptrdiff, glong, LONG_MIN, LONG_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gptrdiff, gulong, ULONG_MAX)
+__CAST_PTRTYPE_TO_STYPE(gptrdiff, gint, INT_MIN, INT_MAX)
+__CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint, UINT_MAX)
+
+__CAST_UTYPE_TO_STYPE(gsize, gint32, INT32_MIN, INT32_MAX)
+__CAST_UTYPE_TO_UTYPE(gsize, guint32, UINT32_MAX)
+
+__CAST_UTYPE_TO_STYPE(gsize, gint, INT_MIN, INT_MAX)
+__CAST_UTYPE_TO_UTYPE(gsize, guint, UINT_MAX)
+
+__CAST_STYPE_TO_STYPE(gssize, gint32, INT32_MIN, INT32_MAX)
+__CAST_STYPE_TO_UTYPE(gssize, guint32, UINT32_MAX)
+
+__CAST_STYPE_TO_STYPE(gssize, gint, INT_MIN, INT_MAX)
+__CAST_STYPE_TO_UTYPE(gssize, guint, UINT_MAX)
+
+__CAST_STYPE_TO_STYPE(gdouble, gint64, INT64_MIN, INT64_MAX)
+__CAST_STYPE_TO_UTYPE(gdouble, guint64, UINT64_MAX)
+__CAST_STYPE_TO_STYPE(gdouble, gint32, INT32_MIN, INT32_MAX)
+__CAST_STYPE_TO_UTYPE(gdouble, guint32, UINT32_MAX)
+
+__CAST_STYPE_TO_UTYPE(gdouble, gsize, SIZE_MAX)
+__CAST_STYPE_TO_STYPE(gdouble, gint, INT_MIN, INT_MAX)
+__CAST_STYPE_TO_UTYPE(gdouble, guint, UINT_MAX)
+
+__CAST_STYPE_TO_UTYPE(gint64, guint64, UINT64_MAX)
+__CAST_STYPE_TO_STYPE(gint64, gint32, INT32_MIN, INT32_MAX)
+__CAST_STYPE_TO_UTYPE(gint64, guint32, UINT32_MAX)
+__CAST_STYPE_TO_STYPE(gint64, gint16, INT16_MIN, INT16_MAX)
+__CAST_STYPE_TO_UTYPE(gint64, guint16, UINT16_MAX)
+__CAST_STYPE_TO_STYPE(gint64, gint8, INT8_MIN, INT8_MAX)
+__CAST_STYPE_TO_UTYPE(gint64, guint8, UINT8_MAX)
+
+__CAST_STYPE_TO_STYPE(gint64, gssize, PTRDIFF_MIN, PTRDIFF_MAX)
+__CAST_STYPE_TO_UTYPE(gint64, gsize, SIZE_MAX)
+__CAST_STYPE_TO_STYPE(gint64, glong, LONG_MIN, LONG_MAX)
+__CAST_STYPE_TO_UTYPE(gint64, gulong, ULONG_MAX)
+__CAST_STYPE_TO_STYPE(gint64, gint, INT_MIN, INT_MAX)
+__CAST_STYPE_TO_UTYPE(gint64, guint, UINT_MAX)
+
+__CAST_UTYPE_TO_STYPE(guint64, gint64, INT64_MIN, INT64_MAX)
+__CAST_UTYPE_TO_STYPE(guint64, gint32, INT32_MIN, INT32_MAX)
+__CAST_UTYPE_TO_UTYPE(guint64, guint32, UINT32_MAX)
+__CAST_UTYPE_TO_STYPE(guint64, gint16, INT16_MIN, INT16_MAX)
+__CAST_UTYPE_TO_UTYPE(guint64, guint16, UINT16_MAX)
+__CAST_UTYPE_TO_STYPE(guint64, gint8, INT8_MIN, INT8_MAX)
+__CAST_UTYPE_TO_UTYPE(guint64, guint8, UINT8_MAX)
+
+__CAST_UTYPE_TO_STYPE(guint64, gssize, PTRDIFF_MIN, PTRDIFF_MAX)
+__CAST_UTYPE_TO_UTYPE(guint64, gsize, SIZE_MAX)
+__CAST_UTYPE_TO_STYPE(guint64, glong, LONG_MIN, LONG_MAX)
+__CAST_UTYPE_TO_UTYPE(guint64, gulong, ULONG_MAX)
+__CAST_UTYPE_TO_STYPE(guint64, gint, INT_MIN, INT_MAX)
+__CAST_UTYPE_TO_UTYPE(guint64, guint, UINT_MAX)
+
+__CAST_STYPE_TO_UTYPE(gint32, guint32, UINT32_MAX)
+__CAST_STYPE_TO_STYPE(gint32, gint16, INT16_MIN, INT16_MAX)
+__CAST_STYPE_TO_UTYPE(gint32, guint16, UINT16_MAX)
+__CAST_STYPE_TO_STYPE(gint32, gint8, INT8_MIN, INT8_MAX)
+__CAST_STYPE_TO_UTYPE(gint32, guint8, UINT8_MAX)
+
+__CAST_STYPE_TO_UTYPE(gint32, guint, UINT_MAX)
+
+__CAST_UTYPE_TO_STYPE(guint32, gint32, INT32_MIN, INT32_MAX)
+__CAST_UTYPE_TO_STYPE(guint32, gint16, INT16_MIN, INT16_MAX)
+__CAST_UTYPE_TO_UTYPE(guint32, guint16, UINT16_MAX)
+__CAST_UTYPE_TO_STYPE(guint32, gint8, INT8_MIN, INT8_MAX)
+__CAST_UTYPE_TO_UTYPE(guint32, guint8, UINT8_MAX)
+
+__CAST_UTYPE_TO_STYPE(guint32, gint, INT_MIN, INT_MAX)
+__CAST_UTYPE_TO_STYPE(guint32, gchar, CHAR_MIN, CHAR_MAX)
+
+__CAST_STYPE_TO_STYPE(gint, gint32, INT32_MIN, INT32_MAX)
+__CAST_STYPE_TO_UTYPE(gint, guint32, UINT32_MAX)
+__CAST_STYPE_TO_STYPE(gint, gint16, INT16_MIN, INT16_MAX)
+__CAST_STYPE_TO_UTYPE(gint, guint16, UINT16_MAX)
+__CAST_STYPE_TO_STYPE(gint, gint8, INT8_MIN, INT8_MAX)
+__CAST_STYPE_TO_UTYPE(gint, guint8, UINT8_MAX)
+
+__CAST_STYPE_TO_UTYPE(gint, guint, UINT_MAX)
+__CAST_STYPE_TO_UTYPE(gint, gunichar2, UINT16_MAX)
+__CAST_STYPE_TO_STYPE(gint, gshort, SHRT_MIN, SHRT_MAX)
+__CAST_STYPE_TO_STYPE(gint, gchar, CHAR_MIN, CHAR_MAX)
+
+__CAST_UTYPE_TO_STYPE(guint, gint32, INT32_MIN, INT32_MAX)
+__CAST_UTYPE_TO_UTYPE(guint, guint32, UINT32_MAX)
+__CAST_UTYPE_TO_STYPE(guint, gint16, INT16_MIN, INT16_MAX)
+__CAST_UTYPE_TO_UTYPE(guint, guint16, UINT16_MAX)
+__CAST_UTYPE_TO_STYPE(guint, gint8, INT8_MIN, INT8_MAX)
+__CAST_UTYPE_TO_UTYPE(guint, guint8, UINT8_MAX)
+
+__CAST_UTYPE_TO_STYPE(guint, gint, INT_MIN, INT_MAX)
+__CAST_UTYPE_TO_UTYPE(guint, gunichar2, UINT16_MAX)
+__CAST_UTYPE_TO_STYPE(guint, gshort, SHRT_MIN, SHRT_MAX)
+__CAST_UTYPE_TO_STYPE(guint, gchar, CHAR_MIN, CHAR_MAX)
+
+__CAST_STYPE_TO_STYPE(glong, gint32, INT32_MIN, INT32_MAX)
+
+__CAST_STYPE_TO_STYPE(gfloat, gint32, INT32_MIN, INT32_MAX)
+__CAST_STYPE_TO_UTYPE(gfloat, guint32, UINT32_MAX)
+
+__CAST_STYPE_TO_STYPE(gfloat, gint, INT_MIN, INT_MAX)
+__CAST_STYPE_TO_UTYPE(gfloat, guint, UINT_MAX)
+
+__CAST_STYPE_TO_STYPE(gint16, gint8, INT8_MIN, INT8_MAX)
+__CAST_STYPE_TO_UTYPE(gint16, guint8, UINT8_MAX)
+
+__CAST_UTYPE_TO_STYPE(guint16, gint8, INT8_MIN, INT8_MAX)
+__CAST_UTYPE_TO_UTYPE(guint16, guint8, UINT8_MAX)
+
+__CAST_UTYPE_TO_STYPE(gunichar, gint16, INT16_MIN, INT16_MAX)
+__CAST_UTYPE_TO_UTYPE(gunichar, guint16, UINT16_MAX)
+__CAST_UTYPE_TO_STYPE(gunichar, gint8, INT8_MIN, INT8_MAX)
+__CAST_UTYPE_TO_UTYPE(gunichar, guint8, UINT8_MAX)
+__CAST_UTYPE_TO_STYPE(gunichar, gchar, CHAR_MIN, CHAR_MAX)
+
+#define G_CAST_PTRTYPE_TO_STYPE(src,dest,v) __cast_ptr_##src##_to_stype_##dest ((v))
+#define G_CAST_PTRTYPE_TO_UTYPE(src,dest,v) __cast_ptr_##src##_to_utype_##dest ((v))
+#define G_CAST_TYPE_TO_TYPE(src,dest,v) __cast_##src##_to_##dest ((v))
+
+#endif
+
+#if !defined(ENABLE_CHECKED_CASTS)
+
+#define G_CAST_PTRTYPE_TO_STYPE(src,dest,v) ((dest)(gssize)(v))
+#define G_CAST_PTRTYPE_TO_UTYPE(src,dest,v) ((dest)(gsize)(v))
+#define G_CAST_TYPE_TO_TYPE(src,dest,v) ((dest)(v))
+
+#endif
+
+// - Pointers should only be converted to or from pointer-sized integers.
+// - Any size integer can be converted to any other size integer.
+// - Therefore a pointer-sized integer is the intermediary between
+//   a pointer and any integer type.
+
+#define G_CAST_STYPE_TO_PTRTYPE(src,dest,v) ((dest)(gssize)(v))
+#define G_CAST_UTYPE_TO_PTRTYPE(src,dest,v) ((dest)(gsize)(v))
+
+#define GPOINTER_TO_INT64(v)     G_CAST_PTRTYPE_TO_STYPE(gpointer, gint64, v)
+#define GPOINTER_TO_UINT64(v)    G_CAST_PTRTYPE_TO_UTYPE(gpointer, guint64, v)
+#define GPOINTER_TO_INT32(v)     G_CAST_PTRTYPE_TO_STYPE(gpointer, gint32, v)
+#define GPOINTER_TO_UINT32(v)    G_CAST_PTRTYPE_TO_UTYPE(gpointer, guint32, v)
+#define GPOINTER_TO_INT16(v)     G_CAST_PTRTYPE_TO_STYPE(gpointer, gint16, v)
+#define GPOINTER_TO_UINT16(v)    G_CAST_PTRTYPE_TO_UTYPE(gpointer, guint16, v)
+#define GPOINTER_TO_INT8(v)      G_CAST_PTRTYPE_TO_STYPE(gpointer, gint8, v)
+#define GPOINTER_TO_UINT8(v)     G_CAST_PTRTYPE_TO_UTYPE(gpointer, guint8, v)
+
+#define GPOINTER_TO_LONG(v)      G_CAST_PTRTYPE_TO_STYPE(gpointer, glong, v)
+#define GPOINTER_TO_ULONG(v)     G_CAST_PTRTYPE_TO_UTYPE(gpointer, gulong, v)
+#define GPOINTER_TO_INT(v)       G_CAST_PTRTYPE_TO_STYPE(gpointer, gint, v)
+#define GPOINTER_TO_UINT(v)      G_CAST_PTRTYPE_TO_UTYPE(gpointer, guint, v)
+
+#define GINTPTR_TO_INT32(v)      G_CAST_PTRTYPE_TO_STYPE(gintptr, gint32, v)
+#define GINTPTR_TO_UINT32(v)     G_CAST_PTRTYPE_TO_UTYPE(gintptr, guint32, v)
+
+#define GINTPTR_TO_INT16(v)      G_CAST_PTRTYPE_TO_STYPE(gintptr, gint16, v)
+#define GINTPTR_TO_UINT16(v)     G_CAST_PTRTYPE_TO_UTYPE(gintptr, guint16, v)
+
+#define GINTPTR_TO_LONG(v)       G_CAST_PTRTYPE_TO_STYPE(gintptr, glong, v)
+#define GINTPTR_TO_INT(v)        G_CAST_PTRTYPE_TO_STYPE(gintptr, gint, v)
+#define GINTPTR_TO_UINT(v)       G_CAST_PTRTYPE_TO_UTYPE(gintptr, guint, v)
+
+#define GUINTPTR_TO_INT32(v)     G_CAST_PTRTYPE_TO_STYPE(guintptr, gint32, v)
+#define GUINTPTR_TO_UINT32(v)    G_CAST_PTRTYPE_TO_UTYPE(guintptr, guint32, v)
+
+#define GUINTPTR_TO_INT16(v)     G_CAST_PTRTYPE_TO_STYPE(guintptr, gint16, v)
+#define GUINTPTR_TO_UINT16(v)    G_CAST_PTRTYPE_TO_UTYPE(guintptr, guint16, v)
+
+#define GUINTPTR_TO_LONG(v)      G_CAST_PTRTYPE_TO_STYPE(guintptr, glong, v)
+#define GUINTPTR_TO_INT(v)       G_CAST_PTRTYPE_TO_STYPE(guintptr, gint, v)
+#define GUINTPTR_TO_UINT(v)      G_CAST_PTRTYPE_TO_UTYPE(guintptr, guint, v)
+
+#define GPTRDIFF_TO_INT32(v)     G_CAST_PTRTYPE_TO_STYPE(gptrdiff, gint32, v)
+#define GPTRDIFF_TO_UINT32(v)    G_CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint32, v)
+#define GPTRDIFF_TO_INT16(v)     G_CAST_PTRTYPE_TO_STYPE(gptrdiff, gint16, v)
+#define GPTRDIFF_TO_UINT16(v)    G_CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint16, v)
+#define GPTRDIFF_TO_INT8(v)      G_CAST_PTRTYPE_TO_STYPE(gptrdiff, gint8, v)
+#define GPTRDIFF_TO_UINT8(v)     G_CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint8, v)
+
+#define GPTRDIFF_TO_LONG(v)      G_CAST_PTRTYPE_TO_STYPE(gptrdiff, glong, v)
+#define GPTRDIFF_TO_INT(v)       G_CAST_PTRTYPE_TO_STYPE(gptrdiff, gint, v)
+#define GPTRDIFF_TO_UINT(v)      G_CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint, v)
+
+#define GSIZE_TO_INT32(v)        G_CAST_TYPE_TO_TYPE(gsize, gint32, v)
+#define GSIZE_TO_UINT32(v)       G_CAST_TYPE_TO_TYPE(gsize, guint32, v)
+
+#define GSIZE_TO_INT(v)          G_CAST_TYPE_TO_TYPE(gsize, gint, v)
+#define GSIZE_TO_UINT(v)         G_CAST_TYPE_TO_TYPE(gsize, guint, v)
+
+#define GSSIZE_TO_INT32(v)       G_CAST_TYPE_TO_TYPE(gssize, gint32, v)
+#define GSSIZE_TO_UINT32(v)      G_CAST_TYPE_TO_TYPE(gssize, guint32, v)
+
+#define GSSIZE_TO_INT(v)         G_CAST_TYPE_TO_TYPE(gssize, gint, v)
+#define GSSIZE_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gssize, guint, v)
+
+#define GDOUBLE_TO_INT64(v)      G_CAST_TYPE_TO_TYPE(gdouble, gint64, v)
+#define GDOUBLE_TO_UINT64(v)     G_CAST_TYPE_TO_TYPE(gdouble, guint64, v)
+#define GDOUBLE_TO_INT32(v)      G_CAST_TYPE_TO_TYPE(gdouble, gint32, v)
+#define GDOUBLE_TO_UINT32(v)     G_CAST_TYPE_TO_TYPE(gdouble, guint32, v)
+
+#define GDOUBLE_TO_SIZE(v)       G_CAST_TYPE_TO_TYPE(gdouble, gsize, v)
+#define GDOUBLE_TO_INT(v)        G_CAST_TYPE_TO_TYPE(gdouble, gint, v)
+#define GDOUBLE_TO_UINT(v)       G_CAST_TYPE_TO_TYPE(gdouble, guint, v)
+
+#define GINT64_TO_UINT64(v)      G_CAST_TYPE_TO_TYPE(gint64, guint64, v)
+#define GINT64_TO_INT32(v)       G_CAST_TYPE_TO_TYPE(gint64, gint32, v)
+#define GINT64_TO_UINT32(v)      G_CAST_TYPE_TO_TYPE(gint64, guint32,v)
+#define GINT64_TO_INT16(v)       G_CAST_TYPE_TO_TYPE(gint64, gint16, v)
+#define GINT64_TO_UINT16(v)      G_CAST_TYPE_TO_TYPE(gint64, guint16, v)
+#define GINT64_TO_INT8(v)        G_CAST_TYPE_TO_TYPE(gint64, gint8, v)
+#define GINT64_TO_UINT8(v)       G_CAST_TYPE_TO_TYPE(gint64, guint8, v)
+
+#define GINT64_TO_INTPTR(v)      G_CAST_STYPE_TO_PTRTYPE(gint64, gintptr, v)
+#define GINT64_TO_UINTPTR(v)     G_CAST_STYPE_TO_PTRTYPE(gint64, guintptr, v)
+#define GINT64_TO_POINTER(v)     G_CAST_STYPE_TO_PTRTYPE(gint64, gpointer, v)
+#define GINT64_TO_SSIZE(v)       G_CAST_TYPE_TO_TYPE(gint64, gssize, v)
+#define GINT64_TO_SIZE(v)        G_CAST_TYPE_TO_TYPE(gint64, gsize, v)
+#define GINT64_TO_LONG(v)        G_CAST_TYPE_TO_TYPE(gint64, glong, v)
+#define GINT64_TO_ULONG(v)       G_CAST_TYPE_TO_TYPE(gint64, gulong, v)
+#define GINT64_TO_INT(v)         G_CAST_TYPE_TO_TYPE(gint64, gint, v)
+#define GINT64_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gint64, guint, v)
+
+#define GUINT64_TO_INT64(v)      G_CAST_TYPE_TO_TYPE(guint64, gint64, v)
+#define GUINT64_TO_INT32(v)      G_CAST_TYPE_TO_TYPE(guint64, gint32, v)
+#define GUINT64_TO_UINT32(v)     G_CAST_TYPE_TO_TYPE(guint64, guint32, v)
+#define GUINT64_TO_INT16(v)      G_CAST_TYPE_TO_TYPE(guint64, gint16, v)
+#define GUINT64_TO_UINT16(v)     G_CAST_TYPE_TO_TYPE(guint64, guint16, v)
+#define GUINT64_TO_INT8(v)       G_CAST_TYPE_TO_TYPE(guint64, gint8, v)
+#define GUINT64_TO_UINT8(v)      G_CAST_TYPE_TO_TYPE(guint64, guint8, v)
+
+#define GUINT64_TO_INTPTR(v)     G_CAST_UTYPE_TO_PTRTYPE(guint64, gintptr, v)
+#define GUINT64_TO_UINTPTR(v)    G_CAST_UTYPE_TO_PTRTYPE(guint64, guintptr, v)
+#define GUINT64_TO_POINTER(v)    G_CAST_UTYPE_TO_PTRTYPE(guint64, gpointer, v)
+#define GUINT64_TO_SSIZE(v)      G_CAST_TYPE_TO_TYPE(guint64, gssize, v)
+#define GUINT64_TO_SIZE(v)       G_CAST_TYPE_TO_TYPE(guint64, gsize, v)
+#define GUINT64_TO_LONG(v)       G_CAST_TYPE_TO_TYPE(guint64, glong, v)
+#define GUINT64_TO_ULONG(v)      G_CAST_TYPE_TO_TYPE(guint64, gulong, v)
+#define GUINT64_TO_INT(v)        G_CAST_TYPE_TO_TYPE(guint64, gint, v)
+#define GUINT64_TO_UINT(v)       G_CAST_TYPE_TO_TYPE(guint64, guint, v)
+
+#define GINT32_TO_UINT32(v)      G_CAST_TYPE_TO_TYPE(gint32, guint32, v)
+#define GINT32_TO_INT16(v)       G_CAST_TYPE_TO_TYPE(gint32, gint16, v)
+#define GINT32_TO_UINT16(v)      G_CAST_TYPE_TO_TYPE(gint32, guint16, v)
+#define GINT32_TO_INT8(v)        G_CAST_TYPE_TO_TYPE(gint32, gint8, v)
+#define GINT32_TO_UINT8(v)       G_CAST_TYPE_TO_TYPE(gint32, guint8, v)
+
+#define GINT32_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gint32, guint, v)
+
+#define GUINT32_TO_INT32(v)      G_CAST_TYPE_TO_TYPE(guint32, gint32, v)
+#define GUINT32_TO_INT16(v)      G_CAST_TYPE_TO_TYPE(guint32, gint16, v)
+#define GUINT32_TO_UINT16(v)     G_CAST_TYPE_TO_TYPE(guint32, guint16, v)
+#define GUINT32_TO_INT8(v)       G_CAST_TYPE_TO_TYPE(guint32, gint8, v)
+#define GUINT32_TO_UINT8(v)      G_CAST_TYPE_TO_TYPE(guint32, guint8, v)
+
+#define GUINT32_TO_INT(v)        G_CAST_TYPE_TO_TYPE(guint32, gint, v)
+#define GUINT32_TO_OPCODE(v)     G_CAST_TYPE_TO_TYPE(guint32, guint16, v)
+#define GUINT32_TO_CHAR(v)       G_CAST_TYPE_TO_TYPE(guint32, gchar, v)
+
+#define GINT_TO_INT32(v)         G_CAST_TYPE_TO_TYPE(gint, gint32, v)
+#define GINT_TO_UINT32(v)        G_CAST_TYPE_TO_TYPE(gint, guint32, v)
+#define GINT_TO_INT16(v)         G_CAST_TYPE_TO_TYPE(gint, gint16, v)
+#define GINT_TO_UINT16(v)        G_CAST_TYPE_TO_TYPE(gint, guint16, v)
+#define GINT_TO_INT8(v)          G_CAST_TYPE_TO_TYPE(gint, gint8, v)
+#define GINT_TO_UINT8(v)         G_CAST_TYPE_TO_TYPE(gint, guint8, v)
+
+#define GINT_TO_INTPTR(v)        G_CAST_STYPE_TO_PTRTYPE(gint, gintptr, v)
+#define GINT_TO_UINTPTR(v)       G_CAST_STYPE_TO_PTRTYPE(gint, guintptr, v)
+#define GINT_TO_POINTER(v)       G_CAST_STYPE_TO_PTRTYPE(gint, gpointer, v)
+#define GINT_TO_UINT(v)          G_CAST_TYPE_TO_TYPE(gint, guint, v)
+#define GINT_TO_OPCODE(v)        G_CAST_TYPE_TO_TYPE(gint, guint16, v)
+#define GINT_TO_UNICHAR2(v)      G_CAST_TYPE_TO_TYPE(gint, gunichar2, v)
+#define GINT_TO_SHORT(v)         G_CAST_TYPE_TO_TYPE(gint, gshort, v)
+#define GINT_TO_CHAR(v)          G_CAST_TYPE_TO_TYPE(gint, gchar, v)
+
+#define GUINT_TO_INT32(v)        G_CAST_TYPE_TO_TYPE(guint, gint32, v)
+#define GUINT_TO_UINT32(v)       G_CAST_TYPE_TO_TYPE(guint, guint32, v)
+#define GUINT_TO_INT16(v)        G_CAST_TYPE_TO_TYPE(guint, gint16, v)
+#define GUINT_TO_UINT16(v)       G_CAST_TYPE_TO_TYPE(guint, guint16, v)
+#define GUINT_TO_INT8(v)         G_CAST_TYPE_TO_TYPE(guint, gint8, v)
+#define GUINT_TO_UINT8(v)        G_CAST_TYPE_TO_TYPE(guint, guint8, v)
+
+#define GUINT_TO_INTPTR(v)       G_CAST_UTYPE_TO_PTRTYPE(guint, gintptr, v)
+#define GUINT_TO_UINTPTR(v)      G_CAST_UTYPE_TO_PTRTYPE(guint, guintptr, v)
+#define GUINT_TO_POINTER(v)      G_CAST_UTYPE_TO_PTRTYPE(guint, gpointer, v)
+#define GUINT_TO_INT(v)          G_CAST_TYPE_TO_TYPE(guint, gint, v)
+#define GUINT_TO_OPCODE(v)       G_CAST_TYPE_TO_TYPE(guint, guint16, v)
+#define GUINT_TO_UNICHAR2(v)     G_CAST_TYPE_TO_TYPE(guint, gunichar2, v)
+#define GUINT_TO_SHORT(v)        G_CAST_TYPE_TO_TYPE(guint, gshort, v)
+#define GUINT_TO_CHAR(v)         G_CAST_TYPE_TO_TYPE(guint, gchar, v)
+
+#define GLONG_TO_INT32(v)        G_CAST_TYPE_TO_TYPE(glong, gint32, v)
+
+#define GFLOAT_TO_INT32(v)       G_CAST_TYPE_TO_TYPE(gfloat, gint32, v)
+#define GFLOAT_TO_UINT32(v)      G_CAST_TYPE_TO_TYPE(gfloat, guint32, v)
+
+#define GFLOAT_TO_INT(v)         G_CAST_TYPE_TO_TYPE(gfloat, gint, v)
+#define GFLOAT_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gfloat, guint, v)
+
+#define GINT16_TO_INT8(v)        G_CAST_TYPE_TO_TYPE(gint16, gint8, v)
+#define GINT16_TO_UINT8(v)       G_CAST_TYPE_TO_TYPE(gint16, guint8, v)
+
+#define GUINT16_TO_INT8(v)       G_CAST_TYPE_TO_TYPE(guint16, gint8, v)
+#define GUINT16_TO_UINT8(v)      G_CAST_TYPE_TO_TYPE(guint16, guint8, v)
+
+#define GUNICHAR_TO_INT16(v)     G_CAST_TYPE_TO_TYPE(gunichar, gint16, v)
+#define GUNICHAR_TO_UINT16(v)    G_CAST_TYPE_TO_TYPE(gunichar, guint16, v)
+#define GUNICHAR_TO_INT8(v)      G_CAST_TYPE_TO_TYPE(gunichar, gint8, v)
+#define GUNICHAR_TO_UINT8(v)     G_CAST_TYPE_TO_TYPE(gunichar, guint8, v)
+#define GUNICHAR_TO_CHAR(v)      G_CAST_TYPE_TO_TYPE(gunichar, gchar, v)
+
+G_BEGIN_DECLS
 /*
  * Macros
  */
@@ -1115,7 +1542,7 @@ g_async_safe_vfprintf (int handle, gchar const *format, va_list args)
 	char print_buff [1024];
 	print_buff [0] = '\0';
 	g_vsnprintf (print_buff, sizeof(print_buff), format, args);
-	int ret = g_write (handle, print_buff, (guint32) strlen (print_buff));
+	int ret = GSSIZE_TO_INT (g_write (handle, print_buff, (guint32) strlen (print_buff)));
 
 	return ret;
 }
@@ -1309,425 +1736,5 @@ mono_qsort (void* base, size_t num, size_t size, int (*compare)(const void*, con
 gint
 g_clock_nanosleep (clockid_t clockid, gint flags, const struct timespec *request, struct timespec *remain);
 #endif
-
-//#define ENABLE_CHECKED_CASTS
-#ifdef ENABLE_CHECKED_CASTS
-
-#define __CAST_PTRTYPE_TO_STYPE(src,dest,min_v,max_v) \
-static inline dest \
-__cast_ptr_##src##_to_stype_##dest (src v) \
-{ \
-	if ((gssize)(v) < min_v) \
-		/* underflow */ \
-		; \
-	if ((gssize)(v) > max_v) \
-		/* overflow */ \
-		; \
-	return ((dest)(gssize)(v)); \
-}
-
-#define __CAST_PTRTYPE_TO_UTYPE(src,dest,max_v) \
-static inline dest \
-__cast_ptr_##src##_to_utype_##dest (src v) \
-{ \
-	if ((gsize)(v) > max_v) \
-		/* overflow */ \
-		; \
-	return ((dest)(gsize)(v)); \
-}
-
-#define __CAST_STYPE_TO_STYPE(src,dest,min_v,max_v) \
-static inline dest \
-__cast_##src##_to_##dest (src v) \
-{ \
-	if (v < min_v) \
-		/* underflow */ \
-		; \
-	if (v > max_v) \
-		/* overflow */ \
-		; \
-	return (dest)(v); \
-}
-
-#define __CAST_UTYPE_TO_UTYPE(src,dest,max_v) \
-static inline dest \
-__cast_##src##_to_##dest (src v) \
-{ \
-	if (v > max_v) \
-		/* overflow */ \
-		; \
-	return (dest)(v); \
-}
-
-#define __CAST_STYPE_TO_UTYPE(src,dest,max_v) \
-static inline dest \
-__cast_##src##_to_##dest (src v) \
-{ \
-	if (v < 0) \
-		/* underflow */ \
-		; \
-	if (v > max_v) \
-		/* overflow */ \
-		; \
-	return (dest)(v); \
-}
-
-#define __CAST_UTYPE_TO_STYPE(src,dest,min_v,max_v) \
-static inline dest \
-__cast_##src##_to_##dest (src v) \
-{ \
-	if (v > max_v) \
-		/* overflow */ \
-		; \
-	return (dest)(v); \
-}
-
-__CAST_PTRTYPE_TO_STYPE(gpointer, gint64, INT64_MIN, INT64_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gpointer, guint64, UINT64_MAX)
-__CAST_PTRTYPE_TO_STYPE(gpointer, gint32, INT32_MIN, INT32_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gpointer, guint32, UINT32_MAX)
-__CAST_PTRTYPE_TO_STYPE(gpointer, gint16, INT16_MIN, INT16_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gpointer, guint16, UINT16_MAX)
-__CAST_PTRTYPE_TO_STYPE(gpointer, gint8, INT8_MIN, INT8_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gpointer, guint8, UINT8_MAX)
-
-__CAST_PTRTYPE_TO_STYPE(gpointer, glong, LONG_MIN, LONG_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gpointer, gulong, ULONG_MAX)
-__CAST_PTRTYPE_TO_STYPE(gpointer, gint, INT_MIN, INT_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gpointer, guint, UINT_MAX)
-
-__CAST_PTRTYPE_TO_STYPE(gintptr, gint32, INT32_MIN, INT32_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gintptr, guint32, UINT32_MAX)
-__CAST_PTRTYPE_TO_STYPE(gintptr, gint16, INT16_MIN, INT16_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gintptr, guint16, UINT16_MAX)
-
-__CAST_PTRTYPE_TO_STYPE(gintptr, glong, LONG_MIN, LONG_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gintptr, gulong, ULONG_MAX)
-__CAST_PTRTYPE_TO_STYPE(gintptr, gint, INT_MIN, INT_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gintptr, guint, UINT_MAX)
-
-__CAST_PTRTYPE_TO_STYPE(guintptr, gint32, INT32_MIN, INT32_MAX)
-__CAST_PTRTYPE_TO_UTYPE(guintptr, guint32, UINT32_MAX)
-__CAST_PTRTYPE_TO_STYPE(guintptr, gint16, INT16_MIN, INT16_MAX)
-__CAST_PTRTYPE_TO_UTYPE(guintptr, guint16, UINT16_MAX)
-
-__CAST_PTRTYPE_TO_STYPE(guintptr, glong, LONG_MIN, LONG_MAX)
-__CAST_PTRTYPE_TO_UTYPE(guintptr, gulong, ULONG_MAX)
-__CAST_PTRTYPE_TO_STYPE(guintptr, gint, INT_MIN, INT_MAX)
-__CAST_PTRTYPE_TO_UTYPE(guintptr, guint, UINT_MAX)
-
-__CAST_PTRTYPE_TO_STYPE(gptrdiff, gint32, INT32_MIN, INT32_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint32, UINT32_MAX)
-__CAST_PTRTYPE_TO_STYPE(gptrdiff, gint16, INT16_MIN, INT16_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint16, UINT16_MAX)
-__CAST_PTRTYPE_TO_STYPE(gptrdiff, gint8, INT8_MIN, INT8_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint8, UINT8_MAX)
-
-__CAST_PTRTYPE_TO_STYPE(gptrdiff, glong, LONG_MIN, LONG_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gptrdiff, gulong, ULONG_MAX)
-__CAST_PTRTYPE_TO_STYPE(gptrdiff, gint, INT_MIN, INT_MAX)
-__CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint, UINT_MAX)
-
-__CAST_UTYPE_TO_STYPE(gsize, gint32, INT32_MIN, INT32_MAX)
-__CAST_UTYPE_TO_UTYPE(gsize, guint32, UINT32_MAX)
-
-__CAST_UTYPE_TO_STYPE(gsize, gint, INT_MIN, INT_MAX)
-__CAST_UTYPE_TO_UTYPE(gsize, guint, UINT_MAX)
-
-__CAST_STYPE_TO_STYPE(gssize, gint32, INT32_MIN, INT32_MAX)
-__CAST_STYPE_TO_UTYPE(gssize, guint32, UINT32_MAX)
-
-__CAST_STYPE_TO_STYPE(gssize, gint, INT_MIN, INT_MAX)
-__CAST_STYPE_TO_UTYPE(gssize, guint, UINT_MAX)
-
-__CAST_STYPE_TO_STYPE(gdouble, gint64, INT64_MIN, INT64_MAX)
-__CAST_STYPE_TO_UTYPE(gdouble, guint64, UINT64_MAX)
-__CAST_STYPE_TO_STYPE(gdouble, gint32, INT32_MIN, INT32_MAX)
-__CAST_STYPE_TO_UTYPE(gdouble, guint32, UINT32_MAX)
-
-__CAST_STYPE_TO_UTYPE(gdouble, gsize, SIZE_MAX)
-__CAST_STYPE_TO_STYPE(gdouble, gint, INT_MIN, INT_MAX)
-__CAST_STYPE_TO_UTYPE(gdouble, guint, UINT_MAX)
-
-__CAST_STYPE_TO_UTYPE(gint64, guint64, UINT64_MAX)
-__CAST_STYPE_TO_STYPE(gint64, gint32, INT32_MIN, INT32_MAX)
-__CAST_STYPE_TO_UTYPE(gint64, guint32, UINT32_MAX)
-__CAST_STYPE_TO_STYPE(gint64, gint16, INT16_MIN, INT16_MAX)
-__CAST_STYPE_TO_UTYPE(gint64, guint16, UINT16_MAX)
-__CAST_STYPE_TO_STYPE(gint64, gint8, INT8_MIN, INT8_MAX)
-__CAST_STYPE_TO_UTYPE(gint64, guint8, UINT8_MAX)
-
-__CAST_STYPE_TO_STYPE(gint64, gssize, PTRDIFF_MIN, PTRDIFF_MAX)
-__CAST_STYPE_TO_UTYPE(gint64, gsize, SIZE_MAX)
-__CAST_STYPE_TO_STYPE(gint64, glong, LONG_MIN, LONG_MAX)
-__CAST_STYPE_TO_UTYPE(gint64, gulong, ULONG_MAX)
-__CAST_STYPE_TO_STYPE(gint64, gint, INT_MIN, INT_MAX)
-__CAST_STYPE_TO_UTYPE(gint64, guint, UINT_MAX)
-
-__CAST_UTYPE_TO_STYPE(guint64, gint64, INT64_MIN, INT64_MAX)
-__CAST_UTYPE_TO_STYPE(guint64, gint32, INT32_MIN, INT32_MAX)
-__CAST_UTYPE_TO_UTYPE(guint64, guint32, UINT32_MAX)
-__CAST_UTYPE_TO_STYPE(guint64, gint16, INT16_MIN, INT16_MAX)
-__CAST_UTYPE_TO_UTYPE(guint64, guint16, UINT16_MAX)
-__CAST_UTYPE_TO_STYPE(guint64, gint8, INT8_MIN, INT8_MAX)
-__CAST_UTYPE_TO_UTYPE(guint64, guint8, UINT8_MAX)
-
-__CAST_UTYPE_TO_STYPE(guint64, gssize, PTRDIFF_MIN, PTRDIFF_MAX)
-__CAST_UTYPE_TO_UTYPE(guint64, gsize, SIZE_MAX)
-__CAST_UTYPE_TO_STYPE(guint64, glong, LONG_MIN, LONG_MAX)
-__CAST_UTYPE_TO_UTYPE(guint64, gulong, ULONG_MAX)
-__CAST_UTYPE_TO_STYPE(guint64, gint, INT_MIN, INT_MAX)
-__CAST_UTYPE_TO_UTYPE(guint64, guint, UINT_MAX)
-
-__CAST_STYPE_TO_UTYPE(gint32, guint32, UINT32_MAX)
-__CAST_STYPE_TO_STYPE(gint32, gint16, INT16_MIN, INT16_MAX)
-__CAST_STYPE_TO_UTYPE(gint32, guint16, UINT16_MAX)
-__CAST_STYPE_TO_STYPE(gint32, gint8, INT8_MIN, INT8_MAX)
-__CAST_STYPE_TO_UTYPE(gint32, guint8, UINT8_MAX)
-
-__CAST_STYPE_TO_UTYPE(gint32, guint, UINT_MAX)
-
-__CAST_UTYPE_TO_STYPE(guint32, gint32, INT32_MIN, INT32_MAX)
-__CAST_UTYPE_TO_STYPE(guint32, gint16, INT16_MIN, INT16_MAX)
-__CAST_UTYPE_TO_UTYPE(guint32, guint16, UINT16_MAX)
-__CAST_UTYPE_TO_STYPE(guint32, gint8, INT8_MIN, INT8_MAX)
-__CAST_UTYPE_TO_UTYPE(guint32, guint8, UINT8_MAX)
-
-__CAST_UTYPE_TO_STYPE(guint32, gint, INT_MIN, INT_MAX)
-__CAST_UTYPE_TO_STYPE(guint32, gchar, CHAR_MIN, CHAR_MAX)
-
-__CAST_STYPE_TO_STYPE(gint, gint32, INT32_MIN, INT32_MAX)
-__CAST_STYPE_TO_UTYPE(gint, guint32, UINT32_MAX)
-__CAST_STYPE_TO_STYPE(gint, gint16, INT16_MIN, INT16_MAX)
-__CAST_STYPE_TO_UTYPE(gint, guint16, UINT16_MAX)
-__CAST_STYPE_TO_STYPE(gint, gint8, INT8_MIN, INT8_MAX)
-__CAST_STYPE_TO_UTYPE(gint, guint8, UINT8_MAX)
-
-__CAST_STYPE_TO_UTYPE(gint, guint, UINT_MAX)
-__CAST_STYPE_TO_UTYPE(gint, gunichar2, UINT16_MAX)
-__CAST_STYPE_TO_STYPE(gint, gshort, SHRT_MIN, SHRT_MAX)
-__CAST_STYPE_TO_STYPE(gint, gchar, CHAR_MIN, CHAR_MAX)
-
-__CAST_UTYPE_TO_STYPE(guint, gint32, INT32_MIN, INT32_MAX)
-__CAST_UTYPE_TO_UTYPE(guint, guint32, UINT32_MAX)
-__CAST_UTYPE_TO_STYPE(guint, gint16, INT16_MIN, INT16_MAX)
-__CAST_UTYPE_TO_UTYPE(guint, guint16, UINT16_MAX)
-__CAST_UTYPE_TO_STYPE(guint, gint8, INT8_MIN, INT8_MAX)
-__CAST_UTYPE_TO_UTYPE(guint, guint8, UINT8_MAX)
-
-__CAST_UTYPE_TO_STYPE(guint, gint, INT_MIN, INT_MAX)
-__CAST_UTYPE_TO_UTYPE(guint, gunichar2, UINT16_MAX)
-__CAST_UTYPE_TO_STYPE(guint, gshort, SHRT_MIN, SHRT_MAX)
-__CAST_UTYPE_TO_STYPE(guint, gchar, CHAR_MIN, CHAR_MAX)
-
-__CAST_STYPE_TO_STYPE(gfloat, gint32, INT32_MIN, INT32_MAX)
-__CAST_STYPE_TO_UTYPE(gfloat, guint32, UINT32_MAX)
-
-__CAST_STYPE_TO_STYPE(gfloat, gint, INT_MIN, INT_MAX)
-__CAST_STYPE_TO_UTYPE(gfloat, guint, UINT_MAX)
-
-__CAST_STYPE_TO_STYPE(gint16, gint8, INT8_MIN, INT8_MAX)
-__CAST_STYPE_TO_UTYPE(gint16, guint8, UINT8_MAX)
-
-__CAST_UTYPE_TO_STYPE(guint16, gint8, INT8_MIN, INT8_MAX)
-__CAST_UTYPE_TO_UTYPE(guint16, guint8, UINT8_MAX)
-
-__CAST_UTYPE_TO_STYPE(gunichar, gint16, INT16_MIN, INT16_MAX)
-__CAST_UTYPE_TO_UTYPE(gunichar, guint16, UINT16_MAX)
-__CAST_UTYPE_TO_STYPE(gunichar, gint8, INT8_MIN, INT8_MAX)
-__CAST_UTYPE_TO_UTYPE(gunichar, guint8, UINT8_MAX)
-__CAST_UTYPE_TO_STYPE(gunichar, gchar, CHAR_MIN, CHAR_MAX)
-
-#define G_CAST_PTRTYPE_TO_STYPE(src,dest,v) __cast_ptr_##src##_to_stype_##dest ((v))
-#define G_CAST_PTRTYPE_TO_UTYPE(src,dest,v) __cast_ptr_##src##_to_utype_##dest ((v))
-#define G_CAST_TYPE_TO_TYPE(src,dest,v) __cast_##src##_to_##dest ((v))
-
-#endif
-
-#if !defined(ENABLE_CHECKED_CASTS)
-
-#define G_CAST_PTRTYPE_TO_STYPE(src,dest,v) ((dest)(gssize)(v))
-#define G_CAST_PTRTYPE_TO_UTYPE(src,dest,v) ((dest)(gsize)(v))
-#define G_CAST_TYPE_TO_TYPE(src,dest,v) ((dest)(v))
-
-#endif
-
-// - Pointers should only be converted to or from pointer-sized integers.
-// - Any size integer can be converted to any other size integer.
-// - Therefore a pointer-sized integer is the intermediary between
-//   a pointer and any integer type.
-
-#define G_CAST_STYPE_TO_PTRTYPE(src,dest,v) ((dest)(gssize)(v))
-#define G_CAST_UTYPE_TO_PTRTYPE(src,dest,v) ((dest)(gsize)(v))
-
-#define GPOINTER_TO_INT64(v)     G_CAST_PTRTYPE_TO_STYPE(gpointer, gint64, v)
-#define GPOINTER_TO_UINT64(v)    G_CAST_PTRTYPE_TO_UTYPE(gpointer, guint64, v)
-#define GPOINTER_TO_INT32(v)     G_CAST_PTRTYPE_TO_STYPE(gpointer, gint32, v)
-#define GPOINTER_TO_UINT32(v)    G_CAST_PTRTYPE_TO_UTYPE(gpointer, guint32, v)
-#define GPOINTER_TO_INT16(v)     G_CAST_PTRTYPE_TO_STYPE(gpointer, gint16, v)
-#define GPOINTER_TO_UINT16(v)    G_CAST_PTRTYPE_TO_UTYPE(gpointer, guint16, v)
-#define GPOINTER_TO_INT8(v)      G_CAST_PTRTYPE_TO_STYPE(gpointer, gint8, v)
-#define GPOINTER_TO_UINT8(v)     G_CAST_PTRTYPE_TO_UTYPE(gpointer, guint8, v)
-
-#define GPOINTER_TO_LONG(v)      G_CAST_PTRTYPE_TO_STYPE(gpointer, glong, v)
-#define GPOINTER_TO_ULONG(v)     G_CAST_PTRTYPE_TO_UTYPE(gpointer, gulong, v)
-#define GPOINTER_TO_INT(v)       G_CAST_PTRTYPE_TO_STYPE(gpointer, gint, v)
-#define GPOINTER_TO_UINT(v)      G_CAST_PTRTYPE_TO_UTYPE(gpointer, guint, v)
-
-#define GINTPTR_TO_INT32(v)      G_CAST_PTRTYPE_TO_STYPE(gintptr, gint32, v)
-#define GINTPTR_TO_UINT32(v)     G_CAST_PTRTYPE_TO_UTYPE(gintptr, guint32, v)
-
-#define GINTPTR_TO_INT16(v)      G_CAST_PTRTYPE_TO_STYPE(gintptr, gint16, v)
-#define GINTPTR_TO_UINT16(v)     G_CAST_PTRTYPE_TO_UTYPE(gintptr, guint16, v)
-
-#define GINTPTR_TO_LONG(v)       G_CAST_PTRTYPE_TO_STYPE(gintptr, glong, v)
-#define GINTPTR_TO_INT(v)        G_CAST_PTRTYPE_TO_STYPE(gintptr, gint, v)
-#define GINTPTR_TO_UINT(v)       G_CAST_PTRTYPE_TO_UTYPE(gintptr, guint, v)
-
-#define GUINTPTR_TO_INT32(v)     G_CAST_PTRTYPE_TO_STYPE(guintptr, gint32, v)
-#define GUINTPTR_TO_UINT32(v)    G_CAST_PTRTYPE_TO_UTYPE(guintptr, guint32, v)
-
-#define GUINTPTR_TO_INT16(v)     G_CAST_PTRTYPE_TO_STYPE(guintptr, gint16, v)
-#define GUINTPTR_TO_UINT16(v)    G_CAST_PTRTYPE_TO_UTYPE(guintptr, guint16, v)
-
-#define GUINTPTR_TO_LONG(v)      G_CAST_PTRTYPE_TO_STYPE(guintptr, glong, v)
-#define GUINTPTR_TO_INT(v)       G_CAST_PTRTYPE_TO_STYPE(guintptr, gint, v)
-#define GUINTPTR_TO_UINT(v)      G_CAST_PTRTYPE_TO_UTYPE(guintptr, guint, v)
-
-#define GPTRDIFF_TO_INT32(v)     G_CAST_PTRTYPE_TO_STYPE(gptrdiff, gint32, v)
-#define GPTRDIFF_TO_UINT32(v)    G_CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint32, v)
-#define GPTRDIFF_TO_INT16(v)     G_CAST_PTRTYPE_TO_STYPE(gptrdiff, gint16, v)
-#define GPTRDIFF_TO_UINT16(v)    G_CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint16, v)
-#define GPTRDIFF_TO_INT8(v)      G_CAST_PTRTYPE_TO_STYPE(gptrdiff, gint8, v)
-#define GPTRDIFF_TO_UINT8(v)     G_CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint8, v)
-
-#define GPTRDIFF_TO_LONG(v)      G_CAST_PTRTYPE_TO_STYPE(gptrdiff, glong, v)
-#define GPTRDIFF_TO_INT(v)       G_CAST_PTRTYPE_TO_STYPE(gptrdiff, gint, v)
-#define GPTRDIFF_TO_UINT(v)      G_CAST_PTRTYPE_TO_UTYPE(gptrdiff, guint, v)
-
-#define GSIZE_TO_INT32(v)        G_CAST_TYPE_TO_TYPE(gsize, gint32, v)
-#define GSIZE_TO_UINT32(v)       G_CAST_TYPE_TO_TYPE(gsize, guint32, v)
-
-#define GSIZE_TO_INT(v)          G_CAST_TYPE_TO_TYPE(gsize, gint, v)
-#define GSIZE_TO_UINT(v)         G_CAST_TYPE_TO_TYPE(gsize, guint, v)
-
-#define GSSIZE_TO_INT32(v)       G_CAST_TYPE_TO_TYPE(gssize, gint32, v)
-#define GSSIZE_TO_UINT32(v)      G_CAST_TYPE_TO_TYPE(gssize, guint32, v)
-
-#define GSSIZE_TO_INT(v)         G_CAST_TYPE_TO_TYPE(gssize, gint, v)
-#define GSSIZE_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gssize, guint, v)
-
-#define GDOUBLE_TO_INT64(v)      G_CAST_TYPE_TO_TYPE(gdouble, gint64, v)
-#define GDOUBLE_TO_UINT64(v)     G_CAST_TYPE_TO_TYPE(gdouble, guint64, v)
-#define GDOUBLE_TO_INT32(v)      G_CAST_TYPE_TO_TYPE(gdouble, gint32, v)
-#define GDOUBLE_TO_UINT32(v)     G_CAST_TYPE_TO_TYPE(gdouble, guint32, v)
-
-#define GDOUBLE_TO_SIZE(v)       G_CAST_TYPE_TO_TYPE(gdouble, gsize, v)
-#define GDOUBLE_TO_INT(v)        G_CAST_TYPE_TO_TYPE(gdouble, gint, v)
-#define GDOUBLE_TO_UINT(v)       G_CAST_TYPE_TO_TYPE(gdouble, guint, v)
-
-#define GINT64_TO_UINT64(v)      G_CAST_TYPE_TO_TYPE(gint64, guint64, v)
-#define GINT64_TO_INT32(v)       G_CAST_TYPE_TO_TYPE(gint64, gint32, v)
-#define GINT64_TO_UINT32(v)      G_CAST_TYPE_TO_TYPE(gint64, guint32,v)
-#define GINT64_TO_INT16(v)       G_CAST_TYPE_TO_TYPE(gint64, gint16, v)
-#define GINT64_TO_UINT16(v)      G_CAST_TYPE_TO_TYPE(gint64, guint16, v)
-#define GINT64_TO_INT8(v)        G_CAST_TYPE_TO_TYPE(gint64, gint8, v)
-#define GINT64_TO_UINT8(v)       G_CAST_TYPE_TO_TYPE(gint64, guint8, v)
-
-#define GINT64_TO_INTPTR(v)      G_CAST_STYPE_TO_PTRTYPE(gint64, gintptr, v)
-#define GINT64_TO_UINTPTR(v)     G_CAST_STYPE_TO_PTRTYPE(gint64, guintptr, v)
-#define GINT64_TO_POINTER(v)     G_CAST_STYPE_TO_PTRTYPE(gint64, gpointer, v)
-#define GINT64_TO_SSIZE(v)       G_CAST_TYPE_TO_TYPE(gint64, gssize, v)
-#define GINT64_TO_SIZE(v)        G_CAST_TYPE_TO_TYPE(gint64, gsize, v)
-#define GINT64_TO_LONG(v)        G_CAST_TYPE_TO_TYPE(gint64, glong, v)
-#define GINT64_TO_ULONG(v)       G_CAST_TYPE_TO_TYPE(gint64, gulong, v)
-#define GINT64_TO_INT(v)         G_CAST_TYPE_TO_TYPE(gint64, gint, v)
-#define GINT64_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gint64, guint, v)
-
-#define GUINT64_TO_INT64(v)      G_CAST_TYPE_TO_TYPE(guint64, gint64, v)
-#define GUINT64_TO_INT32(v)      G_CAST_TYPE_TO_TYPE(guint64, gint32, v)
-#define GUINT64_TO_UINT32(v)     G_CAST_TYPE_TO_TYPE(guint64, guint32, v)
-#define GUINT64_TO_INT16(v)      G_CAST_TYPE_TO_TYPE(guint64, gint16, v)
-#define GUINT64_TO_UINT16(v)     G_CAST_TYPE_TO_TYPE(guint64, guint16, v)
-#define GUINT64_TO_INT8(v)       G_CAST_TYPE_TO_TYPE(guint64, gint8, v)
-#define GUINT64_TO_UINT8(v)      G_CAST_TYPE_TO_TYPE(guint64, guint8, v)
-
-#define GUINT64_TO_INTPTR(v)     G_CAST_UTYPE_TO_PTRTYPE(guint64, gintptr, v)
-#define GUINT64_TO_UINTPTR(v)    G_CAST_UTYPE_TO_PTRTYPE(guint64, guintptr, v)
-#define GUINT64_TO_POINTER(v)    G_CAST_UTYPE_TO_PTRTYPE(guint64, gpointer, v)
-#define GUINT64_TO_SSIZE(v)      G_CAST_TYPE_TO_TYPE(guint64, gssize, v)
-#define GUINT64_TO_SIZE(v)       G_CAST_TYPE_TO_TYPE(guint64, gsize, v)
-#define GUINT64_TO_LONG(v)       G_CAST_TYPE_TO_TYPE(guint64, glong, v)
-#define GUINT64_TO_ULONG(v)      G_CAST_TYPE_TO_TYPE(guint64, gulong, v)
-#define GUINT64_TO_INT(v)        G_CAST_TYPE_TO_TYPE(guint64, gint, v)
-#define GUINT64_TO_UINT(v)       G_CAST_TYPE_TO_TYPE(guint64, guint, v)
-
-#define GINT32_TO_UINT32(v)      G_CAST_TYPE_TO_TYPE(gint32, guint32, v)
-#define GINT32_TO_INT16(v)       G_CAST_TYPE_TO_TYPE(gint32, gint16, v)
-#define GINT32_TO_UINT16(v)      G_CAST_TYPE_TO_TYPE(gint32, guint16, v)
-#define GINT32_TO_INT8(v)        G_CAST_TYPE_TO_TYPE(gint32, gint8, v)
-#define GINT32_TO_UINT8(v)       G_CAST_TYPE_TO_TYPE(gint32, guint8, v)
-
-#define GINT32_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gint32, guint, v)
-
-#define GUINT32_TO_INT32(v)      G_CAST_TYPE_TO_TYPE(guint32, gint32, v)
-#define GUINT32_TO_INT16(v)      G_CAST_TYPE_TO_TYPE(guint32, gint16, v)
-#define GUINT32_TO_UINT16(v)     G_CAST_TYPE_TO_TYPE(guint32, guint16, v)
-#define GUINT32_TO_INT8(v)       G_CAST_TYPE_TO_TYPE(guint32, gint8, v)
-#define GUINT32_TO_UINT8(v)      G_CAST_TYPE_TO_TYPE(guint32, guint8, v)
-
-#define GUINT32_TO_INT(v)        G_CAST_TYPE_TO_TYPE(guint32, gint, v)
-#define GUINT32_TO_OPCODE(v)     G_CAST_TYPE_TO_TYPE(guint32, guint16, v)
-#define GUINT32_TO_CHAR(v)       G_CAST_TYPE_TO_TYPE(guint32, gchar, v)
-
-#define GINT_TO_INT32(v)         G_CAST_TYPE_TO_TYPE(gint, gint32, v)
-#define GINT_TO_UINT32(v)        G_CAST_TYPE_TO_TYPE(gint, guint32, v)
-#define GINT_TO_INT16(v)         G_CAST_TYPE_TO_TYPE(gint, gint16, v)
-#define GINT_TO_UINT16(v)        G_CAST_TYPE_TO_TYPE(gint, guint16, v)
-#define GINT_TO_INT8(v)          G_CAST_TYPE_TO_TYPE(gint, gint8, v)
-#define GINT_TO_UINT8(v)         G_CAST_TYPE_TO_TYPE(gint, guint8, v)
-
-#define GINT_TO_INTPTR(v)        G_CAST_STYPE_TO_PTRTYPE(gint, gintptr, v)
-#define GINT_TO_UINTPTR(v)       G_CAST_STYPE_TO_PTRTYPE(gint, guintptr, v)
-#define GINT_TO_POINTER(v)       G_CAST_STYPE_TO_PTRTYPE(gint, gpointer, v)
-#define GINT_TO_UINT(v)          G_CAST_TYPE_TO_TYPE(gint, guint, v)
-#define GINT_TO_OPCODE(v)        G_CAST_TYPE_TO_TYPE(gint, guint16, v)
-#define GINT_TO_UNICHAR2(v)      G_CAST_TYPE_TO_TYPE(gint, gunichar2, v)
-#define GINT_TO_SHORT(v)         G_CAST_TYPE_TO_TYPE(gint, gshort, v)
-#define GINT_TO_CHAR(v)          G_CAST_TYPE_TO_TYPE(gint, gchar, v)
-
-#define GUINT_TO_INT32(v)        G_CAST_TYPE_TO_TYPE(guint, gint32, v)
-#define GUINT_TO_UINT32(v)       G_CAST_TYPE_TO_TYPE(guint, guint32, v)
-#define GUINT_TO_INT16(v)        G_CAST_TYPE_TO_TYPE(guint, gint16, v)
-#define GUINT_TO_UINT16(v)       G_CAST_TYPE_TO_TYPE(guint, guint16, v)
-#define GUINT_TO_INT8(v)         G_CAST_TYPE_TO_TYPE(guint, gint8, v)
-#define GUINT_TO_UINT8(v)        G_CAST_TYPE_TO_TYPE(guint, guint8, v)
-
-#define GUINT_TO_INTPTR(v)       G_CAST_UTYPE_TO_PTRTYPE(guint, gintptr, v)
-#define GUINT_TO_UINTPTR(v)      G_CAST_UTYPE_TO_PTRTYPE(guint, guintptr, v)
-#define GUINT_TO_POINTER(v)      G_CAST_UTYPE_TO_PTRTYPE(guint, gpointer, v)
-#define GUINT_TO_INT(v)          G_CAST_TYPE_TO_TYPE(guint, gint, v)
-#define GUINT_TO_OPCODE(v)       G_CAST_TYPE_TO_TYPE(guint, guint16, v)
-#define GUINT_TO_UNICHAR2(v)     G_CAST_TYPE_TO_TYPE(guint, gunichar2, v)
-#define GUINT_TO_SHORT(v)        G_CAST_TYPE_TO_TYPE(guint, gshort, v)
-#define GUINT_TO_CHAR(v)         G_CAST_TYPE_TO_TYPE(guint, gchar, v)
-
-#define GFLOAT_TO_INT32(v)       G_CAST_TYPE_TO_TYPE(gfloat, gint32, v)
-#define GFLOAT_TO_UINT32(v)      G_CAST_TYPE_TO_TYPE(gfloat, guint32, v)
-
-#define GFLOAT_TO_INT(v)         G_CAST_TYPE_TO_TYPE(gfloat, gint, v)
-#define GFLOAT_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gfloat, guint, v)
-
-#define GINT16_TO_INT8(v)        G_CAST_TYPE_TO_TYPE(gint16, gint8, v)
-#define GINT16_TO_UINT8(v)       G_CAST_TYPE_TO_TYPE(gint16, guint8, v)
-
-#define GUINT16_TO_INT8(v)       G_CAST_TYPE_TO_TYPE(guint16, gint8, v)
-#define GUINT16_TO_UINT8(v)      G_CAST_TYPE_TO_TYPE(guint16, guint8, v)
-
-#define GUNICHAR_TO_INT16(v)     G_CAST_TYPE_TO_TYPE(gunichar, gint16, v)
-#define GUNICHAR_TO_UINT16(v)    G_CAST_TYPE_TO_TYPE(gunichar, guint16, v)
-#define GUNICHAR_TO_INT8(v)      G_CAST_TYPE_TO_TYPE(gunichar, gint8, v)
-#define GUNICHAR_TO_UINT8(v)     G_CAST_TYPE_TO_TYPE(gunichar, guint8, v)
-#define GUNICHAR_TO_CHAR(v)      G_CAST_TYPE_TO_TYPE(gunichar, gchar, v)
 
 #endif // __GLIB_H

--- a/src/mono/mono/eglib/gspawn.c
+++ b/src/mono/mono/eglib/gspawn.c
@@ -109,7 +109,7 @@ safe_read (int fd, gchar *buffer, gint count, GError **gerror)
 {
 	int res;
 
-	NO_INTR (res, read (fd, buffer, count));
+	NO_INTR (res, GSSIZE_TO_INT (read (fd, buffer, count)));
 	set_error_cond (res == -1, "%s", "Error reading from pipe.");
 	return res;
 }
@@ -211,7 +211,7 @@ write_all (int fd, const void *vbuf, size_t n)
 
 	do {
 		do {
-			w = write (fd, buf + nwritten, n - nwritten);
+			w = GSSIZE_TO_INT (write (fd, buf + nwritten, n - nwritten));
 		} while (w == -1 && errno == EINTR);
 
 		if (w == -1)
@@ -220,7 +220,7 @@ write_all (int fd, const void *vbuf, size_t n)
 		nwritten += w;
 	} while (nwritten < n);
 
-	return nwritten;
+	return GSIZE_TO_INT (nwritten);
 }
 
 #endif // HAVE_G_SPAWN
@@ -235,7 +235,7 @@ eg_getdtablesize (void)
 
 	res = getrlimit (RLIMIT_NOFILE, &limit);
 	g_assert (res == 0);
-	return limit.rlim_cur;
+	return (int)(size_t)limit.rlim_cur;
 #else
 	return getdtablesize ();
 #endif
@@ -412,7 +412,7 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 
 	if ((flags & G_SPAWN_DO_NOT_REAP_CHILD) == 0) {
 		int x;
-		NO_INTR (x, read (info_pipe [0], &pid, sizeof (pid_t))); /* if we read < sizeof (pid_t)... */
+		NO_INTR (x, GSSIZE_TO_INT (read (info_pipe [0], &pid, sizeof (pid_t)))); /* if we read < sizeof (pid_t)... */
 	}
 
 	if (child_pid) {

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2236,7 +2236,7 @@ ep_rt_mono_file_write (
 
 	do {
 		MONO_ENTER_GC_SAFE;
-		ret = write (fd, buffer, numbytes);
+		ret = (uint32_t) write (fd, buffer, numbytes);
 		MONO_EXIT_GC_SAFE;
 	} while (ret == -1 && errno == EINTR &&
 		 !mono_thread_info_is_interrupt_state (info));
@@ -3916,7 +3916,7 @@ ep_rt_mono_write_event_thread_created (ep_rt_thread_id_t tid)
 		return true;
 
 	uint64_t managed_thread = 0;
-	uint32_t native_thread_id = MONO_NATIVE_THREAD_ID_TO_UINT (tid);
+	uint32_t native_thread_id = GSIZE_TO_UINT32 (MONO_NATIVE_THREAD_ID_TO_UINT (tid));
 	uint32_t managed_thread_id = 0;
 	uint32_t flags = 0;
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2511,7 +2511,7 @@ ep_rt_mono_system_time_get (EventPipeSystemTime *system_time)
 		int old_seconds;
 		int new_seconds;
 
-		milliseconds = time_val.tv_usec / MSECS_TO_MIS;
+		milliseconds = (uint16_t)(time_val.tv_usec / MSECS_TO_MIS);
 
 		old_seconds = ut_ptr->tm_sec;
 		new_seconds = time_val.tv_sec % 60;
@@ -2523,13 +2523,13 @@ ep_rt_mono_system_time_get (EventPipeSystemTime *system_time)
 
 	ep_system_time_set (
 		system_time,
-		1900 + ut_ptr->tm_year,
-		ut_ptr->tm_mon + 1,
-		ut_ptr->tm_wday,
-		ut_ptr->tm_mday,
-		ut_ptr->tm_hour,
-		ut_ptr->tm_min,
-		ut_ptr->tm_sec,
+		(uint16_t)(1900 + ut_ptr->tm_year),
+		(uint16_t)ut_ptr->tm_mon + 1,
+		(uint16_t)ut_ptr->tm_wday,
+		(uint16_t)ut_ptr->tm_mday,
+		(uint16_t)ut_ptr->tm_hour,
+		(uint16_t)ut_ptr->tm_min,
+		(uint16_t)ut_ptr->tm_sec,
 		milliseconds);
 }
 
@@ -2609,7 +2609,7 @@ void
 ep_rt_mono_provider_config_init (EventPipeProviderConfiguration *provider_config)
 {
 	if (!ep_rt_utf8_string_compare (ep_config_get_rundown_provider_name_utf8 (), ep_provider_config_get_provider_name (provider_config))) {
-		MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_EVENTPIPE_Context.Level = ep_provider_config_get_logging_level (provider_config);
+		MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_EVENTPIPE_Context.Level = (uint8_t)ep_provider_config_get_logging_level (provider_config);
 		MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_EVENTPIPE_Context.EnabledKeywordsBitmask = ep_provider_config_get_keywords (provider_config);
 		MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_EVENTPIPE_Context.IsEnabled = true;
 	}

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -897,7 +897,7 @@ ep_rt_config_value_get_circular_mb (void)
 	if (!value)
 		value = g_getenv ("COMPlus_EventPipeCircularMB");
 	if (value)
-		circular_mb = strtoul (value, NULL, 10);
+		circular_mb = (uint32_t)strtoul (value, NULL, 10);
 	g_free (value);
 	return circular_mb;
 }

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -147,7 +147,7 @@ disable_gclass_recording (gclass_record_func func, void *user_data)
 }
 
 #define mono_class_new0(klass,struct_type, n_structs)		\
-    ((struct_type *) mono_class_alloc0 ((klass), ((gsize) sizeof (struct_type)) * ((gsize) (n_structs))))
+	((struct_type *) mono_class_alloc0 ((klass), GSIZE_TO_INT (((gsize) sizeof (struct_type)) * ((gsize) (n_structs)))))
 
 /**
  * mono_class_setup_basic_field_info:

--- a/src/mono/mono/metadata/exception.c
+++ b/src/mono/mono/metadata/exception.c
@@ -1131,7 +1131,7 @@ mono_exception_handle_get_native_backtrace (MonoExceptionHandle exc)
 
 	if (MONO_HANDLE_IS_NULL(arr))
 		return g_strdup ("");
-	len = mono_array_handle_length (arr);
+	len = GSIZE_TO_INT (mono_array_handle_length (arr));
 	text = g_string_new_len (NULL, len * 20);
 	MonoGCHandle gchandle;
 	gpointer *addr = MONO_ARRAY_HANDLE_PIN (arr, gpointer, 0, &gchandle);
@@ -1145,7 +1145,7 @@ mono_exception_handle_get_native_backtrace (MonoExceptionHandle exc)
 		MONO_HANDLE_ARRAY_GETVAL (ip, arr, gpointer, i);
 		MonoJitInfo *ji = mono_jit_info_table_find_internal (ip, TRUE, FALSE);
 		if (ji) {
-			char *msg = mono_debug_print_stack_frame (mono_jit_info_get_method (ji), (char*)ip - (char*)ji->code_start, NULL);
+			char *msg = mono_debug_print_stack_frame (mono_jit_info_get_method (ji), (uint32_t) ((char*)ip - (char*)ji->code_start), NULL);
 			g_string_append_printf (text, "%s\n", msg);
 			g_free (msg);
 		} else {

--- a/src/mono/mono/metadata/icall-eventpipe.c
+++ b/src/mono/mono/metadata/icall-eventpipe.c
@@ -220,7 +220,7 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_WaitForSessionSignal (
 	uint64_t session_id,
 	int32_t timeout)
 {
-	return (MonoBoolean) mono_component_event_pipe()->wait_for_session_signal ((EventPipeSessionID)session_id, (uint32_t)timeout);
+	return mono_component_event_pipe()->wait_for_session_signal ((EventPipeSessionID)session_id, (uint32_t)timeout) ? TRUE : FALSE;
 }
 
 void

--- a/src/mono/mono/metadata/icall-eventpipe.c
+++ b/src/mono/mono/metadata/icall-eventpipe.c
@@ -212,7 +212,7 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_GetSessionInfo (
 MonoBoolean
 ves_icall_System_Diagnostics_Tracing_EventPipeInternal_SignalSession (uint64_t session_id)
 {
-	return (MonoBoolean) mono_component_event_pipe()->signal_session ((EventPipeSessionID)session_id);
+	return mono_component_event_pipe()->signal_session ((EventPipeSessionID)session_id) ? TRUE : FALSE;
 }
 
 MonoBoolean

--- a/src/mono/mono/metadata/icall-eventpipe.c
+++ b/src/mono/mono/metadata/icall-eventpipe.c
@@ -212,7 +212,7 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_GetSessionInfo (
 MonoBoolean
 ves_icall_System_Diagnostics_Tracing_EventPipeInternal_SignalSession (uint64_t session_id)
 {
-	return (intptr_t) mono_component_event_pipe()->signal_session ((EventPipeSessionID)session_id);
+	return (MonoBoolean) mono_component_event_pipe()->signal_session ((EventPipeSessionID)session_id);
 }
 
 MonoBoolean
@@ -220,7 +220,7 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_WaitForSessionSignal (
 	uint64_t session_id,
 	int32_t timeout)
 {
-	return (intptr_t) mono_component_event_pipe()->wait_for_session_signal ((EventPipeSessionID)session_id, (uint32_t)timeout);
+	return (MonoBoolean) mono_component_event_pipe()->wait_for_session_signal ((EventPipeSessionID)session_id, (uint32_t)timeout);
 }
 
 void

--- a/src/mono/mono/metadata/memory-manager.c
+++ b/src/mono/mono/metadata/memory-manager.c
@@ -66,7 +66,7 @@ lock_free_mempool_alloc0 (LockFreeMempool *mp, guint size)
 
 	// FIXME: Free the allocator
 
-	size = ALIGN_TO (size, 8);
+	size = (guint)ALIGN_TO (size, 8);
 	chunk = mp->current;
 	if (!chunk) {
 		chunk = lock_free_mempool_chunk_new (mp, size);

--- a/src/mono/mono/metadata/mempool.h
+++ b/src/mono/mono/metadata/mempool.h
@@ -32,7 +32,7 @@ mono_mempool_alloc         (MonoMemPool *pool, unsigned int size);
 MONO_API void*
 mono_mempool_alloc0        (MonoMemPool *pool, unsigned int size);
 
-#define mono_mempool_alloc0(pool, size) (g_cast (mono_mempool_alloc0 ((pool), (size))))
+#define mono_mempool_alloc0(pool, size) (g_cast (mono_mempool_alloc0 ((pool), GSIZE_TO_UINT ((size)))))
 
 MONO_API mono_bool
 mono_mempool_contains_addr (MonoMemPool *pool, void* addr);

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -6177,7 +6177,7 @@ mono_string_new_utf8_len (const char *text, guint length, MonoError *error)
 		//mono_error_set_execution_engine (error, "String conversion error: %s", eg_error->message);
 		g_error_free (eg_error);
 	} else {
-		o = mono_string_new_utf16_handle (ut, items_written, error);
+		o = mono_string_new_utf16_handle (ut, GLONG_TO_INT32 (items_written), error);
 	}
 
 	g_free (ut);
@@ -6247,7 +6247,7 @@ mono_string_new_checked (const char *text, MonoError *error)
 	ut = g_utf8_to_utf16 (text, (glong)strlen (text), NULL, &items_written, &eg_error);
 
 	if (!eg_error)
-		o = mono_string_new_utf16_checked (ut, items_written, error);
+		o = mono_string_new_utf16_checked (ut, GLONG_TO_INT32 (items_written), error);
 	else {
 		mono_error_set_execution_engine (error, "String conversion error: %s", eg_error->message);
 		g_error_free (eg_error);
@@ -6281,7 +6281,7 @@ mono_string_new_wtf8_len_checked (const char *text, guint length, MonoError *err
 	ut = eg_wtf8_to_utf16 (text, length, NULL, &items_written, &eg_error);
 
 	if (!eg_error)
-		o = mono_string_new_utf16_checked (ut, items_written, error);
+		o = mono_string_new_utf16_checked (ut, GLONG_TO_INT32 (items_written), error);
 	else
 		g_error_free (eg_error);
 

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1539,19 +1539,19 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p)
 			p++;
 			while (*p && g_ascii_isspace (*p))
 				p++;
-			assembly->major = strtoul (p, &s, 10);
+			assembly->major = (int32_t) strtoul (p, &s, 10);
 			if (s == p || *s != '.')
 				return 1;
 			p = ++s;
-			assembly->minor = strtoul (p, &s, 10);
+			assembly->minor = (int32_t) strtoul (p, &s, 10);
 			if (s == p || *s != '.')
 				return 1;
 			p = ++s;
-			assembly->build = strtoul (p, &s, 10);
+			assembly->build = (int32_t) strtoul (p, &s, 10);
 			if (s == p || *s != '.')
 				return 1;
 			p = ++s;
-			assembly->revision = strtoul (p, &s, 10);
+			assembly->revision = (int32_t) strtoul (p, &s, 10);
 			if (s == p)
 				return 1;
 			p = s;

--- a/src/mono/mono/metadata/sre-internals.h
+++ b/src/mono/mono/metadata/sre-internals.h
@@ -57,7 +57,7 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb, M
 gpointer
 mono_image_g_malloc0 (MonoImage *image, guint size);
 
-#define mono_image_g_malloc0(image, size) (g_cast (mono_image_g_malloc0 ((image), (size))))
+#define mono_image_g_malloc0(image, size) (g_cast (mono_image_g_malloc0 ((image), (guint)(size))))
 
 gboolean
 mono_is_sre_type_builder (MonoClass *klass);

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -217,10 +217,10 @@ image_strdup (MonoImage *image, const char *s)
 #endif
 
 #define image_g_new(image,struct_type, n_structs)		\
-    ((struct_type *) image_g_malloc (image, ((gsize) sizeof (struct_type)) * ((gsize) (n_structs))))
+	((struct_type *) image_g_malloc (image, GSIZE_TO_UINT (((gsize) sizeof (struct_type)) * ((gsize) (n_structs)))))
 
 #define image_g_new0(image,struct_type, n_structs)		\
-    ((struct_type *) mono_image_g_malloc0 (image, ((gsize) sizeof (struct_type)) * ((gsize) (n_structs))))
+	((struct_type *) mono_image_g_malloc0 (image, GSIZE_TO_UINT (((gsize) sizeof (struct_type)) * ((gsize) (n_structs)))))
 
 
 static void

--- a/src/mono/mono/metadata/w32handle.c
+++ b/src/mono/mono/metadata/w32handle.c
@@ -735,7 +735,7 @@ mono_w32handle_wait_one (gpointer handle, guint32 timeout, gboolean alertable)
 				goto done;
 			}
 
-			waited = mono_w32handle_timedwait_signal_handle (handle_data, timeout - elapsed, FALSE, alertable ? &alerted : NULL);
+			waited = mono_w32handle_timedwait_signal_handle (handle_data, timeout - (guint32)elapsed, FALSE, alertable ? &alerted : NULL);
 		}
 
 		if (alerted) {

--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -315,6 +315,8 @@ endif()
 
 if(HOST_WIN32)
 set_source_files_properties(${ZLIB_SOURCES} PROPERTIES COMPILE_OPTIONS "/wd4005;/wd4127;/wd4131;/wd4244")
+elseif(HOST_BROWSER)
+set_source_files_properties(${ZLIB_SOURCES} PROPERTIES COMPILE_OPTIONS "-Wno-implicit-int-conversion -Wno-shorten-64-to-32")
 endif()
 
 if(NOT HOST_WIN32)

--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -317,6 +317,12 @@ if(HOST_WIN32)
 set_source_files_properties(${ZLIB_SOURCES} PROPERTIES COMPILE_OPTIONS "/wd4005;/wd4127;/wd4131;/wd4244")
 endif()
 
+if(NOT HOST_WIN32)
+  if (CMAKE_C_COMPILER_ID MATCHES "Clang")
+    set_source_files_properties("../utils/dlmalloc.c" PROPERTIES COMPILE_OPTIONS "-Wno-shorten-64-to-32")
+  endif()
+endif()
+
 set(monosgen-sources "${metadata_sources};${utils_sources};${sgen_sources};${icu_shim_sources};${mini_sources};${ZLIB_SOURCES}")
 
 add_library(monosgen-objects OBJECT "${monosgen-sources}")

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -3026,7 +3026,7 @@ encode_value (gint32 value, guint8 *buf, guint8 **endbuf)
 		p [1] = value & 0xff;
 		p += 2;
 	} else if ((value >= 0) && (value <= 0x1fffffff)) {
-		p [0] = (value >> 24) | 0xc0;
+		p [0] = GINT32_TO_UINT8 ((value >> 24) | 0xc0);
 		p [1] = (value >> 16) & 0xff;
 		p [2] = (value >> 8) & 0xff;
 		p [3] = value & 0xff;
@@ -6470,7 +6470,7 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 						}
 					}
 				} else if (patch_info->type == MONO_PATCH_INFO_JIT_ICALL_ADDR) {
-					const char *sym = mono_find_jit_icall_info (patch_info->data.jit_icall_id)->c_symbol;
+					const char *sym = mono_find_jit_icall_info ((MonoJitICallId)patch_info->data.jit_icall_id)->c_symbol;
 					if (!got_only && sym && acfg->aot_opts.direct_icalls) {
 						/* Call to a C function implementing a jit icall */
 						direct_call = TRUE;
@@ -6479,7 +6479,7 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 						direct_call_target = g_strdup_printf ("%s%s", acfg->user_symbol_prefix, sym);
 					}
 				} else if (patch_info->type == MONO_PATCH_INFO_JIT_ICALL_ID) {
-					MonoJitICallInfo * const info = mono_find_jit_icall_info (patch_info->data.jit_icall_id);
+					MonoJitICallInfo * const info = mono_find_jit_icall_info ((MonoJitICallId)patch_info->data.jit_icall_id);
 					const char * const sym = info->c_symbol;
 					if (!got_only && sym && acfg->aot_opts.direct_icalls && info->func == info->wrapper) {
 						/* Call to a jit icall without a wrapper */
@@ -7559,7 +7559,7 @@ get_plt_entry_debug_sym (MonoAotCompile *acfg, MonoJumpInfo *ji, GHashTable *cac
 		debug_sym = get_debug_sym (ji->data.method, prefix, cache);
 		break;
 	case MONO_PATCH_INFO_JIT_ICALL_ID:
-		debug_sym = g_strdup_printf ("%s_jit_icall_%s", prefix, mono_find_jit_icall_info (ji->data.jit_icall_id)->name);
+		debug_sym = g_strdup_printf ("%s_jit_icall_%s", prefix, mono_find_jit_icall_info ((MonoJitICallId)ji->data.jit_icall_id)->name);
 		break;
 	case MONO_PATCH_INFO_RGCTX_FETCH:
 		debug_sym = g_strdup_printf ("%s_rgctx_fetch_%d", prefix, acfg->label_generator ++);
@@ -7576,7 +7576,7 @@ get_plt_entry_debug_sym (MonoAotCompile *acfg, MonoJumpInfo *ji, GHashTable *cac
 		debug_sym = g_strdup_printf ("%s_jit_icall_native_specific_trampoline_lazy_fetch_%lu", prefix, (gulong)ji->data.uindex);
 		break;
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
-		debug_sym = g_strdup_printf ("%s_jit_icall_native_%s", prefix, mono_find_jit_icall_info (ji->data.jit_icall_id)->name);
+		debug_sym = g_strdup_printf ("%s_jit_icall_native_%s", prefix, mono_find_jit_icall_info ((MonoJitICallId)ji->data.jit_icall_id)->name);
 		break;
 	default:
 		break;

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -5657,7 +5657,7 @@ get_new_trampoline_from_page (int tramp_type)
 		 */
 		if (tramp_type != MONO_AOT_TRAMP_SPECIFIC) {
 			/* Register the rest of the page as a single trampoline */
-			sp_info = mono_tramp_info_create (NULL, code, page->trampolines_end - code, NULL, NULL);
+			sp_info = mono_tramp_info_create (NULL, code, (guint32)(page->trampolines_end - code), NULL, NULL);
 			read_page_trampoline_uwinfo (sp_info, tramp_type, FALSE);
 			mono_aot_tramp_info_register (sp_info, NULL);
 		}

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2230,7 +2230,8 @@ load_aot_module (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer 
 #ifndef TARGET_WIN32
 		guint8 *addr;
 		guint8 *page_start, *page_end;
-		int err, len;
+		int err;
+		gssize len;
 
 		addr = amodule->mem_begin;
 		g_assert (addr);

--- a/src/mono/mono/mini/cfgdump.c
+++ b/src/mono/mono/mini/cfgdump.c
@@ -56,7 +56,7 @@ create_socket (const char *hostname, const int port)
     }
 
     serv_addr.sin_family = AF_INET;
-    serv_addr.sin_port = htons (port);
+    serv_addr.sin_port = htons (GINT_TO_UINT16 (port));
     serv_addr.sin_addr.s_addr = inet_addr (hostname);
 
     if (connect (sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
@@ -71,7 +71,7 @@ static void
 write_byte (MonoCompile *cfg, unsigned char b)
 {
 	int ret;
-	while ((ret = write (cfg->gdump_ctx->fd, &b, 1)) < 0 && errno == EINTR);
+	while ((ret = (int) write (cfg->gdump_ctx->fd, &b, 1)) < 0 && errno == EINTR);
 }
 
 static void
@@ -79,14 +79,14 @@ write_short (MonoCompile *cfg, short s)
 {
 	short swap = htons (s);
 	int ret;
-	while ((ret = write (cfg->gdump_ctx->fd, &swap, 2)) < 0 && errno == EINTR);
+	while ((ret = (int) write (cfg->gdump_ctx->fd, &swap, 2)) < 0 && errno == EINTR);
 }
 
 static void
 write_int (MonoCompile *cfg, int v)
 {
 	int swap = htonl (v), ret;
-	while ((ret = write (cfg->gdump_ctx->fd, &swap, 4)) < 0 && errno == EINTR);
+	while ((ret = (int) write (cfg->gdump_ctx->fd, &swap, 4)) < 0 && errno == EINTR);
 }
 
 static void
@@ -152,7 +152,7 @@ add_pool_entry (MonoCompile *cfg, ConstantPoolEntry *entry)
 
 			write_string (cfg, mono_inst_name (insn->opcode));
 			GString *insndesc = mono_print_ins_index_strbuf (-1, insn);
-			const int len = g_strnlen (insndesc->str, 0x2000);
+			const int len = (int) g_strnlen (insndesc->str, 0x2000);
 #define CUTOFF 40
 			if (len > CUTOFF) {
 				insndesc->str[CUTOFF] = '\0';

--- a/src/mono/mono/mini/cfgdump.c
+++ b/src/mono/mono/mini/cfgdump.c
@@ -175,7 +175,7 @@ add_pool_entry (MonoCompile *cfg, ConstantPoolEntry *entry)
 			write_short (cfg, NUM_SUCCESSOR);
 			for (int i = 0; i < NUM_SUCCESSOR; i++) {
 				char *str = g_strdup ("successor1");
-				str[9] = '0' + i;
+				str[9] = '0' + (char)i;
 				write_byte (cfg, 0);
 				write_pool (cfg, create_cp_entry (cfg, (void *) str, PT_STRING));
 			}

--- a/src/mono/mono/mini/debug-mini.c
+++ b/src/mono/mono/mini/debug-mini.c
@@ -370,7 +370,7 @@ encode_value (gint32 value, guint8 *buf, guint8 **endbuf)
 		p [1] = value & 0xff;
 		p += 2;
 	} else if ((value >= 0) && (value <= 0x1fffffff)) {
-		p [0] = (value >> 24) | 0xc0;
+		p [0] = GINT32_TO_UINT8 ((value >> 24) | 0xc0);
 		p [1] = (value >> 16) & 0xff;
 		p [2] = (value >> 8) & 0xff;
 		p [3] = value & 0xff;

--- a/src/mono/mono/mini/dwarfwriter.c
+++ b/src/mono/mono/mini/dwarfwriter.c
@@ -1290,7 +1290,7 @@ emit_loclist (MonoDwarfWriter *w, MonoInst *ins,
 
 	emit_pointer_value (w, loclist_begin_addr);
 	emit_pointer_value (w, loclist_end_addr);
-	emit_byte (w, expr_len % 256);
+	emit_byte (w, GUINT32_TO_UINT8 (expr_len % 256));
 	emit_byte (w, GUINT32_TO_UINT8 (expr_len / 256));
 	emit_bytes (w, expr, expr_len);
 

--- a/src/mono/mono/mini/interp/interp-intrins.c
+++ b/src/mono/mono/mini/interp/interp-intrins.c
@@ -113,7 +113,7 @@ interp_intrins_u32_to_decstr (guint32 value, MonoArray *cache, MonoVTable *vtabl
 	if (bufferLength == 1)
 		return mono_array_get_fast (cache, MonoString*, value);
 
-	int size = (G_STRUCT_OFFSET (MonoString, chars) + (((size_t)bufferLength + 1) * 2));
+	size_t size = (G_STRUCT_OFFSET (MonoString, chars) + (((size_t)bufferLength + 1) * 2));
 	MonoString* result = mono_gc_alloc_string (vtable, size, bufferLength);
 	mono_unichar2 *buffer = &result->chars [0];
 	mono_unichar2 *p = buffer + bufferLength;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -796,7 +796,7 @@ stackval_size (MonoType *type, gboolean pinvoke)
 				size = mono_class_native_size (type->data.klass, NULL);
 			else
 				size = mono_class_value_size (type->data.klass, NULL);
-			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
+			return (int) ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 		}
 	case MONO_TYPE_GENERICINST: {
 		if (mono_type_generic_inst_is_valuetype (type)) {
@@ -806,7 +806,7 @@ stackval_size (MonoType *type, gboolean pinvoke)
 				size = mono_class_native_size (klass, NULL);
 			else
 				size = mono_class_value_size (klass, NULL);
-			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
+			return (int) ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 		}
 		return stackval_size (m_class_get_byval_arg (type->data.generic_class->container_class), pinvoke);
 	}
@@ -882,7 +882,7 @@ stackval_from_data (MonoType *type, stackval *result, const void *data, gboolean
 			else
 				size = mono_class_value_size (type->data.klass, NULL);
 			memcpy (result, data, size);
-			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
+			return (int) ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 		}
 	case MONO_TYPE_GENERICINST: {
 		if (mono_type_generic_inst_is_valuetype (type)) {
@@ -893,7 +893,7 @@ stackval_from_data (MonoType *type, stackval *result, const void *data, gboolean
 			else
 				size = mono_class_value_size (klass, NULL);
 			memcpy (result, data, size);
-			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
+			return (int) ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 		}
 		return stackval_from_data (m_class_get_byval_arg (type->data.generic_class->container_class), result, data, pinvoke);
 	}
@@ -992,7 +992,7 @@ stackval_to_data (MonoType *type, stackval *val, void *data, gboolean pinvoke)
 				size = mono_class_value_size (type->data.klass, NULL);
 				mono_value_copy_internal (data, val, type->data.klass);
 			}
-			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
+			return (int) ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 		}
 	case MONO_TYPE_GENERICINST: {
 		MonoClass *container_class = type->data.generic_class->container_class;
@@ -1007,7 +1007,7 @@ stackval_to_data (MonoType *type, stackval *val, void *data, gboolean pinvoke)
 				size = mono_class_value_size (klass, NULL);
 				mono_value_copy_internal (data, val, klass);
 			}
-			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
+			return (int) ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 		}
 		return stackval_to_data (m_class_get_byval_arg (type->data.generic_class->container_class), val, data, pinvoke);
 	}
@@ -1301,7 +1301,7 @@ compute_arg_offset (MonoMethodSignature *sig, int index, int prev_offset)
 		int size, align;
 		MonoType *type = sig->params [index - 1];
 		size = mono_type_size (type, &align);
-		return prev_offset + ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
+		return prev_offset + (int) ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 	}
 }
 
@@ -2545,7 +2545,7 @@ init_jit_call_info (InterpMethod *rmethod, MonoError *error)
 			 * that could end up doing a jit call.
 			 */
 			gint32 size = mono_class_value_size (klass, NULL);
-			cinfo->res_size = ALIGN_TO (size, MINT_VT_ALIGNMENT);
+			cinfo->res_size = (int32_t) ALIGN_TO (size, MINT_VT_ALIGNMENT);
 		} else {
 			cinfo->res_size = MINT_STACK_SLOT_SIZE;
 		}
@@ -7044,7 +7044,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 
 		MINT_IN_CASE(MINT_LOCALLOC) {
 			int len = LOCAL_VAR (ip [2], gint32);
-			gpointer mem = frame_data_allocator_alloc (&context->data_stack, frame, ALIGN_TO (len, MINT_VT_ALIGNMENT));
+			gpointer mem = frame_data_allocator_alloc (&context->data_stack, frame, (int) ALIGN_TO (len, MINT_VT_ALIGNMENT));
 
 			if (frame->imethod->init_locals)
 				memset (mem, 0, len);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -434,7 +434,7 @@ push_type_explicit (TransformData *td, int type, MonoClass *k, int type_size)
 	td->sp->klass = k;
 	td->sp->flags = 0;
 	td->sp->local = create_interp_stack_local (td, type, k, type_size);
-	td->sp->size = ALIGN_TO (type_size, MINT_STACK_SLOT_SIZE);
+	td->sp->size = (int) ALIGN_TO (type_size, MINT_STACK_SLOT_SIZE);
 	td->sp++;
 }
 
@@ -447,7 +447,7 @@ push_var (TransformData *td, int var_index)
 	td->sp->klass = mono_class_from_mono_type_internal (var->type);
 	td->sp->flags = 0;
 	td->sp->local = var_index;
-	td->sp->size = ALIGN_TO (var->size, MINT_STACK_SLOT_SIZE);
+	td->sp->size = (int) ALIGN_TO (var->size, MINT_STACK_SLOT_SIZE);
 	td->sp++;
 }
 
@@ -1309,7 +1309,7 @@ alloc_var_offset (TransformData *td, int local, gint32 *ptos)
 
 	td->locals [local].offset = offset;
 
-	*ptos = ALIGN_TO (offset + size, MINT_STACK_SLOT_SIZE);
+	*ptos = (gint32) ALIGN_TO (offset + size, MINT_STACK_SLOT_SIZE);
 
 	return td->locals [local].offset;
 }
@@ -2839,7 +2839,7 @@ interp_inline_newobj (TransformData *td, MonoMethod *target_method, MonoMethodSi
 		newobj_fast = interp_add_ins (td, MINT_NEWOBJ_VT_INLINED);
 		interp_ins_set_dreg (newobj_fast, this_reg);
 		interp_ins_set_sreg (newobj_fast, dreg);
-		newobj_fast->data [0] = ALIGN_TO (vtsize, MINT_STACK_SLOT_SIZE);
+		newobj_fast->data [0] = GINT_TO_UINT16 ((int) ALIGN_TO (vtsize, MINT_STACK_SLOT_SIZE));
 	} else {
 		MonoVTable *vtable = mono_class_vtable_checked (klass, error);
 		goto_if_nok (error, fail);
@@ -3245,7 +3245,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 			else
 				res_size = mono_class_value_size (klass, NULL);
 			push_type_vt (td, klass, res_size);
-			res_size = ALIGN_TO (res_size, MINT_VT_ALIGNMENT);
+			res_size = (guint32) ALIGN_TO (res_size, MINT_VT_ALIGNMENT);
 			if (mono_class_has_failure (klass)) {
 				mono_error_set_for_class_failure (error, klass);
 				return FALSE;
@@ -3840,7 +3840,7 @@ interp_method_compute_offsets (TransformData *td, InterpMethod *imethod, MonoMet
 		// Every local takes a MINT_STACK_SLOT_SIZE so IL locals have same behavior as execution locals
 		offset += ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
 	}
-	offset = ALIGN_TO (offset, MINT_VT_ALIGNMENT);
+	offset = (int) ALIGN_TO (offset, MINT_VT_ALIGNMENT);
 	td->il_locals_size = offset - td->il_locals_offset;
 	td->total_locals_size = offset;
 
@@ -5638,7 +5638,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					if (is_vt) {
 						newobj_fast = interp_add_ins (td, MINT_NEWOBJ_VT);
 						interp_ins_set_dreg (newobj_fast, dreg);
-						newobj_fast->data [1] = ALIGN_TO (vtsize, MINT_STACK_SLOT_SIZE);
+						newobj_fast->data [1] = GINT_TO_UINT16 ((int) ALIGN_TO (vtsize, MINT_STACK_SLOT_SIZE));
 					} else {
 						MonoVTable *vtable = mono_class_vtable_checked (klass, error);
 						goto_if_nok (error, exit);
@@ -5861,7 +5861,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			mt = mint_type (m_class_get_byval_arg (field_klass));
 			int field_size = mono_class_value_size (field_klass, NULL);
 			int obj_size = mono_class_value_size (klass, NULL);
-			obj_size = ALIGN_TO (obj_size, MINT_VT_ALIGNMENT);
+			obj_size = (int) ALIGN_TO (obj_size, MINT_VT_ALIGNMENT);
 
 			{
 				if (is_static) {
@@ -9093,7 +9093,7 @@ get_call_param_size (TransformData *td, InterpInst *call)
 
 	int var = *call_args;
 	while (var != -1) {
-		param_size = ALIGN_TO (param_size + td->locals [var].size, MINT_STACK_SLOT_SIZE);
+		param_size = (int) ALIGN_TO (param_size + td->locals [var].size, MINT_STACK_SLOT_SIZE);
 		call_args++;
 		var = *call_args;
 	}
@@ -9429,7 +9429,7 @@ interp_alloc_offsets (TransformData *td)
 			final_total_locals_size = MAX (td->locals [i].offset + td->locals [i].size, final_total_locals_size);
 		}
 	}
-	td->total_locals_size = ALIGN_TO (final_total_locals_size, MINT_STACK_SLOT_SIZE);
+	td->total_locals_size = (int) ALIGN_TO (final_total_locals_size, MINT_STACK_SLOT_SIZE);
 }
 
 /*

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -541,7 +541,7 @@ mono_imul_ovf (gint32 a, gint32 b)
 		return 0;
 	}
 
-	return res;
+	return (gint32) res;
 }
 
 gint32
@@ -556,7 +556,7 @@ mono_imul_ovf_un (guint32 a, guint32 b)
 		return 0;
 	}
 
-	return res;
+	return (gint32)res;
 }
 
 gint32
@@ -571,7 +571,7 @@ mono_imul_ovf_un_oom (guint32 a, guint32 b)
 		return 0;
 	}
 
-	return res;
+	return (gint32)res;
 }
 #endif
 

--- a/src/mono/mono/mini/lldb.c
+++ b/src/mono/mono/mini/lldb.c
@@ -329,7 +329,7 @@ register_codegen_region (gpointer region_start, int region_size, gboolean dynami
 	strcpy (region_entry->magic, OBJFILE_MAGIC);
 	region_entry->id = id;
 	region_entry->start = (gsize)region_start;
-	region_entry->size = (gsize)region_size;
+	region_entry->size = GINT_TO_UINT32 (region_size);
 
 	add_entry (ENTRY_CODE_REGION, buf);
 	buffer_free (buf);

--- a/src/mono/mono/mini/llvm-jit.cpp
+++ b/src/mono/mono/mini/llvm-jit.cpp
@@ -139,7 +139,7 @@ MonoLLVMMemoryManager::allocateCodeSection(uintptr_t Size,
 										  unsigned SectionID,
 										  StringRef SectionName)
 {
-	uint8_t *mem = alloc_code (NULL, Size);
+	uint8_t *mem = alloc_code (NULL, static_cast<int> (Size));
 	PendingCodeMem.push_back (sys::MemoryBlock ((void *)mem, Size));
 	return mem;
 }

--- a/src/mono/mono/mini/mini-amd64-gsharedvt.c
+++ b/src/mono/mono/mini/mini-amd64-gsharedvt.c
@@ -515,7 +515,7 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 		DEBUG_AMD64_GSHAREDVT_PRINT ("RET marshal is %s\n", ret_marshal_name [info->ret_marshal]);
 	}
 
-	info->stack_usage = ALIGN_TO (info->stack_usage, MONO_ARCH_FRAME_ALIGNMENT);
+	info->stack_usage = (int) ALIGN_TO (info->stack_usage, MONO_ARCH_FRAME_ALIGNMENT);
 
 	g_free (callee_cinfo);
 	g_free (caller_cinfo);

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -1226,7 +1226,7 @@ add_valuetype (CallInfo *cinfo, ArgInfo *ainfo, MonoType *t)
 			ainfo->size = size;
 			ainfo->esize = esize;
 			for (i = 0; i < nfields; ++i)
-				ainfo->foffsets [i] = field_offsets [i];
+				ainfo->foffsets [i] = GINT_TO_UINT8 (field_offsets [i]);
 			cinfo->fr += ainfo->nregs;
 		} else {
 			ainfo->nfregs_to_skip = FP_PARAM_REGS > cinfo->fr ? FP_PARAM_REGS - cinfo->fr : 0;
@@ -1984,16 +1984,16 @@ mono_arch_finish_dyn_call (MonoDynCallInfo *info, guint8 *buf)
 		*(gpointer*)ret = (gpointer)res;
 		break;
 	case MONO_TYPE_I1:
-		*(gint8*)ret = res;
+		*(gint8*)ret = (gint8)res;
 		break;
 	case MONO_TYPE_U1:
-		*(guint8*)ret = res;
+		*(guint8*)ret = (guint8)res;
 		break;
 	case MONO_TYPE_I2:
-		*(gint16*)ret = res;
+		*(gint16*)ret = (gint16)res;
 		break;
 	case MONO_TYPE_U2:
-		*(guint16*)ret = res;
+		*(guint16*)ret = (guint16)res;
 		break;
 	case MONO_TYPE_I4:
 		*(gint32*)ret = res;
@@ -2931,7 +2931,7 @@ mono_arch_lowering_pass (MonoCompile *cfg, MonoBasicBlock *bb)
 				temp->inst_c0 = ins->inst_imm;
 				temp->dreg = mono_alloc_ireg (cfg);
 				ins->sreg1 = temp->dreg;
-				ins->opcode = mono_op_imm_to_op (ins->opcode);
+				ins->opcode = (guint16)mono_op_imm_to_op (ins->opcode);
 			}
 			break;
 		case OP_ICOMPARE_IMM:
@@ -5041,7 +5041,7 @@ emit_store_regset_cfa (MonoCompile *cfg, guint8 *code, guint64 regs, int basereg
 
 			for (j = 0; j < nregs; ++j) {
 				if (cfa_regset & (1 << (i + j)))
-					mono_emit_unwind_op_offset (cfg, code, i + j, (- cfa_offset) + offset + ((pos + j) * 8));
+					mono_emit_unwind_op_offset (cfg, code, (guint16)(i + j), (- cfa_offset) + offset + ((pos + j) * 8));
 			}
 
 			i += nregs - 1;

--- a/src/mono/mono/mini/mini-codegen.c
+++ b/src/mono/mono/mini/mini-codegen.c
@@ -183,7 +183,7 @@ mono_regstate_alloc_int (MonoRegState *rs, regmask_t allow)
 			: "=r" (i) : "rm" (mask));
 
 	rs->ifree_mask &= ~ ((regmask_t)1 << i);
-	return i;
+	return (int)i;
  }
 #else
 	int i;

--- a/src/mono/mono/mini/mini-llvm-cpp.cpp
+++ b/src/mono/mono/mini/mini-llvm-cpp.cpp
@@ -762,7 +762,7 @@ mono_llvm_register_overloaded_intrinsic (LLVMModuleRef module, IntrinsicId id, L
 unsigned int
 mono_llvm_get_prim_size_bits (LLVMTypeRef type)
 {
-	return unwrap (type)->getPrimitiveSizeInBits ();
+	return static_cast<unsigned int> (unwrap (type)->getPrimitiveSizeInBits ());
 }
 
 /*

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -1983,13 +1983,13 @@ get_aotconst_name (MonoJumpInfoType type, gconstpointer data, int got_offset)
 		name = g_strdup_printf ("%s", mono_ji_type_to_string (type));
 		len = strlen (name);
 		for (size_t i = 0; i < len; ++i)
-			name [i] = tolower (name [i]);
+			name [i] = (char) tolower (name [i]);
 		break;
 	default:
 		name = g_strdup_printf ("%s_%d", mono_ji_type_to_string (type), got_offset);
 		len = strlen (name);
 		for (size_t i = 0; i < len; ++i)
-			name [i] = tolower (name [i]);
+			name [i] = (char) tolower (name [i]);
 		break;
 	}
 
@@ -4461,7 +4461,7 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 		LLVMValueRef index;
 
 		g_assert (ins->inst_offset % size == 0);
-		index = const_int32 (ins->inst_offset / size);
+		index = const_int32 ((int) (ins->inst_offset / size));
 
 		LLVMTypeRef etype = pointer_type (llvm_sig);
 		callee = LLVMBuildLoad2 (builder, etype, LLVMBuildGEP2 (builder, etype, convert (ctx, values [ins->inst_basereg], pointer_type (etype)), &index, 1, ""), "");
@@ -5735,7 +5735,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 		case OP_LIVERANGE_END:
 			break;
 		case OP_ICONST:
-			values [ins->dreg] = const_int32 (ins->inst_c0);
+			values [ins->dreg] = const_int32 ((int) ins->inst_c0);
 			break;
 		case OP_I8CONST:
 #if TARGET_SIZEOF_VOID_P == 4
@@ -5948,7 +5948,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 
 			if (ins->opcode == OP_ICOMPARE_IMM) {
 				lhs = convert (ctx, lhs, LLVMInt32Type ());
-				rhs = const_int32 (ins->inst_imm);
+				rhs = const_int32 ((int)ins->inst_imm);
 			}
 			if (ins->opcode == OP_LCOMPARE_IMM) {
 				lhs = convert (ctx, lhs, LLVMInt64Type ());
@@ -6295,7 +6295,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			if (spec [MONO_INST_SRC1] == 'l') {
 				imm = const_int64 (GET_LONG_IMM (ins));
 			} else {
-				imm = const_int32 (ins->inst_imm);
+				imm = const_int32 ((int) ins->inst_imm);
 			}
 
 			emit_div_check (ctx, builder, bb, ins, lhs, imm);
@@ -6564,7 +6564,7 @@ MONO_RESTORE_WARNING
 		case OP_LOCALLOC_IMM: {
 			LLVMValueRef v;
 
-			guint32 size = ins->inst_imm;
+			guint32 size = (guint32)ins->inst_imm;
 			size = (size + (MONO_ARCH_FRAME_ALIGNMENT - 1)) & ~ (MONO_ARCH_FRAME_ALIGNMENT - 1);
 
 			v = mono_llvm_build_alloca (builder, LLVMInt8Type (), const_int32 (size), MONO_ARCH_FRAME_ALIGNMENT, "");
@@ -6633,10 +6633,10 @@ MONO_RESTORE_WARNING
 					}
 				} else if (ins->inst_offset % size != 0) {
 					/* Unaligned load */
-					index = const_int32 (ins->inst_offset);
+					index = const_int32 ((int)ins->inst_offset);
 					addr = LLVMBuildGEP2 (builder, i1_t, convert (ctx, base, pointer_type (LLVMInt8Type ())), &index, 1, "");
 				} else {
-					index = const_int32 (ins->inst_offset / size);
+					index = const_int32 ((int)(ins->inst_offset / size));
 					addr = LLVMBuildGEP2 (builder, t, convert (ctx, base, pointer_type (t)), &index, 1, "");
 				}
 			}
@@ -6692,10 +6692,10 @@ MONO_RESTORE_WARNING
 				addr = LLVMBuildGEP2 (builder, i1_t, convert (ctx, gep_base, pointer_type (LLVMInt8Type ())), &gep_offset, 1, "");
 			} else if (ins->inst_offset % size != 0) {
 				/* Unaligned store */
-				index = const_int32 (ins->inst_offset);
+				index = const_int32 ((int)ins->inst_offset);
 				addr = LLVMBuildGEP2 (builder, i1_t, convert (ctx, base, pointer_type (LLVMInt8Type ())), &index, 1, "");
 			} else {
-				index = const_int32 (ins->inst_offset / size);
+				index = const_int32 ((int)(ins->inst_offset / size));
 				addr = LLVMBuildGEP2 (builder, t, convert (ctx, base, pointer_type (t)), &index, 1, "");
 			}
 			if (is_volatile && LLVMGetInstructionOpcode (base) == LLVMAlloca && !(ins->flags & MONO_INST_VOLATILE))
@@ -6731,10 +6731,10 @@ MONO_RESTORE_WARNING
 				addr = LLVMBuildGEP2 (builder, i1_t, convert (ctx, gep_base, pointer_type (LLVMInt8Type ())), &gep_offset, 1, "");
 			} else if (ins->inst_offset % size != 0) {
 				/* Unaligned store */
-				index = const_int32 (ins->inst_offset);
+				index = const_int32 ((int)ins->inst_offset);
 				addr = LLVMBuildGEP2 (builder, i1_t, convert (ctx, base, pointer_type (LLVMInt8Type ())), &index, 1, "");
 			} else {
-				index = const_int32 (ins->inst_offset / size);
+				index = const_int32 ((int)(ins->inst_offset / size));
 				addr = LLVMBuildGEP2 (builder, t, convert (ctx, base, pointer_type (t)), &index, 1, "");
 			}
 			LLVMValueRef srcval = convert (ctx, LLVMConstInt (IntPtrType (), ins->inst_imm, FALSE), t);
@@ -6773,7 +6773,7 @@ MONO_RESTORE_WARNING
 			break;
 		}
 		case OP_AOTCONST: {
-			MonoJumpInfoType ji_type = ins->inst_c1;
+			MonoJumpInfoType ji_type = (MonoJumpInfoType)ins->inst_c1;
 			gpointer ji_data = ins->inst_p0;
 
 			if (ji_type == MONO_PATCH_INFO_ICALL_ADDR) {
@@ -7202,7 +7202,7 @@ MONO_RESTORE_WARNING
 				dname = (char *)"";
 
 			if (ins->inst_offset != 0) {
-				index = const_int32 (ins->inst_offset / size);
+				index = const_int32 ((int)(ins->inst_offset / size));
 				addr = LLVMBuildGEP2 (builder, t, convert (ctx, lhs, pointer_type (t)), &index, 1, "");
 			} else {
 				addr = lhs;
@@ -7244,7 +7244,7 @@ MONO_RESTORE_WARNING
 			t = load_store_to_llvm_type (ins->opcode, &size, &sext, &zext);
 
 			base = values [ins->inst_destbasereg];
-			index = const_int32 (ins->inst_offset / size);
+			index = const_int32 ((int)(ins->inst_offset / size));
 			addr = LLVMBuildGEP2 (builder, t, convert (ctx, base, pointer_type (t)), &index, 1, "");
 			value = convert (ctx, values [ins->sreg1], t);
 
@@ -7602,7 +7602,7 @@ MONO_RESTORE_WARNING
 				element_ix = rhs;
 				break;
 			default:
-				element_ix = const_int32 (ins->inst_c0);
+				element_ix = const_int32 ((int)(ins->inst_c0));
 			}
 			LLVMTypeRef lhs_t = LLVMTypeOf (lhs);
 			int vec_width = mono_llvm_get_prim_size_bits (lhs_t);
@@ -7857,22 +7857,22 @@ MONO_RESTORE_WARNING
 			break;
 		}
 		case OP_INSERT_I1:
-			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMInt8Type ()), const_int32 (ins->inst_c0), dname);
+			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMInt8Type ()), const_int32 ((int)ins->inst_c0), dname);
 			break;
 		case OP_INSERT_I2:
-			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMInt16Type ()), const_int32 (ins->inst_c0), dname);
+			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMInt16Type ()), const_int32 ((int)ins->inst_c0), dname);
 			break;
 		case OP_INSERT_I4:
-			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMInt32Type ()), const_int32 (ins->inst_c0), dname);
+			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMInt32Type ()), const_int32 ((int)ins->inst_c0), dname);
 			break;
 		case OP_INSERT_I8:
-			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMInt64Type ()), const_int32 (ins->inst_c0), dname);
+			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMInt64Type ()), const_int32 ((int)ins->inst_c0), dname);
 			break;
 		case OP_INSERT_R4:
-			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMFloatType ()), const_int32 (ins->inst_c0), dname);
+			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMFloatType ()), const_int32 ((int)ins->inst_c0), dname);
 			break;
 		case OP_INSERT_R8:
-			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMDoubleType ()), const_int32 (ins->inst_c0), dname);
+			values [ins->dreg] = LLVMBuildInsertElement (builder, values [ins->sreg1], convert (ctx, values [ins->sreg2], LLVMDoubleType ()), const_int32 ((int)ins->inst_c0), dname);
 			break;
 		case OP_XCAST: {
 			LLVMTypeRef t = simd_class_to_llvm_type (ctx, ins->klass);
@@ -8196,7 +8196,7 @@ MONO_RESTORE_WARNING
 			int mask [16];
 			LLVMValueRef v1 = NULL, v2 = NULL, mask_values [16];
 			int i, mask_size = 0;
-			int imask = ins->inst_c0;
+			int imask = (int)ins->inst_c0;
 
 			/* Convert the x86 shuffle mask to LLVM's */
 			switch (ins->opcode) {
@@ -8441,14 +8441,14 @@ MONO_RESTORE_WARNING
 					convert (ctx, lhs, sse_i2_t),
 					convert (ctx, rhs, sse_i2_t),
 					create_const_vector_i32 (mask_values, 8), "");
-				values [ins->dreg] = convert (ctx, shuffled, type_to_sse_type (ins->inst_c1));
+				values [ins->dreg] = convert (ctx, shuffled, type_to_sse_type ((int)ins->inst_c1));
 			} else if (ins->inst_c1 == MONO_TYPE_I1 || ins->inst_c1 == MONO_TYPE_U1) {
 				const int mask_values [] = { 0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23 };
 				LLVMValueRef shuffled = LLVMBuildShuffleVector (builder,
 					convert (ctx, lhs, sse_i1_t),
 					convert (ctx, rhs, sse_i1_t),
 					create_const_vector_i32 (mask_values, 16), "");
-				values [ins->dreg] = convert (ctx, shuffled, type_to_sse_type (ins->inst_c1));
+				values [ins->dreg] = convert (ctx, shuffled, type_to_sse_type ((int)ins->inst_c1));
 			} else {
 				g_assert_not_reached ();
 			}
@@ -8466,14 +8466,14 @@ MONO_RESTORE_WARNING
 					convert (ctx, lhs, sse_i2_t),
 					convert (ctx, rhs, sse_i2_t),
 					create_const_vector_i32 (mask_values, 8), "");
-				values [ins->dreg] = convert (ctx, shuffled, type_to_sse_type (ins->inst_c1));
+				values [ins->dreg] = convert (ctx, shuffled, type_to_sse_type ((int)ins->inst_c1));
 			} else if (ins->inst_c1 == MONO_TYPE_I1 || ins->inst_c1 == MONO_TYPE_U1) {
 				const int mask_values [] = { 8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31 };
 				LLVMValueRef shuffled = LLVMBuildShuffleVector (builder,
 					convert (ctx, lhs, sse_i1_t),
 					convert (ctx, rhs, sse_i1_t),
 					create_const_vector_i32 (mask_values, 16), "");
-				values [ins->dreg] = convert (ctx, shuffled, type_to_sse_type (ins->inst_c1));
+				values [ins->dreg] = convert (ctx, shuffled, type_to_sse_type ((int)ins->inst_c1));
 			} else {
 				g_assert_not_reached ();
 			}
@@ -8482,15 +8482,15 @@ MONO_RESTORE_WARNING
 
 		case OP_SSE_LOADU: {
 			LLVMValueRef dst_ptr = convert (ctx, lhs, pointer_type (primitive_type_to_llvm_type (inst_c1_type (ins))));
-			LLVMTypeRef etype = type_to_sse_type (ins->inst_c1);
+			LLVMTypeRef etype = type_to_sse_type ((int)ins->inst_c1);
 			LLVMValueRef dst_vec = LLVMBuildBitCast (builder, dst_ptr, pointer_type (etype), "");
-			values [ins->dreg] = mono_llvm_build_aligned_load (builder, etype, dst_vec, "", FALSE, ins->inst_c0); // inst_c0 is alignment
+			values [ins->dreg] = mono_llvm_build_aligned_load (builder, etype, dst_vec, "", FALSE, (int)ins->inst_c0); // inst_c0 is alignment
 			break;
 		}
 		case OP_SSE_MOVSS: {
 			LLVMValueRef addr = convert (ctx, lhs, pointer_type (LLVMFloatType ()));
 			LLVMValueRef val = LLVMBuildLoad2 (builder, LLVMFloatType (), addr, "");
-			values [ins->dreg] = LLVMBuildInsertElement (builder, LLVMConstNull (type_to_sse_type (ins->inst_c1)), val, const_int32 (0), "");
+			values [ins->dreg] = LLVMBuildInsertElement (builder, LLVMConstNull (type_to_sse_type ((int)ins->inst_c1)), val, const_int32 (0), "");
 			break;
 		}
 		case OP_SSE_MOVSS_STORE: {
@@ -8572,7 +8572,7 @@ MONO_RESTORE_WARNING
 
 		case OP_SSE_STORE: {
 			LLVMValueRef dst_vec = convert (ctx, lhs, pointer_type (LLVMTypeOf (rhs)));
-			mono_llvm_build_aligned_store (builder, rhs, dst_vec, FALSE, ins->inst_c0);
+			mono_llvm_build_aligned_store (builder, rhs, dst_vec, FALSE, (int)ins->inst_c0);
 			break;
 		}
 
@@ -8584,7 +8584,7 @@ MONO_RESTORE_WARNING
 		}
 		case OP_SSE_MOVNTPS: {
 			LLVMValueRef addr = convert (ctx, lhs, pointer_type (LLVMTypeOf (rhs)));
-			LLVMValueRef store = mono_llvm_build_aligned_store (builder, rhs, addr, FALSE, ins->inst_c0);
+			LLVMValueRef store = mono_llvm_build_aligned_store (builder, rhs, addr, FALSE, (int)ins->inst_c0);
 			set_nontemporal_flag (store);
 			break;
 		}
@@ -8617,7 +8617,7 @@ MONO_RESTORE_WARNING
 			LLVMValueRef vec_lhs_i64 = convert (ctx, lhs, sse_i8_t);
 			LLVMValueRef vec_rhs_i64 = convert (ctx, rhs, sse_i8_t);
 			LLVMValueRef vec_and = LLVMBuildOr (builder, vec_lhs_i64, vec_rhs_i64, "");
-			values [ins->dreg] = LLVMBuildBitCast (builder, vec_and, type_to_sse_type (ins->inst_c1), "");
+			values [ins->dreg] = LLVMBuildBitCast (builder, vec_and, type_to_sse_type ((int)ins->inst_c1), "");
 			break;
 		}
 
@@ -8625,7 +8625,7 @@ MONO_RESTORE_WARNING
 			LLVMValueRef vec_lhs_i64 = convert (ctx, lhs, sse_i8_t);
 			LLVMValueRef vec_rhs_i64 = convert (ctx, rhs, sse_i8_t);
 			LLVMValueRef vec_and = LLVMBuildXor (builder, vec_lhs_i64, vec_rhs_i64, "");
-			values [ins->dreg] = LLVMBuildBitCast (builder, vec_and, type_to_sse_type (ins->inst_c1), "");
+			values [ins->dreg] = LLVMBuildBitCast (builder, vec_and, type_to_sse_type ((int)ins->inst_c1), "");
 			break;
 		}
 
@@ -8633,7 +8633,7 @@ MONO_RESTORE_WARNING
 			LLVMValueRef vec_lhs_i64 = convert (ctx, lhs, sse_i8_t);
 			LLVMValueRef vec_rhs_i64 = convert (ctx, rhs, sse_i8_t);
 			LLVMValueRef vec_and = LLVMBuildAnd (builder, vec_lhs_i64, vec_rhs_i64, "");
-			values [ins->dreg] = LLVMBuildBitCast (builder, vec_and, type_to_sse_type (ins->inst_c1), "");
+			values [ins->dreg] = LLVMBuildBitCast (builder, vec_and, type_to_sse_type ((int)ins->inst_c1), "");
 			break;
 		}
 
@@ -8645,7 +8645,7 @@ MONO_RESTORE_WARNING
 			LLVMValueRef vec_xor = LLVMBuildXor (builder, vec_lhs_i64, LLVMConstVector (minus_one, 2), "");
 			LLVMValueRef vec_rhs_i64 = convert (ctx, rhs, sse_i8_t);
 			LLVMValueRef vec_and = LLVMBuildAnd (builder, vec_rhs_i64, vec_xor, "");
-			values [ins->dreg] = LLVMBuildBitCast (builder, vec_and, type_to_sse_type (ins->inst_c1), "");
+			values [ins->dreg] = LLVMBuildBitCast (builder, vec_and, type_to_sse_type ((int)ins->inst_c1), "");
 			break;
 		}
 
@@ -8910,8 +8910,8 @@ MONO_RESTORE_WARNING
 			case OP_PADDW_SAT_UN: type = MONO_TYPE_U2; break;
 			case OP_PSUBB_SAT_UN: type = MONO_TYPE_U1; is_add = FALSE; break;
 			case OP_PSUBW_SAT_UN: type = MONO_TYPE_U2; is_add = FALSE; break;
-			case OP_SSE2_ADDS: type = ins->inst_c1; break;
-			case OP_SSE2_SUBS: type = ins->inst_c1; is_add = FALSE; break;
+			case OP_SSE2_ADDS: type = (int)ins->inst_c1; break;
+			case OP_SSE2_SUBS: type = (int)ins->inst_c1; is_add = FALSE; break;
 			default: g_assert_not_reached ();
 			}
 			if (is_add) {
@@ -8944,7 +8944,7 @@ MONO_RESTORE_WARNING
 			args [1] = convert (ctx, rhs, sse_i2_t);
 			values [ins->dreg] = convert (ctx,
 				call_intrins (ctx, INTRINS_SSE_PACKUSWB, args, dname),
-				type_to_sse_type (ins->inst_c1));
+				type_to_sse_type ((int)ins->inst_c1));
 			break;
 		}
 
@@ -8952,7 +8952,7 @@ MONO_RESTORE_WARNING
 			LLVMValueRef args [] = { lhs, rhs };
 			values [ins->dreg] = convert (ctx,
 				call_intrins (ctx, INTRINS_SSE_PSRLI_W, args, dname),
-				type_to_sse_type (ins->inst_c1));
+				type_to_sse_type ((int)ins->inst_c1));
 			break;
 		}
 
@@ -9006,7 +9006,7 @@ MONO_RESTORE_WARNING
 			LLVMPositionBuilderAtEnd (builder, cbb);
 			values [ins->dreg] = LLVMBuildPhi (builder, LLVMTypeOf (phi_values [0]), "");
 			LLVMAddIncoming (values [ins->dreg], phi_values, bbs, nelems + 1);
-			values [ins->dreg] = convert (ctx, values [ins->dreg], type_to_sse_type (ins->inst_c1));
+			values [ins->dreg] = convert (ctx, values [ins->dreg], type_to_sse_type ((int)ins->inst_c1));
 
 			ctx->bblocks [bb->block_num].end_bblock = cbb;
 			break;
@@ -9167,7 +9167,7 @@ MONO_RESTORE_WARNING
 			// %sub = sub <16 x i8> zeroinitializer, %arg
 			// %cmp = icmp sgt <16 x i8> %arg, zeroinitializer
 			// %abs = select <16 x i1> %cmp, <16 x i8> %arg, <16 x i8> %sub
-			LLVMTypeRef typ = type_to_sse_type (ins->inst_c1);
+			LLVMTypeRef typ = type_to_sse_type ((int)ins->inst_c1);
 			LLVMValueRef sub = LLVMBuildSub(builder, LLVMConstNull(typ), lhs, "");
 			LLVMValueRef cmp = LLVMBuildICmp(builder, LLVMIntSGT, lhs, LLVMConstNull(typ), "");
 			LLVMValueRef abs = LLVMBuildSelect (builder, cmp, lhs, sub, "");
@@ -9209,7 +9209,7 @@ MONO_RESTORE_WARNING
 		}
 
 		case OP_SSE41_ROUNDP: {
-			LLVMValueRef args [] = { lhs, const_int32 (ins->inst_c0) };
+			LLVMValueRef args [] = { lhs, const_int32 ((int)ins->inst_c0) };
 			values [ins->dreg] = call_intrins (ctx, ins->inst_c1 == MONO_TYPE_R4 ? INTRINS_SSE_ROUNDPS : INTRINS_SSE_ROUNDPD, args, dname);
 			break;
 		}
@@ -9217,7 +9217,7 @@ MONO_RESTORE_WARNING
 			LLVMValueRef args [3];
 			args [0] = lhs;
 			args [1] = rhs;
-			args [2] = const_int32 (ins->inst_c0);
+			args [2] = const_int32 ((int)ins->inst_c0);
 			values [ins->dreg] = call_intrins (ctx, ins->inst_c1 == MONO_TYPE_R4 ? INTRINS_SSE_ROUNDSS : INTRINS_SSE_ROUNDSD, args, dname);
 			break;
 		}
@@ -9397,7 +9397,7 @@ MONO_RESTORE_WARNING
 
 		case OP_SSE41_LOADANT: {
 			LLVMValueRef dst_ptr = convert (ctx, lhs, pointer_type (primitive_type_to_llvm_type (inst_c1_type (ins))));
-			LLVMTypeRef etype = type_to_sse_type (ins->inst_c1);
+			LLVMTypeRef etype = type_to_sse_type ((int)ins->inst_c1);
 			LLVMValueRef dst_vec = LLVMBuildBitCast (builder, dst_ptr, pointer_type (etype), "");
 			LLVMValueRef load = mono_llvm_build_aligned_load (builder, etype, dst_vec, "", FALSE, 16);
 			set_nontemporal_flag (load);
@@ -9430,7 +9430,7 @@ MONO_RESTORE_WARNING
 		case OP_SSE42_CRC64: {
 			LLVMValueRef args [2];
 			args [0] = lhs;
-			args [1] = convert (ctx, rhs, primitive_type_to_llvm_type (ins->inst_c0));
+			args [1] = convert (ctx, rhs, primitive_type_to_llvm_type ((int)ins->inst_c0));
 			IntrinsicId id;
 			switch (ins->inst_c0) {
 			case MONO_TYPE_U1: id = INTRINS_SSE_CRC32_32_8; break;
@@ -12508,7 +12508,7 @@ add_intrinsic (LLVMModuleRef module, int id)
 		for (int vw = 0; vw < INTRIN_vectorwidths; ++vw) {
 			for (int ew = 0; ew < INTRIN_elementwidths; ++ew) {
 				llvm_ovr_tag_t vec_bit = INTRIN_vector128 >> ((INTRIN_vectorwidths - 1) - vw);
-				llvm_ovr_tag_t elem_bit = INTRIN_int8 << ew;
+				llvm_ovr_tag_t elem_bit = (llvm_ovr_tag_t) (INTRIN_int8 << ew);
 				llvm_ovr_tag_t test = vec_bit | elem_bit;
 				if ((spec & test) == test) {
 					uint8_t kind = intrin_kind [id];
@@ -13583,7 +13583,7 @@ emit_dbg_loc (EmitContext *ctx, LLVMBuilderRef builder, const unsigned char *cil
 		MonoDebugSourceLocation *loc;
 		LLVMValueRef loc_md;
 
-		loc = mono_debug_method_lookup_location (ctx->minfo, cil_code - cfg->header->code);
+		loc = mono_debug_method_lookup_location (ctx->minfo, GSSIZE_TO_INT (cil_code - cfg->header->code));
 
 		if (loc) {
 			loc_md = (LLVMValueRef)mono_llvm_di_create_location (ctx->module->di_builder, ctx->dbg_md, loc->row, loc->column);

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -7273,7 +7273,7 @@ MONO_RESTORE_WARNING
 			values [ins->dreg] = LLVMBuildLoad2 (builder, IntPtrType (), LLVMBuildIntToPtr (builder, LLVMConstInt (IntPtrType (), ins->inst_offset, TRUE), ptrtype, ""), "");
 #elif defined(TARGET_AMD64) && defined(TARGET_OSX)
 			/* See mono_amd64_emit_tls_get () */
-			int offset = mono_amd64_get_tls_gs_offset () + (ins->inst_offset * 8);
+			int offset = mono_amd64_get_tls_gs_offset () + (int)(ins->inst_offset * 8);
 
 			// 256 == GS segment register
 			LLVMTypeRef ptrtype = LLVMPointerType (IntPtrType (), 256);

--- a/src/mono/mono/mini/mini-posix.c
+++ b/src/mono/mono/mini/mini-posix.c
@@ -452,7 +452,7 @@ clock_sleep_ns_abs (guint64 ns_abs)
 	kern_return_t ret;
 	mach_timespec_t then, remain_unused;
 
-	then.tv_sec = ns_abs / 1000000000;
+	then.tv_sec = (unsigned int)(ns_abs / 1000000000);
 	then.tv_nsec = ns_abs % 1000000000;
 
 	do {

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -1084,7 +1084,7 @@ mono_print_ji (const MonoJumpInfo *ji)
 		break;
 	}
 	case MONO_PATCH_INFO_JIT_ICALL_ID:
-		printf ("[JIT_ICALL %s]", mono_find_jit_icall_info (ji->data.jit_icall_id)->name);
+		printf ("[JIT_ICALL %s]", mono_find_jit_icall_info ((MonoJitICallId)ji->data.jit_icall_id)->name);
 		break;
 	case MONO_PATCH_INFO_CLASS:
 	case MONO_PATCH_INFO_VTABLE: {
@@ -1444,13 +1444,13 @@ mono_resolve_patch_target_ext (MonoMemoryManager *mem_manager, MonoMethod *metho
 		target = ip;
 		break;
 	case MONO_PATCH_INFO_JIT_ICALL_ID: {
-		MonoJitICallInfo * const mi = mono_find_jit_icall_info (patch_info->data.jit_icall_id);
+		MonoJitICallInfo * const mi = mono_find_jit_icall_info ((MonoJitICallId)patch_info->data.jit_icall_id);
 		target = mono_icall_get_wrapper (mi);
 		break;
 	}
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL: {
-		MonoJitICallInfo * const mi = mono_find_jit_icall_info (patch_info->data.jit_icall_id);
+		MonoJitICallInfo * const mi = mono_find_jit_icall_info ((MonoJitICallId)patch_info->data.jit_icall_id);
 		target = mi->func;
 		break;
 	}
@@ -2127,7 +2127,7 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
 		memset (&record, 0, sizeof (record));
 
 		add_basic_JitCodeLoadRecord_info (&record);
-		record.header.total_size = sizeof (record) + nameLen + 1 + jinfo->code_size;
+		record.header.total_size = GSIZE_TO_UINT32 (sizeof (record) + nameLen + 1 + jinfo->code_size);
 		record.vma = (guint64)jinfo->code_start;
 		record.code_addr = (guint64)jinfo->code_start;
 		record.code_size = (guint64)jinfo->code_size;
@@ -2154,7 +2154,7 @@ add_basic_JitCodeLoadRecord_info (JitCodeLoadRecord *record)
 	record->header.id = JIT_CODE_LOAD;
 	record->header.timestamp = mono_clock_get_time_ns (clock_id);
 	record->pid = perf_dump_pid;
-	record->tid = syscall (SYS_gettid);
+	record->tid = (guint32) syscall (SYS_gettid);
 }
 
 void

--- a/src/mono/mono/mini/tramp-amd64-gsharedvt.c
+++ b/src/mono/mono/mini/tramp-amd64-gsharedvt.c
@@ -224,7 +224,7 @@ mono_arch_get_gsharedvt_trampoline (MonoTrampInfo **info, gboolean aot)
 
 	/*callconv in regs */
 	caller_reg_area_offset = offset;
-	reg_area_size = ALIGN_TO ((n_arg_regs + n_arg_fregs) * 8, MONO_ARCH_FRAME_ALIGNMENT);
+	reg_area_size = (int) ALIGN_TO ((n_arg_regs + n_arg_fregs) * 8, MONO_ARCH_FRAME_ALIGNMENT);
 	offset += reg_area_size;
 
 	framesize = offset;

--- a/src/mono/mono/mini/tramp-amd64.c
+++ b/src/mono/mono/mini/tramp-amd64.c
@@ -271,7 +271,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	offset += 4 * sizeof (target_mgreg_t);
 #endif
 
-	framesize = ALIGN_TO (offset, MONO_ARCH_FRAME_ALIGNMENT);
+	framesize = (int) ALIGN_TO (offset, MONO_ARCH_FRAME_ALIGNMENT);
 
 	// CFA = sp + 16 (the trampoline address is on the stack)
 	cfa_offset = 16;
@@ -923,7 +923,7 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 	ctx_offset = framesize;
 	framesize += sizeof (MonoContext);
 
-	framesize = ALIGN_TO (framesize, MONO_ARCH_FRAME_ALIGNMENT);
+	framesize = (int) ALIGN_TO (framesize, MONO_ARCH_FRAME_ALIGNMENT);
 
 	// CFA = sp + 8
 	cfa_offset = 8;
@@ -1146,7 +1146,7 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 
 	ctx_offset = framesize;
 	framesize += MONO_ABI_SIZEOF (CallContext);
-	framesize = ALIGN_TO (framesize, MONO_ARCH_FRAME_ALIGNMENT);
+	framesize = (int) ALIGN_TO (framesize, MONO_ARCH_FRAME_ALIGNMENT);
 
 	// CFA = sp + 8
 	cfa_offset = 8;

--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -454,7 +454,7 @@ emit_string (MonoProfiler *prof, const char *str)
 static void
 emit_record (MonoProfiler *prof, AotProfRecordType type, int id)
 {
-	emit_byte (prof, type);
+	emit_byte (prof, (guint8)type);
 	emit_int32 (prof, id);
 }
 

--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -134,7 +134,7 @@ parse_arg (const char *arg)
 		usage ();
 	} else if (match_option (arg, "duration", &val)) {
 		char *end;
-		aot_profiler.duration = strtoul (val, &end, 10);
+		aot_profiler.duration = (int) strtoul (val, &end, 10);
 	} else if (match_option (arg, "write-at-method", &val)) {
 		aot_profiler.write_at = mono_method_desc_new (val, TRUE);
 		if (!aot_profiler.write_at) {
@@ -154,7 +154,7 @@ parse_arg (const char *arg)
 		aot_profiler.outfile_name = g_strdup (val);
 	} else if (match_option (arg, "port", &val)) {
 		char *end;
-		aot_profiler.command_port = strtoul (val, &end, 10);
+		aot_profiler.command_port = (int) strtoul (val, &end, 10);
 	} else if (match_option (arg, "verbose", NULL)) {
 		aot_profiler.verbose = TRUE;
 	} else {
@@ -263,7 +263,7 @@ helper_thread (void *arg)
 					continue;
 
 				char buf [64];
-				int len = read (fd, buf, sizeof (buf) - 1);
+				int len = (int) read (fd, buf, sizeof (buf) - 1);
 
 				if (len == SOCKET_ERROR)
 					continue;
@@ -382,7 +382,7 @@ mono_profiler_init_aot (const char *desc)
 			g_assert_not_reached ();
 #endif
 		}  else if (*aot_profiler.outfile_name == '#') {
-			aot_profiler.outfile = fdopen (strtol (aot_profiler.outfile_name + 1, NULL, 10), "a");
+			aot_profiler.outfile = fdopen ((int) strtol (aot_profiler.outfile_name + 1, NULL, 10), "a");
 		} else {
 			aot_profiler.outfile = fopen (aot_profiler.outfile_name, "w");
 		}

--- a/src/mono/mono/sgen/sgen-debug.c
+++ b/src/mono/mono/sgen/sgen-debug.c
@@ -1041,7 +1041,7 @@ sgen_dump_section (GCMemSection *section, const char *type)
 	fprintf (heap_dump_file, "<section type=\"%s\" size=\"%lu\">\n", type, (unsigned long)(section->end_data - section->data));
 
 	while (start < end) {
-		guint size;
+		gsize size;
 		//GCVTable vt;
 		//MonoClass *class;
 

--- a/src/mono/mono/sgen/sgen-descriptor.c
+++ b/src/mono/mono/sgen/sgen-descriptor.c
@@ -59,7 +59,7 @@ alloc_complex_descriptor (gsize *bitmap, int numbits)
 
 	SGEN_ASSERT (0, sizeof (gsize) == sizeof (mword), "We expect gsize and mword to have same size");
 
-	numbits = ALIGN_TO (numbits, GC_BITS_PER_WORD);
+	numbits = (int)ALIGN_TO (numbits, GC_BITS_PER_WORD);
 	nwords = numbits / GC_BITS_PER_WORD + 1;
 
 	sgen_gc_lock ();

--- a/src/mono/mono/sgen/sgen-marksweep.c
+++ b/src/mono/mono/sgen/sgen-marksweep.c
@@ -148,7 +148,7 @@ typedef struct {
 		first = FALSE;						\
 		while (!(tmp_mark_word & (ONE_P << (b)))) {		\
 			old_mark_word = tmp_mark_word;			\
-			tmp_mark_word = mono_atomic_cas_i32 ((volatile gint32*)&(bl)->mark_words [w], old_mark_word | (ONE_P << (b)), old_mark_word); \
+			tmp_mark_word = mono_atomic_cas_i32 ((volatile gint32*)&(bl)->mark_words [w], (gint32)(old_mark_word | (ONE_P << (b))), old_mark_word); \
 			if (tmp_mark_word == old_mark_word) {		\
 				first = TRUE;				\
 				break;					\

--- a/src/mono/mono/sgen/sgen-memory-governor.c
+++ b/src/mono/mono/sgen/sgen-memory-governor.c
@@ -395,10 +395,10 @@ This tracks the total usage of memory by the GC. This includes
 managed and unmanaged memory.
 */
 
-static unsigned long
+static unsigned int
 prot_flags_for_activate (int activate)
 {
-	unsigned long prot_flags = activate? MONO_MMAP_READ|MONO_MMAP_WRITE: MONO_MMAP_NONE;
+	unsigned int prot_flags = activate? MONO_MMAP_READ|MONO_MMAP_WRITE: MONO_MMAP_NONE;
 	return prot_flags | MONO_MMAP_PRIVATE | MONO_MMAP_ANON;
 }
 

--- a/src/mono/mono/utils/lock-free-alloc.c
+++ b/src/mono/mono/utils/lock-free-alloc.c
@@ -121,10 +121,10 @@ sb_header_for_addr (gpointer addr, size_t block_size)
 
 /* Taken from SGen */
 
-static unsigned long
+static unsigned int
 prot_flags_for_activate (int activate)
 {
-	unsigned long prot_flags = activate? MONO_MMAP_READ|MONO_MMAP_WRITE: MONO_MMAP_NONE;
+	unsigned int prot_flags = activate? MONO_MMAP_READ|MONO_MMAP_WRITE: MONO_MMAP_NONE;
 	return prot_flags | MONO_MMAP_PRIVATE | MONO_MMAP_ANON;
 }
 

--- a/src/mono/mono/utils/mono-logger-internals.h
+++ b/src/mono/mono/utils/mono-logger-internals.h
@@ -62,7 +62,7 @@ gboolean
 mono_trace_is_traced (GLogLevelFlags level, MonoTraceMask mask);
 
 #define MONO_TRACE_IS_TRACED(level, mask) \
-	G_UNLIKELY ((level) <= mono_internal_current_level && ((mask) & mono_internal_current_mask))
+	G_UNLIKELY ((level) <= mono_internal_current_level && ((mask) & mono_internal_current_mask) != 0)
 
 G_GNUC_UNUSED static void
 mono_tracev (GLogLevelFlags level, MonoTraceMask mask, const char *format, va_list args)

--- a/src/mono/mono/utils/mono-logger.c
+++ b/src/mono/mono/utils/mono-logger.c
@@ -343,7 +343,7 @@ mono_trace_set_mask_string (const char *value)
 gboolean
 mono_trace_is_traced (GLogLevelFlags level, MonoTraceMask mask)
 {
-	return MONO_TRACE_IS_TRACED (level, mask);
+	return !!MONO_TRACE_IS_TRACED (level, mask);
 }
 
 /**

--- a/src/mono/mono/utils/mono-mmap.c
+++ b/src/mono/mono/utils/mono-mmap.c
@@ -155,7 +155,7 @@ mono_pagesize (void)
 
 	// Prefer sysconf () as it's signal safe.
 #if defined (HAVE_SYSCONF) && defined (_SC_PAGESIZE)
-	saved_pagesize = sysconf (_SC_PAGESIZE);
+	saved_pagesize = (int) sysconf (_SC_PAGESIZE);
 #else
 	saved_pagesize = getpagesize ();
 #endif

--- a/src/mono/mono/utils/mono-path.c
+++ b/src/mono/mono/utils/mono-path.c
@@ -119,7 +119,7 @@ resolve_symlink (const char *path)
 	p = g_strdup (path);
 	do {
 		iterations++;
-		n = readlink (p, buffer, sizeof (buffer)-1);
+		n = (int) readlink (p, buffer, sizeof (buffer)-1);
 		if (n < 0){
 			char *copy = p;
 			p = mono_path_canonicalize (copy);

--- a/src/mono/mono/utils/mono-proclib.c
+++ b/src/mono/mono/utils/mono-proclib.c
@@ -167,7 +167,7 @@ mono_cpu_count (void)
 #endif
 #if defined (_SC_NPROCESSORS_ONLN) && defined (HAVE_SYSCONF)
 	{
-		int count = sysconf (_SC_NPROCESSORS_ONLN);
+		int count = (int)sysconf (_SC_NPROCESSORS_ONLN);
 		if (count > 0)
 			return count;
 	}

--- a/src/mono/mono/utils/mono-proclib.c
+++ b/src/mono/mono/utils/mono-proclib.c
@@ -150,7 +150,7 @@ mono_cpu_count (void)
 
 #if defined (_SC_NPROCESSORS_CONF) && defined (HAVE_SYSCONF)
 	{
-		int count = sysconf (_SC_NPROCESSORS_CONF);
+		int count = (int) sysconf (_SC_NPROCESSORS_CONF);
 		if (count > 0)
 			return count;
 	}

--- a/src/mono/mono/utils/mono-rand.c
+++ b/src/mono/mono/utils/mono-rand.c
@@ -157,7 +157,7 @@ get_entropy_from_egd (const char *path, guchar *buffer, gssize buffer_size, Mono
 
 		/* block until daemon can return enough entropy */
 		request [0] = 2;
-		request [1] = buffer_size < 255 ? buffer_size : 255;
+		request [1] = buffer_size < 255 ? (guchar)buffer_size : 255;
 		while (count < 2) {
 			int sent = write (socket_fd, request + count, 2 - count);
 			err = errno;

--- a/src/mono/mono/utils/mono-rand.c
+++ b/src/mono/mono/utils/mono-rand.c
@@ -159,7 +159,7 @@ get_entropy_from_egd (const char *path, guchar *buffer, gssize buffer_size, Mono
 		request [0] = 2;
 		request [1] = buffer_size < 255 ? (guchar)buffer_size : 255;
 		while (count < 2) {
-			int sent = write (socket_fd, request + count, 2 - count);
+			int sent = (int) write (socket_fd, request + count, 2 - count);
 			err = errno;
 			if (sent >= 0) {
 				count += sent;
@@ -176,7 +176,7 @@ get_entropy_from_egd (const char *path, guchar *buffer, gssize buffer_size, Mono
 		count = 0;
 		while (count != request [1]) {
 			int received;
-			received = read (socket_fd, buffer + offset, request [1] - count);
+			received = (int) read (socket_fd, buffer + offset, request [1] - count);
 			err = errno;
 			if (received > 0) {
 				count += received;

--- a/src/mono/mono/utils/mono-threads.c
+++ b/src/mono/mono/utils/mono-threads.c
@@ -973,8 +973,8 @@ mono_thread_info_init (size_t info_size)
 		mono_set_errno (0);
 		long threshold = strtol(sleepLimit, NULL, 10);
 		if ((errno == 0) && (threshold >= 40))  {
-			sleepAbortDuration = threshold;
-			sleepWarnDuration = threshold / 20;
+			sleepAbortDuration = (guint32) threshold;
+			sleepWarnDuration = (guint32) (threshold / 20);
 		} else
 			g_warning("MONO_SLEEP_ABORT_LIMIT must be a number >= 40");
 		g_free (sleepLimit);

--- a/src/mono/mono/utils/monobitset.c
+++ b/src/mono/mono/utils/monobitset.c
@@ -292,7 +292,7 @@ my_g_bit_nth_lsf (gsize mask, gint nth_bit)
 
 	__asm__("bsfq %1,%0\n\t"
 			: "=r" (r) : "rm" (mask));
-	return nth_bit + r;
+	return (gint)(nth_bit + r);
  }
 #else
 	while (! (mask & 0x1)) {
@@ -319,7 +319,7 @@ my_g_bit_nth_lsf_nomask (gsize mask)
 
 	__asm__("bsfq %1,%0\n\t"
 			: "=r" (r) : "rm" (mask));
-	return r;
+	return (gint)r;
 #else
 	int nth_bit = 0;
 

--- a/src/mono/mono/utils/os-event-unix.c
+++ b/src/mono/mono/utils/os-event-unix.c
@@ -198,7 +198,7 @@ mono_os_event_wait_multiple (MonoOSEvent **events, gsize nevents, gboolean waita
 				goto done;
 			}
 
-			res = mono_os_cond_timedwait (&signal_cond, &signal_mutex, timeout - elapsed);
+			res = mono_os_cond_timedwait (&signal_cond, &signal_mutex, timeout - (guint32)elapsed);
 			if (res != 0) {
 				ret = MONO_OS_EVENT_WAIT_RET_TIMEOUT;
 				goto done;

--- a/src/native/eventpipe/ds-ipc-pal-socket.c
+++ b/src/native/eventpipe/ds-ipc-pal-socket.c
@@ -635,7 +635,7 @@ ipc_socket_recv (
 			buffer_cursor,
 			bytes_to_read - total_bytes_read,
 			0);
-		if (ipc_retry_syscall (current_bytes_read))
+		if (ipc_retry_syscall ((int)current_bytes_read))
 			continue;
 		continue_recv = current_bytes_read > 0;
 		if (!continue_recv)
@@ -669,7 +669,7 @@ ipc_socket_send (
 			buffer_cursor,
 			bytes_to_write - total_bytes_written,
 			0);
-		if (ipc_retry_syscall (current_bytes_written))
+		if (ipc_retry_syscall ((int)current_bytes_written))
 			continue;
 		continue_send = current_bytes_written != DS_IPC_SOCKET_ERROR;
 		if (!continue_send)

--- a/src/native/eventpipe/ds-ipc-pal-socket.c
+++ b/src/native/eventpipe/ds-ipc-pal-socket.c
@@ -467,7 +467,7 @@ ipc_poll_fds (
 		if (timeout != EP_INFINITE_WAIT)
 			start = ep_rt_perf_counter_query ();
 
-		result_poll = poll (fds, nfds, (int)timeout);
+		result_poll = poll (fds, (nfds_t)nfds, (int)timeout);
 		retry_poll = ipc_retry_syscall (result_poll);
 
 		if (retry_poll && timeout != EP_INFINITE_WAIT) {


### PR DESCRIPTION
See https://clang.llvm.org/docs/DiagnosticsReference.html#wshorten-64-to-32

Follow-up to https://github.com/dotnet/runtime/pull/69236

Related to https://github.com/dotnet/runtime/pull/70026