### PR TITLE
JIT ARM32: Fix passing odd sized structs from arbitrary sources

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3270,6 +3270,17 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                         makeOutArgCopy = true;
                     }
 
+                    // ARM32 has an edge case where we need to pass 3 bytes in
+                    // the last register, which would require two loads and a
+                    // shift to avoid loading too much if the source is a
+                    // potentially arbitrary address. Handle the edge case here
+                    // by copying into the local stack frame first so we can
+                    // use a register wide load.
+                    if (!arg.AbiInfo.IsSplit() && (((arg.AbiInfo.NumRegs * REGSIZE_BYTES) - passingSize) == 1))
+                    {
+                        makeOutArgCopy = true;
+                    }
+
                     if (structSize < TARGET_POINTER_SIZE)
                     {
                         makeOutArgCopy = true;
@@ -3854,7 +3865,8 @@ GenTree* Compiler::fgMorphMultiregStructArg(CallArg* arg)
                         break;
 #endif // (TARGET_ARM64) || (UNIX_AMD64_ABI) || (TARGET_LOONGARCH64)
                     default:
-                        noway_assert(!"NYI: odd sized struct in fgMorphMultiregStructArg");
+                        noway_assert(!"Cannot load odd sized last element from arbitrary source; expected source to be "
+                                      "local in this case");
                         break;
                 }
             }

--- a/src/tests/JIT/Directed/StructABI/SevenByteStruct.cs
+++ b/src/tests/JIT/Directed/StructABI/SevenByteStruct.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+// On ARM32 the following has S0 passed in two registers, which requires passing 3 bytes in the last register.
+// We cannot do that in a single load from an arbitrary source and must copy it to a local first.
+
+public struct S0
+{
+    public byte F0;
+    public byte F1;
+    public byte F2;
+    public byte F3;
+    public byte F4;
+    public byte F5;
+    public byte F6;
+}
+
+public class SevenByteStruct
+{
+    public static S0 s_4 = new S0 { F0 = 1, F1 = 2, F2 = 3, F3 = 4, F4 = 5, F5 = 6, F6 = 7 };
+    public static int Main()
+    {
+        ref S0 vr0 = ref s_4;
+        int sum = M35(vr0);
+        return sum == 28 ? 100 : -1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int M35(S0 arg0)
+    {
+        return arg0.F0 + arg0.F1 + arg0.F2 + arg0.F3 + arg0.F4 + arg0.F5 + arg0.F6;
+    }
+}

--- a/src/tests/JIT/Directed/StructABI/SevenByteStruct.csproj
+++ b/src/tests/JIT/Directed/StructABI/SevenByteStruct.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SevenByteStruct.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -543,12 +543,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Stress/ABI/pinvokes_do/**">
             <Issue>https://github.com/dotnet/runtime/issues/66745</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Stress/ABI/tailcalls_d/**">
-            <Issue>https://github.com/dotnet/runtime/issues/70042</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Stress/ABI/tailcalls_do/**">
-            <Issue>https://github.com/dotnet/runtime/issues/70042</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows arm64 specific excludes -->
@@ -677,18 +671,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_56953/Runtime_56953/*">
             <Issue>https://github.com/dotnet/runtime/issues/57856</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Stress/ABI/tailcalls_d/**">
-            <Issue>https://github.com/dotnet/runtime/issues/68837</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Stress/ABI/tailcalls_do/**">
-            <Issue>https://github.com/dotnet/runtime/issues/68837</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Stress/ABI/pinvokes_d/**">
-            <Issue>https://github.com/dotnet/runtime/issues/68837</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Stress/ABI/pinvokes_do/**">
-            <Issue>https://github.com/dotnet/runtime/issues/68837</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/profiler/multiple/multiple/*">
             <Issue>https://github.com/dotnet/runtime/issues/57875</Issue>


### PR DESCRIPTION
ARM32 ABI allows passing structs in register even when their sizes are
not divisible by 4. This means we sometimes need to pass 3 bytes in the
last register. The JIT would not handle this when the source was an
arbitrary memory location (this would require multiple loads and
shifts). The fix is to just force a copy into the local stack frame for
this case.

Fix #61168
Fix #68837
Fix #70042