### PR TITLE
Disable flaky DNS cancellation tests during jitstress

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -197,7 +197,6 @@ namespace System.Net.NameResolution.Tests
         // This is a regression test for https://github.com/dotnet/runtime/issues/63552
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
-        [SkipOnCoreClr("JitStress interferes with cancellation timing", RuntimeTestModes.JitStress | RuntimeTestModes.JitStressRegs)]
         public async Task DnsGetHostAddresses_ResolveParallelCancelOnFailure_AllCallsReturn()
         {
             string invalidAddress = TestSettings.UncachedHost;

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -178,6 +178,7 @@ namespace System.Net.NameResolution.Tests
     public class GetHostAddressesTest_Cancellation
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
         public async Task DnsGetHostAddresses_PostCancelledToken_Throws()
         {
             using var cts = new CancellationTokenSource();
@@ -198,6 +199,7 @@ namespace System.Net.NameResolution.Tests
 
         // This is a regression test for https://github.com/dotnet/runtime/issues/63552
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
         public async Task DnsGetHostAddresses_ResolveParallelCancelOnFailure_AllCallsReturn()
         {
             string invalidAddress = TestSettings.UncachedHost;

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -184,17 +184,13 @@ namespace System.Net.NameResolution.Tests
             using var cts = new CancellationTokenSource();
 
             Task task = Dns.GetHostAddressesAsync(TestSettings.UncachedHost, cts.Token);
+
+            // This test might flake if the cancellation token takes too long to trigger:
+            // It's a race between the DNS server getting back to us and the cancellation processing.
             cts.Cancel();
 
-            // This test is nondeterministic, the cancellation may take too long to trigger:
-            // It's a race between the DNS server getting back to us and the cancellation processing.
-            // since the host does not exist, both cases throw an exception.
-            Exception ex = await Assert.ThrowsAnyAsync<Exception>(() => task);
-            if (ex is OperationCanceledException oce)
-            {
-                // canceled in time
-                Assert.Equal(cts.Token, oce.CancellationToken);
-            }
+            OperationCanceledException oce = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+            Assert.Equal(cts.Token, oce.CancellationToken);
         }
 
         // This is a regression test for https://github.com/dotnet/runtime/issues/63552

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -179,6 +179,7 @@ namespace System.Net.NameResolution.Tests
     {
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
+        [SkipOnCoreClr("JitStress interferes with cancellation timing", RuntimeTestModes.JitStress | RuntimeTestModes.JitStressRegs)]
         public async Task DnsGetHostAddresses_PostCancelledToken_Throws()
         {
             using var cts = new CancellationTokenSource();
@@ -196,6 +197,7 @@ namespace System.Net.NameResolution.Tests
         // This is a regression test for https://github.com/dotnet/runtime/issues/63552
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
+        [SkipOnCoreClr("JitStress interferes with cancellation timing", RuntimeTestModes.JitStress | RuntimeTestModes.JitStressRegs)]
         public async Task DnsGetHostAddresses_ResolveParallelCancelOnFailure_AllCallsReturn()
         {
             string invalidAddress = TestSettings.UncachedHost;

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -81,7 +81,7 @@ namespace System.Net.NameResolution.Tests
         [ConditionalTheory(nameof(GetHostEntryWorks))]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
-        public async Task Dns_GetHostEntryAsync_HostString_Ok(string hostName)    
+        public async Task Dns_GetHostEntryAsync_HostString_Ok(string hostName)
         {
             await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(hostName));
         }
@@ -122,7 +122,7 @@ namespace System.Net.NameResolution.Tests
                 {
                     Assert.NotEqual(AddressFamily.InterNetworkV6, address.AddressFamily);
                 }
-            }   
+            }
         }
 
         [ConditionalTheory(nameof(GetHostEntry_DisableIPv6_Condition))]
@@ -315,9 +315,10 @@ namespace System.Net.NameResolution.Tests
     [Collection(nameof(DisableParallelization))]
     public class GetHostEntryTest_Cancellation
     {
+        [Fact]
         [OuterLoop]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
-        [Fact]
+        [SkipOnCoreClr("JitStress interferes with cancellation timing", RuntimeTestModes.JitStress | RuntimeTestModes.JitStressRegs)]
         public async Task DnsGetHostEntry_PostCancelledToken_Throws()
         {
             // Windows 7 name resolution is synchronous and does not respect cancellation.


### PR DESCRIPTION
Related to #69993.

Original fix (#70044), while removing the flakyness, made the test effectively useless (see https://github.com/dotnet/runtime/pull/70044#discussion_r886866234). Based on the discussion we decided that it is better to disable the test during jitstress.

This PR also reverts #70009, as the implementation of async name resolution on *nix platforms was reverted in https://github.com/dotnet/runtime/pull/48666