### PR TITLE
Do not read position when tar archive stream is unseekable

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -311,7 +311,10 @@ namespace System.Formats.Tar
             byte[] emptyRecord = new byte[TarHelpers.RecordSize];
             _archiveStream.Write(emptyRecord);
             _archiveStream.Write(emptyRecord);
-            _archiveStream.SetLength(_archiveStream.Position);
+            if (_archiveStream.CanSeek)
+            {
+                _archiveStream.SetLength(_archiveStream.Position);
+            }
         }
 
         // Partial method for reading an entry from disk and writing it into the archive stream.

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -311,10 +311,6 @@ namespace System.Formats.Tar
             byte[] emptyRecord = new byte[TarHelpers.RecordSize];
             _archiveStream.Write(emptyRecord);
             _archiveStream.Write(emptyRecord);
-            if (_archiveStream.CanSeek)
-            {
-                _archiveStream.SetLength(_archiveStream.Position);
-            }
         }
 
         // Partial method for reading an entry from disk and writing it into the archive stream.

--- a/src/libraries/System.Formats.Tar/tests/CompressedTar.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/CompressedTar.Tests.cs
@@ -37,7 +37,6 @@ namespace System.Formats.Tar.Tests
                 using GZipStream decompressorStream = new GZipStream(streamToDecompress, CompressionMode.Decompress);
                 using TarReader reader = new TarReader(decompressorStream);
                 TarEntry entry = reader.GetNextEntry();
-                Assert.NotNull(entry);
                 Assert.Equal(TarFormat.Pax, reader.Format);
                 Assert.Equal(fileName, entry.Name);
                 Assert.Null(reader.GetNextEntry());

--- a/src/libraries/System.Formats.Tar/tests/CompressedTar.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/CompressedTar.Tests.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using System.IO;
+using Xunit;
+
+namespace System.Formats.Tar.Tests
+{
+    public class CompressedTar_Tests : TarTestsBase
+    {
+        [Fact]
+        public void TarGz_TarWriter_TarReader()
+        {
+            using TempDirectory root = new TempDirectory();
+
+            string archivePath = Path.Join(root.Path, "compressed.tar.gz");
+
+            string fileName = "file.txt";
+            string filePath = Path.Join(root.Path, fileName);
+            File.Create(filePath).Dispose();
+
+            // Create tar.gz archive
+            using (FileStream streamToCompress = File.Create(archivePath))
+            {
+                using GZipStream compressorStream = new GZipStream(streamToCompress, CompressionMode.Compress);
+                using TarWriter writer = new TarWriter(compressorStream);
+                writer.WriteEntry(fileName: filePath, entryName: fileName);
+            }
+            FileInfo fileInfo = new FileInfo(archivePath);
+            Assert.True(fileInfo.Exists);
+            Assert.True(fileInfo.Length > 0);
+
+            // Verify tar.gz archive contents
+            using (FileStream streamToDecompress = File.OpenRead(archivePath))
+            {
+                using GZipStream decompressorStream = new GZipStream(streamToDecompress, CompressionMode.Decompress);
+                using TarReader reader = new TarReader(decompressorStream);
+                TarEntry entry = reader.GetNextEntry();
+                Assert.NotNull(entry);
+                Assert.Equal(TarFormat.Pax, reader.Format);
+                Assert.Equal(fileName, entry.Name);
+                Assert.Null(reader.GetNextEntry());
+            }
+        }
+
+        [Fact]
+        public void TarGz_TarFile_CreateFromDir_ExtractToDir()
+        {
+            using TempDirectory root = new TempDirectory();
+
+            string archivePath = Path.Join(root.Path, "compressed.tar.gz");
+
+            string sourceDirectory = Path.Join(root.Path, "source");
+            Directory.CreateDirectory(sourceDirectory);
+
+            string destinationDirectory = Path.Join(root.Path, "destination");
+            Directory.CreateDirectory(destinationDirectory);
+
+            string fileName = "file.txt";
+            string filePath = Path.Join(sourceDirectory, fileName);
+            File.Create(filePath).Dispose();
+
+            using (FileStream streamToCompress = File.Create(archivePath))
+            {
+                using GZipStream compressorStream = new GZipStream(streamToCompress, CompressionMode.Compress);
+                TarFile.CreateFromDirectory(sourceDirectory, compressorStream, includeBaseDirectory: false);
+            }
+            FileInfo fileInfo = new FileInfo(archivePath);
+            Assert.True(fileInfo.Exists);
+            Assert.True(fileInfo.Length > 0);
+
+            using (FileStream streamToDecompress = File.OpenRead(archivePath))
+            {
+                using GZipStream decompressorStream = new GZipStream(streamToDecompress, CompressionMode.Decompress);
+                TarFile.ExtractToDirectory(decompressorStream, destinationDirectory, overwriteFiles: true);
+                Assert.True(File.Exists(filePath));
+            }
+        }
+    }
+}

--- a/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
+++ b/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs" Link="Common\System\IO\TempDirectory.cs" />
+    <Compile Include="CompressedTar.Tests.cs" />
     <Compile Include="TarEntry\TarEntryV7.Tests.cs" />
     <Compile Include="TarEntry\TarEntryUstar.Tests.cs" />
     <Compile Include="TarEntry\TarEntryPax.Tests.cs" />

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
@@ -91,14 +91,15 @@ namespace System.Formats.Tar.Tests
                 writer.WriteEntry(paxEntry);
             } // The final records should get written, and the length should not be set because position cannot be read
 
-            stream.Seek(0, SeekOrigin.Begin); // Rewind the base stream (wrapped cannot be rewinded)
+            stream.Seek(0, SeekOrigin.Begin); // Rewind the base stream (wrapped cannot be rewound)
 
-            using TarReader reader = new TarReader(wrapped);
-            TarEntry entry = reader.GetNextEntry();
-            Assert.NotNull(entry);
-            Assert.Equal(TarFormat.Pax, reader.Format);
-            Assert.Equal(TarEntryType.RegularFile, entry.EntryType);
-            Assert.Null(reader.GetNextEntry());
+            using (TarReader reader = new TarReader(wrapped))
+            {
+                TarEntry entry = reader.GetNextEntry();
+                Assert.Equal(TarFormat.Pax, reader.Format);
+                Assert.Equal(TarEntryType.RegularFile, entry.EntryType);
+                Assert.Null(reader.GetNextEntry());
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
@@ -82,8 +82,8 @@ namespace System.Formats.Tar.Tests
         [Fact]
         public void Write_To_UnseekableStream()
         {
-            MemoryStream stream = new MemoryStream();
-            using WrappedStream wrapped = new WrappedStream(stream, canRead: true, canWrite: true, canSeek: false);
+            using MemoryStream inner = new MemoryStream();
+            using WrappedStream wrapped = new WrappedStream(inner, canRead: true, canWrite: true, canSeek: false);
 
             using (TarWriter writer = new TarWriter(wrapped, leaveOpen: true))
             {
@@ -91,7 +91,7 @@ namespace System.Formats.Tar.Tests
                 writer.WriteEntry(paxEntry);
             } // The final records should get written, and the length should not be set because position cannot be read
 
-            stream.Seek(0, SeekOrigin.Begin); // Rewind the base stream (wrapped cannot be rewound)
+            inner.Seek(0, SeekOrigin.Begin); // Rewind the base stream (wrapped cannot be rewound)
 
             using (TarReader reader = new TarReader(wrapped))
             {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/70172

The position was being read at the very last moment of creating the archive, to set the archive size one byte after the empty records. This causes an exception to be thrown when compressing directly into a gzip stream, which is unseekable (position cannot be accessed).

cc @rainersigwald 