### PR TITLE
Enabling console logger queue length and mode to be configurable

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Logging.Console
         public bool IncludeScopes { get { throw null; } set { } }
         public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get { throw null; } set { } }
         public int MaxQueueLength { get { throw null; } set { } }
-        public Microsoft.Extensions.Logging.Console.ConsoleLoggerBufferFullMode QueueFullMode { get { throw null; } set { } }
+        public Microsoft.Extensions.Logging.Console.ConsoleLoggerQueueFullMode QueueFullMode { get { throw null; } set { } }
         [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Use ConsoleFormatterOptions.TimestampFormat instead.")]
         public string? TimestampFormat { get { throw null; } set { } }
         [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.")]
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.Logging.Console
         public void Dispose() { }
         public void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
     }
-    public enum ConsoleLoggerBufferFullMode
+    public enum ConsoleLoggerQueueFullMode
     {
         Wait = 0,
         DropWrite = 1,

--- a/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
@@ -62,6 +62,8 @@ namespace Microsoft.Extensions.Logging.Console
         [System.ObsoleteAttribute("ConsoleLoggerOptions.IncludeScopes has been deprecated. Use ConsoleFormatterOptions.IncludeScopes instead.")]
         public bool IncludeScopes { get { throw null; } set { } }
         public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get { throw null; } set { } }
+        public int MaxQueueLength { get { throw null; } set { } }
+        public Microsoft.Extensions.Logging.Console.ConsoleLoggerBufferFullMode BufferFullMode { get { throw null; } set { } }
         [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Use ConsoleFormatterOptions.TimestampFormat instead.")]
         public string? TimestampFormat { get { throw null; } set { } }
         [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.")]
@@ -76,6 +78,11 @@ namespace Microsoft.Extensions.Logging.Console
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string name) { throw null; }
         public void Dispose() { }
         public void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
+    }
+    public enum ConsoleLoggerBufferFullMode
+    {
+        Wait = 0,
+        DropWrite = 1,
     }
     public partial class JsonConsoleFormatterOptions : Microsoft.Extensions.Logging.Console.ConsoleFormatterOptions
     {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Logging.Console
         public bool IncludeScopes { get { throw null; } set { } }
         public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get { throw null; } set { } }
         public int MaxQueueLength { get { throw null; } set { } }
-        public Microsoft.Extensions.Logging.Console.ConsoleLoggerBufferFullMode BufferFullMode { get { throw null; } set { } }
+        public Microsoft.Extensions.Logging.Console.ConsoleLoggerBufferFullMode QueueFullMode { get { throw null; } set { } }
         [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Use ConsoleFormatterOptions.TimestampFormat instead.")]
         public string? TimestampFormat { get { throw null; } set { } }
         [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.")]

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -64,16 +64,16 @@ namespace Microsoft.Extensions.Logging.Console
         [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.")]
         public bool UseUtcTimestamp { get; set; }
 
-        private ConsoleLoggerBufferFullMode _bufferFullMode = ConsoleLoggerBufferFullMode.Wait;
+        private ConsoleLoggerQueueFullMode _bufferFullMode = ConsoleLoggerQueueFullMode.Wait;
         /// <summary>
         /// Gets or sets the desired console logger behavior when buffer becomes full. Defaults to <c>Wait</c>.
         /// </summary>
-        public ConsoleLoggerBufferFullMode QueueFullMode
+        public ConsoleLoggerQueueFullMode QueueFullMode
         {
             get => _bufferFullMode;
             set
             {
-                if (value != ConsoleLoggerBufferFullMode.Wait && value != ConsoleLoggerBufferFullMode.DropWrite)
+                if (value != ConsoleLoggerQueueFullMode.Wait && value != ConsoleLoggerQueueFullMode.DropWrite)
                 {
                     throw new ArgumentOutOfRangeException(SR.Format(SR.BufferModeNotSupported, nameof(value)));
                 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Extensions.Logging.Console
 
         private ConsoleLoggerBufferFullMode _bufferFullMode = ConsoleLoggerBufferFullMode.Wait;
         /// <summary>
-        /// Gets or sets the desired console logger behavior when buffer becomes full. Defaults to <c>Wait</c>.
+        /// Gets or sets the desired console logger behavior when the queue becomes full. Defaults to <c>Wait</c>.
         /// </summary>
         public ConsoleLoggerBufferFullMode QueueFullMode
         {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Gets or sets the desired console logger behavior when buffer becomes full. Defaults to <c>Wait</c>.
         /// </summary>
-        public ConsoleLoggerBufferFullMode BufferFullMode
+        public ConsoleLoggerBufferFullMode QueueFullMode
         {
             get => _bufferFullMode;
             set

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -64,20 +64,20 @@ namespace Microsoft.Extensions.Logging.Console
         [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.")]
         public bool UseUtcTimestamp { get; set; }
 
-        private ConsoleLoggerQueueFullMode _bufferFullMode = ConsoleLoggerQueueFullMode.Wait;
+        private ConsoleLoggerQueueFullMode _queueFullMode = ConsoleLoggerQueueFullMode.Wait;
         /// <summary>
         /// Gets or sets the desired console logger behavior when the queue becomes full. Defaults to <c>Wait</c>.
         /// </summary>
         public ConsoleLoggerQueueFullMode QueueFullMode
         {
-            get => _bufferFullMode;
+            get => _queueFullMode;
             set
             {
                 if (value != ConsoleLoggerQueueFullMode.Wait && value != ConsoleLoggerQueueFullMode.DropWrite)
                 {
-                    throw new ArgumentOutOfRangeException(SR.Format(SR.BufferModeNotSupported, nameof(value)));
+                    throw new ArgumentOutOfRangeException(SR.Format(SR.QueueModeNotSupported, nameof(value)));
                 }
-                _bufferFullMode = value;
+                _queueFullMode = value;
             }
         }
 
@@ -94,7 +94,7 @@ namespace Microsoft.Extensions.Logging.Console
             {
                 if (value <= 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(value)} must be larger than zero.");
+                    throw new ArgumentOutOfRangeException(SR.Format(SR.MaxQueueLengthBadValue, nameof(value)));
                 }
 
                 _maxQueuedMessages = value;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -81,11 +81,11 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
-        internal const int DefaultMaxQueueLengthValue = 1024 * 1024;
+        internal const int DefaultMaxQueueLengthValue = 2500;
         private int _maxQueuedMessages = DefaultMaxQueueLengthValue;
 
         /// <summary>
-        /// Gets or sets the maximum number of enqueued messages. Defaults to 1024 * 1024.
+        /// Gets or sets the maximum number of enqueued messages. Defaults to 2500.
         /// </summary>
         public int MaxQueueLength
         {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.Logging.Console
             {
                 if (value != ConsoleLoggerBufferFullMode.Wait && value != ConsoleLoggerBufferFullMode.DropWrite)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(value)} is not a supported buffer mode value.");
+                    throw new ArgumentOutOfRangeException(SR.Format(SR.BufferModeNotSupported, nameof(value)));
                 }
                 _bufferFullMode = value;
             }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -64,15 +64,28 @@ namespace Microsoft.Extensions.Logging.Console
         [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.")]
         public bool UseUtcTimestamp { get; set; }
 
+        private ConsoleLoggerBufferFullMode _bufferFullMode = ConsoleLoggerBufferFullMode.Wait;
         /// <summary>
         /// Gets or sets the desired console logger behavior when buffer becomes full. Defaults to <c>Wait</c>.
         /// </summary>
-        public ConsoleLoggerBufferFullMode BufferFullMode { get; set; }
+        public ConsoleLoggerBufferFullMode BufferFullMode
+        {
+            get => _bufferFullMode;
+            set
+            {
+                if (value != ConsoleLoggerBufferFullMode.Wait && value != ConsoleLoggerBufferFullMode.DropWrite)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(value)} is not a supported buffer mode value.");
+                }
+                _bufferFullMode = value;
+            }
+        }
 
-        private int _maxQueuedMessages = 1048576;
+        internal const int DefaultMaxQueueLengthValue = 1024 * 1024;
+        private int _maxQueuedMessages = DefaultMaxQueueLengthValue;
 
         /// <summary>
-        /// Gets or sets the maximum number of enqueued messages. Defaults to 1048576.
+        /// Gets or sets the maximum number of enqueued messages. Defaults to 1024 * 1024.
         /// </summary>
         public int MaxQueueLength
         {
@@ -81,7 +94,7 @@ namespace Microsoft.Extensions.Logging.Console
             {
                 if (value <= 0)
                 {
-                    throw new ArgumentException(nameof(MaxQueueLength));
+                    throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(value)} must be larger than zero.");
                 }
 
                 _maxQueuedMessages = value;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -63,5 +63,29 @@ namespace Microsoft.Extensions.Logging.Console
         /// </summary>
         [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.")]
         public bool UseUtcTimestamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the desired console logger behavior when buffer becomes full. Defaults to <c>Wait</c>.
+        /// </summary>
+        public ConsoleLoggerBufferFullMode BufferFullMode { get; set; }
+
+        private int _maxQueuedMessages = 1048576;
+
+        /// <summary>
+        /// Gets or sets the maximum number of enqueued messages. Defaults to 1048576.
+        /// </summary>
+        public int MaxQueueLength
+        {
+            get => _maxQueuedMessages;
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentException(nameof(MaxQueueLength));
+                }
+
+                _maxQueuedMessages = value;
+            }
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Extensions.Logging.Console
                     Monitor.Wait(_messageQueue);
                 }
 
-                if (_messageQueue.Count < MaxQueueLength)
+                if (_messageQueue.Count < MaxQueueLength && !_isAddingCompleted)
                 {
                     _messageQueue.Enqueue(item);
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Extensions.Logging.Console
     [UnsupportedOSPlatform("browser")]
     internal class ConsoleLoggerProcessor : IDisposable
     {
-        private const string WarningMessageOnDrop = " message(s) dropped because of queue size limit. Increase the queue size or decrease logging verbosity to avoid this. You may change `ConsoleLoggerBufferFullMode` to stop dropping messages.";
         private readonly Queue<LogMessageEntry> _messageQueue;
         private int _messagesDropped;
         private bool _isAddingCompleted;
@@ -127,7 +126,7 @@ namespace Microsoft.Extensions.Logging.Console
                     if (_messagesDropped > 0)
                     {
                         _messageQueue.Enqueue(new LogMessageEntry(
-                            message: _messagesDropped + WarningMessageOnDrop + Environment.NewLine,
+                            message: _messagesDropped + SR.WarningMessageOnDrop + Environment.NewLine,
                             logAsError: true
                         ));
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Extensions.Logging.Console
                     // _fullMode is used inside the lock and is safer to guard setter with lock as well
                     // this set is not expected to happen frequently
                     _fullMode = value;
+                    Monitor.PulseAll(_messageQueue);
                 }
             }
         }
@@ -196,8 +197,8 @@ namespace Microsoft.Extensions.Logging.Console
         {
             lock (_messageQueue)
             {
-                Monitor.PulseAll(_messageQueue);
                 _isAddingCompleted = true;
+                Monitor.PulseAll(_messageQueue);
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Extensions.Logging.Console
                     Monitor.Wait(_messageQueue);
                 }
 
-                if (!_isAddingCompleted)
+                if (_messageQueue.Count < MaxQueueLength)
                 {
                     _messageQueue.Enqueue(item);
 
@@ -155,7 +155,7 @@ namespace Microsoft.Extensions.Logging.Console
                     Monitor.Wait(_messageQueue);
                 }
 
-                if (!_isAddingCompleted)
+                if (_messageQueue.Count > 0)
                 {
                     item = _messageQueue.Dequeue();
                     if (_messageQueue.Count == MaxQueueLength - 1)

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -35,13 +35,13 @@ namespace Microsoft.Extensions.Logging.Console
                 }
             }
         }
-        private ConsoleLoggerBufferFullMode _fullMode = ConsoleLoggerBufferFullMode.Wait;
-        public ConsoleLoggerBufferFullMode FullMode
+        private ConsoleLoggerQueueFullMode _fullMode = ConsoleLoggerQueueFullMode.Wait;
+        public ConsoleLoggerQueueFullMode FullMode
         {
             get => _fullMode;
             set
             {
-                if (value != ConsoleLoggerBufferFullMode.Wait && value != ConsoleLoggerBufferFullMode.DropWrite)
+                if (value != ConsoleLoggerQueueFullMode.Wait && value != ConsoleLoggerQueueFullMode.DropWrite)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(value)} is not a supported buffer mode value.");
                 }
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.Logging.Console
         public IConsole Console { get; }
         public IConsole ErrorConsole { get; }
 
-        public ConsoleLoggerProcessor(IConsole console, IConsole errorConsole, ConsoleLoggerBufferFullMode fullMode, int maxQueueLength)
+        public ConsoleLoggerProcessor(IConsole console, IConsole errorConsole, ConsoleLoggerQueueFullMode fullMode, int maxQueueLength)
         {
             _messageQueue = new Queue<LogMessageEntry>();
             FullMode = fullMode;
@@ -112,13 +112,13 @@ namespace Microsoft.Extensions.Logging.Console
             {
                 while (_messageQueue.Count >= MaxQueueLength && !_isAddingCompleted)
                 {
-                    if (FullMode == ConsoleLoggerBufferFullMode.DropWrite)
+                    if (FullMode == ConsoleLoggerQueueFullMode.DropWrite)
                     {
                         _messagesDropped++;
                         return true;
                     }
 
-                    Debug.Assert(FullMode == ConsoleLoggerBufferFullMode.Wait);
+                    Debug.Assert(FullMode == ConsoleLoggerQueueFullMode.Wait);
                     Monitor.Wait(_messageQueue);
                 }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Logging.Console
                 var messagesDropped = Interlocked.Exchange(ref _messagesDropped, 0);
                 if (messagesDropped != 0)
                 {
-                    System.Console.Error.WriteLine($"{messagesDropped} message(s) dropped because of queue size limit. Increase the queue size or decrease logging verbosity to avoid this.{Environment.NewLine}");
+                    ErrorConsole.Write($"{messagesDropped} message(s) dropped because of queue size limit. Increase the queue size or decrease logging verbosity to avoid this.{Environment.NewLine}");
                 }
 
                 IConsole console = entry.LogAsError ? ErrorConsole : Console;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Logging.Console
             {
                 if (value <= 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(value)} must be larger than zero.");
+                    throw new ArgumentOutOfRangeException(SR.Format(SR.MaxQueueLengthBadValue, nameof(value)));
                 }
 
                 lock (_messageQueue)
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.Logging.Console
             {
                 if (value != ConsoleLoggerQueueFullMode.Wait && value != ConsoleLoggerQueueFullMode.DropWrite)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(value)} is not a supported buffer mode value.");
+                    throw new ArgumentOutOfRangeException(SR.Format(SR.QueueModeNotSupported, nameof(value)));
                 }
 
                 lock (_messageQueue)
@@ -129,7 +129,7 @@ namespace Microsoft.Extensions.Logging.Console
                     if (_messagesDropped > 0)
                     {
                         _messageQueue.Enqueue(new LogMessageEntry(
-                            message: _messagesDropped + SR.WarningMessageOnDrop + Environment.NewLine,
+                            message: SR.Format(SR.WarningMessageOnDrop + Environment.NewLine, _messagesDropped),
                             logAsError: true
                         ));
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.Logging.Console
             _messageQueue = new ConsoleLoggerProcessor(
                 console,
                 errorConsole,
-                options.CurrentValue.BufferFullMode,
+                options.CurrentValue.QueueFullMode,
                 options.CurrentValue.MaxQueueLength);
 
             ReloadLoggerOptions(options.CurrentValue);
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Logging.Console
 #pragma warning restore CS0618
             }
 
-            _messageQueue.FullMode = options.BufferFullMode;
+            _messageQueue.FullMode = options.QueueFullMode;
             _messageQueue.MaxQueueLength = options.MaxQueueLength;
 
             foreach (KeyValuePair<string, ConsoleLogger> logger in _loggers)

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -56,7 +56,6 @@ namespace Microsoft.Extensions.Logging.Console
                 errorConsole = new AnsiParsingLogConsole(stdErr: true);
             }
             _messageQueue = new ConsoleLoggerProcessor(
-                "LoggingConsoleQueue",
                 console,
                 errorConsole,
                 options.CurrentValue.BufferFullMode,

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerQueueFullMode.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerQueueFullMode.cs
@@ -4,16 +4,16 @@
 namespace Microsoft.Extensions.Logging.Console
 {
     /// <summary>
-    /// Determines the console logger behavior when buffer becomes full.
+    /// Determines the console logger behavior when the queue becomes full.
     /// </summary>
     public enum ConsoleLoggerBufferFullMode
     {
         /// <summary>
-        /// Blocks the logging threads once the buffer limit is reached.
+        /// Blocks the logging threads once the queue limit is reached.
         /// </summary>
         Wait,
         /// <summary>
-        /// Drops new log messages when the buffer is full
+        /// Drops new log messages when the queue is full.
         /// </summary>
         DropWrite
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerQueueFullMode.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerQueueFullMode.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Extensions.Logging.Console
     /// <summary>
     /// Determines the console logger behavior when buffer becomes full.
     /// </summary>
-    public enum ConsoleLoggerBufferFullMode
+    public enum ConsoleLoggerQueueFullMode
     {
         /// <summary>
         /// Blocks the logging threads once the buffer limit is reached.

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerQueueFullMode.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerQueueFullMode.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    /// <summary>
+    /// Determines the console logger behavior when buffer becomes full.
+    /// </summary>
+    public enum ConsoleLoggerBufferFullMode
+    {
+        /// <summary>
+        /// Blocks the console thread once the buffer limit is reached
+        /// </summary>
+        Wait,
+        /// <summary>
+        /// Drops new log messages when the buffer is full
+        /// </summary>
+        DropWrite
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerQueueFullMode.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerQueueFullMode.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Logging.Console
     public enum ConsoleLoggerBufferFullMode
     {
         /// <summary>
-        /// Blocks the console thread once the buffer limit is reached
+        /// Blocks the logging threads once the buffer limit is reached.
         /// </summary>
         Wait,
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
@@ -123,4 +123,7 @@
   <data name="BufferModeNotSupported" xml:space="preserve">
     <value>{0} is not a supported buffer mode value.</value>
   </data>
+  <data name="WarningMessageOnDrop" xml:space="preserve">
+    <value> message(s) dropped because of queue size limit. Increase the queue size or decrease logging verbosity to avoid this. You may change `ConsoleLoggerBufferFullMode` to stop dropping messages.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
@@ -124,6 +124,6 @@
     <value>{0} is not a supported buffer mode value.</value>
   </data>
   <data name="WarningMessageOnDrop" xml:space="preserve">
-    <value> message(s) dropped because of queue size limit. Increase the queue size or decrease logging verbosity to avoid this. You may change `ConsoleLoggerBufferFullMode` to stop dropping messages.</value>
+    <value> message(s) dropped because of queue size limit. Increase the queue size or decrease logging verbosity to avoid this. You may change `ConsoleLoggerQueueFullMode` to stop dropping messages.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
@@ -121,7 +121,7 @@
     <value>Cannot allocate a buffer of size {0}.</value>
   </data>
   <data name="BufferModeNotSupported" xml:space="preserve">
-    <value>{0} is not a supported buffer mode value.</value>
+    <value>{0} is not a supported queue mode value.</value>
   </data>
   <data name="WarningMessageOnDrop" xml:space="preserve">
     <value> message(s) dropped because of queue size limit. Increase the queue size or decrease logging verbosity to avoid this. You may change `ConsoleLoggerBufferFullMode` to stop dropping messages.</value>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
@@ -120,10 +120,13 @@
   <data name="BufferMaximumSizeExceeded" xml:space="preserve">
     <value>Cannot allocate a buffer of size {0}.</value>
   </data>
-  <data name="BufferModeNotSupported" xml:space="preserve">
+  <data name="QueueModeNotSupported" xml:space="preserve">
     <value>{0} is not a supported queue mode value.</value>
   </data>
+  <data name="MaxQueueLengthBadValue" xml:space="preserve">
+    <value>{0} must be larger than zero.</value>
+  </data>
   <data name="WarningMessageOnDrop" xml:space="preserve">
-    <value> message(s) dropped because of queue size limit. Increase the queue size or decrease logging verbosity to avoid this. You may change `ConsoleLoggerQueueFullMode` to stop dropping messages.</value>
+    <value>{0} message(s) dropped because of queue size limit. Increase the queue size or decrease logging verbosity to avoid this. You may change `ConsoleLoggerQueueFullMode` to stop dropping messages.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
@@ -120,4 +120,7 @@
   <data name="BufferMaximumSizeExceeded" xml:space="preserve">
     <value>Cannot allocate a buffer of size {0}.</value>
   </data>
+  <data name="BufferModeNotSupported" xml:space="preserve">
+    <value>{0} is not a supported buffer mode value.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
@@ -38,7 +38,9 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var errorSink = new ConsoleSink();
             var console = new TestConsole(sink);
             var errorConsole = new TestConsole(errorSink);
-            var consoleLoggerProcessor = new TestLoggerProcessor(console, errorConsole);
+            var bufferMode = options == null ? ConsoleLoggerBufferFullMode.Wait : options.BufferFullMode;
+            var maxQueueLength = options == null ? ConsoleLoggerProcessorTests.DefaultMaxQueueLengthValue : options.MaxQueueLength;
+            var consoleLoggerProcessor = new TestLoggerProcessor(console, errorConsole, bufferMode, maxQueueLength);
 
             var formatters = new ConcurrentDictionary<string, ConsoleFormatter>(ConsoleLoggerTest.GetFormatters(simpleOptions, systemdOptions, jsonOptions).ToDictionary(f => f.Name));
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var errorSink = new ConsoleSink();
             var console = new TestConsole(sink);
             var errorConsole = new TestConsole(errorSink);
-            var bufferMode = options == null ? ConsoleLoggerBufferFullMode.Wait : options.BufferFullMode;
+            var bufferMode = options == null ? ConsoleLoggerBufferFullMode.Wait : options.QueueFullMode;
             var maxQueueLength = options == null ? ConsoleLoggerOptions.DefaultMaxQueueLengthValue : options.MaxQueueLength;
             var consoleLoggerProcessor = new TestLoggerProcessor(console, errorConsole, bufferMode, maxQueueLength);
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var console = new TestConsole(sink);
             var errorConsole = new TestConsole(errorSink);
             var bufferMode = options == null ? ConsoleLoggerBufferFullMode.Wait : options.BufferFullMode;
-            var maxQueueLength = options == null ? ConsoleLoggerProcessorTests.DefaultMaxQueueLengthValue : options.MaxQueueLength;
+            var maxQueueLength = options == null ? ConsoleLoggerOptions.DefaultMaxQueueLengthValue : options.MaxQueueLength;
             var consoleLoggerProcessor = new TestLoggerProcessor(console, errorConsole, bufferMode, maxQueueLength);
 
             var formatters = new ConcurrentDictionary<string, ConsoleFormatter>(ConsoleLoggerTest.GetFormatters(simpleOptions, systemdOptions, jsonOptions).ToDictionary(f => f.Name));

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var errorSink = new ConsoleSink();
             var console = new TestConsole(sink);
             var errorConsole = new TestConsole(errorSink);
-            var bufferMode = options == null ? ConsoleLoggerBufferFullMode.Wait : options.QueueFullMode;
+            var bufferMode = options == null ? ConsoleLoggerQueueFullMode.Wait : options.QueueFullMode;
             var maxQueueLength = options == null ? ConsoleLoggerOptions.DefaultMaxQueueLengthValue : options.MaxQueueLength;
             var consoleLoggerProcessor = new TestLoggerProcessor(console, errorConsole, bufferMode, maxQueueLength);
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -15,7 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Xunit;
 
-namespace Microsoft.Extensions.Logging.Test
+namespace Microsoft.Extensions.Logging.Console.Test
 {
     public class ConsoleLoggerExtensionsTests
     {
@@ -354,6 +355,48 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Null(logger.Options.FormatterName);
             var formatter = Assert.IsType<SystemdConsoleFormatter>(logger.Formatter);
             Assert.Equal("HH:mm:ss ", formatter.FormatterOptions.TimestampFormat);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void AddConsole_MaxQueueLengthSetToNegativeOrZero_IgnoresValue(int invalidMaxQueueLength)
+        {
+            var configs = new[] {
+                new KeyValuePair<string, string>("Console:MaxQueueLength", invalidMaxQueueLength.ToString()),
+            };
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(configs).Build();
+
+            IServiceProvider serviceProvider = new ServiceCollection()
+                .AddLogging(builder => builder
+                    .AddConfiguration(configuration)
+                    .AddConsole(o => { })
+                )
+                .BuildServiceProvider();
+
+            // the configuration binder throws TargetInvocationException when setting options property MaxQueueLength throws exception
+            Assert.Throws<TargetInvocationException>(() => serviceProvider.GetRequiredService<ILoggerProvider>());
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public void AddConsole_MaxQueueLengthLargerThanZero_ConfiguredProperly()
+        {
+            var configs = new[] {
+                new KeyValuePair<string, string>("Console:MaxQueueLength", "12345"),
+            };
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(configs).Build();
+
+            var loggerProvider = new ServiceCollection()
+                .AddLogging(builder => builder
+                    .AddConfiguration(configuration)
+                    .AddConsole(o => { })
+                )
+                .BuildServiceProvider()
+                .GetRequiredService<ILoggerProvider>();
+
+            var consoleLoggerProvider = Assert.IsType<ConsoleLoggerProvider>(loggerProvider);
+            var logger = (ConsoleLogger)consoleLoggerProvider.CreateLogger("Category");
+            Assert.Equal(12345, logger.Options.MaxQueueLength);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
@@ -360,7 +360,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(-1)]
         [InlineData(0)]
-        public void AddConsole_MaxQueueLengthSetToNegativeOrZero_IgnoresValue(int invalidMaxQueueLength)
+        public void AddConsole_MaxQueueLengthSetToNegativeOrZero_Throws(int invalidMaxQueueLength)
         {
             var configs = new[] {
                 new KeyValuePair<string, string>("Console:MaxQueueLength", invalidMaxQueueLength.ToString()),

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
@@ -1,0 +1,183 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.Extensions.Logging.Test.Console;
+using Xunit;
+#pragma warning disable CS0618
+
+namespace Microsoft.Extensions.Logging.Console.Test
+{
+    public class ConsoleLoggerProcessorTests
+    {
+        internal const int DefaultMaxQueueLengthValue = 1048576;
+        private const string _loggerName = "test";
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public void LogAfterDisposeWritesLog()
+        {
+            // Arrange
+            var sink = new ConsoleSink();
+            var console = new TestConsole(sink);
+            var processor = new ConsoleLoggerProcessor(nameof(LogAfterDisposeWritesLog), console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
+
+            var logger = new ConsoleLogger(_loggerName, loggerProcessor: processor,
+                new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(new SimpleConsoleFormatterOptions())),
+                null, new ConsoleLoggerOptions());
+            Assert.Null(logger.Options.FormatterName);
+            UpdateFormatterOptions(logger.Formatter, logger.Options);
+
+            // Act
+            processor.Dispose();
+            logger.LogInformation("Logging after dispose");
+
+            // Assert
+            Assert.Equal(2, sink.Writes.Count);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public static void SetNegativeMaxQueueLength_IgnoresWhenNotPositive()
+        {
+            // Arrange
+            var sink = new ConsoleSink();
+            var console = new TestConsole(sink);
+            var processor = new ConsoleLoggerProcessor(nameof(SetNegativeMaxQueueLength_IgnoresWhenNotPositive), console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
+            var formatter = new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(
+                new SimpleConsoleFormatterOptions()));
+
+            var logger = new ConsoleLogger(_loggerName, processor, formatter, null, new ConsoleLoggerOptions());
+            Assert.Null(logger.Options.FormatterName);
+            UpdateFormatterOptions(logger.Formatter, logger.Options);
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => processor.MaxQueueLength = -1);
+        }
+
+        [ConditionalTheory(nameof(IsThreadingAndRemoteExecutorSupported))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CheckForNotificationWhenQueueIsFull(bool dropWrite)
+        {
+            RemoteExecutor.Invoke((okToDropMessages) =>
+            {
+                using (var stringWriter = new StringWriter())
+                {
+                    System.Console.SetError(stringWriter);
+                    bool okToDrop = bool.Parse(okToDropMessages);
+                    using (var listener = new ConsoleTraceListener(useErrorStream: true))
+                    {
+                        // Arrange
+                        var sink = new ConsoleSink();
+                        var console = new TestConsole(sink);
+                        string queueName = nameof(CheckForNotificationWhenQueueIsFull) + (okToDrop ? "InDropWriteMode" : "InWaitMode");
+                        var processor = new ConsoleLoggerProcessor(queueName, console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
+                        var formatter = new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(
+                            new SimpleConsoleFormatterOptions()));
+
+                        var logger = new ConsoleLogger(_loggerName, processor, formatter, null, new ConsoleLoggerOptions());
+                        Assert.Null(logger.Options.FormatterName);
+                        UpdateFormatterOptions(logger.Formatter, logger.Options);
+                        string messageTemplate = string.Join(", ", Enumerable.Range(1, 100).Select(x => "{A" + x + "}"));
+                        object[] messageParams = Enumerable.Range(1, 100).Select(x => (object)x).ToArray();
+
+                        // Act
+                        processor.MaxQueueLength = 1;
+                        processor.FullMode = okToDrop ? ConsoleLoggerBufferFullMode.DropWrite : ConsoleLoggerBufferFullMode.Wait;
+                        for (int i = 0; i < 2000; i++)
+                        {
+                            logger.LogInformation(messageTemplate, messageParams);
+                        }
+
+                        // Assert
+                        if (okToDrop)
+                        {
+                            Assert.Contains("dropped because of queue size limit", stringWriter.ToString());
+                        }
+                        else
+                        {
+                            Assert.DoesNotContain("dropped because of queue size limit", stringWriter.ToString());                        
+                        }
+                    }
+                }
+            }, dropWrite.ToString()).Dispose();
+        }
+
+        private class TimesWriteCalledConsole : IConsole
+        {
+            public volatile int TimesWriteCalled;
+            public void Write(string message)
+            {
+                TimesWriteCalled++;
+            }
+        }
+
+        private class WriteThrowingConsole : IConsole
+        {
+            public void Write(string message)
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        [OuterLoop]
+        [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
+        public void ThrowDuringProcessLog_ShutsDownGracefully()
+        {
+            var console = new TimesWriteCalledConsole();
+            var writeThrowingConsole = new WriteThrowingConsole();
+            var processor = new ConsoleLoggerProcessor(
+                nameof(ThrowDuringProcessLog_ShutsDownGracefully),
+                console,
+                writeThrowingConsole,
+                ConsoleLoggerBufferFullMode.Wait,
+                1024);
+
+            var formatter = new SimpleConsoleFormatter(
+                new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(
+                    new SimpleConsoleFormatterOptions()));
+
+            var logger = new ConsoleLogger(_loggerName, processor, formatter, null, new ConsoleLoggerOptions()
+            {
+                LogToStandardErrorThreshold = LogLevel.Error
+            });
+
+            Assert.Null(logger.Options.FormatterName);
+            UpdateFormatterOptions(logger.Formatter, logger.Options);
+            logger.LogInformation("Process 1st log normally using {DesiredConsole}", nameof(TimesWriteCalledConsole));
+            logger.LogInformation("Process 2nd log normally using {DesiredConsole}", nameof(TimesWriteCalledConsole));
+            while (console.TimesWriteCalled != 2); // wait until the logs are processed
+            Assert.Equal(2, console.TimesWriteCalled);
+            logger.LogError("Causing exception to throw in {ClassName} using {DesiredConsole}", nameof(ConsoleLoggerProcessor), nameof(WriteThrowingConsole));
+            logger.LogInformation("After the write logic threw exception, {ClassName} stopped gracefully, no longer processing next logs", nameof(ConsoleLoggerProcessor));
+            Assert.Equal(2, console.TimesWriteCalled);
+        }
+
+        private static void UpdateFormatterOptions(ConsoleFormatter formatter, ConsoleLoggerOptions deprecatedFromOptions)
+        {
+            // kept for deprecated apis:
+            if (formatter is SimpleConsoleFormatter defaultFormatter)
+            {
+                defaultFormatter.FormatterOptions.ColorBehavior = deprecatedFromOptions.DisableColors ? 
+                    LoggerColorBehavior.Disabled : LoggerColorBehavior.Enabled;
+                defaultFormatter.FormatterOptions.IncludeScopes = deprecatedFromOptions.IncludeScopes;
+                defaultFormatter.FormatterOptions.TimestampFormat = deprecatedFromOptions.TimestampFormat;
+                defaultFormatter.FormatterOptions.UseUtcTimestamp = deprecatedFromOptions.UseUtcTimestamp;
+            }
+            else
+            if (formatter is SystemdConsoleFormatter systemdFormatter)
+            {
+                systemdFormatter.FormatterOptions.IncludeScopes = deprecatedFromOptions.IncludeScopes;
+                systemdFormatter.FormatterOptions.TimestampFormat = deprecatedFromOptions.TimestampFormat;
+                systemdFormatter.FormatterOptions.UseUtcTimestamp = deprecatedFromOptions.UseUtcTimestamp;
+            }
+        }
+
+        public static bool IsThreadingAndRemoteExecutorSupported =>
+            PlatformDetection.IsThreadingSupported && RemoteExecutor.IsSupported;
+    }
+}
+#pragma warning restore CS0618

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
+            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerQueueFullMode.Wait, 1024);
 
             var logger = new ConsoleLogger(_loggerName, loggerProcessor: processor,
                 new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(new SimpleConsoleFormatterOptions())),
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
+            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerQueueFullMode.Wait, 1024);
 
             // Act & Assert
             Assert.Throws<ArgumentOutOfRangeException>(() => processor.MaxQueueLength = invalidMaxQueueLength);
@@ -56,10 +56,10 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
+            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerQueueFullMode.Wait, 1024);
 
             // Act & Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => processor.FullMode = (ConsoleLoggerBufferFullMode)10);
+            Assert.Throws<ArgumentOutOfRangeException>(() => processor.FullMode = (ConsoleLoggerQueueFullMode)10);
         }
 
         [OuterLoop]
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var console = new TestConsole(sink);
             var errorConsole = new TimesWriteCalledConsole();
             string queueName = nameof(CheckForNotificationWhenQueueIsFull) + (okToDrop ? "InDropWriteMode" : "InWaitMode");
-            var fullMode = okToDrop ? ConsoleLoggerBufferFullMode.DropWrite : ConsoleLoggerBufferFullMode.Wait;
+            var fullMode = okToDrop ? ConsoleLoggerQueueFullMode.DropWrite : ConsoleLoggerQueueFullMode.Wait;
             var processor = new ConsoleLoggerProcessor(console, errorConsole, fullMode, maxQueueLength: 1);
             var formatter = new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(
                 new SimpleConsoleFormatterOptions()));
@@ -127,7 +127,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var processor = new ConsoleLoggerProcessor(
                 console,
                 writeThrowingConsole,
-                ConsoleLoggerBufferFullMode.Wait,
+                ConsoleLoggerQueueFullMode.Wait,
                 1024);
 
             var formatter = new SimpleConsoleFormatter(

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging.Test.Console;
 using Xunit;
-#pragma warning disable CS0618
 
 namespace Microsoft.Extensions.Logging.Console.Test
 {
@@ -154,6 +153,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
 
         private static void UpdateFormatterOptions(ConsoleFormatter formatter, ConsoleLoggerOptions deprecatedFromOptions)
         {
+#pragma warning disable CS0618
             // kept for deprecated apis:
             if (formatter is SimpleConsoleFormatter defaultFormatter)
             {
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 systemdFormatter.FormatterOptions.TimestampFormat = deprecatedFromOptions.TimestampFormat;
                 systemdFormatter.FormatterOptions.UseUtcTimestamp = deprecatedFromOptions.UseUtcTimestamp;
             }
+#pragma warning restore CS0618
         }
     }
 }
-#pragma warning restore CS0618

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [OuterLoop]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(true)]
         [InlineData(false)]
         public void CheckForNotificationWhenQueueIsFull(bool okToDrop)
@@ -73,7 +73,8 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var console = new TestConsole(sink);
             var errorConsole = new TimesWriteCalledConsole();
             string queueName = nameof(CheckForNotificationWhenQueueIsFull) + (okToDrop ? "InDropWriteMode" : "InWaitMode");
-            var processor = new ConsoleLoggerProcessor(console, errorConsole, ConsoleLoggerBufferFullMode.Wait, 1024);
+            var fullMode = okToDrop ? ConsoleLoggerBufferFullMode.DropWrite : ConsoleLoggerBufferFullMode.Wait;
+            var processor = new ConsoleLoggerProcessor(console, errorConsole, fullMode, maxQueueLength: 1);
             var formatter = new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(
                 new SimpleConsoleFormatterOptions()));
 
@@ -84,8 +85,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
             object[] messageParams = Enumerable.Range(1, 100).Select(x => (object)x).ToArray();
 
             // Act
-            processor.MaxQueueLength = 1;
-            processor.FullMode = okToDrop ? ConsoleLoggerBufferFullMode.DropWrite : ConsoleLoggerBufferFullMode.Wait;
             for (int i = 0; i < 20000; i++)
             {
                 logger.LogInformation(messageTemplate, messageParams);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
@@ -48,12 +48,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
             var processor = new ConsoleLoggerProcessor(nameof(MaxQueueLength_SetInvalid_Throws), console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
-            var formatter = new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(
-                new SimpleConsoleFormatterOptions()));
-
-            var logger = new ConsoleLogger(_loggerName, processor, formatter, null, new ConsoleLoggerOptions());
-            Assert.Null(logger.Options.FormatterName);
-            UpdateFormatterOptions(logger.Formatter, logger.Options);
 
             // Act & Assert
             Assert.Throws<ArgumentOutOfRangeException>(() => processor.MaxQueueLength = invalidMaxQueueLength);
@@ -66,12 +60,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
             var processor = new ConsoleLoggerProcessor(nameof(FullMode_SetInvalid_Throws), console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
-            var formatter = new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(
-                new SimpleConsoleFormatterOptions()));
-
-            var logger = new ConsoleLogger(_loggerName, processor, formatter, null, new ConsoleLoggerOptions());
-            Assert.Null(logger.Options.FormatterName);
-            UpdateFormatterOptions(logger.Formatter, logger.Options);
 
             // Act & Assert
             Assert.Throws<ArgumentOutOfRangeException>(() => processor.FullMode = (ConsoleLoggerBufferFullMode)10);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
 {
     public class ConsoleLoggerProcessorTests
     {
-        internal const int DefaultMaxQueueLengthValue = ConsoleLoggerOptions.DefaultMaxQueueLengthValue;
         private const string _loggerName = "test";
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var processor = new ConsoleLoggerProcessor(nameof(LogAfterDisposeWritesLog), console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
+            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
 
             var logger = new ConsoleLogger(_loggerName, loggerProcessor: processor,
                 new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(new SimpleConsoleFormatterOptions())),
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var processor = new ConsoleLoggerProcessor(nameof(MaxQueueLength_SetInvalid_Throws), console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
+            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
 
             // Act & Assert
             Assert.Throws<ArgumentOutOfRangeException>(() => processor.MaxQueueLength = invalidMaxQueueLength);
@@ -57,7 +57,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var processor = new ConsoleLoggerProcessor(nameof(FullMode_SetInvalid_Throws), console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
+            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerBufferFullMode.Wait, 1024);
 
             // Act & Assert
             Assert.Throws<ArgumentOutOfRangeException>(() => processor.FullMode = (ConsoleLoggerBufferFullMode)10);
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var console = new TestConsole(sink);
             var errorConsole = new TimesWriteCalledConsole();
             string queueName = nameof(CheckForNotificationWhenQueueIsFull) + (okToDrop ? "InDropWriteMode" : "InWaitMode");
-            var processor = new ConsoleLoggerProcessor(queueName, console, errorConsole, ConsoleLoggerBufferFullMode.Wait, 1024);
+            var processor = new ConsoleLoggerProcessor(console, errorConsole, ConsoleLoggerBufferFullMode.Wait, 1024);
             var formatter = new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(
                 new SimpleConsoleFormatterOptions()));
 
@@ -127,7 +127,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var console = new TimesWriteCalledConsole();
             var writeThrowingConsole = new WriteThrowingConsole();
             var processor = new ConsoleLoggerProcessor(
-                nameof(ThrowDuringProcessLog_ShutsDownGracefully),
                 console,
                 writeThrowingConsole,
                 ConsoleLoggerBufferFullMode.Wait,

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -1418,7 +1418,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
     internal class TestLoggerProcessor : ConsoleLoggerProcessor
     {
         public TestLoggerProcessor(IConsole console, IConsole errorConsole, ConsoleLoggerBufferFullMode fullMode, int maxQueueLength)
-            : base(nameof(TestLoggerProcessor), console, errorConsole, fullMode, maxQueueLength)
+            : base(console, errorConsole, fullMode, maxQueueLength)
         {
         }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -1184,7 +1184,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void ConsoleLoggerOptions_SetInvalidBufferMode_Throws()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new ConsoleLoggerOptions() { QueueFullMode = (ConsoleLoggerBufferFullMode)10 });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ConsoleLoggerOptions() { QueueFullMode = (ConsoleLoggerQueueFullMode)10 });
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -1303,13 +1303,13 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var logger = (ConsoleLogger)loggerProvider.CreateLogger("Name");
 
             // Act & Assert
-            Assert.Equal(ConsoleLoggerBufferFullMode.Wait, logger.Options.QueueFullMode);
+            Assert.Equal(ConsoleLoggerQueueFullMode.Wait, logger.Options.QueueFullMode);
             Assert.Equal(ConsoleLoggerOptions.DefaultMaxQueueLengthValue, logger.Options.MaxQueueLength);
             monitor.Set(new ConsoleLoggerOptions() {
-                QueueFullMode = ConsoleLoggerBufferFullMode.DropWrite,
+                QueueFullMode = ConsoleLoggerQueueFullMode.DropWrite,
                 MaxQueueLength = 10
             });
-            Assert.Equal(ConsoleLoggerBufferFullMode.DropWrite, logger.Options.QueueFullMode);
+            Assert.Equal(ConsoleLoggerQueueFullMode.DropWrite, logger.Options.QueueFullMode);
             Assert.Equal(10, logger.Options.MaxQueueLength);
         }
 
@@ -1417,7 +1417,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
 
     internal class TestLoggerProcessor : ConsoleLoggerProcessor
     {
-        public TestLoggerProcessor(IConsole console, IConsole errorConsole, ConsoleLoggerBufferFullMode fullMode, int maxQueueLength)
+        public TestLoggerProcessor(IConsole console, IConsole errorConsole, ConsoleLoggerQueueFullMode fullMode, int maxQueueLength)
             : base(console, errorConsole, fullMode, maxQueueLength)
         {
         }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
 
             ConsoleFormatter? formatter = null;
             var loggerOptions = options ?? new ConsoleLoggerOptions();
-            var consoleLoggerProcessor = new TestLoggerProcessor(console, errorConsole, loggerOptions.BufferFullMode, loggerOptions.MaxQueueLength);
+            var consoleLoggerProcessor = new TestLoggerProcessor(console, errorConsole, loggerOptions.QueueFullMode, loggerOptions.MaxQueueLength);
             Func<LogLevel, string> levelAsString;
             int writesPerMsg;
             switch (loggerOptions.Format)
@@ -424,7 +424,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 var sink = new ConsoleSink();
                 var console = new TestConsole(sink);
                 var loggerOptions = new ConsoleLoggerOptions();
-                var consoleLoggerProcessor = new TestLoggerProcessor(console, null!);
+                var consoleLoggerProcessor = new TestLoggerProcessor(console, null!, loggerOptions.QueueFullMode, loggerOptions.MaxQueueLength);
 
                 var loggerProvider = new ServiceCollection()
                     .AddLogging(builder => builder
@@ -1184,7 +1184,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void ConsoleLoggerOptions_SetInvalidBufferMode_Throws()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new ConsoleLoggerOptions() { BufferFullMode = (ConsoleLoggerBufferFullMode)10 });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ConsoleLoggerOptions() { QueueFullMode = (ConsoleLoggerBufferFullMode)10 });
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -1303,13 +1303,13 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var logger = (ConsoleLogger)loggerProvider.CreateLogger("Name");
 
             // Act & Assert
-            Assert.Equal(ConsoleLoggerBufferFullMode.Wait, logger.Options.BufferFullMode);
+            Assert.Equal(ConsoleLoggerBufferFullMode.Wait, logger.Options.QueueFullMode);
             Assert.Equal(ConsoleLoggerOptions.DefaultMaxQueueLengthValue, logger.Options.MaxQueueLength);
             monitor.Set(new ConsoleLoggerOptions() {
-                BufferFullMode = ConsoleLoggerBufferFullMode.DropWrite,
+                QueueFullMode = ConsoleLoggerBufferFullMode.DropWrite,
                 MaxQueueLength = 10
             });
-            Assert.Equal(ConsoleLoggerBufferFullMode.DropWrite, logger.Options.BufferFullMode);
+            Assert.Equal(ConsoleLoggerBufferFullMode.DropWrite, logger.Options.QueueFullMode);
             Assert.Equal(10, logger.Options.MaxQueueLength);
         }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -1304,7 +1304,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
 
             // Act & Assert
             Assert.Equal(ConsoleLoggerBufferFullMode.Wait, logger.Options.BufferFullMode);
-            Assert.Equal(ConsoleLoggerProcessorTests.DefaultMaxQueueLengthValue, logger.Options.MaxQueueLength);
+            Assert.Equal(ConsoleLoggerOptions.DefaultMaxQueueLengthValue, logger.Options.MaxQueueLength);
             monitor.Set(new ConsoleLoggerOptions() {
                 BufferFullMode = ConsoleLoggerBufferFullMode.DropWrite,
                 MaxQueueLength = 10

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -1173,6 +1173,20 @@ namespace Microsoft.Extensions.Logging.Console.Test
             Assert.Throws<ArgumentOutOfRangeException>(() => new ConsoleLoggerOptions() { Format = (ConsoleLoggerFormat)10 });
         }
 
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void ConsoleLoggerOptions_SetInvalidMaxQueueLength_Throws(int invalidMaxQueueLength)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ConsoleLoggerOptions() { MaxQueueLength = invalidMaxQueueLength });
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public void ConsoleLoggerOptions_SetInvalidBufferMode_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ConsoleLoggerOptions() { BufferFullMode = (ConsoleLoggerBufferFullMode)10 });
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void ConsoleLoggerOptions_DisableColors_IsReadFromLoggingConfiguration()
         {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/Microsoft.Extensions.Logging.Console.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/Microsoft.Extensions.Logging.Console.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/Microsoft.Extensions.Logging.Console.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/Microsoft.Extensions.Logging.Console.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
     <EnableDefaultItems>true</EnableDefaultItems>


### PR DESCRIPTION
### Description

Adds configuration for console logger's queue length and mode

- Adds new APIs for the logging console queue processor
- Replaces BlockingCollection with Queue implementation
- Adds code coverage for ConsoleLoggerProcessor (except for for `ThreadStateException` case in Dispose and `GetQueueSize` metrics logic)
- Adds queue name and metrics

### Performance testing

#### Comparing original `BlockingCollection` with new `Queue` implementation

Using a custom log formatter which only writes the string in message template, with no padding or prefix, using the snippet below:

```c#
        var howManyBytes = _1000Chars.Length * sizeof(char);
        var logger = loggerFactory.CreateLogger<Program>();
        var sw = new Stopwatch();
        sw.Start();
        for (int i = 0; i < 100000; i++)
        {
            logger.LogInformation(_1000Chars);
        }
        sw.Stop();
        var elapsedForLoggingConsole = sw.ElapsedMilliseconds;

        Console.Error.WriteLine($"Bytes written {howManyBytes * 100000 / (1024 * 1024)} MB");
        Console.Error.WriteLine($"elapsedForLoggingConsole: {elapsedForLoggingConsole} ms");
        Console.Error.WriteLine($"Speed: {(howManyBytes * 100000 / (1024 * 1024)) / (elapsedForLoggingConsole / 1000.0f)} MB/sec");
```

Table below shows the perf numbers comparing `BlockingCollection` vs. new `Queue` implementation given different max length sizes, running:

```
> dotnet run -c Release >> output-to-file.txt
```

```
|           Queue type | Max length |  Time elapsed |            Speed |   Bytes written |      Notes        |
|----------------------|------------|---------------|------------------|-----------------|-------------------|
|   BlockingCollection |         1  |      4319 ms  |  43.99167 MB/sec |          190 MB | Fastest (10 runs) |
|   BlockingCollection |         1  |      4546 ms  | 41.794983 MB/sec |          190 MB | Slowest (10 runs) |
|                Queue |         1  |      4309 ms  | 44.093758 MB/sec |          190 MB | Fastest (10 runs) |
|                Queue |         1  |      5078 ms  | 37.416306 MB/sec |          190 MB | Slowest (10 runs) |
|   BlockingCollection |        10  |      4269 ms  |  44.50691 MB/sec |          190 MB | Fastest (10 runs) |
|   BlockingCollection |        10  |      4482 ms  | 42.391792 MB/sec |          190 MB | Slowest (10 runs) |
|                Queue |        10  |      4374 ms  |   43.4385 MB/sec |          190 MB | Fastest (10 runs) |
|                Queue |        10  |      4496 ms  |  42.25979 MB/sec |          190 MB | Slowest (10 runs) |
|   BlockingCollection |      1024  |      4295 ms  |  44.50691 MB/sec |          190 MB | Fastest (10 runs) |
|   BlockingCollection |      1024  |      4574 ms  | 41.539135 MB/sec |          190 MB | Slowest (10 runs) |
|                Queue |      1024  |      4223 ms  |  44.99171 MB/sec |          190 MB | Fastest (10 runs) |
|                Queue |      1024  |      4675 ms  |  40.64171 MB/sec |          190 MB | Slowest (10 runs) |
```

This shows there's no time regression caused by using the queue approach. All of the cases above would hit the max queue length limit and they all have a perf hit because of hitting that limit.

The other test involves setting max queue length to a value that the logging load would not hit.
At this higher max value (making sure it wont hit max for looping 100_000 logs, total of 190 MB), both `BlockingCollection` and `Queue` approaches get a big performance boost when logging the same amount of logs: 

```
Bytes written: 190 MB

Time elapsed using BlockingCollection (fastest after 10 reruns): 170 ms
Speed (fastest after 10 reruns): 1117.6471 MB/sec

Time elapsed using BlockingCollection (slowest after 10 reruns): 203 ms
Speed (slowest after 10 reruns): 935.96063 MB/sec

vs.

Time elapsed using Queue (fastest after 10 reruns): 169 ms
Speed (fastest after 10 reruns): 1124.2604 MB/sec

Time elapsed using Queue (slowest after 10 reruns): 201 ms
Speed (slowest after 10 reruns): 945.2736 MB/sec

vs.

System.Console
Time elapsed using System.Console: 4741 ms
Speed: 40.07593 MB/sec
```

Note: Given that these numbers are from manually using stopwatch, it doesn't cover the standard deviation error between using BlockingCollection and Queue. Overall both approaches remain in the same range in performance.

Fixes #65264