### PR TITLE
Stop unnecessary exceptions from being thrown from crossgen when a reference is not actually a managed dll

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -123,9 +123,9 @@ namespace ILCompiler
             return null;
         }
 
-        public EcmaModule GetModuleFromPath(string filePath)
+        public EcmaModule GetModuleFromPath(string filePath, bool throwOnFailureToLoad = true)
         {
-            return GetOrAddModuleFromPath(filePath, true);
+            return GetOrAddModuleFromPath(filePath, true, throwOnFailureToLoad: throwOnFailureToLoad);
         }
 
         public EcmaModule GetMetadataOnlyModuleFromPath(string filePath)
@@ -133,7 +133,7 @@ namespace ILCompiler
             return GetOrAddModuleFromPath(filePath, false);
         }
 
-        private EcmaModule GetOrAddModuleFromPath(string filePath, bool useForBinding)
+        private EcmaModule GetOrAddModuleFromPath(string filePath, bool useForBinding, bool throwOnFailureToLoad = true)
         {
             filePath = Path.GetFullPath(filePath);
 
@@ -144,7 +144,7 @@ namespace ILCompiler
                     return entry.Module;
             }
 
-            return AddModule(filePath, null, useForBinding);
+            return AddModule(filePath, null, useForBinding, throwOnFailureToLoad: throwOnFailureToLoad);
         }
 
         public static unsafe PEReader OpenPEFile(string filePath, out MemoryMappedViewAccessor mappedViewAccessor)
@@ -182,7 +182,7 @@ namespace ILCompiler
             }
         }
 
-        private EcmaModule AddModule(string filePath, string expectedSimpleName, bool useForBinding, ModuleData oldModuleData = null)
+        private EcmaModule AddModule(string filePath, string expectedSimpleName, bool useForBinding, ModuleData oldModuleData = null, bool throwOnFailureToLoad = true)
         {
             filePath = Path.GetFullPath(filePath);
 
@@ -208,6 +208,11 @@ namespace ILCompiler
                     peReader = oldModuleData.Module.PEReader;
                     mappedViewAccessor = oldModuleData.MappedViewAccessor;
                     pdbReader = oldModuleData.Module.PdbReader;
+                }
+
+                if (!peReader.HasMetadata && !throwOnFailureToLoad)
+                {
+                    return null;
                 }
 
                 EcmaModule module = EcmaModule.Create(this, peReader, containingAssembly: null, pdbReader);

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -472,7 +472,10 @@ namespace ILCompiler
                 {
                     try
                     {
-                        EcmaModule module = _typeSystemContext.GetModuleFromPath(referenceFile);
+                        EcmaModule module = _typeSystemContext.GetModuleFromPath(referenceFile, throwOnFailureToLoad: false);
+                        if (module == null)
+                            continue;
+
                         _referenceableModules.Add(module);
                         if (_commandLineOptions.InputBubble && _inputbubblereferenceFilePaths.Count == 0)
                         {
@@ -490,7 +493,11 @@ namespace ILCompiler
                     {
                         try
                         {
-                            EcmaModule module = _typeSystemContext.GetModuleFromPath(referenceFile);
+                            EcmaModule module = _typeSystemContext.GetModuleFromPath(referenceFile, throwOnFailureToLoad: false);
+
+                            if (module == null)
+                                continue;
+
                             versionBubbleModulesHash.Add(module);
                         }
                         catch { } // Ignore non-managed pe files


### PR DESCRIPTION
- Makes ad hoc usage of crossgen2 much more convenient on Windows as the exceptions generated are annoying to deal with in the debugger