### PR TITLE
[mono][interp] Fix performance regression

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7005,7 +7005,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_TIER_ENTER_METHOD) {
 			frame->imethod->entry_count++;
 			if (frame->imethod->entry_count > INTERP_TIER_ENTRY_LIMIT)
-				mono_interp_tier_up_frame_enter (frame, context, &ip);
+				ip = mono_interp_tier_up_frame_enter (frame, context);
 			else
 				ip++;
 			MINT_IN_BREAK;
@@ -7013,7 +7013,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_TIER_PATCHPOINT) {
 			frame->imethod->entry_count++;
 			if (frame->imethod->entry_count > INTERP_TIER_ENTRY_LIMIT)
-				mono_interp_tier_up_frame_patchpoint (frame, context, &ip);
+				ip = mono_interp_tier_up_frame_patchpoint (frame, context, ip [1]);
 			else
 				ip += 2;
 			MINT_IN_BREAK;

--- a/src/mono/mono/mini/interp/tiering.c
+++ b/src/mono/mono/mini/interp/tiering.c
@@ -155,8 +155,8 @@ mono_interp_register_imethod_patch_site (gpointer *imethod_ptr)
 	mono_os_mutex_unlock (&tiering_mutex);
 }
 
-void
-mono_interp_tier_up_frame_enter (InterpFrame *frame, ThreadContext *context, const guint16 **ip)
+const guint16*
+mono_interp_tier_up_frame_enter (InterpFrame *frame, ThreadContext *context)
 {
 	InterpMethod *optimized_method;
 	if (frame->imethod->optimized_imethod)
@@ -165,7 +165,7 @@ mono_interp_tier_up_frame_enter (InterpFrame *frame, ThreadContext *context, con
 		optimized_method = tier_up_method (frame->imethod, context);
 	context->stack_pointer = (guchar*)frame->stack + optimized_method->alloca_size;
 	frame->imethod = optimized_method;
-	*ip = optimized_method->code;
+	return optimized_method->code;
 }
 
 static int
@@ -180,8 +180,8 @@ lookup_patchpoint_data (InterpMethod *imethod, int data)
        return G_MAXINT32;
 }
 
-void
-mono_interp_tier_up_frame_patchpoint (InterpFrame *frame, ThreadContext *context, const guint16 **ip)
+const guint16*
+mono_interp_tier_up_frame_patchpoint (InterpFrame *frame, ThreadContext *context, int bb_index)
 {
 	InterpMethod *unoptimized_method = frame->imethod;
 	InterpMethod *optimized_method;
@@ -209,6 +209,5 @@ mono_interp_tier_up_frame_patchpoint (InterpFrame *frame, ThreadContext *context
 	}
 	context->stack_pointer = (guchar*)frame->stack + optimized_method->alloca_size;
 	frame->imethod = optimized_method;
-	int bb_index = (*ip) [1];
-	*ip = optimized_method->code + lookup_patchpoint_data (optimized_method, bb_index);
+	return optimized_method->code + lookup_patchpoint_data (optimized_method, bb_index);
 }

--- a/src/mono/mono/mini/interp/tiering.h
+++ b/src/mono/mono/mini/interp/tiering.h
@@ -17,10 +17,10 @@ mono_interp_register_imethod_data_items (gpointer *data_items, GSList *indexes);
 void
 mono_interp_register_imethod_patch_site (gpointer *imethod_ptr);
 
-void
-mono_interp_tier_up_frame_enter (InterpFrame *frame, ThreadContext *context, const guint16 **ip);
+const guint16*
+mono_interp_tier_up_frame_enter (InterpFrame *frame, ThreadContext *context);
 
-void
-mono_interp_tier_up_frame_patchpoint (InterpFrame *frame, ThreadContext *context, const guint16 **ip);
+const guint16*
+mono_interp_tier_up_frame_patchpoint (InterpFrame *frame, ThreadContext *context, int bb_index);
 
 #endif /* __MONO_MINI_INTERP_TIERING_H__ */


### PR DESCRIPTION
Taking address of `ip` is not only questionable design wise, but also very bad for performance, since it is a hot variable in the interpreter loop and it is normally allocated in a register. Taking its address forces spills.