### PR TITLE
Optimize `HashCode.AddBytes` for inputs larger than 16 bytes.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
@@ -337,14 +337,17 @@ namespace System
                 switch (_length % 4)
                 {
                     case 1:
+                        Debug.Assert(Unsafe.ByteOffset(ref pos, ref end) >= sizeof(int));
                         Add(Unsafe.ReadUnaligned<int>(ref pos));
                         pos = ref Unsafe.Add(ref pos, sizeof(int));
                         goto case 2;
                     case 2:
+                        Debug.Assert(Unsafe.ByteOffset(ref pos, ref end) >= sizeof(int));
                         Add(Unsafe.ReadUnaligned<int>(ref pos));
                         pos = ref Unsafe.Add(ref pos, sizeof(int));
                         goto case 3;
                     case 3:
+                        Debug.Assert(Unsafe.ByteOffset(ref pos, ref end) >= sizeof(int));
                         Add(Unsafe.ReadUnaligned<int>(ref pos));
                         pos = ref Unsafe.Add(ref pos, sizeof(int));
                         break;
@@ -354,9 +357,9 @@ namespace System
             // With the queue clear, we add sixteen bytes at a time until the input has fewer than sixteen bytes remaining.
             // We first have to round the end pointer to the nearest 16-byte block from the offset. This makes the loop's condition simpler.
             ref byte blockEnd = ref Unsafe.Subtract(ref end, Unsafe.ByteOffset(ref pos, ref end) % (sizeof(int) * 4));
-            Debug.Assert(Unsafe.ByteOffset(ref pos, ref blockEnd) >= (sizeof(int) * 4));
             while (Unsafe.IsAddressLessThan(ref pos, ref blockEnd))
             {
+                Debug.Assert((nint)Unsafe.ByteOffset(ref pos, ref blockEnd) >= (sizeof(int) * 4));
                 uint v1 = Unsafe.ReadUnaligned<uint>(ref pos);
                 _v1 = Round(_v1, v1);
                 uint v2 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref pos, sizeof(int) * 1));

--- a/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
@@ -320,7 +320,7 @@ namespace System
             ref byte pos = ref MemoryMarshal.GetReference(value);
             ref byte end = ref Unsafe.Add(ref pos, value.Length);
 
-            if (Unsafe.ByteOffset(ref pos, ref end) < (sizeof(int) * 4))
+            if (value.Length < (sizeof(int) * 4))
             {
                 goto Small;
             }
@@ -332,7 +332,7 @@ namespace System
             }
             else
             {
-                // If we have more than 16 bytes to hash, we can add them in 16-byte batches,
+                // If we have at least 16 bytes to hash, we can add them in 16-byte batches,
                 // but we first have to add enough data to flush any queued values.
                 switch (_length % 4)
                 {
@@ -359,7 +359,7 @@ namespace System
             ref byte blockEnd = ref Unsafe.Subtract(ref end, Unsafe.ByteOffset(ref pos, ref end) % (sizeof(int) * 4));
             while (Unsafe.IsAddressLessThan(ref pos, ref blockEnd))
             {
-                Debug.Assert((nint)Unsafe.ByteOffset(ref pos, ref blockEnd) >= (sizeof(int) * 4));
+                Debug.Assert(Unsafe.ByteOffset(ref pos, ref blockEnd) >= (sizeof(int) * 4));
                 uint v1 = Unsafe.ReadUnaligned<uint>(ref pos);
                 _v1 = Round(_v1, v1);
                 uint v2 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref pos, sizeof(int) * 1));
@@ -375,7 +375,7 @@ namespace System
 
         Small:
             // Add four bytes at a time until the input has fewer than four bytes remaining.
-            while ((nint)Unsafe.ByteOffset(ref pos, ref end) >= sizeof(int))
+            while (Unsafe.ByteOffset(ref pos, ref end) >= sizeof(int))
             {
                 Add(Unsafe.ReadUnaligned<int>(ref pos));
                 pos = ref Unsafe.Add(ref pos, sizeof(int));


### PR DESCRIPTION
The `HashCode.AddBytes` method is optimized to read four bytes at a time and feed them to the private `HashCode.Add(int)` method, but this method is not that much optimized in processing large amounts of input; because the xxHash algorithm works in batches of 16 bytes, this implementation has to queue the integers in separate fields until four of them are accumulated and then update the hash's state, and that whole logic has a couple of branches.

This PR avoids this queueing logic, instead reading input and directly updating the hash's state in batches of 16 bytes, if the input is large enough.

Benchmarks show significant improvements:

``` ini
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1706 (21H2)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.100-preview.5.22267.11
  [Host]     : .NET 7.0.0 (7.0.22.26611), X64 RyuJIT
  DefaultJob : .NET 7.0.0 (7.0.22.26611), X64 RyuJIT
```

|               Method | Size |       Mean |      Error |     StdDev |     Median | Ratio | RatioSD | Rank |
|--------------------- |----- |-----------:|-----------:|-----------:|-----------:|------:|--------:|-----:|
|             **HashCode** |    **1** |   **7.030 ns** |  **0.1780 ns** |  **0.2496 ns** |   **6.974 ns** |  **1.00** |    **0.00** |    **2** |
|          HashCodeNeo |    1 |   6.266 ns |  0.1628 ns |  0.3993 ns |   6.133 ns |  0.90 |    0.05 |    1 |
| HashCodeNeoUnaligned |    1 |   8.613 ns |  0.2078 ns |  0.3236 ns |   8.581 ns |  1.23 |    0.06 |    3 |
|                      |      |            |            |            |            |       |         |      |
|             **HashCode** |    **4** |   **6.838 ns** |  **0.1740 ns** |  **0.3891 ns** |   **6.750 ns** |  **1.00** |    **0.00** |    **2** |
|          HashCodeNeo |    4 |   6.412 ns |  0.1057 ns |  0.0988 ns |   6.374 ns |  0.90 |    0.03 |    1 |
| HashCodeNeoUnaligned |    4 |   8.074 ns |  0.1010 ns |  0.0945 ns |   8.062 ns |  1.14 |    0.05 |    3 |
|                      |      |            |            |            |            |       |         |      |
|             **HashCode** |   **15** |  **19.204 ns** |  **0.3502 ns** |  **0.3276 ns** |  **19.162 ns** |  **1.00** |    **0.00** |    **1** |
|          HashCodeNeo |   15 |  19.744 ns |  0.3940 ns |  0.3290 ns |  19.788 ns |  1.03 |    0.03 |    2 |
| HashCodeNeoUnaligned |   15 |  21.063 ns |  0.3948 ns |  0.3297 ns |  21.092 ns |  1.09 |    0.02 |    3 |
|                      |      |            |            |            |            |       |         |      |
|             **HashCode** |   **16** |  **15.327 ns** |  **0.3363 ns** |  **0.2626 ns** |  **15.349 ns** |  **1.00** |    **0.00** |    **2** |
|          HashCodeNeo |   16 |   8.100 ns |  0.1721 ns |  0.1609 ns |   8.065 ns |  0.53 |    0.01 |    1 |
| HashCodeNeoUnaligned |   16 |  17.034 ns |  0.3768 ns |  0.5639 ns |  16.981 ns |  1.13 |    0.05 |    3 |
|                      |      |            |            |            |            |       |         |      |
|             **HashCode** |  **127** | **105.052 ns** |  **2.1090 ns** |  **3.2834 ns** | **104.696 ns** |  **1.00** |    **0.00** |    **3** |
|          HashCodeNeo |  127 |  37.389 ns |  0.6605 ns |  0.5855 ns |  37.213 ns |  0.35 |    0.01 |    1 |
| HashCodeNeoUnaligned |  127 |  38.687 ns |  0.7336 ns |  0.6862 ns |  38.650 ns |  0.36 |    0.01 |    2 |
|                      |      |            |            |            |            |       |         |      |
|             **HashCode** |  **128** | **106.665 ns** |  **2.4307 ns** |  **7.1669 ns** | **106.236 ns** |  **1.00** |    **0.00** |    **3** |
|          HashCodeNeo |  128 |  28.700 ns |  0.6030 ns |  0.6452 ns |  28.573 ns |  0.28 |    0.02 |    1 |
| HashCodeNeoUnaligned |  128 |  34.053 ns |  1.0040 ns |  2.8152 ns |  32.880 ns |  0.32 |    0.04 |    2 |
|                      |      |            |            |            |            |       |         |      |
|             **HashCode** | **1023** | **728.836 ns** | **14.1223 ns** | **16.2633 ns** | **724.195 ns** |  **1.00** |    **0.00** |    **3** |
|          HashCodeNeo | 1023 | 180.836 ns |  3.2205 ns |  4.6187 ns | 180.949 ns |  0.25 |    0.01 |    2 |
| HashCodeNeoUnaligned | 1023 | 176.570 ns |  3.0476 ns |  2.7017 ns | 175.528 ns |  0.24 |    0.01 |    1 |
|                      |      |            |            |            |            |       |         |      |
|             **HashCode** | **1024** | **708.242 ns** | **14.1710 ns** | **29.2656 ns** | **693.824 ns** |  **1.00** |    **0.00** |    **2** |
|          HashCodeNeo | 1024 | 174.507 ns |  2.6961 ns |  2.2513 ns | 174.225 ns |  0.24 |    0.01 |    1 |
| HashCodeNeoUnaligned | 1024 | 176.265 ns |  2.2253 ns |  1.8583 ns | 176.354 ns |  0.24 |    0.01 |    1 |

I ran them by copy-pasting the changed `HashCode` class to a file in my benchmark project, and comparing it to .NET's `HashCode`. The `Unaligned` benchmarks first add an integer before calling `AddBytes` (to test the impact of the additional logic that empties the `HashCode`'s cache.