### PR TITLE
Fixing the costing of GT_CNS_DBL and GT_CNS_VEC instructions

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4575,17 +4575,21 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
             {
                 level = 0;
 #if defined(TARGET_XARCH)
-                /* We use fldz and fld1 to load 0.0 and 1.0, but all other  */
-                /* floating point constants are loaded using an indirection */
                 if (tree->IsFloatPositiveZero())
                 {
+                    // We generate `xorp* tgtReg, tgtReg` which is 3-5 bytes
+                    // but which can be elided by the instruction decoder.
+
                     costEx = 1;
-                    costSz = 1;
+                    costSz = 2;
                 }
                 else
                 {
+                    // We generate `movs* tgtReg, [mem]` which is 4-6 bytes
+                    // and which has the same cost as an indirection.
+
                     costEx = IND_COST_EX;
-                    costSz = 4;
+                    costSz = 2;
                 }
 #elif defined(TARGET_ARM)
                 var_types targetType = tree->TypeGet();
@@ -4603,13 +4607,18 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
 #elif defined(TARGET_ARM64)
                 if (tree->IsFloatPositiveZero() || emitter::emitIns_valid_imm_for_fmov(tree->AsDblCon()->gtDconVal))
                 {
+                    // Zero and certain other immediates can be specially created with a single instruction
+                    // These can be cheaply reconstituted but still take up 4-bytes of native codegen
+
                     costEx = 1;
-                    costSz = 1;
+                    costSz = 2;
                 }
                 else
                 {
+                    // We load the constant from memory and so will take the same cost as GT_IND
+
                     costEx = IND_COST_EX;
-                    costSz = 4;
+                    costSz = 2;
                 }
 #elif defined(TARGET_LOONGARCH64)
                 // TODO-LoongArch64-CQ: tune the costs.
@@ -4623,9 +4632,25 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
 
             case GT_CNS_VEC:
             {
-                costEx = IND_COST_EX;
-                costSz = 4;
                 level  = 0;
+
+                if (tree->AsVecCon()->IsAllBitsSet() || tree->AsVecCon()->IsZero())
+                {
+                    // We generate `cmpeq* tgtReg, tgtReg`, which is 4-5 bytes, for AllBitsSet
+                    // and generate `xorp* tgtReg, tgtReg`, which is 3-5 bytes, for Zero
+                    // both of which can be elided by the instruction decoder.
+
+                    costEx = 1;
+                    costSz = 2;
+                }
+                else
+                {
+                    // We generate `movup* tgtReg, [mem]` which is 4-6 bytes
+                    // and which has the same cost as an indirection.
+
+                    costEx = IND_COST_EX;
+                    costSz = 2;
+                }
                 break;
             }
 
@@ -4972,16 +4997,12 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                         costSz += 1;
                     }
 
+#ifdef TARGET_ARM
                     if (isflt)
                     {
-                        if (tree->TypeGet() == TYP_DOUBLE)
-                        {
-                            costEx += 1;
-                        }
-#ifdef TARGET_ARM
                         costSz += 2;
-#endif // TARGET_ARM
                     }
+#endif // TARGET_ARM
 
                     // Can we form an addressing mode with this indirection?
                     // TODO-CQ: Consider changing this to op1->gtEffectiveVal() to take into account

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4632,7 +4632,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
 
             case GT_CNS_VEC:
             {
-                level  = 0;
+                level = 0;
 
                 if (tree->AsVecCon()->IsAllBitsSet() || tree->AsVecCon()->IsZero())
                 {


### PR DESCRIPTION
This fixes the costing of `GT_CNS_DBL` and `GT_CNS_VEC` to be inline with the costing of `GT_IND` and to ensure that the cost of `Zero` and `AllBitsSet` have a more correct size estimate.

For `GT_CNS_VEC`, `Zero` is considered cheap and so we end up being able to see "we have a zero" in more places, which means we can rely on values being zero for the many optimizations around it.
```diff
-       vxorps   ymm2, ymm2, ymm2
-       align    [9 bytes for IG09]
-                        ;; size=55 bbWeight=0.50 PerfScore 5.04
+       align    [2 bytes for IG09]
+                        ;; size=43 bbWeight=0.50 PerfScore 4.88
 G_M3377_IG09:
        vpcmpeqw ymm1, ymm0, ymmword ptr[rcx+2*r9]
-       vpcmpeqw ymm1, ymm1, ymm2
-       vpmovmskb eax, ymm1
-       cmp      eax, -1
+       vptest   ymm1, ymm1
```

However, this also looks to "regress" some places as we aren't CSE'ing the value anymore due to the low cost. This ideally would be handled by the register allocator seeing "we need zero, and we already have zero in `xmm1`", which is related to https://github.com/dotnet/runtime/issues/70182:
```diff
+       vxorps   xmm1, xmm1, xmm1
        vpunpcklbw xmm0, xmm0, xmm1
```

There is a case in `MemoryExtensions:SequenceEqual` and `MemoryExtensions:CommonPrefixLength` where a general-purpose register selection changed. However there are no new CSEs, changes to the locals or costs, or even frame size changes. So this seems suspect and potentially like something that should be investigated.

There are cases in `System.Linq.Parallel`, such as `FirstQueryOperatorEnumerator_1:MoveNext`, where the register allocator is deciding to use `caller saved registers` (namely `ymm6/ymm7` rather than the previous `ymm0`/`ymm1` it had chosen. Part of this seems related to https://github.com/dotnet/runtime/issues/70182, but it also seems odd that it chose to spill because `Zero` is cheap to compute, it looks unused in at least one path, and it should likely be preferred to load constants from their emitted local slot rather than spilling.