### PR TITLE
Delete a little more dead rationalizer code

### DIFF
--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -708,23 +708,6 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
                 DISPTREERANGE(BlockRange(), use.Def());
                 JITDUMP("\n");
             }
-            else
-            {
-                // This code depends on the fact that NONE of the SIMD intrinsics take vector operands
-                // of a different width.  If that assumption changes, we will EITHER have to make these type
-                // transformations during importation, and plumb the types all the way through the JIT,
-                // OR add a lot of special handling here.
-
-                // TODO-Review: the comment above seems outdated. TYP_SIMDs have been "plumbed through" the Jit.
-                // It may be that this code is actually dead.
-                for (GenTree* operand : simdNode->Operands())
-                {
-                    if (operand->TypeIs(TYP_STRUCT))
-                    {
-                        operand->ChangeType(simdType);
-                    }
-                }
-            }
         }
         break;
 #endif // FEATURE_SIMD


### PR DESCRIPTION
This was a leftover from the initial `FEATURE_SIMD` implementation.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1805818&view=ms.vss-build-web.run-extensions-tab).