### PR TITLE
fix: [Wasm] Restore _free default export for Emcc 3.1.7 or later

### DIFF
--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -131,7 +131,7 @@
 
     <PropertyGroup>
       <_DefaultExportedFunctions Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))"
-                                >_malloc,stackSave,stackRestore,stackAlloc,_memalign,_memset,_htons,_ntohs</_DefaultExportedFunctions>
+                                >_malloc,stackSave,stackRestore,stackAlloc,_memalign,_memset,_htons,_ntohs,_free</_DefaultExportedFunctions>
 
       <!-- _htons,_ntohs,__get_daylight,__get_timezone,__get_tzname are exported temporarily, until the issue is fixed in emscripten, https://github.com/dotnet/runtime/issues/64724  -->
       <_DefaultExportedFunctions Condition="'$(_DefaultExportedFunctions)' == '' and $([MSBuild]::VersionGreaterThan('$(_EmccVersion)', '3.0'))"


### PR DESCRIPTION
Restores the default export or `_free` as is used in:

https://github.com/dotnet/runtime/blob/a598ebb67973f03b1d6b3fd6c50f75bae3fe1c51/src/mono/wasm/runtime/strings.ts#L238