### PR TITLE
[wasm][debugger] Added Default Interface Method static tests.

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -588,10 +588,10 @@ namespace DebuggerTests
         [InlineData(true, "RunNonUserCode", "DebuggerAttribute", 1, 867, 8)]
         [InlineData(false, "RunStepThroughWithNonUserCode", "DebuggerAttribute", 1, 933, 8)]
         [InlineData(true, "RunStepThroughWithNonUserCode", "DebuggerAttribute", 1, 933, 8)]
-        [InlineData(false, "EvaluateStepThroughAttr", "DefaultInterfaceMethod", 2, 1091, 4)]
-        [InlineData(true, "EvaluateStepThroughAttr", "DefaultInterfaceMethod", 2, 1091, 4)]
-        [InlineData(false, "EvaluateNonUserCodeAttr", "DefaultInterfaceMethod", 2, 1048, 4, "NonUserCodeDefaultMethod")]
-        [InlineData(true, "EvaluateNonUserCodeAttr", "DefaultInterfaceMethod", 2, 1097, 4)]
+        [InlineData(false, "EvaluateStepThroughAttr", "DefaultInterfaceMethod", 2, 1108, 4)]
+        [InlineData(true, "EvaluateStepThroughAttr", "DefaultInterfaceMethod", 2, 1108, 4)]
+        [InlineData(false, "EvaluateNonUserCodeAttr", "DefaultInterfaceMethod", 2, 1065, 4, "NonUserCodeDefaultMethod")]
+        [InlineData(true, "EvaluateNonUserCodeAttr", "DefaultInterfaceMethod", 2, 1114, 4)]
         public async Task StepThroughOrNonUserCodeAttributeStepInNoBp(bool justMyCodeEnabled, string evalFunName, string evalClassName, int bpLine, int line, int col, string funcName="")
         {
             var bp_init = await SetBreakpointInMethod("debugger-test.dll", evalClassName, evalFunName, bpLine);
@@ -821,9 +821,11 @@ namespace DebuggerTests
         }
 
         [ConditionalTheory(nameof(RunningOnChrome))]
-        [InlineData("IDefaultInterface", "DefaultMethod", "Evaluate", 1070, 1001, 999, 1003)]
-        [InlineData("IExtendIDefaultInterface", "IDefaultInterface.DefaultMethodToOverride", "Evaluate", 1071, 1030, 1028, 1032)]
-        [InlineData("IDefaultInterface", "DefaultMethodAsync", "EvaluateAsync", 37, 1014, 1012, 1016, true, "Start<IDefaultInterface/<DefaultMethodAsync>d__2>")]
+        [InlineData("IDefaultInterface", "DefaultMethod", "Evaluate", 1087, 1003, 1001, 1005)]
+        [InlineData("IExtendIDefaultInterface", "IDefaultInterface.DefaultMethodToOverride", "Evaluate", 1088, 1047, 1045, 1049)]
+        [InlineData("IDefaultInterface", "DefaultMethodAsync", "EvaluateAsync", 37, 1016, 1014, 1018, true, "Start<IDefaultInterface/<DefaultMethodAsync>d__3>")]
+        [InlineData("IDefaultInterface", "DefaultMethodStatic", "EvaluateStatic", 1124, 1022, 1020, 1024)]
+        [InlineData("IDefaultInterface", "DefaultMethodAsyncStatic", "EvaluateAsyncStatic", 37, 1031, 1029, 1033, true, "Start<IDefaultInterface/<DefaultMethodAsyncStatic>d__5>")]
         public async Task BreakInDefaultInterfaceMethod(
             string dimClassName, string dimName, string entryMethod,  int evaluateAsPrevFrameLine, int dimAsPrevFrameLine, int functionLocationLine, int functionEndLine, bool isAsync = false, string asyncPrevFrameInDim = "")
         {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -1237,5 +1237,21 @@ namespace DebuggerTests
                     ("this", TObject("DIMClass")),
                     ("this.dimClassMember", TNumber(123)));
             });
+
+        [Theory]
+        [InlineData("DefaultMethodStatic", "IDefaultInterface", "EvaluateStatic")]
+        [InlineData("DefaultMethodAsyncStatic", "IDefaultInterface", "EvaluateAsyncStatic", true)]
+        public async Task EvaluateLocalsInDefaultInterfaceMethodStatic(string pauseMethod, string methodInterface, string entryMethod, bool isAsync = false) =>
+            await CheckInspectLocalsAtBreakpointSite(
+            methodInterface, pauseMethod, 2, isAsync ? "MoveNext" : pauseMethod,
+            $"window.setTimeout(function() {{ invoke_static_method ('[debugger-test] DefaultInterfaceMethod:{entryMethod}'); }})",
+            wait_for_event_fn: async (pause_location) =>
+            {
+                var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("localString", TString($"{pauseMethod}()")),
+                    ("IDefaultInterface.defaultInterfaceMember", TString("defaultInterfaceMember")) //without interface name: "defaultInterfaceMember" fails; Issue #70135
+                );
+            });
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -996,6 +996,8 @@ public class TestHotReloadUsingSDB {
 #region Default Interface Method
 public interface IDefaultInterface
 {
+    public static string defaultInterfaceMember = "defaultInterfaceMember";
+
     string DefaultMethod()
     {
         string localString = "DefaultMethod()";
@@ -1012,6 +1014,21 @@ public interface IDefaultInterface
     async System.Threading.Tasks.Task DefaultMethodAsync()
     {
         string localString = "DefaultMethodAsync()";
+        DefaultInterfaceMethod.MethodForCallingFromDIM();
+        await System.Threading.Tasks.Task.FromResult(0);
+    }
+    static string DefaultMethodStatic()
+    {
+        string localString = "DefaultMethodStatic()";
+        DefaultInterfaceMethod.MethodForCallingFromDIM();
+        return $"{localString} from IDefaultInterface";
+    }
+
+    // cannot override the static method of the interface - skipping
+
+    static async System.Threading.Tasks.Task DefaultMethodAsyncStatic()
+    {
+        string localString = "DefaultMethodAsyncStatic()";
         DefaultInterfaceMethod.MethodForCallingFromDIM();
         await System.Threading.Tasks.Task.FromResult(0);
     }
@@ -1101,6 +1118,16 @@ public static class DefaultInterfaceMethod
     {
         IExtendIDefaultInterface extendDefaultInter = new DIMClass();
         extendDefaultInter.NonUserCodeDefaultMethod(extendDefaultInter.BoundaryBp);
+    }
+
+    public static void EvaluateStatic()
+    {
+        IExtendIDefaultInterface.DefaultMethodStatic();
+    }
+
+    public static async void EvaluateAsyncStatic()
+    {
+        await IExtendIDefaultInterface.DefaultMethodAsyncStatic();
     }
 
     public static void MethodForCallingFromDIM()


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/69747.
Adds test of Default Interface Method checking if:
- We can access local variables and static members on pause in static DIM and static async DIM (EvaluateLocalsInDefaultInterfaceMethodStatic);
- We can set and hit a breakpoint in static DIM and static async DIM and resume it (BreakInDefaultInterfaceMethod) - here we are checking previous frame from DIM and then we call a method in DIM to check from there the previous frame that belongs to DIM;

Found one issue while preparing these tests: https://github.com/dotnet/runtime/issues/70135.