### PR TITLE
Re-enable the pause intrinsic test for x86/x64 CoreCLR

### DIFF
--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -314,6 +314,21 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
         return NI_Throw_PlatformNotSupportedException;
     }
 
+#if defined(TARGET_XARCH)
+    if ((isa == InstructionSet_Vector128) || (isa == InstructionSet_Vector256))
+#elif defined(TARGET_ARM64)
+    if ((isa == InstructionSet_Vector64) || (isa == InstructionSet_Vector128))
+#endif
+    {
+        if (!comp->IsBaselineSimdIsaSupported())
+        {
+            // Special case: For Vector64/128/256 we currently don't accelerate any of the methods when SSE/SSE2
+            // aren't supported since IsHardwareAccelerated reports false. To simplify the importation logic we'll
+            // just return illegal here and let it fallback to the software path instead.
+            return NI_Illegal;
+        }
+    }
+
     for (int i = 0; i < (NI_HW_INTRINSIC_END - NI_HW_INTRINSIC_START - 1); i++)
     {
         const HWIntrinsicInfo& intrinsicInfo = hwIntrinsicInfoArray[i];

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -325,11 +325,6 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
     assert(category != HW_Category_Scalar);
     assert(!HWIntrinsicInfo::isScalarIsa(HWIntrinsicInfo::lookupIsa(intrinsic)));
 
-    if (!IsBaselineSimdIsaSupported())
-    {
-        return nullptr;
-    }
-
     assert(numArgs >= 0);
 
     var_types simdBaseType = JitType2PreciseVarType(simdBaseJitType);

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -550,11 +550,6 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
     GenTree* op3     = nullptr;
     GenTree* op4     = nullptr;
 
-    if (!IsBaselineSimdIsaSupported())
-    {
-        return nullptr;
-    }
-
     CORINFO_InstructionSet isa = HWIntrinsicInfo::lookupIsa(intrinsic);
 
     if ((isa == InstructionSet_Vector256) && !compExactlyDependsOn(InstructionSet_AVX))

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -54,9 +54,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/rvastatics/RVAOrderingTest/*">
             <Issue>https://github.com/dotnet/runtime/issues/55966</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XUnitTestBinBase)/JIT/HardwareIntrinsics/X86/X86Base/Pause*/**">
-            <Issue>https://github.com/dotnet/runtime/issues/62423</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/binding/tracing/BinderTracingTest.Basic/*">
             <Issue>https://github.com/dotnet/runtime/issues/57786</Issue>
         </ExcludeList>
@@ -1499,7 +1496,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/ShiftOperations/*">
           <Issue>There is a known undefined behavior with shifts and 0xFFFFFFFF overflows, so skip the test for mono.</Issue>
         </ExcludeList>
-      
+
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTestWithMcj/*">
             <Issue>Tests features specific to coreclr</Issue>
         </ExcludeList>


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/62423

