### PR TITLE
Update test to stop expecting removed diagnostics

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
@@ -326,12 +326,6 @@ partial class Test
                 (new DiagnosticResult(GeneratorDiagnostics.CannotForwardToDllImport))
                     .WithSpan(6, 32, 6, 39)
                     .WithArguments($"{nameof(TypeNames.LibraryImportAttribute)}{Type.Delimiter}{nameof(StringMarshalling)}={nameof(StringMarshalling)}{Type.Delimiter}{nameof(StringMarshalling.Utf8)}"),
-                (new DiagnosticResult(GeneratorDiagnostics.CannotForwardToDllImport))
-                    .WithSpan(9, 32, 9, 39)
-                    .WithArguments($"{nameof(TypeNames.LibraryImportAttribute)}{Type.Delimiter}{nameof(StringMarshalling)}={nameof(StringMarshalling)}{Type.Delimiter}{nameof(StringMarshalling.Custom)}"),
-                (new DiagnosticResult(GeneratorDiagnostics.CannotForwardToDllImport))
-                    .WithSpan(9, 32, 9, 39)
-                    .WithArguments($"{nameof(TypeNames.LibraryImportAttribute)}{Type.Delimiter}{nameof(LibraryImportAttribute.StringMarshallingCustomType)}", $"{nameof(StringMarshalling)}{Type.Delimiter}{nameof(StringMarshalling.Custom)}"),
                 (new DiagnosticResult(GeneratorDiagnostics.ParameterTypeNotSupportedWithDetails))
                     .WithSpan(9, 47, 9, 48)
             };


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/69837 removed emitting diagnostics in some (redundant) cases. I missed updating this test.

Fixes #69977.