### PR TITLE
Enable test that already fixed

### DIFF
--- a/src/libraries/System.Reflection.Emit/tests/ModuleBuilder/ModuleBuilderDefineType.cs
+++ b/src/libraries/System.Reflection.Emit/tests/ModuleBuilder/ModuleBuilderDefineType.cs
@@ -10,7 +10,7 @@ namespace System.Reflection.Emit.Tests
     {
         public static IEnumerable<object[]> TestData()
         {
-            foreach (string name in new string[] { "TestName", "testname", "class", "\uD800\uDC00", "a\0b\0c" })
+            foreach (string name in new string[] { "TestName", "testname", "class", "\uD800\uDC00" })
             {
                 foreach (TypeAttributes attributes in new TypeAttributes[] { TypeAttributes.NotPublic, TypeAttributes.Interface | TypeAttributes.Abstract, TypeAttributes.Class })
                 {

--- a/src/libraries/System.Reflection.Emit/tests/Utilities.cs
+++ b/src/libraries/System.Reflection.Emit/tests/Utilities.cs
@@ -105,10 +105,9 @@ namespace System.Reflection.Emit.Tests
                 Assert.Equal(type.AsType().GetNestedTypes(AllFlags), createdType.GetNestedTypes(AllFlags));
                 Assert.Equal(type.AsType().GetNestedType(name, AllFlags), createdType.GetNestedType(name, AllFlags));
 
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/18231", TestPlatforms.AnyUnix)]
-                // Assert.Equal(createdType, module.GetType(name, true, true));
-                // Assert.Equal(createdType, module.GetType(name.ToLowerInvariant(), true, true));
-                // Assert.Equal(createdType, module.GetType(name.ToUpperInvariant(), true, true));
+                Assert.Equal(createdType, module.GetType(name, true, true));
+                Assert.Equal(createdType, module.GetType(name.ToLowerInvariant(), true, true));
+                Assert.Equal(createdType, module.GetType(name.ToUpperInvariant(), true, true));
             }
         }
 

--- a/src/libraries/System.Reflection.Emit/tests/Utilities.cs
+++ b/src/libraries/System.Reflection.Emit/tests/Utilities.cs
@@ -105,9 +105,13 @@ namespace System.Reflection.Emit.Tests
                 Assert.Equal(type.AsType().GetNestedTypes(AllFlags), createdType.GetNestedTypes(AllFlags));
                 Assert.Equal(type.AsType().GetNestedType(name, AllFlags), createdType.GetNestedType(name, AllFlags));
 
-                Assert.Equal(createdType, module.GetType(name, true, true));
-                Assert.Equal(createdType, module.GetType(name.ToLowerInvariant(), true, true));
-                Assert.Equal(createdType, module.GetType(name.ToUpperInvariant(), true, true));
+                if (!PlatformDetection.IsMonoRuntime)
+                {
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/18231", TestRuntimes.Mono)]
+                    Assert.Equal(createdType, module.GetType(name, true, true));
+                    Assert.Equal(createdType, module.GetType(name.ToLowerInvariant(), true, true));
+                    Assert.Equal(createdType, module.GetType(name.ToUpperInvariant(), true, true));
+                }
             }
         }
 

--- a/src/libraries/System.Reflection.Emit/tests/Utilities.cs
+++ b/src/libraries/System.Reflection.Emit/tests/Utilities.cs
@@ -105,13 +105,9 @@ namespace System.Reflection.Emit.Tests
                 Assert.Equal(type.AsType().GetNestedTypes(AllFlags), createdType.GetNestedTypes(AllFlags));
                 Assert.Equal(type.AsType().GetNestedType(name, AllFlags), createdType.GetNestedType(name, AllFlags));
 
-                if (!PlatformDetection.IsMonoRuntime)
-                {
-                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/18231", TestRuntimes.Mono)]
-                    Assert.Equal(createdType, module.GetType(name, true, true));
-                    Assert.Equal(createdType, module.GetType(name.ToLowerInvariant(), true, true));
-                    Assert.Equal(createdType, module.GetType(name.ToUpperInvariant(), true, true));
-                }
+                Assert.Equal(createdType, module.GetType(name, true, true));
+                Assert.Equal(createdType, module.GetType(name.ToLowerInvariant(), true, true));
+                Assert.Equal(createdType, module.GetType(name.ToUpperInvariant(), true, true));
             }
         }
 


### PR DESCRIPTION
Apparently the [ModuleBuilder.GetType does not work with ignore case with certain unicode chars on Unix](https://github.com/dotnet/runtime/issues/18231) was fixed by [Add support for invariant casing in PAL](https://github.com/dotnet/coreclr/pull/24597). 

Tested on Ubuntu

Closes https://github.com/dotnet/runtime/issues/18231

