### PR TITLE
Make the property `DataContractSerializer.SerializationSurrogateProvider` public

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -192,11 +192,14 @@ namespace System.Runtime.Serialization
             get { return _maxItemsInObjectGraph; }
         }
 
-        // TODO: rename to "SurrogateProvider"
+        /// <summary>
+        ///  Gets or sets a serialization surrogate provider.
+        /// </summary>
+        // TODO: I propose to rename this to "SurrogateProvider".
         // This change cannot break API compatibility because the accessibility was internal.
         public ISerializationSurrogateProvider? SerializationSurrogateProvider
         {
-            // TODO: convert to the auto-implemented property.
+            // TODO: I propose to convert to the auto-implemented property.
             get { return _serializationSurrogateProvider; }
             set { _serializationSurrogateProvider = value; }
         }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -192,8 +192,11 @@ namespace System.Runtime.Serialization
             get { return _maxItemsInObjectGraph; }
         }
 
-        internal ISerializationSurrogateProvider? SerializationSurrogateProvider
+        // TODO: rename to "SurrogateProvider"
+        // This change cannot break API compatibility because the accessibility was internal.
+        public ISerializationSurrogateProvider? SerializationSurrogateProvider
         {
+            // TODO: convert to the auto-implemented property.
             get { return _serializationSurrogateProvider; }
             set { _serializationSurrogateProvider = value; }
         }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializerExtensions.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializerExtensions.cs
@@ -5,6 +5,8 @@ namespace System.Runtime.Serialization
 {
     public static class DataContractSerializerExtensions
     {
+        // TODO: add an Obsolete attribute to the below two methods.
+
         public static ISerializationSurrogateProvider? GetSerializationSurrogateProvider(this DataContractSerializer serializer)
         {
             return serializer.SerializationSurrogateProvider;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializerExtensions.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializerExtensions.cs
@@ -5,7 +5,7 @@ namespace System.Runtime.Serialization
 {
     public static class DataContractSerializerExtensions
     {
-        // TODO: add an Obsolete attribute to the below two methods.
+        // TODO: I propose to add an Obsolete attribute to the below two methods.
 
         public static ISerializationSurrogateProvider? GetSerializationSurrogateProvider(this DataContractSerializer serializer)
         {

--- a/src/libraries/System.Runtime.Serialization.Xml/ref/System.Runtime.Serialization.Xml.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/ref/System.Runtime.Serialization.Xml.cs
@@ -29,6 +29,7 @@ namespace System.Runtime.Serialization
         public int MaxItemsInObjectGraph { get { throw null; } }
         public bool PreserveObjectReferences { get { throw null; } }
         public bool SerializeReadOnlyTypes { get { throw null; } }
+        public ISerializationSurrogateProvider? SerializationSurrogateProvider { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Data Contract Serialization and Deserialization might require types that cannot be statically analyzed. Make sure all of the required types are preserved.")]
         public override bool IsStartObject(System.Xml.XmlDictionaryReader reader) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Data Contract Serialization and Deserialization might require types that cannot be statically analyzed. Make sure all of the required types are preserved.")]

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -793,7 +793,7 @@ public static partial class DataContractSerializerTests
         Assert.True(y.RO1.Count == 1);
         Assert.True((char)y.RO1[0] == 'x');
     }
-	
+
     [Fact]
     public static void DCS_EnumerableMemberConcreteTypeWithoutDefaultContructor()
     {
@@ -3943,6 +3943,42 @@ public static partial class DataContractSerializerTests
                 }
             }
         }
+    }
+
+    [Fact]
+    public static void DCS_SurrogateProvider()
+    {
+        DataContractSerializer dcs = new DataContractSerializer(typeof(object));
+
+        // When the property 'SerializationSurrogateProvider' is updated,
+        // the extension method 'GetSerializationSurrogateProvider()' returns same as it.
+        dcs.SerializationSurrogateProvider = null;
+        Assert.Equal(null, dcs.SerializationSurrogateProvider);
+        Assert.Equal(null, dcs.GetSerializationSurrogateProvider());
+
+        var mpsp = new MyPersonSurrogateProvider();
+        dcs.SerializationSurrogateProvider = mpsp;
+        Assert.Equal(mpsp, dcs.SerializationSurrogateProvider);
+        Assert.Equal(mpsp, dcs.GetSerializationSurrogateProvider());
+
+        var mfssp = MyFileStreamSurrogateProvider.Singleton;
+        dcs.SerializationSurrogateProvider = mfssp;
+        Assert.Equal(mfssp, dcs.SerializationSurrogateProvider);
+        Assert.Equal(mfssp, dcs.GetSerializationSurrogateProvider());
+
+        // The value of the property 'SerializationSurrogateProvider' may modified by
+        // the extension method 'SetSerializationSurrogateProvider()'.
+        dcs.SetSerializationSurrogateProvider(null);
+        Assert.Equal(null, dcs.SerializationSurrogateProvider);
+        Assert.Equal(null, dcs.GetSerializationSurrogateProvider());
+
+        dcs.SetSerializationSurrogateProvider(mpsp);
+        Assert.Equal(mpsp, dcs.SerializationSurrogateProvider);
+        Assert.Equal(mpsp, dcs.GetSerializationSurrogateProvider());
+
+        dcs.SetSerializationSurrogateProvider(mfssp);
+        Assert.Equal(mfssp, dcs.SerializationSurrogateProvider);
+        Assert.Equal(mfssp, dcs.GetSerializationSurrogateProvider());
     }
 
     [Fact]


### PR DESCRIPTION
* This PR resolves #65826.
* I implemented to make the property `DataContractSerializer.SerializationSurrogateProvider` public to illustrate.
