### PR TITLE
Fix crash on osx-arm64 with Vector3

### DIFF
--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -1705,17 +1705,12 @@ double ExtendedDefaultPolicy::DetermineMultiplier()
     }
 
     // Slow down if there are already too many locals
-    if (m_RootCompiler->lvaCount >= 32)
+    if (m_RootCompiler->lvaTableCnt > 64)
     {
-        // We don't expect to be here in case if we already have more than we can track
-        assert(!m_RootCompiler->lvaHaveManyLocals());
-
-        // E.g. MaxLocalsToTrack = 1024 and lvaCount = 512 -> multiplier *= 0.5;
-        const double lclFullness = (double)m_RootCompiler->lvaCount / JitConfig.JitMaxLocalsToTrack();
-        assert(lclFullness >= 0.0 && lclFullness <= 1.0);
-
-        multiplier *= 1.0 - lclFullness;
-        JITDUMP("\nCaller has lots of locals (%d).  Multiplier decreased to %g.", m_RootCompiler->lvaCount, multiplier);
+        // E.g. MaxLocalsToTrack = 1024 and lvaTableCnt = 512 -> multiplier *= 0.5;
+        const double lclFullness = min(1.0, (double)m_RootCompiler->lvaTableCnt / JitConfig.JitMaxLocalsToTrack());
+        multiplier *= (1.0 - lclFullness);
+        JITDUMP("\nCaller has %d locals.  Multiplier decreased to %g.", m_RootCompiler->lvaTableCnt, multiplier);
     }
 
     if (m_BackwardJump)

--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -1705,12 +1705,17 @@ double ExtendedDefaultPolicy::DetermineMultiplier()
     }
 
     // Slow down if there are already too many locals
-    if (m_RootCompiler->lvaTableCnt > 64)
+    if (m_RootCompiler->lvaCount >= 32)
     {
-        // E.g. MaxLocalsToTrack = 1024 and lvaTableCnt = 512 -> multiplier *= 0.5;
-        const double lclFullness = min(1.0, (double)m_RootCompiler->lvaTableCnt / JitConfig.JitMaxLocalsToTrack());
-        multiplier *= (1.0 - lclFullness);
-        JITDUMP("\nCaller has %d locals.  Multiplier decreased to %g.", m_RootCompiler->lvaTableCnt, multiplier);
+        // We don't expect to be here in case if we already have more than we can track
+        assert(!m_RootCompiler->lvaHaveManyLocals());
+
+        // E.g. MaxLocalsToTrack = 1024 and lvaCount = 512 -> multiplier *= 0.5;
+        const double lclFullness = (double)m_RootCompiler->lvaCount / JitConfig.JitMaxLocalsToTrack();
+        assert(lclFullness >= 0.0 && lclFullness <= 1.0);
+
+        multiplier *= 1.0 - lclFullness;
+        JITDUMP("\nCaller has lots of locals (%d).  Multiplier decreased to %g.", m_RootCompiler->lvaCount, multiplier);
     }
 
     if (m_BackwardJump)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_63354/Runtime_63354.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_63354/Runtime_63354.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+public class Runtime_63354
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Test1(Vector3 v1, ref Vector3 v2)
+    {
+        v1.X = 100;
+        v2 = v1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static Vector3 Test2(Vector3 v)
+    {
+        for (int i = 0; i < 1; i++)
+        {
+            var vs = new Vector3[] { v };
+            Box(v);
+            v.X = 0;
+        }
+        return v;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Box(object o) {}
+
+    public static int Main()
+    {
+        for (int i = 0; i < 1; i++)
+        {
+            Test2(Vector3.Zero);
+        }
+
+        Vector3 v = default;
+        Test1(v, ref v);
+        return (int)v.X;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_63354/Runtime_63354.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_63354/Runtime_63354.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Normally, we promote SIMD12 to SIMD16 but not on osx-arm64 ABI. The crash happened because `genStoreLclTypeSIMD12` expected data to be on stack rather in registers so I added `mov reg, reg` just like in the SIMD16 path.

Fixes https://github.com/dotnet/runtime/issues/63354

Technically, we might consider backporting it to 6.0 - all apps with Vector3 usage are in danger on Apple M1 basically.