### PR TITLE
Ignoring test for NativeAOT since GetCallingAssembly is unsupported

### DIFF
--- a/src/libraries/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/MethodInfoTests.cs
@@ -772,6 +772,7 @@ namespace System.Reflection.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/69919", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static void CallStackFrame_AggressiveInlining()
         {
             MethodInfo mi = typeof(System.Reflection.TestAssembly.ClassToInvoke).GetMethod(nameof(System.Reflection.TestAssembly.ClassToInvoke.CallMe_AggressiveInlining),


### PR DESCRIPTION
Ignoring this test for NativeAOT because it failed with PlatformNotSupportedException since it depends on GetCallingAssembly  which is not supported in NativeAOT.

[FAIL] System.Reflection.Tests.MethodInfoTests.CallStackFrame_AggressiveInlining
System.PlatformNotSupportedException : Operation is not supported on this platform.
at System.Reflection.Assembly.GetCallingAssembly() + 0x5b
at System.Reflection.TestAssembly.ClassToInvoke.CallMeActual() + 0x9
at System.Reflection.TestAssembly.ClassToInvoke.CallMe_AggressiveInlining() + 0xa
at System.Reflection.Tests!<BaseAddress>+0x5c9efc
at System.InvokeUtils.CallDynamicInvokeMethod(Object, IntPtr, IntPtr, IntPtr, Object, Object[], BinderBundle, Boolean, Boolean) + 0x113