### PR TITLE
JIT: fix invariant analysis for cloning

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6306,7 +6306,7 @@ protected:
 
     bool optIsLoopTestEvalIntoTemp(Statement* testStmt, Statement** newTestStmt);
     unsigned optIsLoopIncrTree(GenTree* incr);
-    bool optCheckIterInLoopTest(unsigned loopInd, GenTree* test, BasicBlock* from, BasicBlock* to, unsigned iterVar);
+    bool optCheckIterInLoopTest(unsigned loopInd, GenTree* test, unsigned iterVar);
     bool optComputeIterInfo(GenTree* incr, BasicBlock* from, BasicBlock* to, unsigned* pIterVar);
     bool optPopulateInitInfo(unsigned loopInd, BasicBlock* initBlock, GenTree* init, unsigned iterVar);
     bool optExtractInitTestIncr(
@@ -6400,7 +6400,7 @@ protected:
 
     bool optIsVarAssgLoop(unsigned lnum, unsigned var);
 
-    int optIsSetAssgLoop(unsigned lnum, ALLVARSET_VALARG_TP vars, varRefKinds inds = VR_NONE);
+    bool optIsSetAssgLoop(unsigned lnum, ALLVARSET_VALARG_TP vars, varRefKinds inds = VR_NONE);
 
     bool optNarrowTree(GenTree* tree, var_types srct, var_types dstt, ValueNumPair vnpNarrow, bool doit);
 

--- a/src/tests/JIT/opt/Cloning/Runtime_61040_1.cs
+++ b/src/tests/JIT/opt/Cloning/Runtime_61040_1.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+struct ArrayWrapper
+{
+    public int[] Array;
+}
+
+class Runtime_61040_1
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void JitUse<T>(T arg) { }
+    
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static void Problem(ArrayWrapper a)
+    {
+        a = GetArrayLong();
+        
+        JitUse(a);
+        JitUse(a);
+        
+        for (int i = 0; i < 10000; i++)
+        {
+            a = GetArray();
+            JitUse(a.Array[i]);
+        }
+    }
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ArrayWrapper GetArray() => new() { Array = new int[0] };
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ArrayWrapper GetArrayLong() => new() { Array = new int[10000] };
+
+    public static int Main()
+    {
+        int result = -1;
+        try
+        {
+            Problem(default);
+        }
+        catch (IndexOutOfRangeException e)
+        {
+            Console.WriteLine(e.Message);
+            result = 100;
+        }
+        return result;
+    }
+}
+    

--- a/src/tests/JIT/opt/Cloning/Runtime_61040_1.csproj
+++ b/src/tests/JIT/opt/Cloning/Runtime_61040_1.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/opt/Cloning/Runtime_61040_2.cs
+++ b/src/tests/JIT/opt/Cloning/Runtime_61040_2.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Explicit)]
+struct StructWithHoles
+{
+    [FieldOffset(0)]
+    public int Index;
+    [FieldOffset(5)]
+    public byte B;
+    [FieldOffset(8)]
+    public int C;
+}
+
+class Runtime_61040_2
+{
+    static int z = 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void JitUse(int arg) { z += arg; }
+    
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int Problem(StructWithHoles a, StructWithHoles b, int[] d)
+    {
+        var a1 = a;
+        var b1 = b;
+
+        try 
+        {
+            for (a1.Index = 0; a1.Index < 10; a1.Index = a1.Index + 1)
+            {
+                a1 = b1;
+                JitUse(d[a1.Index]);
+            }
+        }
+        catch (IndexOutOfRangeException)
+        {
+            return z + 100;
+        }
+
+        return -1;
+    }
+
+    public static int Main() => Problem(new() { Index = 0 }, new() { Index = 100_000_000 }, new int[10]);
+}

--- a/src/tests/JIT/opt/Cloning/Runtime_61040_2.csproj
+++ b/src/tests/JIT/opt/Cloning/Runtime_61040_2.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/opt/Cloning/Runtime_61040_3.cs
+++ b/src/tests/JIT/opt/Cloning/Runtime_61040_3.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+struct StructWithIndex
+{
+    public int Index;
+    public int Value;
+}
+
+class Runtime_61040_3
+{
+    static int z = 100;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void JitUse(int arg) { z++; }
+    
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int Problem(StructWithIndex a, int[] d)
+    {
+        var a1 = a;
+
+        try
+        {
+            for (a1.Index = 0; a1.Index < 10; a1.Index = a1.Index + 1)
+            {
+                a1 = GetStructWithIndex();
+                JitUse(d[a1.Index]);
+            }
+        }
+        catch (IndexOutOfRangeException)
+        {
+            return z;
+        }
+
+        return -1;
+    }
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static StructWithIndex GetStructWithIndex() => new() { Index = 100_000_000 };
+    
+    public static int Main() => Problem(new() { Index = 0, Value = 33 }, new int[10]);
+}

--- a/src/tests/JIT/opt/Cloning/Runtime_61040_3.csproj
+++ b/src/tests/JIT/opt/Cloning/Runtime_61040_3.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/opt/Cloning/Runtime_61040_4.cs
+++ b/src/tests/JIT/opt/Cloning/Runtime_61040_4.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Runtime_61040_4
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void JitUse<T>(T arg) { }
+    
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int Problem()
+    {
+        int[] a = GetArray();
+        int[] b = a;
+        int[] c = GetArray();
+        
+        JitUse(a);
+        JitUse(b);
+        JitUse(c);
+        
+        int r = 0;
+
+        try 
+        {
+            for (int i = 0; i < a.Length; i++)
+            {
+                a = GetArrayLong();
+                r += b[i];
+            }
+        }
+        catch (IndexOutOfRangeException)
+        {
+            return r;
+        }
+
+        return -1;
+    }
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int[] GetArray() => new int[] { 1, 2, 3, 4, 90 };
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int[] GetArrayLong() => new int[10000];
+
+    public static int Main() => Problem();
+}
+

--- a/src/tests/JIT/opt/Cloning/Runtime_61040_4.csproj
+++ b/src/tests/JIT/opt/Cloning/Runtime_61040_4.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix some cases where the JIT was not sufficiently careful in verifing that
operands in a loop were suitably invariant.

Closes #61040.