### PR TITLE
NonBacktracking inner matching loop optimizations

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
@@ -127,10 +127,6 @@ namespace System.Text.RegularExpressions.Symbolic
             return list;
         }
 
-        internal bool IsNullable => Node.IsNullable;
-
-        internal bool CanBeNullable => Node.CanBeNullable;
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool IsNullableFor(uint nextCharKind)
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
@@ -23,8 +23,6 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal int Id { get; set; }
 
-        internal bool IsInitialState { get; set; }
-
         /// <summary>This is a deadend state</summary>
         internal bool IsDeadend => Node.IsNothing;
 
@@ -129,8 +127,12 @@ namespace System.Text.RegularExpressions.Symbolic
             return list;
         }
 
+        internal bool IsNullable => Node.IsNullable;
+
+        internal bool CanBeNullable => Node.CanBeNullable;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool IsNullable(uint nextCharKind)
+        internal bool IsNullableFor(uint nextCharKind)
         {
             Debug.Assert(nextCharKind is 0 or CharKind.BeginningEnd or CharKind.Newline or CharKind.WordLetter or CharKind.NewLineS);
             uint context = CharKind.Context(PrevCharKind, nextCharKind);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -609,21 +609,6 @@ namespace System.Text.RegularExpressions.Symbolic
             }
         }
 
-        /// <summary>Gets or creates a new DFA transition. This version takes and returns state IDs.</summary>
-        public bool TryCreateNewTransition(
-            int sourceStateId, int mintermId, int offset, bool checkThreshold, out int nextStateId)
-        {
-            Debug.Assert(sourceStateId > 0);
-            Debug.Assert(_stateArray is not null);
-            if (TryCreateNewTransition(_stateArray[sourceStateId], mintermId, offset, checkThreshold, out DfaMatchingState<TSet>? nextState))
-            {
-                nextStateId = nextState.Id;
-                return true;
-            }
-            nextStateId = -1;
-            return false;
-        }
-
         /// <summary>Gets or creates a new NFA transition.</summary>
         public int[] CreateNewNfaTransition(int nfaStateId, int mintermId, int nfaOffset)
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Dgml.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Dgml.cs
@@ -29,7 +29,7 @@ namespace System.Text.RegularExpressions.Symbolic
             foreach (DfaMatchingState<TSet> state in _builder._stateCache)
             {
                 writer.WriteLine("        <Node Id=\"{0}\" Label=\"{0}\" Category=\"State\" Group=\"Collapsed\" StateInfo=\"{1}\">", state.Id, state.DgmlView);
-                if (state.IsInitialState)
+                if (_builder._stateInfo![state.Id].IsInitial)
                 {
                     writer.WriteLine("            <Category Ref=\"InitialState\" />");
                 }
@@ -143,16 +143,17 @@ namespace System.Text.RegularExpressions.Symbolic
                 foreach (DfaMatchingState<TSet> source in builder._stateCache)
                 {
                     // Get the span of entries in delta that gives the transitions for the different minterms
-                    Span<DfaMatchingState<TSet>?> deltas = builder.GetDeltasFor(source);
+                    Span<int> deltas = builder.GetDeltasFor(source);
                     Span<int[]?> nfaDeltas = builder.GetNfaDeltasFor(source);
                     Debug.Assert(deltas.Length == builder._minterms.Length);
                     for (int i = 0; i < deltas.Length; ++i)
                     {
-                        // null entries are transitions not explored yet, so skip them
-                        if (deltas[i] is DfaMatchingState<TSet> target)
+                        // negative entries are transitions not explored yet, so skip them
+                        int targetId = deltas[i];
+                        if (targetId >= 0)
                         {
                             // Get or create the data for this (source,destination) state ID pair
-                            (int Source, int Target) key = (source.Id, target.Id);
+                            (int Source, int Target) key = (source.Id, targetId);
                             if (!result.TryGetValue(key, out (TSet Rule, List<int> NfaTargets) entry))
                             {
                                 entry = (builder._solver.Empty, new List<int>());

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Dgml.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Dgml.cs
@@ -29,7 +29,7 @@ namespace System.Text.RegularExpressions.Symbolic
             foreach (DfaMatchingState<TSet> state in _builder._stateCache)
             {
                 writer.WriteLine("        <Node Id=\"{0}\" Label=\"{0}\" Category=\"State\" Group=\"Collapsed\" StateInfo=\"{1}\">", state.Id, state.DgmlView);
-                if (_builder._stateInfo![state.Id].IsInitial)
+                if (_builder.GetStateInfo(state.Id).IsInitial)
                 {
                     writer.WriteLine("            <Category Ref=\"InitialState\" />");
                 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
@@ -83,25 +83,25 @@ namespace System.Text.RegularExpressions.Symbolic
                     {
                         // Unconditionally final state or end of the input due to \Z anchor for example
                         if (NfaStateHandler.IsNullable(ref statesWrapper) ||
-                            NfaStateHandler.IsNullable(ref statesWrapper, CharKind.BeginningEnd))
+                            NfaStateHandler.IsNullableFor(_builder, ref statesWrapper, CharKind.BeginningEnd))
                         {
                             possibleEndings.Add("");
                         }
 
                         // End of line due to end-of-line anchor
-                        if (NfaStateHandler.IsNullable(ref statesWrapper, CharKind.Newline))
+                        if (NfaStateHandler.IsNullableFor(_builder, ref statesWrapper, CharKind.Newline))
                         {
                             possibleEndings.Add("\n");
                         }
 
                         // Related to wordborder due to \b or \B
-                        if (NfaStateHandler.IsNullable(ref statesWrapper, CharKind.WordLetter))
+                        if (NfaStateHandler.IsNullableFor(_builder, ref statesWrapper, CharKind.WordLetter))
                         {
                             possibleEndings.Add(ChooseChar(random, asciiWordCharacters, ascii, charSetSolver).ToString());
                         }
 
                         // Related to wordborder due to \b or \B
-                        if (NfaStateHandler.IsNullable(ref statesWrapper, CharKind.General))
+                        if (NfaStateHandler.IsNullableFor(_builder, ref statesWrapper, CharKind.General))
                         {
                             possibleEndings.Add(ChooseChar(random, asciiNonWordCharacters, ascii, charSetSolver).ToString());
                         }
@@ -125,7 +125,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     }
 
                     // Shuffle the minterms, including the last end-of-line marker if appropriate
-                    int[] mintermIds = NfaStateHandler.StartsWithLineAnchor(ref statesWrapper) ?
+                    int[] mintermIds = NfaStateHandler.StartsWithLineAnchor(_builder, ref statesWrapper) ?
                         Shuffle(random, mintermIdsWithZ) :
                         Shuffle(random, mintermIdsWithoutZ);
                     foreach (int mintermId in mintermIds)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -192,8 +192,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 // but observe that the behavior from the state may ultimately depend on the previous
                 // input char e.g. possibly causing nullability of \b or \B or of a start-of-line anchor,
                 // in that sense there can be several "versions" (not more than StateCount) of the initial state.
-                DfaMatchingState<TSet> state = _builder.CreateState(_dotStarredPattern, i, capturing: false);
-                state.IsInitialState = true;
+                DfaMatchingState<TSet> state = _builder.CreateState(_dotStarredPattern, i, capturing: false, isInitialState: true);
                 dotstarredInitialStates[i] = state;
             }
             _dotstarredInitialStates = dotstarredInitialStates;
@@ -255,7 +254,7 @@ namespace System.Text.RegularExpressions.Symbolic
             int c = input[i];
 
             // Find the minterm, handling the special case for the last \n for states that start with a relevant anchor
-            int mintermId = c == '\n' && i == input.Length - 1 && TStateHandler.StartsWithLineAnchor(ref state) ?
+            int mintermId = c == '\n' && i == input.Length - 1 && TStateHandler.StartsWithLineAnchor(builder, ref state) ?
                 builder._minterms!.Length : // mintermId = minterms.Length represents an \n at the very end of input
                 _mintermClassifier.GetMintermID(c);
 
@@ -315,7 +314,8 @@ namespace System.Text.RegularExpressions.Symbolic
             // As an example, consider the pattern a{1,3}(b*) run against an input of aacaaaabbbc: phase 1 will find
             // the position of the last b: aacaaaabbbc.  It additionally records the position of the first a after
             // the c as the low boundary for the starting position.
-            int matchEnd = FindEndPosition(input, startat, timeoutOccursAt, mode, out int matchStartLowBoundary, out int matchStartLengthMarker, perThreadData);
+            int matchStartLowBoundary, matchStartLengthMarker;
+            int matchEnd = SpecializedFindEndPosition(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData);
 
             // If there wasn't a match, we're done.
             if (matchEnd == NoMatchExists)
@@ -350,7 +350,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 Debug.Assert(matchEnd >= startat - 1);
                 matchStart = matchEnd < startat ?
                     startat :
-                    FindStartPosition(input, matchEnd, matchStartLowBoundary, perThreadData);
+                    SpecializedFindStartPosition(input, matchEnd, matchStartLowBoundary, perThreadData);
             }
 
             // Phase 3:
@@ -367,51 +367,51 @@ namespace System.Text.RegularExpressions.Symbolic
                 Registers endRegisters = FindSubcaptures(input, matchStart, matchEnd, perThreadData);
                 return new SymbolicMatch(matchStart, matchEnd - matchStart, endRegisters.CaptureStarts, endRegisters.CaptureEnds);
             }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            int SpecializedFindEndPosition(ReadOnlySpan<char> input, int pos, long timeoutOccursAt, RegexRunnerMode mode, out int initialStatePos, out int matchLength, PerThreadData perThreadData) =>
+                _findOpts is null ?
+                    SpecializedFindEndPosition2<NoFindOptimizationsHandler>(input, pos, timeoutOccursAt, mode, out initialStatePos, out matchLength, perThreadData) :
+                    SpecializedFindEndPosition2<InitialStateFindOptimizationsHandler>(input, pos, timeoutOccursAt, mode, out initialStatePos, out matchLength, perThreadData);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            int SpecializedFindEndPosition2<TFindOptimizationsHandler>(ReadOnlySpan<char> input, int pos, long timeoutOccursAt, RegexRunnerMode mode, out int initialStatePos, out int matchLength, PerThreadData perThreadData)
+                where TFindOptimizationsHandler : struct, IFindOptimizationsHandler =>
+                _pattern._info.ContainsSomeAnchor ?
+                    FindEndPosition<TFindOptimizationsHandler, FullNullabilityHandler>(input, pos, timeoutOccursAt, mode, out initialStatePos, out matchLength, perThreadData) :
+                    FindEndPosition<TFindOptimizationsHandler, NoAnchorsNullabilityHandler>(input, pos, timeoutOccursAt, mode, out initialStatePos, out matchLength, perThreadData);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            int SpecializedFindStartPosition(ReadOnlySpan<char> input, int i, int matchStartBoundary, PerThreadData perThreadData) =>
+                _pattern._info.ContainsSomeAnchor ?
+                    FindStartPosition<FullNullabilityHandler>(input, i, matchStartBoundary, perThreadData) :
+                    FindStartPosition<NoAnchorsNullabilityHandler>(input, i, matchStartBoundary, perThreadData);
         }
 
         /// <summary>Performs the initial Phase 1 match to find the end position of the match, or first final state if this is an isMatch call.</summary>
         /// <param name="input">The input text.</param>
-        /// <param name="i">The starting position in <paramref name="input"/>.</param>
+        /// <param name="pos">The starting position in <paramref name="input"/>.</param>
         /// <param name="timeoutOccursAt">The time at which timeout occurs, if timeouts are being checked.</param>
         /// <param name="mode">The mode of execution based on the regex operation being performed.</param>
-        /// <param name="initialStateIndex">The last position the initial state of <see cref="_dotStarredPattern"/> was visited before the end position was found.</param>
+        /// <param name="initialStatePos">The last position the initial state of <see cref="_dotStarredPattern"/> was visited before the end position was found.</param>
         /// <param name="matchLength">Length of the match if there's a match; otherwise, -1.</param>
         /// <param name="perThreadData">Per thread data reused between calls.</param>
         /// <returns>
         /// A one-past-the-end index into input for the preferred match, or first final state position if isMatch is true, or NoMatchExists if no match exists.
         /// </returns>
-        private int FindEndPosition(ReadOnlySpan<char> input, int i, long timeoutOccursAt, RegexRunnerMode mode, out int initialStateIndex, out int matchLength, PerThreadData perThreadData)
+        private int FindEndPosition<TFindOptimizationsHandler, TNullabilityHandler>(ReadOnlySpan<char> input, int pos, long timeoutOccursAt, RegexRunnerMode mode, out int initialStatePos, out int matchLength, PerThreadData perThreadData)
+            where TFindOptimizationsHandler : struct, IFindOptimizationsHandler
+            where TNullabilityHandler : struct, INullabilityHandler
         {
-            int endPosition = NoMatchExists;
+            int endPos = NoMatchExists;
 
-            matchLength = -1;
-            initialStateIndex = i;
-            int initialStateIndexCandidate = i;
+            initialStatePos = pos;
+            int initialStatePosCandidate = pos;
 
-            var currentState = new CurrentState(_dotstarredInitialStates[GetCharKind(input, i - 1)]);
-            SymbolicRegexBuilder<TSet> builder = _pattern._builder;
+            var currentState = new CurrentState(_dotstarredInitialStates[GetCharKind(input, pos - 1)]);
 
             while (true)
             {
-                if (currentState.DfaState is { IsInitialState: true })
-                {
-                    if (_findOpts is RegexFindOptimizations findOpts)
-                    {
-                        // Find the first position i that matches with some likely character.
-                        if (!findOpts.TryFindNextStartingPosition(input, ref i, 0))
-                        {
-                            // no match was found
-                            break;
-                        }
-                    }
-
-                    initialStateIndexCandidate = i;
-
-                    // Update the starting state based on where TryFindNextStartingPosition moved us to.
-                    // As with the initial starting state, if it's a dead end, no match exists.
-                    currentState = new CurrentState(_dotstarredInitialStates[GetCharKind(input, i - 1)]);
-                }
-
                 // Now run the DFA or NFA traversal from the current point using the current state. If timeouts are being checked,
                 // we need to pop out of the inner loop every now and then to do the timeout check in this outer loop. Note that
                 // the timeout exists not to provide perfect guarantees around execution time but rather as a mitigation against
@@ -419,46 +419,35 @@ namespace System.Text.RegularExpressions.Symbolic
                 // still check the timeout now and again to provide some semblance of the behavior a developer experiences with
                 // the backtracking engines.  We can, however, choose a large number here, since it's not actually needed for security.
                 const int CharsPerTimeoutCheck = 1_000;
-                ReadOnlySpan<char> inputForInnerLoop = _checkTimeout && input.Length - i > CharsPerTimeoutCheck ?
-                    input.Slice(0, i + CharsPerTimeoutCheck) :
+                ReadOnlySpan<char> inputForInnerLoop = _checkTimeout && input.Length - pos > CharsPerTimeoutCheck ?
+                    input.Slice(0, pos + CharsPerTimeoutCheck) :
                     input;
 
-                int newEndPosition;
-                int findResult = currentState.NfaState is not null ?
-                    FindEndPositionDeltas<NfaStateHandler>(builder, inputForInnerLoop, mode, ref i, ref currentState, ref matchLength, out newEndPosition) :
-                    FindEndPositionDeltas<DfaStateHandler>(builder, inputForInnerLoop, mode, ref i, ref currentState, ref matchLength, out newEndPosition);
+                bool done = SpecializedFindEndPositionDeltas(this, inputForInnerLoop, mode, ref pos, ref currentState, ref endPos, ref initialStatePos, ref initialStatePosCandidate);
 
-                // If a new end position was found, commit to the matching initial state index
-                if (newEndPosition != -1)
+                if (done)
                 {
-                    endPosition = newEndPosition;
-                    initialStateIndex = initialStateIndexCandidate;
-                }
-
-                // If we reached the end of input or a deadend state, we're done.
-                if (findResult > 0)
-                {
+                    // If we reached the end of input or a deadend state, we're done.
                     break;
                 }
-
-                // The search did not finish, so we either hit an initial state (in which case we want to loop around to apply our initial
-                // state processing logic and optimizations), or failed to transition (which should only happen if we were in DFA mode and
-                // need to switch over to NFA mode). If we exited because we hit an initial state, find result will be 0, otherwise -1.
-                if (findResult < 0)
+                else
                 {
-                    if (i >= input.Length)
+                    // The search did not finish, so we either failed to transition (which should only happen if we were in DFA mode and
+                    // need to switch over to NFA mode) or ran out of input in the inner loop. For the latter case check if there is more
+                    // input available.
+                    if (pos >= input.Length)
                     {
                         // We ran out of input.
                         break;
                     }
-
-                    if (i < inputForInnerLoop.Length)
+                    else if (pos < inputForInnerLoop.Length)
                     {
                         // We failed to transition. Upgrade to DFA mode.
-                        Debug.Assert(i < inputForInnerLoop.Length);
-                        Debug.Assert(currentState.DfaState is not null);
+                        Debug.Assert(pos < inputForInnerLoop.Length);
+                        DfaMatchingState<TSet>? dfaState = currentState.DfaState(_builder);
+                        Debug.Assert(dfaState is not null);
                         NfaMatchingState nfaState = perThreadData.NfaState;
-                        nfaState.InitializeFrom(currentState.DfaState);
+                        nfaState.InitializeFrom(dfaState);
                         currentState = new CurrentState(nfaState);
                     }
                 }
@@ -470,19 +459,33 @@ namespace System.Text.RegularExpressions.Symbolic
                 }
             }
 
-            return endPosition;
+            // Check whether there's a fixed-length marker for the current state.  If there is, we can
+            // use that length to optimize subsequent matching phases.
+            matchLength = currentState.NfaState is not null ?
+                NfaStateHandler.FixedLength(_builder, ref currentState, GetCharKind(input, endPos)) :
+                DfaStateHandler.FixedLength(_builder, ref currentState, GetCharKind(input, endPos));
+            return endPos;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static bool SpecializedFindEndPositionDeltas(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, RegexRunnerMode mode,
+                    ref int pos, ref CurrentState state, ref int endPos, ref int initialStatePos, ref int initialStatePosCandidate)
+            {
+                return state.NfaState is not null ?
+                    matcher.FindEndPositionDeltas<NfaStateHandler, TFindOptimizationsHandler, TNullabilityHandler>(matcher._builder, input, mode, ref pos, ref state, ref endPos, ref initialStatePos, ref initialStatePosCandidate) :
+                    matcher.FindEndPositionDeltas<DfaStateHandler, TFindOptimizationsHandler, TNullabilityHandler>(matcher._builder, input, mode, ref pos, ref state, ref endPos, ref initialStatePos, ref initialStatePosCandidate);
+            }
         }
 
         /// <summary>
         /// Workhorse inner loop for <see cref="FindEndPosition"/>.  Consumes the <paramref name="input"/> character by character,
-        /// starting at <paramref name="i"/>, for each character transitioning from one state in the DFA or NFA graph to the next state,
+        /// starting at <paramref name="posRef"/>, for each character transitioning from one state in the DFA or NFA graph to the next state,
         /// lazily building out the graph as needed.
         /// </summary>
         /// <remarks>
         /// The <typeparamref name="TStateHandler"/> supplies the actual transitioning logic, controlling whether processing is
-        /// performed in DFA mode or in NFA mode.  However, it expects <paramref name="currentState"/> to be configured to match,
-        /// so for example if <typeparamref name="TStateHandler"/> is a <see cref="DfaStateHandler"/>, it expects the <paramref name="currentState"/>'s
-        /// <see cref="CurrentState.DfaState"/> to be non-null and its <see cref="CurrentState.NfaState"/> to be null; vice versa for
+        /// performed in DFA mode or in NFA mode.  However, it expects <paramref name="stateRef"/> to be configured to match,
+        /// so for example if <typeparamref name="TStateHandler"/> is a <see cref="DfaStateHandler"/>, it expects the <paramref name="stateRef"/>'s
+        /// <see cref="CurrentState.DfaStateId"/> to be non-negative and its <see cref="CurrentState.NfaState"/> to be null; vice versa for
         /// <see cref="NfaStateHandler"/>.
         /// </remarks>
         /// <returns>
@@ -490,64 +493,79 @@ namespace System.Text.RegularExpressions.Symbolic
         /// 0 if iteration completed because we reached an initial state.
         /// A negative value if iteration completed because we ran out of input or we failed to transition.
         /// </returns>
-        private int FindEndPositionDeltas<TStateHandler>(SymbolicRegexBuilder<TSet> builder, ReadOnlySpan<char> input, RegexRunnerMode mode, ref int i, ref CurrentState currentState, ref int matchLength, out int endPosition)
+        private bool FindEndPositionDeltas<TStateHandler, TFindOptimizationsHandler, TNullabilityHandler>(SymbolicRegexBuilder<TSet> builder, ReadOnlySpan<char> input, RegexRunnerMode mode,
+                ref int posRef, ref CurrentState stateRef, ref int endPosRef, ref int initialStatePosRef, ref int initialStatePosCandidateRef)
             where TStateHandler : struct, IStateHandler
+            where TFindOptimizationsHandler : struct, IFindOptimizationsHandler
+            where TNullabilityHandler : struct, INullabilityHandler
         {
             // To avoid frequent reads/writes to ref and out values, make and operate on local copies, which we then copy back once before returning.
-            int pos = i;
-            CurrentState state = currentState;
-            int endPos = -1;
+            int pos = posRef;
+            CurrentState state = stateRef;
+            int endPos = endPosRef;
+            int initialStatePos = initialStatePosRef;
+            int initialStatePosCandidate = initialStatePosCandidateRef;
             try
             {
                 // Loop through each character in the input, transitioning from state to state for each.
                 while (true)
                 {
+                    var (isInitial, isDeadend, isNullable, canBeNullable) = TStateHandler.GetStateInfo(builder, ref state);
+                    // Now that currentState and our position are coherent, check if currentState represents an initial state.
+                    // If it does, we exit out in order to allow our find optimizations to kick in to hopefully more quickly
+                    // find the next possible starting location.
+                    if (isInitial)
+                    {
+                        if (!TFindOptimizationsHandler.TryFindNextStartingPosition(this, input, ref state, ref pos))
+                        {
+                            return true;
+                        }
+                        initialStatePosCandidate = pos;
+                    }
+
+                    // If the state is a dead end, such that we can't transition anywhere else, end the search.
+                    if (isDeadend)
+                    {
+                        return true;
+                    }
+
                     // If the state is nullable for the next character, meaning it accepts the empty string,
                     // we found a potential end state.
-                    if (TStateHandler.IsNullable(ref state, GetCharKind(input, pos)))
+                    if (TNullabilityHandler.IsNullableAt<TStateHandler>(this, ref state, input, pos, isNullable, canBeNullable))
                     {
-                        // Check whether there's a fixed-length marker for the current state.  If there is, we can
-                        // use that length to optimize subsequent matching phases.
-                        matchLength = TStateHandler.FixedLength(ref state, GetCharKind(input, pos));
                         endPos = pos;
+                        initialStatePos = initialStatePosCandidate;
 
                         // A match is known to exist.  If that's all we need to know, we're done.
                         if (mode == RegexRunnerMode.ExistenceRequired)
                         {
-                            return 1;
+                            return true;
                         }
                     }
 
-                    // If the state is a dead end, such that we can't transition anywhere else, end the search.
-                    if (TStateHandler.IsDeadend(ref state))
+                    if ((uint)pos >= (uint)input.Length)
                     {
-                        return 1;
+                        return false;
                     }
 
                     // If there is more input available try to transition with the next character.
-                    if ((uint)pos >= (uint)input.Length || !TryTakeTransition<TStateHandler>(builder, input, pos, ref state))
+                    if (!TryTakeTransition<TStateHandler>(builder, input, pos, ref state))
                     {
-                        return -1;
+                        return false;
                     }
 
                     // We successfully transitioned, so update our current input index to match.
                     pos++;
-
-                    // Now that currentState and our position are coherent, check if currentState represents an initial state.
-                    // If it does, we exit out in order to allow our find optimizations to kick in to hopefully more quickly
-                    // find the next possible starting location.
-                    if (TStateHandler.IsInitialState(ref state))
-                    {
-                        return 0;
-                    }
                 }
             }
             finally
             {
-                // Write back the local copies of the ref and out values.
-                currentState = state;
-                i = pos;
-                endPosition = endPos;
+                // Write back the local copies of the ref values.
+                posRef = pos;
+                stateRef = state;
+                endPosRef = endPos;
+                initialStatePosRef = initialStatePos;
+                initialStatePosCandidateRef = initialStatePosCandidate;
             }
         }
 
@@ -564,7 +582,8 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="matchStartBoundary">The initial starting location discovered in phase 1, a point we must not walk earlier than.</param>
         /// <param name="perThreadData">Per thread data reused between calls.</param>
         /// <returns>The found starting position for the match.</returns>
-        private int FindStartPosition(ReadOnlySpan<char> input, int i, int matchStartBoundary, PerThreadData perThreadData)
+        private int FindStartPosition<TNullabilityHandler>(ReadOnlySpan<char> input, int i, int matchStartBoundary, PerThreadData perThreadData)
+            where TNullabilityHandler : struct, INullabilityHandler
         {
             Debug.Assert(i >= 0, $"{nameof(i)} == {i}");
             Debug.Assert(matchStartBoundary >= 0 && matchStartBoundary <= input.Length, $"{nameof(matchStartBoundary)} == {matchStartBoundary}");
@@ -577,13 +596,13 @@ namespace System.Text.RegularExpressions.Symbolic
             int lastStart = -1; // invalid sentinel value
 
             // Walk backwards to the furthest accepting state of the reverse pattern but no earlier than matchStartBoundary.
-            SymbolicRegexBuilder<TSet> builder = currentState.DfaState!.Node._builder;
+            SymbolicRegexBuilder<TSet> builder = _builder;
             while (true)
             {
                 // Run the DFA or NFA traversal backwards from the current point using the current state.
                 bool done = currentState.NfaState is not null ?
-                    FindStartPositionDeltas<NfaStateHandler>(builder, input, ref i, matchStartBoundary, ref currentState, ref lastStart) :
-                    FindStartPositionDeltas<DfaStateHandler>(builder, input, ref i, matchStartBoundary, ref currentState, ref lastStart);
+                    FindStartPositionDeltas<NfaStateHandler, TNullabilityHandler>(builder, input, ref i, matchStartBoundary, ref currentState, ref lastStart) :
+                    FindStartPositionDeltas<DfaStateHandler, TNullabilityHandler>(builder, input, ref i, matchStartBoundary, ref currentState, ref lastStart);
 
                 // If we found the starting position, we're done.
                 if (done)
@@ -595,9 +614,10 @@ namespace System.Text.RegularExpressions.Symbolic
                 // if we were unable to transition, which should only happen if we were in DFA mode and exceeded our graph size.
                 // Upgrade to NFA mode and continue.
                 Debug.Assert(i >= matchStartBoundary);
-                Debug.Assert(currentState.DfaState is not null);
+                DfaMatchingState<TSet>? dfaState = currentState.DfaState(_builder);
+                Debug.Assert(dfaState is not null);
                 NfaMatchingState nfaState = perThreadData.NfaState;
-                nfaState.InitializeFrom(currentState.DfaState);
+                nfaState.InitializeFrom(dfaState);
                 currentState = new CurrentState(nfaState);
             }
 
@@ -610,8 +630,9 @@ namespace System.Text.RegularExpressions.Symbolic
         /// starting at <paramref name="i"/>, for each character transitioning from one state in the DFA or NFA graph to the next state,
         /// lazily building out the graph as needed.
         /// </summary>
-        private bool FindStartPositionDeltas<TStateHandler>(SymbolicRegexBuilder<TSet> builder, ReadOnlySpan<char> input, ref int i, int startThreshold, ref CurrentState currentState, ref int lastStart)
+        private bool FindStartPositionDeltas<TStateHandler, TNullabilityHandler>(SymbolicRegexBuilder<TSet> builder, ReadOnlySpan<char> input, ref int i, int startThreshold, ref CurrentState currentState, ref int lastStart)
             where TStateHandler : struct, IStateHandler
+            where TNullabilityHandler : struct, INullabilityHandler
         {
             // To avoid frequent reads/writes to ref values, make and operate on local copies, which we then copy back once before returning.
             int pos = i;
@@ -621,23 +642,30 @@ namespace System.Text.RegularExpressions.Symbolic
                 // Loop backwards through each character in the input, transitioning from state to state for each.
                 while (true)
                 {
+                    var (isInitial, isDeadend, isNullable, canBeNullable) = TStateHandler.GetStateInfo(builder, ref state);
+
                     // If the state accepts the empty string, we found a valid starting position.  Record it and keep going,
                     // since we're looking for the earliest one to occur within bounds.
-                    if (TStateHandler.IsNullable(ref state, GetCharKind(input, pos - 1)))
+                    if (TNullabilityHandler.IsNullableAt<TStateHandler>(this, ref state, input, pos - 1, isNullable, canBeNullable))
+                    {
                         lastStart = pos;
+                    }
 
                     // If we are past the start threshold or if the state is a dead end, bail; we should have already
                     // found a valid starting location.
-                    if (pos <= startThreshold || TStateHandler.IsDeadend(ref state))
+                    if (pos <= startThreshold || isDeadend)
                     {
                         Debug.Assert(lastStart != -1);
                         return true;
                     }
 
                     // Try to transition with the next character, the one before the current position.
+                    //int mintermId = GenericMintermHandler.GetMintermId<TStateHandler>(this, ref state, input, pos - 1);
                     if (!TryTakeTransition<TStateHandler>(builder, input, pos - 1, ref state))
+                    {
                         // Return false to indicate the search didn't finish.
                         return false;
+                    }
 
                     // Since we successfully transitioned, update our current index to match the fact that we consumed the previous character in the input.
                     pos--;
@@ -721,7 +749,7 @@ namespace System.Text.RegularExpressions.Symbolic
                             Registers newRegisters = j != transitions.Count - 1 ? sourceRegisters.Clone() : sourceRegisters;
                             newRegisters.ApplyEffects(effects, i);
                             next.Update(index, targetState.Id, newRegisters);
-                            if (targetState.IsNullable(GetCharKind(input, i + 1)))
+                            if (targetState.IsNullableFor(GetCharKind(input, i + 1)))
                             {
                                 // No lower priority transitions from this or other source states are taken because the
                                 // backtracking engines would return the match ending here.
@@ -745,7 +773,7 @@ namespace System.Text.RegularExpressions.Symbolic
             foreach (var (endStateId, endRegisters) in current.Values)
             {
                 DfaMatchingState<TSet> endState = _builder._capturingStateArray[endStateId];
-                if (endState.IsNullable(GetCharKind(input, iEnd)))
+                if (endState.IsNullableFor(GetCharKind(input, iEnd)))
                 {
                     // Apply effects for finishing at the stored end state
                     endState.Node.ApplyEffects((effect, args) => args.Registers.ApplyEffect(effect, args.Pos),
@@ -776,17 +804,17 @@ namespace System.Text.RegularExpressions.Symbolic
                 char nextChar = input[i];
                 if (nextChar == '\n')
                 {
-                    return
-                        _builder._newLineSet.Equals(_builder._solver.Empty) ? 0 : // ignore \n
+                    return _builder._newLineSet.Equals(_builder._solver.Empty) ? 0 : // ignore \n
                         i == 0 || i == input.Length - 1 ? CharKind.NewLineS : // very first or very last \n. Detection of very first \n is needed for rev(\Z).
                         CharKind.Newline;
                 }
 
                 uint[] asciiCharKinds = _asciiCharKinds;
-                return
-                    nextChar < (uint)asciiCharKinds.Length ? asciiCharKinds[nextChar] :
-                    _builder._solver.And(GetMinterm(nextChar), _builder._wordLetterForBoundariesSet).Equals(_builder._solver.Empty) ? 0 : // intersect with the wordletter set to compute the kind of the next character
-                    CharKind.WordLetter;
+                return nextChar < (uint)asciiCharKinds.Length ?
+                    asciiCharKinds[nextChar] :
+                    _builder._solver.And(GetMinterm(nextChar), _builder._wordLetterForBoundariesSet).Equals(_builder._solver.Empty) ? // intersect with the wordletter set to compute the kind of the next character
+                        CharKind.General :
+                        CharKind.WordLetter;
             }
         }
 
@@ -935,80 +963,82 @@ namespace System.Text.RegularExpressions.Symbolic
             /// <summary>Initializes the state as a DFA state.</summary>
             public CurrentState(DfaMatchingState<TSet> dfaState)
             {
-                DfaState = dfaState;
+                DfaStateId = dfaState.Id;
                 NfaState = null;
             }
 
             /// <summary>Initializes the state as an NFA state.</summary>
             public CurrentState(NfaMatchingState nfaState)
             {
-                DfaState = null;
+                DfaStateId = -1;
                 NfaState = nfaState;
             }
 
             /// <summary>The DFA state.</summary>
-            public DfaMatchingState<TSet>? DfaState;
+            public int DfaStateId;
             /// <summary>The NFA state.</summary>
             public NfaMatchingState? NfaState;
+
+            public DfaMatchingState<TSet>? DfaState(SymbolicRegexBuilder<TSet> builder) => DfaStateId > 0 ? builder._stateArray![DfaStateId] : null;
         }
 
         /// <summary>Represents a set of routines for operating over a <see cref="CurrentState"/>.</summary>
         private interface IStateHandler
         {
-            public static abstract bool StartsWithLineAnchor(ref CurrentState state);
-            public static abstract bool IsNullable(ref CurrentState state, uint nextCharKind);
-            public static abstract bool IsDeadend(ref CurrentState state);
-            public static abstract int FixedLength(ref CurrentState state, uint nextCharKind);
-            public static abstract bool IsInitialState(ref CurrentState state);
+            public static abstract bool StartsWithLineAnchor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state);
+            public static abstract bool IsNullableFor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind);
+            public static abstract int FixedLength(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind);
             public static abstract bool TakeTransition(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, int mintermId);
+            public static abstract (bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable) GetStateInfo(SymbolicRegexBuilder<TSet> builder, ref CurrentState state);
         }
 
         /// <summary>An <see cref="IStateHandler"/> for operating over <see cref="CurrentState"/> instances configured as DFA states.</summary>
         private readonly struct DfaStateHandler : IStateHandler
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool StartsWithLineAnchor(ref CurrentState state) => state.DfaState!.StartsWithLineAnchor;
+            public static bool StartsWithLineAnchor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state) => state.DfaState(builder)!.StartsWithLineAnchor;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool IsNullable(ref CurrentState state, uint nextCharKind) => state.DfaState!.IsNullable(nextCharKind);
-
-            /// <summary>Gets whether this is a dead-end state, meaning there are no transitions possible out of the state.</summary>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool IsDeadend(ref CurrentState state) => state.DfaState!.IsDeadend;
+            public static bool IsNullableFor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind) => state.DfaState(builder)!.IsNullableFor(nextCharKind);
 
             /// <summary>Gets the length of any fixed-length marker that exists for this state, or -1 if there is none.</summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static int FixedLength(ref CurrentState state, uint nextCharKind) => state.DfaState!.FixedLength(nextCharKind);
-
-            /// <summary>Gets whether this is an initial state.</summary>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool IsInitialState(ref CurrentState state) => state.DfaState!.IsInitialState;
+            public static int FixedLength(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind) => state.DfaState(builder)!.FixedLength(nextCharKind);
 
             /// <summary>Take the transition to the next DFA state.</summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static bool TakeTransition(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, int mintermId)
             {
-                Debug.Assert(state.DfaState is not null, $"Expected non-null {nameof(state.DfaState)}.");
+                Debug.Assert(state.DfaStateId > 0, $"Expected non-zero {nameof(state.DfaStateId)}.");
                 Debug.Assert(state.NfaState is null, $"Expected null {nameof(state.NfaState)}.");
                 Debug.Assert(builder._delta is not null);
-
-                // Get the current state.
-                DfaMatchingState<TSet> dfaMatchingState = state.DfaState!;
 
                 // Use the mintermId for the character being read to look up which state to transition to.
                 // If that state has already been materialized, move to it, and we're done. If that state
                 // hasn't been materialized, try to create it; if we can, move to it, and we're done.
-                int dfaOffset = (dfaMatchingState.Id << builder._mintermsLog) | mintermId;
-                DfaMatchingState<TSet>? nextState = builder._delta[dfaOffset];
-                if (nextState is not null || builder.TryCreateNewTransition(dfaMatchingState, mintermId, dfaOffset, checkThreshold: true, out nextState))
+                int dfaOffset = (state.DfaStateId << builder._mintermsLog) | mintermId;
+                int nextStateId = builder._delta[dfaOffset];
+                if (nextStateId > 0 || builder.TryCreateNewTransition(state.DfaStateId, mintermId, dfaOffset, checkThreshold: true, out nextStateId))
                 {
                     // There was an existing state for this transition or we were able to create one.  Move to it and
                     // return that we're still operating as a DFA and can keep going.
-                    state.DfaState = nextState;
+                    state.DfaStateId = nextStateId;
                     return true;
                 }
 
                 return false;
+            }
+
+            /// <summary>
+            /// Gets context independent state information:
+            /// - whether this is an initial state
+            /// - whether this is a dead-end state, meaning there are no transitions possible out of the state
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static (bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable) GetStateInfo(SymbolicRegexBuilder<TSet> builder, ref CurrentState state)
+            {
+                Debug.Assert(state.DfaStateId > 0);
+                return builder._stateInfo![state.DfaStateId];
             }
         }
 
@@ -1016,9 +1046,8 @@ namespace System.Text.RegularExpressions.Symbolic
         private readonly struct NfaStateHandler : IStateHandler
         {
             /// <summary>Check if any underlying core state starts with a line anchor.</summary>
-            public static bool StartsWithLineAnchor(ref CurrentState state)
+            public static bool StartsWithLineAnchor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state)
             {
-                SymbolicRegexBuilder<TSet> builder = state.NfaState!.Builder;
                 foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
                 {
                     if (builder.GetCoreState(nfaState.Key).StartsWithLineAnchor)
@@ -1030,13 +1059,12 @@ namespace System.Text.RegularExpressions.Symbolic
                 return false;
             }
 
-            /// <summary>Check if any underlying core state is nullable.</summary>
-            public static bool IsNullable(ref CurrentState state, uint nextCharKind)
+            /// <summary>Check if any underlying core state is nullable in the context of the next character kind.</summary>
+            public static bool IsNullableFor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind)
             {
-                SymbolicRegexBuilder<TSet> builder = state.NfaState!.Builder;
                 foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
                 {
-                    if (builder.GetCoreState(nfaState.Key).IsNullable(nextCharKind))
+                    if (builder.GetCoreState(nfaState.Key).IsNullableFor(nextCharKind))
                     {
                         return true;
                     }
@@ -1045,22 +1073,14 @@ namespace System.Text.RegularExpressions.Symbolic
                 return false;
             }
 
-            /// <summary>Gets whether this is a dead-end state, meaning there are no transitions possible out of the state.</summary>
-            /// <remarks>In NFA mode, an empty set of states means that it is a dead end.</remarks>
-            public static bool IsDeadend(ref CurrentState state) => state.NfaState!.NfaStateSet.Count == 0;
-
             /// <summary>Gets the length of any fixed-length marker that exists for this state, or -1 if there is none.</summary>
             /// <summary>In NFA mode, there are no fixed-length markers.</summary>
-            public static int FixedLength(ref CurrentState state, uint nextCharKind) => -1;
-
-            /// <summary>Gets whether this is an initial state.</summary>
-            /// <summary>In NFA mode, no set of states qualifies as an initial state.</summary>
-            public static bool IsInitialState(ref CurrentState state) => false;
+            public static int FixedLength(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind) => -1;
 
             /// <summary>Take the transition to the next NFA state.</summary>
             public static bool TakeTransition(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, int mintermId)
             {
-                Debug.Assert(state.DfaState is null, $"Expected null {nameof(state.DfaState)}.");
+                Debug.Assert(state.DfaStateId < 0, $"Expected negative {nameof(state.DfaStateId)}.");
                 Debug.Assert(state.NfaState is not null, $"Expected non-null {nameof(state.NfaState)}.");
 
                 NfaMatchingState nfaState = state.NfaState!;
@@ -1110,11 +1130,55 @@ namespace System.Text.RegularExpressions.Symbolic
                 }
             }
 
+            /// <summary>
+            /// Gets context independent state information:
+            /// - whether this is an initial state
+            /// - whether this is a dead-end state, meaning there are no transitions possible out of the state
+            /// </summary>
+            /// <remarks>
+            /// In NFA mode:
+            /// - an empty set of states means that it is a dead end
+            /// - no set of states qualifies as an initial state. This could be made more accurate, but with that the
+            ///   matching logic would need to be updated to handle the fact that <see cref="InitialStateFindOptimizationsHandler"/>
+            ///   can transition back to a DFA state.
+            /// </remarks>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static (bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable) GetStateInfo(SymbolicRegexBuilder<TSet> builder, ref CurrentState state) =>
+                (false, state.NfaState!.NfaStateSet.Count == 0, IsNullable(builder, ref state), CanBeNullable(builder, ref state));
+
+            /// <summary>Check if any underlying core state is unconditionally nullable.</summary>
+            private static bool IsNullable(SymbolicRegexBuilder<TSet> builder, ref CurrentState state)
+            {
+                foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
+                {
+                    if (builder.GetCoreState(nfaState.Key).IsNullable)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            /// <summary>Check if any underlying core state can be nullable in some context.</summary>
+            private static bool CanBeNullable(SymbolicRegexBuilder<TSet> builder, ref CurrentState state)
+            {
+                foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
+                {
+                    if (builder.GetCoreState(nfaState.Key).CanBeNullable)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
 #if DEBUG
             /// <summary>Undo a previous call to <see cref="TakeTransition"/>.</summary>
             public static void UndoTransition(ref CurrentState state)
             {
-                Debug.Assert(state.DfaState is null, $"Expected null {nameof(state.DfaState)}.");
+                Debug.Assert(state.DfaStateId < 0, $"Expected negative {nameof(state.DfaState)}.");
                 Debug.Assert(state.NfaState is not null, $"Expected non-null {nameof(state.NfaState)}.");
 
                 NfaMatchingState nfaState = state.NfaState!;
@@ -1159,6 +1223,67 @@ namespace System.Text.RegularExpressions.Symbolic
                 return false;
             }
 #endif
+        }
+
+        private interface IFindOptimizationsHandler
+        {
+            public static abstract bool TryFindNextStartingPosition(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, ref CurrentState state, ref int pos);
+        }
+
+        private readonly struct NoFindOptimizationsHandler : IFindOptimizationsHandler
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool TryFindNextStartingPosition(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, ref CurrentState state, ref int pos)
+            {
+                // return true to indicate that the current position is a possible starting position
+                return true;
+            }
+        }
+
+        private readonly struct InitialStateFindOptimizationsHandler : IFindOptimizationsHandler
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool TryFindNextStartingPosition(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, ref CurrentState state, ref int pos)
+            {
+                // Find the first position that matches with some likely character.
+                if (!matcher._findOpts!.TryFindNextStartingPosition(input, ref pos, 0))
+                {
+                    // No match exists
+                    return false;
+                }
+
+                // Update the starting state based on where TryFindNextStartingPosition moved us to.
+                // As with the initial starting state, if it's a dead end, no match exists.
+                state = new CurrentState(matcher._dotstarredInitialStates[matcher.GetCharKind(input, pos - 1)]);
+                return true;
+            }
+        }
+
+        private interface INullabilityHandler
+        {
+            public static abstract bool IsNullableAt<TStateHandler>(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, ReadOnlySpan<char> input, int pos, bool isNullable, bool canBeNullable)
+                    where TStateHandler : struct, IStateHandler;
+        }
+
+        private readonly struct NoAnchorsNullabilityHandler : INullabilityHandler
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool IsNullableAt<TStateHandler>(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, ReadOnlySpan<char> input, int pos, bool isNullable, bool canBeNullable)
+                where TStateHandler : struct, IStateHandler
+            {
+                Debug.Assert(!matcher._pattern._info.ContainsSomeAnchor);
+                return isNullable;
+            }
+        }
+
+        private readonly struct FullNullabilityHandler : INullabilityHandler
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool IsNullableAt<TStateHandler>(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, ReadOnlySpan<char> input, int pos, bool isNullable, bool canBeNullable)
+                where TStateHandler : struct, IStateHandler
+            {
+                return isNullable || (canBeNullable && TStateHandler.IsNullableFor(matcher._builder, ref state, matcher.GetCharKind(input, pos)));
+            }
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -315,12 +315,12 @@ namespace System.Text.RegularExpressions.Symbolic
             // the position of the last b: aacaaaabbbc.  It additionally records the position of the first a after
             // the c as the low boundary for the starting position.
             int matchStartLowBoundary, matchStartLengthMarker;
-            int matchEnd = (_findOpts is null, _pattern._info.ContainsSomeAnchor) switch
+            int matchEnd = (_findOpts is not null, _pattern._info.ContainsSomeAnchor) switch
             {
-                (false, false) => FindEndPosition<NoOptimizationsInitialStateHandler, NoAnchorsNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
+                (true, true) => FindEndPosition<InitialStateFindOptimizationsHandler, FullNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
                 (true, false) => FindEndPosition<InitialStateFindOptimizationsHandler, NoAnchorsNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
                 (false, true) => FindEndPosition<NoOptimizationsInitialStateHandler, FullNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
-                (true, true) => FindEndPosition<InitialStateFindOptimizationsHandler, FullNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
+                (false, false) => FindEndPosition<NoOptimizationsInitialStateHandler, NoAnchorsNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
             };
 
             // If there wasn't a match, we're done.
@@ -1024,7 +1024,7 @@ namespace System.Text.RegularExpressions.Symbolic
             public static (bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable) GetStateInfo(SymbolicRegexBuilder<TSet> builder, ref CurrentState state)
             {
                 Debug.Assert(state.DfaStateId > 0);
-                return builder._stateInfo![state.DfaStateId];
+                return builder.GetStateInfo(state.DfaStateId);
             }
         }
 
@@ -1166,7 +1166,7 @@ namespace System.Text.RegularExpressions.Symbolic
             {
                 foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
                 {
-                    if (builder._stateInfo![builder.GetCoreStateId(nfaState.Key)].IsNullable)
+                    if (builder.GetStateInfo(builder.GetCoreStateId(nfaState.Key)).IsNullable)
                     {
                         return true;
                     }
@@ -1180,7 +1180,7 @@ namespace System.Text.RegularExpressions.Symbolic
             {
                 foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
                 {
-                    if (builder._stateInfo![builder.GetCoreStateId(nfaState.Key)].CanBeNullable)
+                    if (builder.GetStateInfo(builder.GetCoreStateId(nfaState.Key)).CanBeNullable)
                     {
                         return true;
                     }


### PR DESCRIPTION
This PR addresses the regressions related to the inner matching loop performance in https://github.com/dotnet/runtime/issues/70022 introduced by https://github.com/dotnet/runtime/pull/69839 and includes further optimizations. The changes in the PR are roughly:

- https://github.com/dotnet/runtime/pull/69839 caused a regression by making fixed length marker evaluation character context aware, which made it more expensive. Fixed length markers were evaluated whenever a nullable state was found in the first phase of the search. This PR pulls the evaluation outside the inner matching loop by recording the state ID instead, which in DFA mode is just an `int` assignment. I've also implemented support for fixed length markers in NFA mode.
- Pulls the decision to try to use `RegexFindOptimizations` out of the inner matching loop by using a `IInitialStateHandler` interface and the "templating" technique with structs implementing the interface as generic type arguments that we already use for DFA and NFA mode.
- Introduces a decision outside the inner matching loop to never evaluate contextual nullability for patterns that don't have any anchors. This also uses the "templating" technique with a `INullabilityHandler` interface.
- Tabulate an array of `(bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable)` in the `SymbolicRegexBuilder` that can be accessed by state IDs. This reduces pointer chasing involved in looking these up from the `DfaMatchingState` and its related `SymbolicRegexNode`. The existing `IsInitial` field from `DfaMatchingState` is removed for some memory saving.
- Makes `CurrentState` hold the ID (an `int`) of the current DFA state instead of the `DfaMatchingState` instance. This allows cached transitions to be taken in DFA mode without ever dereferencing the current `DfaMatchingState`. Coupled with the above optimization the `DfaMatchingState` is rarely needed in typical patterns.

One optimization that I evaluated, but that didn't decisively help was pulling out the decision to handle the "last end of line" special minterm outside the inner matching loop. I'm guessing the `char == '\n' && pos == input.Length - 1` check is already cheap enough that it isn't really visible.

I compared performance after implementing each optimization to check that each was helping. Here's a total before and after comparison for NonBacktracking on all the relevant benchmarks in dotnet/performance. The baseline here is the situation after the regressions in https://github.com/dotnet/runtime/issues/70022.
summary:
better: 58, geomean: 1.360
worse: 5, geomean: 1.057
total diff: 63

| Slower                                                                                                                                         | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| ---------------------------------------------------------------------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| -------- |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "Tom\|Sawyer\|Huckleberry\|Finn", Options: NonBacktracking)       |      1.11 |       4785248.08 |       5325761.46 | several?|
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "Tom.{10,25}river\|river.{10,25}Tom", Options: NonBacktracking) |      1.06 |       9628288.00 |      10195706.67 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 12, Options: NonBacktracking)                            |      1.05 |           133.03 |           139.37 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 13, Options: NonBacktracking)                            |      1.04 |           134.98 |           139.74 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_SliceSlice.Count(Options: IgnoreCase, NonBacktracking)                                |      1.03 |    2029181900.00 |    2094702200.00 | several?|

| Faster                                                                                                                                                                                                  | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| -------- |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "[^\\n]*", Options: NonBacktracking)                                                                          |      2.59 |      15286261.76 |       5901962.79 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?s).*", Options: NonBacktracking)                                                                           |      2.51 |      10022464.58 |       4000825.81 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Mariomkas.Count(Pattern: "[\\w]+://[^/\\s?#]+[^\\s?#]+(?:\\?[^\\s#]*)?(?:#[^\\s]*)?", Options: NonBacktracking)                                |      2.22 |       6771215.28 |       3045911.11 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\b\\w+n\\b", Options: NonBacktracking)                                                                      |      2.17 |      10788114.58 |       4964147.06 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: ".*", Options: NonBacktracking)                                                                               |      1.96 |      12170225.00 |       6225097.67 | bimodal |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\w+\\s+Holmes", Options: NonBacktracking)                                                                   |      1.88 |       4073781.25 |       2171156.90 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_SliceSlice.Count(Options: NonBacktracking)                                                                                                     |      1.86 |    1099632850.00 |     590537400.00 | several?|
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "[a-zA-Z]+ing", Options: NonBacktracking)                                                                     |      1.82 |       8657798.33 |       4762550.98 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Holmes", Options: NonBacktracking)                                                                           |      1.80 |        159116.57 |         88287.89 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\s[a-zA-Z]{0,12}ing\\s", Options: NonBacktracking)                                                          |      1.78 |       4577136.36 |       2567926.42 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "the\\s+\\w+", Options: NonBacktracking)                                                                      |      1.76 |       1961271.43 |       1115444.84 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Holmes.{0,25}Watson\|Watson.{0,25}Holmes", Options: NonBacktracking)                                          |      1.72 |        199215.34 |        115912.40 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\w+", Options: NonBacktracking)                                                                             |      1.69 |      23110975.00 |      13655700.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\w+\\s+Holmes\\s+\\w+", Options: NonBacktracking)                                                           |      1.61 |       3377971.43 |       2104111.40 | bimodal |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sher[a-z]+\|Hol[a-z]+", Options: NonBacktracking)                                                             |      1.59 |        204743.55 |        128662.45 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "[a-q][^u-z]{13}x", Options: NonBacktracking)                                                                 |      1.57 |         88111.27 |         56102.58 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "the", Options: NonBacktracking)                                                                              |      1.50 |       1033139.24 |        687533.78 | bimodal |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sherlock\\s+Holmes", Options: NonBacktracking)                                                               |      1.47 |         86482.44 |         58707.08 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sherlock\|Holmes", Options: NonBacktracking)                                                                  |      1.47 |        177346.23 |        120786.17 | bimodal |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: ".{2,4}(Tom\|Sawyer\|Huckleberry\|Finn)", Options: NonBacktracking)                                                        |      1.41 |      67257150.00 |      47606437.50 | several?|
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sherlock\|Street", Options: NonBacktracking)                                                                  |      1.40 |         76250.69 |         54275.02 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: ".{0,2}(Tom\|Sawyer\|Huckleberry\|Finn)", Options: NonBacktracking)                                                        |      1.40 |      67197850.00 |      47843350.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "zqj", Options: NonBacktracking)                                                                              |      1.40 |         53884.39 |         38434.69 | several?|
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\p{Lu}", Options: NonBacktracking)                                                                          |      1.37 |       2540423.68 |       1849647.01 | several?|
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 5, Options: NonBacktracking)                                                                                      |      1.37 |           206.84 |           150.82 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 3, Options: NonBacktracking)                                                                                      |      1.37 |           242.66 |           177.47 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sherlock", Options: NonBacktracking)                                                                         |      1.34 |         66087.55 |         49360.96 | bimodal |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sherlock\|Holmes\|Watson\|Irene\|Adler\|John\|Baker", Options: NonBacktracking)                                    |      1.33 |       3037911.41 |       2280343.52 | several?|
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\p{Ll}", Options: NonBacktracking)                                                                          |      1.33 |      40920612.50 |      30728875.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sherlock\|Holmes\|Watson", Options: NonBacktracking)                                                           |      1.32 |        211902.74 |        160457.22 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\p{L}", Options: NonBacktracking)                                                                           |      1.31 |      40560162.50 |      30977100.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sherlock Holmes", Options: NonBacktracking)                                                                  |      1.31 |         68187.37 |         52127.82 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "The", Options: NonBacktracking)                                                                              |      1.30 |        130572.40 |        100326.33 | several?|
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 4, Options: NonBacktracking)                                                                                      |      1.29 |           181.44 |           140.99 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "aqj", Options: NonBacktracking)                                                                              |      1.26 |         48508.51 |         38491.90 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "aei", Options: NonBacktracking)                                                                              |      1.26 |         59747.35 |         47496.19 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?m)^Sherlock Holmes\|Sherlock Holmes$", Options: NonBacktracking)                                            |      1.25 |         64672.47 |         51940.21 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?i)the", Options: NonBacktracking)                                                                          |      1.24 |       1523287.44 |       1232909.66 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 10, Options: NonBacktracking)                                                                                     |      1.13 |           123.15 |           108.83 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 2, Options: NonBacktracking)                                                                                      |      1.12 |           161.55 |           143.72 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 6, Options: NonBacktracking)                                                                                      |      1.11 |           114.45 |           103.11 | several?|
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 7, Options: NonBacktracking)                                                                                      |      1.09 |           101.74 |            93.39 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 9, Options: NonBacktracking)                                                                                      |      1.08 |           112.40 |           103.77 | bimodal |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Mariomkas.Count(Pattern: "(?:(?:25[0-5]\|2[0-4][0-9]\|[01]?[0-9][0-9])\\.){3}(?:25[0-5]\|2[0-4][0-9]\|[01]?[0-9][0-9])", Options: NonBacktracking) |      1.07 |      13209031.58 |      12307950.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?i)Sher[a-z]+\|Hol[a-z]+", Options: NonBacktracking)                                                         |      1.06 |        984012.25 |        924302.87 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "[a-z]shing", Options: NonBacktracking)                                                                                 |      1.06 |       2657380.00 |       2513476.53 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Mariomkas.Count(Pattern: "[\\w\\.+-]+@[\\w\\.-]+\\.[\\w\\.-]+", Options: NonBacktracking)                                                      |      1.06 |        638071.50 |        603662.24 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "Twain", Options: NonBacktracking)                                                                                      |      1.05 |       2494026.73 |       2386224.76 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 0, Options: NonBacktracking)                                                                                      |      1.04 |            83.28 |            79.90 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 8, Options: NonBacktracking)                                                                                      |      1.04 |           106.23 |           102.07 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "([A-Za-z]awyer\|[A-Za-z]inn)\\s", Options: NonBacktracking)                                                             |      1.04 |      15942657.14 |      15355812.50 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "(?i)Tom\|Sawyer\|Huckleberry\|Finn", Options: NonBacktracking)                                                            |      1.04 |      75034250.00 |      72294600.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?i)Sherlock", Options: NonBacktracking)                                                                     |      1.04 |        103258.57 |         99506.47 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?i)Sherlock\|Holmes\|Watson\|Irene\|Adler\|John\|Baker", Options: NonBacktracking)                                |      1.03 |       3304392.00 |       3202143.59 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?i)Holmes", Options: NonBacktracking)                                                                       |      1.03 |        507619.96 |        492948.24 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?i)Sherlock\|Holmes\|Watson", Options: NonBacktracking)                                                       |      1.03 |       2190175.00 |       2130422.17 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "(?i)Twain", Options: NonBacktracking)                                                                                  |      1.03 |       6689778.38 |       6510337.84 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Mariomkas.Ctor(Pattern: "(?:(?:25[0-5]\|2[0-4][0-9]\|[01]?[0-9][0-9])\\.){3}(?:25[0-5]\|2[0-4][0-9]\|[01]?[0-9][0-9])", Options: NonBacktracking)  |      1.02 |        212577.91 |        208770.25 |         |
