### PR TITLE
[mono] Extend mono AOT compiler to ingest .mibc profiles

### DIFF
--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -969,7 +969,7 @@ mono_assembly_load_reference (MonoImage *image, int index)
 		goto commit_reference;
 	}
 
-	if (image->assembly) {
+	if (image->assembly || image->not_executable) {
 		if (mono_trace_is_traced (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY)) {
 			char *aname_str = mono_stringify_assembly_name (&aname);
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Loading reference %d of %s (%s), looking for %s",

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -969,23 +969,20 @@ mono_assembly_load_reference (MonoImage *image, int index)
 		goto commit_reference;
 	}
 
-	if (image->assembly || image->not_executable) {
-		if (mono_trace_is_traced (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY)) {
-			char *aname_str = mono_stringify_assembly_name (&aname);
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Loading reference %d of %s (%s), looking for %s",
-				    index, image->name, mono_alc_is_default (mono_image_get_alc (image)) ? "default ALC" : "custom ALC" ,
-				    aname_str);
-			g_free (aname_str);
-		}
-
-		MonoAssemblyByNameRequest req;
-		mono_assembly_request_prepare_byname (&req, mono_image_get_alc (image));
-		req.requesting_assembly = image->assembly;
-		//req.no_postload_search = TRUE; // FIXME: should this be set?
-		reference = mono_assembly_request_byname (&aname, &req, NULL);
-	} else {
-		g_assertf (image->assembly, "While loading reference %d MonoImage %s doesn't have a MonoAssembly", index, image->name);
+	g_assertf (image->assembly || image->not_executable, "While loading reference %d, executable MonoImage %s doesn't have a MonoAssembly", index, image->name);
+	if (mono_trace_is_traced (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY)) {
+		char *aname_str = mono_stringify_assembly_name (&aname);
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Loading reference %d of %s (%s), looking for %s",
+				index, image->name, mono_alc_is_default (mono_image_get_alc (image)) ? "default ALC" : "custom ALC" ,
+				aname_str);
+		g_free (aname_str);
 	}
+
+	MonoAssemblyByNameRequest req;
+	mono_assembly_request_prepare_byname (&req, mono_image_get_alc (image));
+	req.requesting_assembly = image->assembly;
+	//req.no_postload_search = TRUE; // FIXME: should this be set?
+	reference = mono_assembly_request_byname (&aname, &req, NULL);
 
 	if (reference == NULL){
 		char *extra_msg;
@@ -1603,7 +1600,7 @@ mono_assembly_request_open (const char *filename, const MonoAssemblyOpenRequest 
 	}
 
 	if (!image)
-		image = mono_image_open_a_lot (load_req.alc, fname, status);
+		image = mono_image_open_a_lot (load_req.alc, fname, status, FALSE);
 
 	if (!image){
 		if (*status == MONO_IMAGE_OK)

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -1599,8 +1599,10 @@ mono_assembly_request_open (const char *filename, const MonoAssemblyOpenRequest 
 		loaded_from_bundle = image != NULL;
 	}
 
-	if (!image)
-		image = mono_image_open_a_lot (load_req.alc, fname, status, FALSE);
+	if (!image) {
+		MonoImageOpenOptions options = {0, };
+		image = mono_image_open_a_lot (load_req.alc, fname, status, &options);
+	}
 
 	if (!image){
 		if (*status == MONO_IMAGE_OK)

--- a/src/mono/mono/metadata/image-internals.h
+++ b/src/mono/mono/metadata/image-internals.h
@@ -9,6 +9,17 @@
 #include <mono/metadata/image.h>
 #include <mono/metadata/loader-internals.h>
 
+typedef struct {
+	int care_about_cli : 1;
+	int care_about_pecoff : 1;
+} ImageLoadOptions;
+
+typedef struct {
+	ImageLoadOptions load_options;
+	int not_executable : 1;
+	int metadata_only : 1;
+} ImageOpenOptions;
+
 MonoImage*
 mono_image_loaded_internal (MonoAssemblyLoadContext *alc, const char *name);
 
@@ -19,9 +30,6 @@ MonoImage*
 mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error);
 
 MonoImage *
-mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status);
-
-MonoImage *
-mono_image_open_mibc (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status);
+mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean not_executable);
 
 #endif /* __MONO_METADATA_IMAGE_INTERNALS_H__ */

--- a/src/mono/mono/metadata/image-internals.h
+++ b/src/mono/mono/metadata/image-internals.h
@@ -21,4 +21,7 @@ mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error);
 MonoImage *
 mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status);
 
+MonoImage *
+mono_image_open_mibc (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status);
+
 #endif /* __MONO_METADATA_IMAGE_INTERNALS_H__ */

--- a/src/mono/mono/metadata/image-internals.h
+++ b/src/mono/mono/metadata/image-internals.h
@@ -10,15 +10,15 @@
 #include <mono/metadata/loader-internals.h>
 
 typedef struct {
-	int care_about_cli : 1;
-	int care_about_pecoff : 1;
-} ImageLoadOptions;
+	int dont_care_about_cli : 1;
+	int dont_care_about_pecoff : 1;
+} MonoImageLoadOptions;
 
 typedef struct {
-	ImageLoadOptions load_options;
+	MonoImageLoadOptions load_options;
 	int not_executable : 1;
 	int metadata_only : 1;
-} ImageOpenOptions;
+} MonoImageOpenOptions;
 
 MonoImage*
 mono_image_loaded_internal (MonoAssemblyLoadContext *alc, const char *name);
@@ -30,6 +30,6 @@ MonoImage*
 mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error);
 
 MonoImage *
-mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean not_executable);
+mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, const MonoImageOpenOptions *options);
 
 #endif /* __MONO_METADATA_IMAGE_INTERNALS_H__ */

--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -1881,6 +1881,14 @@ mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImag
 	return mono_image_open_a_lot_parameterized (li, alc, fname, status);
 }
 
+MonoImage *
+mono_image_open_mibc (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status)
+{
+	MonoImage *mibcImage = mono_image_open_a_lot (alc, fname, status);
+	mibcImage->not_executable = TRUE;
+	return mibcImage;
+}
+
 /**
  * mono_image_open:
  * \param fname filename that points to the module we want to open

--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -104,7 +104,7 @@ mono_images_unlock(void)
 }
 
 static MonoImage *
-mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status);
+mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean not_executable);
 
 /* Maps string keys to MonoImageStorage values.
  *
@@ -1174,8 +1174,7 @@ dump_encmap (MonoImage *image)
 }
 
 static MonoImage *
-do_mono_image_load (MonoImage *image, MonoImageOpenStatus *status,
-		    gboolean care_about_cli, gboolean care_about_pecoff)
+do_mono_image_load (MonoImage *image, MonoImageOpenStatus *status, const ImageLoadOptions *options)
 {
 	ERROR_DECL (error);
 	GSList *l;
@@ -1201,7 +1200,7 @@ do_mono_image_load (MonoImage *image, MonoImageOpenStatus *status,
 		if (status)
 			*status = MONO_IMAGE_IMAGE_INVALID;
 
-		if (care_about_pecoff == FALSE)
+		if (options->care_about_pecoff == FALSE)
 			goto done;
 
 		if (!mono_image_load_pe_data (image))
@@ -1210,7 +1209,7 @@ do_mono_image_load (MonoImage *image, MonoImageOpenStatus *status,
 		image->loader = (MonoImageLoader*)&pe_loader;
 	}
 
-	if (care_about_cli == FALSE) {
+	if (options->care_about_cli == FALSE) {
 		goto done;
 	}
 
@@ -1409,8 +1408,7 @@ mono_image_storage_new_raw_data (char *datac, guint32 data_len, gboolean raw_dat
 }
 
 static MonoImage *
-do_mono_image_open (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status,
-					gboolean care_about_cli, gboolean care_about_pecoff, gboolean metadata_only)
+do_mono_image_open (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, const ImageOpenOptions *options)
 {
 	MonoCLIImageInfo *iinfo;
 	MonoImage *image;
@@ -1424,6 +1422,7 @@ do_mono_image_open (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOp
 	}
 
 	image = g_new0 (MonoImage, 1);
+	image->ref_count = 1;
 	image->storage = storage;
 	mono_image_init_raw_data (image, storage);
 	if (!image->raw_data) {
@@ -1433,14 +1432,14 @@ do_mono_image_open (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOp
 			*status = MONO_IMAGE_IMAGE_INVALID;
 		return NULL;
 	}
-	iinfo = g_new0 (MonoCLIImageInfo, 1);
-	image->image_info = iinfo;
+	image->not_executable = !!options->not_executable;
+	image->metadata_only = !!options->metadata_only;
 	image->name = mono_path_resolve_symlinks (fname);
 	image->filename = g_strdup (image->name);
-	image->metadata_only = !!metadata_only;
-	image->ref_count = 1;
+	iinfo = g_new0 (MonoCLIImageInfo, 1);
+	image->image_info = iinfo;
 	image->alc = alc;
-	return do_mono_image_load (image, status, care_about_cli, care_about_pecoff);
+	return do_mono_image_load (image, status, &options->load_options);
 }
 
 /**
@@ -1627,7 +1626,10 @@ mono_image_open_from_data_internal (MonoAssemblyLoadContext *alc, char *data, gu
 	image->ref_count = 1;
 	image->alc = alc;
 
-	image = do_mono_image_load (image, status, TRUE, TRUE);
+	ImageLoadOptions options = {0, };
+	options.care_about_cli = 1;
+	options.care_about_pecoff = 1;
+	image = do_mono_image_load (image, status, &options);
 	if (image == NULL)
 		return NULL;
 
@@ -1742,7 +1744,10 @@ mono_image_open_from_module_handle (MonoAssemblyLoadContext *alc, HMODULE module
 	image->ref_count = has_entry_point ? 0 : 1;
 	image->alc = alc;
 
-	image = do_mono_image_load (image, status, TRUE, TRUE);
+	ImageLoadOptions options = {0, };
+	options.care_about_cli = 1;
+	options.care_about_pecoff = 1;
+	image = do_mono_image_load (image, status, &options);
 	if (image == NULL)
 		return NULL;
 
@@ -1761,11 +1766,11 @@ mono_image_open_full (const char *fname, MonoImageOpenStatus *status, gboolean r
 			*status = MONO_IMAGE_NOT_SUPPORTED;
 		return NULL;
 	}
-	return mono_image_open_a_lot (mono_alc_get_default (), fname, status);
+	return mono_image_open_a_lot (mono_alc_get_default (), fname, status, FALSE);
 }
 
 static MonoImage *
-mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status)
+mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean not_executable)
 {
 	MonoImage *image;
 	GHashTable *loaded_images = mono_loaded_images_get_hash (li);
@@ -1867,7 +1872,11 @@ mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadConte
 	mono_images_unlock ();
 
 	// Image not loaded, load it now
-	image = do_mono_image_open (alc, fname, status, TRUE, TRUE, FALSE);
+	ImageOpenOptions options = {0, };
+	options.load_options.care_about_cli = 1;
+	options.load_options.care_about_pecoff = 1;
+	options.not_executable = !!not_executable;
+	image = do_mono_image_open (alc, fname, status, &options);
 	if (image == NULL)
 		return NULL;
 
@@ -1875,18 +1884,10 @@ mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadConte
 }
 
 MonoImage *
-mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status)
+mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean not_executable)
 {
 	MonoLoadedImages *li = mono_alc_get_loaded_images (alc);
-	return mono_image_open_a_lot_parameterized (li, alc, fname, status);
-}
-
-MonoImage *
-mono_image_open_mibc (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status)
-{
-	MonoImage *mibcImage = mono_image_open_a_lot (alc, fname, status);
-	mibcImage->not_executable = TRUE;
-	return mibcImage;
+	return mono_image_open_a_lot_parameterized (li, alc, fname, status, not_executable);
 }
 
 /**
@@ -1901,7 +1902,7 @@ mono_image_open_mibc (MonoAssemblyLoadContext *alc, const char *fname, MonoImage
 MonoImage *
 mono_image_open (const char *fname, MonoImageOpenStatus *status)
 {
-	return mono_image_open_a_lot (mono_alc_get_default (), fname, status);
+	return mono_image_open_a_lot (mono_alc_get_default (), fname, status, FALSE);
 }
 
 /**
@@ -1919,7 +1920,9 @@ mono_pe_file_open (const char *fname, MonoImageOpenStatus *status)
 {
 	g_return_val_if_fail (fname != NULL, NULL);
 
-	return do_mono_image_open (mono_alc_get_default (), fname, status, FALSE, TRUE, FALSE);
+	ImageOpenOptions options = {0, };
+	options.load_options.care_about_pecoff = 1;
+	return do_mono_image_open (mono_alc_get_default (), fname, status, &options);
 }
 
 /**
@@ -1934,7 +1937,8 @@ mono_image_open_raw (MonoAssemblyLoadContext *alc, const char *fname, MonoImageO
 {
 	g_return_val_if_fail (fname != NULL, NULL);
 
-	return do_mono_image_open (alc, fname, status, FALSE, FALSE, FALSE);
+	ImageOpenOptions options = {0, };
+	return do_mono_image_open (alc, fname, status, &options);
 }
 
 /*
@@ -1945,7 +1949,11 @@ mono_image_open_raw (MonoAssemblyLoadContext *alc, const char *fname, MonoImageO
 MonoImage *
 mono_image_open_metadata_only (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status)
 {
-	return do_mono_image_open (alc, fname, status, TRUE, TRUE, TRUE);
+	ImageOpenOptions options = {0, };
+	options.load_options.care_about_cli = 1;
+	options.load_options.care_about_pecoff = 1;
+	options.metadata_only = 1;
+	return do_mono_image_open (alc, fname, status, &options);
 }
 
 /**

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -306,7 +306,7 @@ struct _MonoImage {
 	guint8 dynamic : 1;
 
 	/* Whenever this image is not an executable, such as .mibc */
-	gboolean not_executable;
+	guint8 not_executable : 1;
 
 	/* Whenever this image contains uncompressed metadata */
 	guint8 uncompressed_metadata : 1;

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -305,6 +305,9 @@ struct _MonoImage {
 	/* Whenever this is a dynamically emitted module */
 	guint8 dynamic : 1;
 
+	/* Whenever this image is not an executable, such as .mibc */
+	gboolean not_executable;
+
 	/* Whenever this image contains uncompressed metadata */
 	guint8 uncompressed_metadata : 1;
 

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -13281,10 +13281,11 @@ add_mibc_group_method_methods (MonoAotCompile *acfg, MonoMethod *mibcGroupMethod
 				state = FIND_METHOD_TYPE_ENTRY_START;
 			continue;
 		}
+		g_assert (il_op == MONO_CEE_LDTOKEN);
 		state = FIND_METHOD_TYPE_ENTRY_END;
 
 		g_assert (opcodeIp + 4 < opcodeEnd);
-		guint32 mibcGroupMethodEntryToken = *(guint32 *)(opcodeIp + 1);
+		guint32 mibcGroupMethodEntryToken = read32 (opcodeIp + 1);
 		g_assertf ((mono_metadata_token_table (mibcGroupMethodEntryToken) == MONO_TABLE_MEMBERREF || mono_metadata_token_table (mibcGroupMethodEntryToken) == MONO_TABLE_METHODSPEC), "token %x is not MemberRef or MethodSpec.\n", mibcGroupMethodEntryToken);
 
 		MonoMethod *methodEntry = mono_get_method_checked (image, mibcGroupMethodEntryToken, mibcModuleClass, context, error);
@@ -13331,7 +13332,9 @@ static void
 add_mibc_profile_methods (MonoAotCompile *acfg, char *filename)
 {
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
-	MonoImage *image = mono_image_open_a_lot (mono_alc_get_default (), filename, &status, TRUE);
+	MonoImageOpenOptions options = {0, };
+	options.not_executable = 1;
+	MonoImage *image = mono_image_open_a_lot (mono_alc_get_default (), filename, &status, &options);
 	g_assert (image != NULL);
 	g_assert (status == MONO_IMAGE_OK);
 
@@ -13362,7 +13365,7 @@ add_mibc_profile_methods (MonoAotCompile *acfg, char *filename)
 			continue;
 
 		g_assert (opcodeIp + 4 < opcodeEnd);
-		guint32 token = *(guint32 *)(opcodeIp + 1);
+		guint32 token = read32 (opcodeIp + 1);
 
 		MonoMethod *mibcGroupMethod = mono_get_method_checked (image, token, mibcModuleClass, context, error);
 		mono_error_assert_ok (error);

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -117,6 +117,11 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     public string[]? AotProfilePath { get; set; }
 
     /// <summary>
+    /// Mibc file to use for profile-guided optimization, *only* the methods described in the file will be AOT compiled.
+    /// </summary>
+    public string[]? MibcProfilePath { get; set; }
+
+    /// <summary>
     /// List of profilers to use.
     /// </summary>
     public string[]? Profilers { get; set; }
@@ -273,6 +278,18 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
                 if (!File.Exists(path))
                 {
                     Log.LogError($"AotProfilePath '{path}' doesn't exist.");
+                    return false;
+                }
+            }
+        }
+
+        if (MibcProfilePath != null)
+        {
+            foreach (var path in MibcProfilePath)
+            {
+                if (!File.Exists(path))
+                {
+                    Log.LogError($"MibcProfilePath '{path}' doesn't exist.");
                     return false;
                 }
             }
@@ -736,6 +753,15 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             foreach (var path in AotProfilePath)
             {
                 aotArgs.Add($"profile={path}");
+            }
+        }
+
+        if (MibcProfilePath?.Length > 0)
+        {
+            aotArgs.Add("profile-only");
+            foreach (var path in MibcProfilePath)
+            {
+                aotArgs.Add($"mibc-profile={path}");
             }
         }
 


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/69268 and https://github.com/dotnet/runtime/issues/69512.

In effort to bring back Profiled Ahead-Of-Time compilation on Mono through leveraging [EventPipe diagnostics-tracing](https://github.com/dotnet/runtime/blob/main/docs/design/mono/diagnostics-tracing.md) and [CoreCLR's dotnet-pgo tool](https://github.com/dotnet/runtime/tree/main/src/coreclr/tools/dotnet-pgo), this PR enables Mono's AOT Compiler to directly consume a [`.mibc` (Managed Instrumented Block Counts)](https://github.com/dotnet/runtime/blob/main/src/coreclr/tools/dotnet-pgo/dotnet-pgo-experiment.md#mibc-file-format) Portable Executable file generated through [dotnet-pgo](https://github.com/dotnet/runtime/blob/138547979dd308539b9db9cb759a7a88d0623f9f/src/coreclr/tools/dotnet-pgo/MibcEmitter.cs#L215-L304) for the purpose of AOT compiling methods traced during an app run.

This follows the work to [emit MethodDetails and BulkType events](https://github.com/dotnet/runtime/pull/68571) on the mono runtime, which was imperative to know exactly which methods were encountered during an app run.

---------------

## Prior Profiled AOT .aotprofile processing
Mono's [AOT Compiler](https://github.com/dotnet/runtime/blob/main/src/mono/mono/mini/aot-compiler.c) (mono-sgen) prior Profiled AOT story involved a `.aotprofile` file which recorded identifying components of methods, embedded types, generic instantiations of methods/types, and the overarching modules https://github.com/mono/mono/tree/main/mcs/class/Mono.Profiler.Log/Mono.Profiler.Aot. The compiler, when compiling particular assemblies, would leverage `.aotprofile` data to determine which methods to AOT compile by:
1. [Loading](https://github.com/dotnet/runtime/blob/b44fd4aeffafd68bc710b2feec66318835ca3edc/src/mono/mono/mini/aot-compiler.c#L12770) the data into [ProfileData structs](https://github.com/dotnet/runtime/blob/b44fd4aeffafd68bc710b2feec66318835ca3edc/src/mono/mono/mini/aot-compiler.c#L134-L166)
2. [Resolving](https://github.com/dotnet/runtime/blob/b44fd4aeffafd68bc710b2feec66318835ca3edc/src/mono/mono/mini/aot-compiler.c#L12979) the ProfileData structs into the corresponding images, classes, generic instantiations, and methods within the assemblies loaded through the compiler
3. [Adding the .aotprofile methods](https://github.com/dotnet/runtime/blob/b44fd4aeffafd68bc710b2feec66318835ca3edc/src/mono/mono/mini/aot-compiler.c#L13136) with some filtering to a particular assembly's (`X.dll`)  AOT image (`X.dll.so`/`X.dll.dylib`/other native extensions) if they are inherently from that assembly, or related to that assembly. (e.g. method `List<Q>.ToArray()` where `List` is in `System.Private.CoreLib.dll`, but `Q` is in `Q.dll`, the method is related to assembly `Q.dll`)

[.aotprofile example](https://github.com/xamarin/xamarin-android/blob/main/src/profiled-aot/dotnet.aotprofile)

## Proposed Profiled AOT .mibc processing
The [.mibc file format](https://github.com/dotnet/runtime/blob/main/src/coreclr/tools/dotnet-pgo/dotnet-pgo-experiment.md#mibc-file-format) as a Portable Executable already contains comprehensive information of traced methods (as a result of MethodDetails and BulkType events from https://github.com/dotnet/runtime/pull/68571). As such, there is no need to neither generate nor load ProfileData structs. Instead, we:
1. Leverage .mibc's AssemblyDictionary global function to obtain each `mibcGroupMethod` - `add_mibc_profile_methods`
2. Iterate through each method entry within a `mibcGroupMethod` - `add_mibc_group_method_methods`
3. Add individual .mibc methods using the same [filter](https://github.com/dotnet/runtime/blob/99ccd25907f9b230c8573d9f68124b0556892e2d/src/mono/mono/mini/aot-compiler.c#L13145-L13213) and [method addition](https://github.com/dotnet/runtime/blob/99ccd25907f9b230c8573d9f68124b0556892e2d/src/mono/mono/mini/aot-compiler.c#L13129) used when processing .aotprofile - `add_single_mibc_profile_method`

[.mibc from HelloWorld mono sample](https://github.com/dotnet/runtime/files/8833401/HelloWorld_arm64.mibc.zip)
[Breakdown of HelloWorld Sample .mibc file](https://gist.github.com/mdh1418/d8f6df8e83d3cd5ea587588caabd3fdf)

--------------

This PR makes the following changes:
1. Introduces .mibc profile file into the mono AOT compilation pipeline
2. Extends mono's image handling to allow for loading MemberRefs from non executable images and replace boolean image open/load options with MonoImage(Open/Load)Options structs for scalability
3. Bootstrap the MonoAOTCompiler to use the introduced .mibc processing

--------------

Using the mono-sgen compiler to process `.mibc`
1. `./build -s mono+libs -os <OS> -arch <arch> -c <config>`
2. `MONO_LOG_MASK=asm MONO_LOG_LEVEL=debug MONO_PATH=./artifacts/bin/HelloWorld/arm64/Release/osx-arm64/publish/ artifacts/obj/mono/OSX.arm64.Release/out/bin/mono-sgen --aot=profile-only,mibc-profile=/Users/mihw/runtime_two/HelloWorld_arm64.mibc  artifacts/bin/HelloWorld/arm64/Release/osx-arm64/publish/System.Console.dll artifacts/bin/HelloWorld/arm64/Release/osx-arm64/publish/System.Private.CoreLib.dll artifacts/bin/HelloWorld/arm64/Release/osx-arm64/publish/HelloWorld.dll`
![Screen Shot 2022-06-03 at 12 08 04 PM](https://user-images.githubusercontent.com/16830051/171904194-1d0b3cc4-4e06-4cf0-81d3-64250bb2dae5.png)

