### PR TITLE
JIT: Handle enums in box-unbox optimization

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7457,8 +7457,28 @@ int Compiler::impBoxPatternMatch(CORINFO_RESOLVED_TOKEN* pResolvedToken,
                 const TypeCompareState compare =
                     info.compCompHnd->compareTypesForEquality(unboxResolvedToken.hClass, pResolvedToken->hClass);
 
+                bool optimize = false;
+
                 // If so, box/unbox.any is a nop.
                 if (compare == TypeCompareState::Must)
+                {
+                    optimize = true;
+                }
+                else if (compare == TypeCompareState::MustNot)
+                {
+                    // An attempt to catch cases where we mix enums and primitives, e.g.:
+                    //   (IntEnum)(object)myInt
+                    //   (byte)(object)myByteEnum
+                    //
+                    CorInfoType typ = info.compCompHnd->getTypeForPrimitiveValueClass(unboxResolvedToken.hClass);
+                    if ((typ >= CORINFO_TYPE_BYTE) && (typ <= CORINFO_TYPE_ULONG) &&
+                        (info.compCompHnd->getTypeForPrimitiveValueClass(pResolvedToken->hClass) == typ))
+                    {
+                        optimize = true;
+                    }
+                }
+
+                if (optimize)
                 {
                     JITDUMP("\n Importing BOX; UNBOX.ANY as NOP\n");
                     // Skip the next unbox.any instruction


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/55355

When we box a enum and unbox it as integer (and vice versa) JIT should be able to optimize it as no-op. E.g. https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABABgAJiBGAOgCUBXAOwwEt8YaBhCfAB1YAbGFADKIgG6swMXAG4AsACgy5UQAtsUPgBlsweszYdFS5cQBMlKgHZlAb2Xln5ANoApVhgDiMJiOkACgwATz4YCAAzQIBRJgZ8KgBKJIBdZwB6DPImCAwnF1cAWRgMdQgAEwBJfkFAkrLKmr5BAHk+NggmXBoAQQBzfthcXFYJGCqmQVYmGf60gudiAGZrJHJgCAhBcgAJPAAxQWx+gB4AFQA+QPPyCWxBBhg0clvI4/nF8kclFz/KGzkQKBGYYJKBCDAABWMDAYPujxg5AAZEDQeDITC4Ul3ickuQALwEtEsDHQ2Fg3H9Ux/AC+ynpZhUqz8CXIcQSVG+5F6LwAQuRaUA==

New codegen:
```asm
; Program.HasFlag
       and      ecx, edx
       xor      eax, eax
       cmp      ecx, edx
       sete     al
       ret      
; Total bytes of code: 10
```
The change is small, the verbosity is due to JIT-EE update, I had to add a flag to `compareTypesForEquality` because in some places it's still expected to be more conservative around enums vs integers.