### PR TITLE
Fix VTableCallHolder writeable mapping size with W^X

### DIFF
--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -1179,8 +1179,9 @@ VTableCallHolder* VirtualCallStubManager::GenerateVTableCallStub(DWORD slot)
     } CONTRACT_END;
 
     //allocate from the requisite heap and copy the template over it.
-    VTableCallHolder * pHolder = (VTableCallHolder*)(void*)vtable_heap->AllocAlignedMem(VTableCallHolder::GetHolderSize(slot), CODE_SIZE_ALIGN);
-    ExecutableWriterHolder<VTableCallHolder> vtableWriterHolder(pHolder, sizeof(VTableCallHolder));
+    size_t vtableHolderSize = VTableCallHolder::GetHolderSize(slot);
+    VTableCallHolder * pHolder = (VTableCallHolder*)(void*)vtable_heap->AllocAlignedMem(vtableHolderSize, CODE_SIZE_ALIGN);
+    ExecutableWriterHolder<VTableCallHolder> vtableWriterHolder(pHolder, vtableHolderSize);
     vtableWriterHolder.GetRW()->Initialize(slot);
 
     ClrFlushInstructionCache(pHolder->stub(), pHolder->stub()->size());


### PR DESCRIPTION
The size of this holder is dynamic, but when we are creating the writeable
mapping of this holder to initialize its code, we don't take that into account.
So in case the holder is located at the end of a memory page and crosses its
boundary, the writeable mapping covers only the beginning of the holder and
so we either crash during the initialization if the following memory page is
not mapped or read only, or we corrupt a completely unrelated memory page
in case it is mapped and writeable.

The fix is to use the real size of the holder instead of sizeof(...).