### PR TITLE
Unpin locals

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -614,6 +614,8 @@ public:
     unsigned char lvSingleDefDisqualifyReason = 'H';
 #endif
 
+    unsigned char lvAllDefsAreNoGc : 1; // True if all defs of this local are no-gc
+
 #if FEATURE_MULTIREG_ARGS
     regNumber lvRegNumForSlot(unsigned slotNum)
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -614,7 +614,7 @@ public:
     unsigned char lvSingleDefDisqualifyReason = 'H';
 #endif
 
-    unsigned char lvAllDefsAreNoGc : 1; // True if all defs of this local are no-gc
+    unsigned char lvAllDefsAreNoGc : 1; // For pinned locals: true if all defs of this local are no-gc
 
 #if FEATURE_MULTIREG_ARGS
     regNumber lvRegNumForSlot(unsigned slotNum)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1110,6 +1110,11 @@ public:
         return true;
     }
 
+    bool IsNotGcDef() const
+    {
+        return IsIntegralConst(0) || IsLocalAddrExpr();
+    }
+
     // LIR flags
     //   These helper methods, along with the flag values they manipulate, are defined in lir.h
     //

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4206,8 +4206,6 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
 
                     switch (op2->gtOper)
                     {
-                        unsigned lclNum;
-
                         case GT_CNS_INT:
 
                             if (op2->AsIntCon()->gtIconVal == 0)

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4231,10 +4231,7 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
 
                         NOT_BOOL:
 
-                            lclNum = op1->AsLclVarCommon()->GetLclNum();
-                            noway_assert(lclNum < lvaCount);
-
-                            lvaTable[lclNum].lvIsBoolean = false;
+                            varDsc->lvIsBoolean = false;
                             break;
                     }
                 }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4181,49 +4181,62 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
 
             /* Is this an assignment to a local variable? */
 
-            if (op1->gtOper == GT_LCL_VAR && op2->gtType != TYP_BOOL)
+            if (op1->gtOper == GT_LCL_VAR)
             {
-                /* Only simple assignments allowed for booleans */
+                LclVarDsc* varDsc = lvaGetDesc(op1->AsLclVarCommon());
 
-                if (tree->gtOper != GT_ASG)
+                if (varDsc->lvPinned && varDsc->lvAllDefsAreNoGc)
                 {
-                    goto NOT_BOOL;
+                    if (!op2->IsNotGcDef())
+                    {
+                        varDsc->lvAllDefsAreNoGc = false;
+                    }
                 }
 
-                /* Is the RHS clearly a boolean value? */
-
-                switch (op2->gtOper)
+                if (op2->gtType != TYP_BOOL)
                 {
-                    unsigned lclNum;
+                    /* Only simple assignments allowed for booleans */
 
-                    case GT_CNS_INT:
+                    if (tree->gtOper != GT_ASG)
+                    {
+                        goto NOT_BOOL;
+                    }
 
-                        if (op2->AsIntCon()->gtIconVal == 0)
-                        {
+                    /* Is the RHS clearly a boolean value? */
+
+                    switch (op2->gtOper)
+                    {
+                        unsigned lclNum;
+
+                        case GT_CNS_INT:
+
+                            if (op2->AsIntCon()->gtIconVal == 0)
+                            {
+                                break;
+                            }
+                            if (op2->AsIntCon()->gtIconVal == 1)
+                            {
+                                break;
+                            }
+
+                            // Not 0 or 1, fall through ....
+                            FALLTHROUGH;
+
+                        default:
+
+                            if (op2->OperIsCompare())
+                            {
+                                break;
+                            }
+
+                        NOT_BOOL:
+
+                            lclNum = op1->AsLclVarCommon()->GetLclNum();
+                            noway_assert(lclNum < lvaCount);
+
+                            lvaTable[lclNum].lvIsBoolean = false;
                             break;
-                        }
-                        if (op2->AsIntCon()->gtIconVal == 1)
-                        {
-                            break;
-                        }
-
-                        // Not 0 or 1, fall through ....
-                        FALLTHROUGH;
-
-                    default:
-
-                        if (op2->OperIsCompare())
-                        {
-                            break;
-                        }
-
-                    NOT_BOOL:
-
-                        lclNum = op1->AsLclVarCommon()->GetLclNum();
-                        noway_assert(lclNum < lvaCount);
-
-                        lvaTable[lclNum].lvIsBoolean = false;
-                        break;
+                    }
                 }
             }
         }
@@ -4278,7 +4291,8 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
     {
         if (lvaVarAddrExposed(lclNum))
         {
-            varDsc->lvIsBoolean = false;
+            varDsc->lvIsBoolean      = false;
+            varDsc->lvAllDefsAreNoGc = false;
         }
 
         if (tree->gtOper == GT_LCL_FLD)
@@ -4703,6 +4717,8 @@ void Compiler::lvaComputeRefCounts(bool isRecompute, bool setSlotNumbers)
             varDsc->setLvRefCnt(0);
             varDsc->setLvRefCntWtd(BB_ZERO_WEIGHT);
 
+            varDsc->lvAllDefsAreNoGc = true;
+
             // Special case for some varargs params ... these must
             // remain unreferenced.
             const bool isSpecialVarargsParam = varDsc->lvIsParam && raIsVarargsStackArg(lclNum);
@@ -4750,6 +4766,8 @@ void Compiler::lvaComputeRefCounts(bool isRecompute, bool setSlotNumbers)
         {
             varDsc->lvSingleDef             = varDsc->lvIsParam;
             varDsc->lvSingleDefRegCandidate = varDsc->lvIsParam;
+
+            varDsc->lvAllDefsAreNoGc = true;
         }
     }
 
@@ -4867,6 +4885,13 @@ void Compiler::lvaComputeRefCounts(bool isRecompute, bool setSlotNumbers)
             {
                 varDsc->lvImplicitlyReferenced = 1;
             }
+        }
+
+        if (varDsc->lvPinned && varDsc->lvAllDefsAreNoGc)
+        {
+            varDsc->lvPinned = 0;
+
+            JITDUMP("V%02u was unpinned as all def candidates were local.\n", lclNum);
         }
     }
 }


### PR DESCRIPTION
This unpins pinned locals when the pinned address is pointing to the stack. This does not cover Spans created with stackalloc's as tracking them requires more extensive state keeping.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1807922&view=ms.vss-build-web.run-extensions-tab)

Example:
```diff
 ; 0 inlinees with PGO data; 1 single block inlinees; 0 inlinees without PGO data
 ; Final local variable assignments
 ;
-;  V00 loc0         [V00    ] (  2,  2   )    long  ->  [rsp+30H]   do-not-enreg[X] addr-exposed ld-addr-op
+;  V00 loc0         [V00    ] (  2,  2   )    long  ->  [rsp+20H]   do-not-enreg[X] addr-exposed ld-addr-op
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+00H]   "OutgoingArgSpace"
-;  V02 tmp1         [V02    ] (  4,  4   )   byref  ->  [rsp+28H]   pinned "Inline stloc first use temp"
+;  V02 tmp1         [V02,T01] (  2,  2   )   byref  ->  rcx         "Inline stloc first use temp"
 ;* V03 tmp2         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline stloc first use temp"
 ;  V04 tmp3         [V04,T00] (  2,  4   )    long  ->  rcx         "Cast away GC"
 ;
-; Lcl frame size = 56
+; Lcl frame size = 40

 G_M59712_IG01:              ;; offset=0000H
-       4883EC38             sub      rsp, 56
+       4883EC28             sub      rsp, 40
                                                 ;; size=4 bbWeight=1    PerfScore 0.25
 G_M59712_IG02:              ;; offset=0004H
-       488D4C2430           lea      rcx, bword ptr [rsp+30H]
-       48894C2428           mov      bword ptr [rsp+28H], rcx
-       488B4C2428           mov      rcx, bword ptr [rsp+28H]
+       488D4C2420           lea      rcx, bword ptr [rsp+20H]
        48B8105C861DFF7F0000 mov      rax, 0x7FFF1D865C10
-                                                ;; size=25 bbWeight=1    PerfScore 2.75
-G_M59712_IG03:              ;; offset=001DH
+                                                ;; size=15 bbWeight=1    PerfScore 0.75
+G_M59712_IG03:              ;; offset=0013H
        FFD0                 call     rax ; Program:QueryPerformanceCounter(long):int
-       33C0                 xor      eax, eax
-       4889442428           mov      bword ptr [rsp+28H], rax
-       4889442428           mov      bword ptr [rsp+28H], rax
-       833DC6E8FE5F00       cmp      dword ptr [(reloc 0x7ffe32111cf8)], 0
+       833DDCE8016000       cmp      dword ptr [(reloc 0x7ffe32111cf8)], 0
        750A                 jne      SHORT G_M59712_IG06
-                                                ;; size=23 bbWeight=1    PerfScore 9.25
-G_M59712_IG04:              ;; offset=0034H
-       488B442430           mov      rax, qword ptr [rsp+30H]
+                                                ;; size=11 bbWeight=1    PerfScore 7.00
+G_M59712_IG04:              ;; offset=001EH
+       488B442420           mov      rax, qword ptr [rsp+20H]
                                                 ;; size=5 bbWeight=1    PerfScore 1.00
-G_M59712_IG05:              ;; offset=0039H
-       4883C438             add      rsp, 56
+G_M59712_IG05:              ;; offset=0023H
+       4883C428             add      rsp, 40
        C3                   ret
                                                 ;; size=5 bbWeight=1    PerfScore 1.25
-G_M59712_IG06:              ;; offset=003EH
-       E88D77715E           call     CORINFO_HELP_POLL_GC
+G_M59712_IG06:              ;; offset=0028H
+       E8A377745E           call     CORINFO_HELP_POLL_GC
        EBEF                 jmp      SHORT G_M59712_IG04
                                                 ;; size=7 bbWeight=0    PerfScore 0.00

-; Total bytes of code 69, prolog size 4, PerfScore 21.40, instruction count 16, allocated bytes for code 69 (MethodHash=6ac616bf) for method Program:JitDisam():long
-; ============================================================
-
+; Total bytes of code 47, prolog size 4, PerfScore 14.95, instruction count 11, allocated bytes for code 47 (MethodHash=6ac616bf) for method Program:JitDisam():long
```
Contributes #40553