### PR TITLE
Fix STAThreadAttribute/MTAThreadAttribute on main entry point not respected by NativeAOT

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -105,12 +105,12 @@ namespace Internal.IL.Stubs.StartupCode
             MethodDesc initApartmentState = startup?.GetMethod("InitializeApartmentState", null);
             if (initApartmentState != null)
             {
-                if (_mainMethod.HasCustomAttribute("System", "STAThreadAttribute"))
+                if (_mainMethod.WrappedMethod.HasCustomAttribute("System", "STAThreadAttribute"))
                 {
                     codeStream.EmitLdc((int)System.Threading.ApartmentState.STA);
                     codeStream.Emit(ILOpcode.call, emitter.NewToken(initApartmentState));
                 }
-                if (_mainMethod.HasCustomAttribute("System", "MTAThreadAttribute"))
+                if (_mainMethod.WrappedMethod.HasCustomAttribute("System", "MTAThreadAttribute"))
                 {
                     codeStream.EmitLdc((int)System.Threading.ApartmentState.MTA);
                     codeStream.Emit(ILOpcode.call, emitter.NewToken(initApartmentState));


### PR DESCRIPTION
Fixes dotnet/runtime#70066
Bug introduced in dotnet/runtimelab#1384

/cc @MichalStrehovsky