### PR TITLE
Exempt MemberNotNullWhen from genapi ref assembly requirements

### DIFF
--- a/eng/DefaultGenApiDocIds.txt
+++ b/eng/DefaultGenApiDocIds.txt
@@ -5,6 +5,7 @@ T:System.Configuration.ConfigurationPropertyAttribute
 T:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
 T:System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute
 T:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute
+T:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute
 T:System.Diagnostics.CodeAnalysis.SuppressMessageAttribute
 T:System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute
 T:System.Diagnostics.DebuggerBrowsableAttribute


### PR DESCRIPTION
As with MemberNotNull, MemberNotNullWhen is an implementation detail when it refers to a private member (even when attributed on a public API).  The tooling shouldn't require it in reference assemblies, as in such situations it a) isn't meaningful to a consumer and b) leaks implementation details.

Fixes https://github.com/dotnet/runtime/pull/67198#issuecomment-1144160681
cc: @bartonjs, @SteveDunn 