### PR TITLE
Enabling System.Threading tests for NativeAOT

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -395,6 +395,7 @@
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Reflection\tests\System.Reflection.Tests.csproj" 
                        Condition="'$(TargetOS)' == 'windows'" />
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
+    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Threading\tests\System.Threading.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I've tested this on Windows and Linux x64 and they pass with no issues. 6 tests are skipped for other reasons. 


```
Finished System.Threading.Tests, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51

Tests run: 603, Errors: 0, Failures: 0, Skipped: 6. Time: 13.4230432s
```