### PR TITLE
Add AVX2 SIMD code paths for ASCIIUtility

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -1653,7 +1653,7 @@ namespace System.Text
 
                 currentOffset = NarrowUtf16ToAscii_Avx2(pUtf16Buffer, pAsciiBuffer, elementCount);
             }
-            else if (Sse2.IsSupported && envsetting == "SSE")
+            else if (Sse2.IsSupported)
             {
                 Debug.Assert(BitConverter.IsLittleEndian, "Assume little endian if SSE2 is supported.");
 
@@ -1684,7 +1684,7 @@ namespace System.Text
                     currentOffset = NarrowUtf16ToAscii_Sse2(pUtf16Buffer, pAsciiBuffer, elementCount);
                 }
             }
-            else if (Vector.IsHardwareAccelerated && envsetting == "VECTOR")
+            else if (Vector.IsHardwareAccelerated)
             {
                 uint SizeOfVector = (uint)Unsafe.SizeOf<Vector<byte>>(); // JIT will make this a const
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -2238,7 +2238,7 @@ namespace System.Text
             {
                 currentOffset = WidenAsciiToUtf16_Avx2(pAsciiBuffer, pUtf16Buffer, elementCount);
             }
-            else if (Sse2.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) && envsetting2 == "SSE")
+            else if (Sse2.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian))
             {
                 if (elementCount >= 2 * (uint)Unsafe.SizeOf<Vector128<byte>>())
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -12,8 +12,8 @@ namespace System.Text
 {
     internal static partial class ASCIIUtility
     {
-        private static string? envsetting = Environment.GetEnvironmentVariable("AVX_TEST");
-        private static string? envsetting2 = Environment.GetEnvironmentVariable("AVX_TEST2");
+        //private static string? envsetting = Environment.GetEnvironmentVariable("AVX_TEST");
+        //private static string? envsetting2 = Environment.GetEnvironmentVariable("AVX_TEST2");
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool AllBytesInUInt64AreAscii(ulong value)
@@ -624,11 +624,11 @@ namespace System.Text
             // pmovmskb which we know are optimized, and (b) we can avoid downclocking the processor while
             // this method is running.
 
-            if (Avx2.IsSupported && envsetting == "AVX2")
+            if (Avx2.IsSupported)
             {
                 return GetIndexOfFirstNonAsciiChar_Avx2(pBuffer, bufferLength);
             }
-            else if (Sse2.IsSupported && envsetting == "SSE")
+            else if (Sse2.IsSupported)
             {
                 return GetIndexOfFirstNonAsciiChar_Sse2(pBuffer, bufferLength);
             }
@@ -1625,7 +1625,7 @@ namespace System.Text
             // pmovmskb, ptest, vpminuw which we know are optimized, and (b) we can avoid downclocking the
             // processor while this method is running.
 
-            if (Avx2.IsSupported && envsetting == "AVX2" && elementCount >= 2 * (uint)Unsafe.SizeOf<Vector256<byte>>())
+            if (Avx2.IsSupported && elementCount >= 2 * (uint)Unsafe.SizeOf<Vector256<byte>>())
             {
                 Debug.Assert(BitConverter.IsLittleEndian, "Assume little endian if AVX2 is supported.");
 
@@ -2234,7 +2234,7 @@ namespace System.Text
             // pmovmskb which we know are optimized, and (b) we can avoid downclocking the processor while
             // this method is running.
 
-            if (Avx2.IsSupported && envsetting2 == "AVX2" && elementCount >= 2 * (uint)Unsafe.SizeOf<Vector256<byte>>())
+            if (Avx2.IsSupported && elementCount >= 2 * (uint)Unsafe.SizeOf<Vector256<byte>>())
             {
                 currentOffset = WidenAsciiToUtf16_Avx2(pAsciiBuffer, pUtf16Buffer, elementCount);
             }


### PR DESCRIPTION
This PR adds AVX2 SIMD code paths to the following methods in ASCIIUtility, which influence ASCII / UTF8 transcoding...

- NarrowUtf16ToAscii
- WidenAsciiToUtf16
- GetIndexOfFirstNonAsciiByte
- GetIndexOfFirstNonAsciiChar

Please consider this PR as a draft PR for some feedback. On my PC, I get the following numbers when comparing two runs of benchmarkdotnet Perf.Encoding.cs benchmark for `GetBytes` and `GetChars`. `Base Mean` and `Base Error` show the mean and error in ns for the SSE pathway, `Comp Mean` and `Comp Error` show the mean and error in ns for the AVX pathway. `Diff` shows the difference between SSE and AVX mean, and `Percent Speedup` shows the percentage improvement over `Base Mean`. I have added additional sizes to the benchmark, originally, only 16 and 512 are tested.

```
      Method  size encName  Base Mean  Base Error  Comp Mean  Comp Error   Diff  Percent Speedup
0   GetBytes    16   ascii      15.11       0.800      15.31       0.227  -0.20        -1.323627
1   GetBytes    16   utf-8      15.96       0.554      15.89       0.340   0.07         0.438596
2   GetBytes    32   ascii      16.72       0.194      16.95       0.244  -0.23        -1.375598
3   GetBytes    32   utf-8      17.06       0.238      17.03       0.266   0.03         0.175850
4   GetBytes    64   ascii      19.95       0.273      19.75       0.218   0.20         1.002506
5   GetBytes    64   utf-8      28.97       0.271      29.14       0.581  -0.17        -0.586814
6   GetBytes   128   ascii      26.30       0.229      24.07       0.414   2.23         8.479087
7   GetBytes   128   utf-8      38.24       0.626      35.97       0.550   2.27         5.936192
8   GetBytes   256   ascii      37.39       0.402      33.79       0.449   3.60         9.628243
9   GetBytes   256   utf-8      55.00       0.465      46.18       0.445   8.82        16.036364
10  GetBytes   512   ascii      64.37       0.936      52.03       0.537  12.34        19.170421
11  GetBytes   512   utf-8      89.73       1.762      70.09       0.964  19.64        21.887886
12  GetBytes  1024   ascii     105.74       0.911      93.31       0.923  12.43        11.755249
13  GetBytes  1024   utf-8     156.69       1.388     125.74       1.033  30.95        19.752377
```

```
      Method  size encName  Base Mean  Base Error  Comp Mean  Comp Error   Diff  Percent Speedup
0   GetChars    16   ascii      17.38       0.331      17.62       0.226  -0.24        -1.380898
1   GetChars    16   utf-8      23.70       0.262      26.18       0.311  -2.48       -10.464135
2   GetChars    32   ascii      20.85       0.230      20.01       0.197   0.84         4.028777
3   GetChars    32   utf-8      27.94       0.475      26.42       0.444   1.52         5.440229
4   GetChars    64   ascii      26.29       0.250      25.68       0.512   0.61         2.320274
5   GetChars    64   utf-8      32.59       0.556      32.35       0.560   0.24         0.736422
6   GetChars   128   ascii      34.94       0.447      34.87       0.380   0.07         0.200343
7   GetChars   128   utf-8      43.22       0.496      41.62       0.664   1.60         3.701990
8   GetChars   256   ascii      54.28       1.064      50.26       0.570   4.02         7.406043
9   GetChars   256   utf-8      63.84       1.026      58.42       0.720   5.42         8.489975
10  GetChars   512   ascii      99.85       1.172      81.53       0.922  18.32        18.347521
11  GetChars   512   utf-8     109.45       1.017      92.25       0.930  17.20        15.714938
12  GetChars  1024   ascii     177.09       1.522     154.57       1.681  22.52        12.716698
13  GetChars  1024   utf-8     206.62       1.853     165.61       1.341  41.01        19.848030
```

We can see speedup at larger sizes. As it currently stands, the code can be further optimized by adding additional `Vector128` fallbacks in the `AVX` paths.

What I would like to get some feedback on, is:

1. What final numbers, or test cases, need to be improved and performant for this optimization to be worthy?
2. How much should we optimize the AVX code path, e.g., add `Vector128` fallback paths in the AVX code?
3. Should we instead begin to favor a primary `Vector256` implementation, as opposed to the AVX/AVX2 intrinsic paths?

Any feedback is appreciated.