### PR TITLE
Always use portable tailcalling mechanism for delegate tailcalls

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5649,7 +5649,7 @@ private:
 #endif
     bool     fgCheckStmtAfterTailCall();
     GenTree* fgMorphTailCallViaHelpers(GenTreeCall* call, CORINFO_TAILCALL_HELPERS& help);
-    bool fgCanTailCallViaJitHelper();
+    bool fgCanTailCallViaJitHelper(GenTreeCall* call);
     void fgMorphTailCallViaJitHelper(GenTreeCall* call);
     GenTree* fgCreateCallDispatcherAndGetResult(GenTreeCall*          origCall,
                                                 CORINFO_METHOD_HANDLE callTargetStubHnd,

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6645,7 +6645,7 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
 
         // On x86 we have a faster mechanism than the general one which we use
         // in almost all cases. See fgCanTailCallViaJitHelper for more information.
-        if (fgCanTailCallViaJitHelper())
+        if (fgCanTailCallViaJitHelper(call))
         {
             tailCallViaJitHelper = true;
         }
@@ -17688,10 +17688,13 @@ bool Compiler::fgCheckStmtAfterTailCall()
 // fgCanTailCallViaJitHelper: check whether we can use the faster tailcall
 // JIT helper on x86.
 //
+// Arguments:
+//   call - the tailcall
+//
 // Return Value:
 //    'true' if we can; or 'false' if we should use the generic tailcall mechanism.
 //
-bool Compiler::fgCanTailCallViaJitHelper()
+bool Compiler::fgCanTailCallViaJitHelper(GenTreeCall* call)
 {
 #if !defined(TARGET_X86) || defined(UNIX_X86_ABI)
     // On anything except windows X86 we have no faster mechanism available.
@@ -17700,11 +17703,22 @@ bool Compiler::fgCanTailCallViaJitHelper()
     // For R2R make sure we go through portable mechanism that the 'EE' side
     // will properly turn into a runtime JIT.
     if (opts.IsReadyToRun())
+    {
         return false;
+    }
 
     // The JIT helper does not properly handle the case where localloc was used.
     if (compLocallocUsed)
+    {
         return false;
+    }
+
+    // Delegate calls may go through VSD stub in rare cases. Those look at the
+    // call site so we cannot use the JIT helper.
+    if (call->IsDelegateInvoke())
+    {
+        return false;
+    }
 
     return true;
 #endif

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70259/Runtime_70259.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70259/Runtime_70259.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Note: This test file is the source of the Runtime_70259.il file. It requires
+// InlineIL.Fody to compile. It is not used as anything but a reference of that
+// IL file.
+
+using InlineIL;
+using System;
+using System.Runtime.CompilerServices;
+
+class Runtime_70259
+{
+    private static int Main()
+    {
+        // This creates an open delegate that goes through shuffle thunk and then VSD stub.
+        C c = new C();
+        c.Delegate = typeof(IFace).GetMethod("Method").CreateDelegate<Func<IFace, int, int>>();
+
+        // Do a static call to C.Method to get started -- this is needed to get
+        // a call site of the form `call [rel32]` which triggers the bug.
+        IL.Push(c);
+        IL.Push(100_000);
+        IL.Emit.Call(new MethodRef(typeof(C), nameof(C.Method)));
+        return IL.Return<int>();
+    }
+
+    interface IFace
+    {
+        int Method(int left);
+    }
+
+    class C : IFace
+    {
+        public Func<IFace, int, int> Delegate;
+
+        [SkipLocalsInit]
+        public virtual int Method(int left)
+        {
+            if (left == 0)
+                return 100;
+
+            LargeStruct s;
+            Consume(s);
+
+            IL.Push(Delegate);
+            IL.Push(this);
+            IL.Push(left - 1);
+            IL.Emit.Tail();
+            IL.Emit.Call(new MethodRef(typeof(Func<IFace, int, int>), "Invoke"));
+            return IL.Return<int>();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Consume(in LargeStruct s) { }
+
+        private unsafe struct LargeStruct
+        {
+            public fixed byte Bytes[1024];
+        }
+    }
+}
+

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70259/Runtime_70259.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70259/Runtime_70259.il
@@ -13,12 +13,12 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
   .ver 7:0:0:0
 }
-.assembly playground
+.assembly Runtime_70259
 {
 }
-.module playground.dll
+.module Runtime_70259.dll
 // MVID: {78ECA09B-26A9-44BB-9FD2-D94B639A44D5}
-.custom instance void [System.Runtime]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+.custom instance void [System.Runtime]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 )
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
@@ -34,7 +34,7 @@
 {
   .class interface abstract auto ansi nested private IFace
   {
-    .method public hidebysig newslot abstract virtual 
+    .method public hidebysig newslot abstract virtual
             instance int32  Method() cil managed
     {
     } // end of method IFace::Method
@@ -45,7 +45,7 @@
          extends [System.Runtime]System.Object
          implements Runtime_70259/IFace
   {
-    .method public hidebysig newslot virtual 
+    .method public hidebysig newslot virtual
             instance int32  Method() cil managed
     {
       // Code size       3 (0x3)
@@ -54,7 +54,7 @@
       IL_0002:  ret
     } // end of method C::Method
 
-    .method public hidebysig specialname rtspecialname 
+    .method public hidebysig specialname rtspecialname
             instance void  .ctor() cil managed
     {
       // Code size       7 (0x7)
@@ -66,7 +66,7 @@
 
   } // end of class C
 
-  .method private hidebysig static int32 
+  .method private hidebysig static int32
           Main() cil managed
   {
     .entrypoint
@@ -81,7 +81,7 @@
     IL_001e:  ret
   } // end of method Runtime_70259::Main
 
-  .method private hidebysig static int32 
+  .method private hidebysig static int32
           CallMe(class [System.Runtime]System.Func`2<class Runtime_70259/IFace,int32> del) cil managed noinlining
   {
     // Code size       14 (0xe)
@@ -93,7 +93,7 @@
     IL_000d:  ret
   } // end of method Runtime_70259::CallMe
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70259/Runtime_70259.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70259/Runtime_70259.il
@@ -1,10 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Note: This file is produced from Runtime_70259.cs.
-
+// See Runtime_70259.cs.
 
 //  Microsoft (R) .NET IL Disassembler.  Version 7.0.0-dev
+
+
 
 // Metadata version: v4.0.30319
 .assembly extern System.Runtime
@@ -16,14 +17,14 @@
 {
 }
 .module playground.dll
-// MVID: {D76932D2-B329-4511-BC19-7A4B6B78D720}
-.custom instance void [System.Runtime]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 )
+// MVID: {78ECA09B-26A9-44BB-9FD2-D94B639A44D5}
+.custom instance void [System.Runtime]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000027337C40000
+// Image base: 0x000001F5DF740000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -33,8 +34,8 @@
 {
   .class interface abstract auto ansi nested private IFace
   {
-    .method public hidebysig newslot abstract virtual
-            instance int32  Method(int32 left) cil managed
+    .method public hidebysig newslot abstract virtual 
+            instance int32  Method() cil managed
     {
     } // end of method IFace::Method
 
@@ -44,70 +45,16 @@
          extends [System.Runtime]System.Object
          implements Runtime_70259/IFace
   {
-    .class sequential ansi sealed nested private beforefieldinit LargeStruct
-           extends [System.Runtime]System.ValueType
+    .method public hidebysig newslot virtual 
+            instance int32  Method() cil managed
     {
-      .class sequential ansi sealed nested public beforefieldinit '<Bytes>e__FixedBuffer'
-             extends [System.Runtime]System.ValueType
-      {
-        .pack 0
-        .size 1024
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.UnsafeValueTypeAttribute::.ctor() = ( 01 00 00 00 )
-        .field public uint8 FixedElementField
-      } // end of class '<Bytes>e__FixedBuffer'
-
-      .field public valuetype Runtime_70259/C/LargeStruct/'<Bytes>e__FixedBuffer' Bytes
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.FixedBufferAttribute::.ctor(class [System.Runtime]System.Type,
-                                                                                                        int32) = ( 01 00 5E 53 79 73 74 65 6D 2E 42 79 74 65 2C 20   // ..^System.Byte,
-                                                                                                                   53 79 73 74 65 6D 2E 52 75 6E 74 69 6D 65 2C 20   // System.Runtime,
-                                                                                                                   56 65 72 73 69 6F 6E 3D 37 2E 30 2E 30 2E 30 2C   // Version=7.0.0.0,
-                                                                                                                   20 43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C   //  Culture=neutral
-                                                                                                                   2C 20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E   // , PublicKeyToken
-                                                                                                                   3D 62 30 33 66 35 66 37 66 31 31 64 35 30 61 33   // =b03f5f7f11d50a3
-                                                                                                                   61 00 04 00 00 00 00 )                            // a......
-    } // end of class LargeStruct
-
-    .field public class [System.Runtime]System.Func`3<class Runtime_70259/IFace,int32,int32> Delegate
-    .method public hidebysig newslot virtual
-            instance int32  Method(int32 left) cil managed
-    {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.SkipLocalsInitAttribute::.ctor() = ( 01 00 00 00 )
-      // Code size       32 (0x20)
-      .maxstack  4
-      .locals (valuetype Runtime_70259/C/LargeStruct V_0)
-      IL_0000:  ldarg.1
-      IL_0001:  brtrue.s   IL_0006
-
-      IL_0003:  ldc.i4.s   100
-      IL_0005:  ret
-
-      IL_0006:  ldarg.0
-      IL_0007:  ldloca.s   V_0
-      IL_0009:  call       instance void Runtime_70259/C::Consume(valuetype Runtime_70259/C/LargeStruct&)
-      IL_000e:  ldarg.0
-      IL_000f:  ldfld      class [System.Runtime]System.Func`3<class Runtime_70259/IFace,int32,int32> Runtime_70259/C::Delegate
-      IL_0014:  ldarg.0
-      IL_0015:  ldarg.1
-      IL_0016:  ldc.i4.1
-      IL_0017:  sub
-      IL_0018:  tail.
-      IL_001a:  call       instance !2 class [System.Runtime]System.Func`3<class Runtime_70259/IFace,int32,int32>::Invoke(!0,
-                                                                                                                          !1)
-      IL_001f:  ret
+      // Code size       3 (0x3)
+      .maxstack  8
+      IL_0000:  ldc.i4.s   100
+      IL_0002:  ret
     } // end of method C::Method
 
-    .method private hidebysig instance void
-            Consume([in] valuetype Runtime_70259/C/LargeStruct& s) cil managed noinlining
-    {
-      .param [1]
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
-      // Code size       1 (0x1)
-      .maxstack  8
-      IL_0000:  ret
-    } // end of method C::Consume
-
-    .method public hidebysig specialname rtspecialname
+    .method public hidebysig specialname rtspecialname 
             instance void  .ctor() cil managed
     {
       // Code size       7 (0x7)
@@ -119,26 +66,34 @@
 
   } // end of class C
 
-  .method private hidebysig static int32
+  .method private hidebysig static int32 
           Main() cil managed
   {
     .entrypoint
-    // Code size       47 (0x2f)
-    .maxstack  4
-    IL_0000:  newobj     instance void Runtime_70259/C::.ctor()
-    IL_0005:  dup
-    IL_0006:  ldtoken    Runtime_70259/IFace
-    IL_000b:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-    IL_0010:  ldstr      "Method"
-    IL_0015:  call       instance class [System.Runtime]System.Reflection.MethodInfo [System.Runtime]System.Type::GetMethod(string)
-    IL_001a:  callvirt   instance !!0 [System.Runtime]System.Reflection.MethodInfo::CreateDelegate<class [System.Runtime]System.Func`3<class Runtime_70259/IFace,int32,int32>>()
-    IL_001f:  stfld      class [System.Runtime]System.Func`3<class Runtime_70259/IFace,int32,int32> Runtime_70259/C::Delegate
-    IL_0024:  ldc.i4     0x186a0
-    IL_0029:  call       instance int32 Runtime_70259/C::Method(int32)
-    IL_002e:  ret
+    // Code size       31 (0x1f)
+    .maxstack  8
+    IL_0000:  ldtoken    Runtime_70259/IFace
+    IL_0005:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_000a:  ldstr      "Method"
+    IL_000f:  call       instance class [System.Runtime]System.Reflection.MethodInfo [System.Runtime]System.Type::GetMethod(string)
+    IL_0014:  callvirt   instance !!0 [System.Runtime]System.Reflection.MethodInfo::CreateDelegate<class [System.Runtime]System.Func`2<class Runtime_70259/IFace,int32>>()
+    IL_0019:  call       int32 Runtime_70259::CallMe(class [System.Runtime]System.Func`2<class Runtime_70259/IFace,int32>)
+    IL_001e:  ret
   } // end of method Runtime_70259::Main
 
-  .method public hidebysig specialname rtspecialname
+  .method private hidebysig static int32 
+          CallMe(class [System.Runtime]System.Func`2<class Runtime_70259/IFace,int32> del) cil managed noinlining
+  {
+    // Code size       14 (0xe)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  newobj     instance void Runtime_70259/C::.ctor()
+    IL_0006:  tail.
+    IL_0008:  call       instance !1 class [System.Runtime]System.Func`2<class Runtime_70259/IFace,int32>::Invoke(!0)
+    IL_000d:  ret
+  } // end of method Runtime_70259::CallMe
+
+  .method public hidebysig specialname rtspecialname 
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -149,7 +104,6 @@
   } // end of method Runtime_70259::.ctor
 
 } // end of class Runtime_70259
-
 
 // =============================================================
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70259/Runtime_70259.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70259/Runtime_70259.il
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Note: This file is produced from Runtime_70259.cs.
+
+
+//  Microsoft (R) .NET IL Disassembler.  Version 7.0.0-dev
+
+// Metadata version: v4.0.30319
+.assembly extern System.Runtime
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 7:0:0:0
+}
+.assembly playground
+{
+}
+.module playground.dll
+// MVID: {D76932D2-B329-4511-BC19-7A4B6B78D720}
+.custom instance void [System.Runtime]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 )
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+// Image base: 0x0000027337C40000
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class private auto ansi beforefieldinit Runtime_70259
+       extends [System.Runtime]System.Object
+{
+  .class interface abstract auto ansi nested private IFace
+  {
+    .method public hidebysig newslot abstract virtual
+            instance int32  Method(int32 left) cil managed
+    {
+    } // end of method IFace::Method
+
+  } // end of class IFace
+
+  .class auto ansi nested private beforefieldinit C
+         extends [System.Runtime]System.Object
+         implements Runtime_70259/IFace
+  {
+    .class sequential ansi sealed nested private beforefieldinit LargeStruct
+           extends [System.Runtime]System.ValueType
+    {
+      .class sequential ansi sealed nested public beforefieldinit '<Bytes>e__FixedBuffer'
+             extends [System.Runtime]System.ValueType
+      {
+        .pack 0
+        .size 1024
+        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [System.Runtime]System.Runtime.CompilerServices.UnsafeValueTypeAttribute::.ctor() = ( 01 00 00 00 )
+        .field public uint8 FixedElementField
+      } // end of class '<Bytes>e__FixedBuffer'
+
+      .field public valuetype Runtime_70259/C/LargeStruct/'<Bytes>e__FixedBuffer' Bytes
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.FixedBufferAttribute::.ctor(class [System.Runtime]System.Type,
+                                                                                                        int32) = ( 01 00 5E 53 79 73 74 65 6D 2E 42 79 74 65 2C 20   // ..^System.Byte,
+                                                                                                                   53 79 73 74 65 6D 2E 52 75 6E 74 69 6D 65 2C 20   // System.Runtime,
+                                                                                                                   56 65 72 73 69 6F 6E 3D 37 2E 30 2E 30 2E 30 2C   // Version=7.0.0.0,
+                                                                                                                   20 43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C   //  Culture=neutral
+                                                                                                                   2C 20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E   // , PublicKeyToken
+                                                                                                                   3D 62 30 33 66 35 66 37 66 31 31 64 35 30 61 33   // =b03f5f7f11d50a3
+                                                                                                                   61 00 04 00 00 00 00 )                            // a......
+    } // end of class LargeStruct
+
+    .field public class [System.Runtime]System.Func`3<class Runtime_70259/IFace,int32,int32> Delegate
+    .method public hidebysig newslot virtual
+            instance int32  Method(int32 left) cil managed
+    {
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.SkipLocalsInitAttribute::.ctor() = ( 01 00 00 00 )
+      // Code size       32 (0x20)
+      .maxstack  4
+      .locals (valuetype Runtime_70259/C/LargeStruct V_0)
+      IL_0000:  ldarg.1
+      IL_0001:  brtrue.s   IL_0006
+
+      IL_0003:  ldc.i4.s   100
+      IL_0005:  ret
+
+      IL_0006:  ldarg.0
+      IL_0007:  ldloca.s   V_0
+      IL_0009:  call       instance void Runtime_70259/C::Consume(valuetype Runtime_70259/C/LargeStruct&)
+      IL_000e:  ldarg.0
+      IL_000f:  ldfld      class [System.Runtime]System.Func`3<class Runtime_70259/IFace,int32,int32> Runtime_70259/C::Delegate
+      IL_0014:  ldarg.0
+      IL_0015:  ldarg.1
+      IL_0016:  ldc.i4.1
+      IL_0017:  sub
+      IL_0018:  tail.
+      IL_001a:  call       instance !2 class [System.Runtime]System.Func`3<class Runtime_70259/IFace,int32,int32>::Invoke(!0,
+                                                                                                                          !1)
+      IL_001f:  ret
+    } // end of method C::Method
+
+    .method private hidebysig instance void
+            Consume([in] valuetype Runtime_70259/C/LargeStruct& s) cil managed noinlining
+    {
+      .param [1]
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
+      // Code size       1 (0x1)
+      .maxstack  8
+      IL_0000:  ret
+    } // end of method C::Consume
+
+    .method public hidebysig specialname rtspecialname
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method C::.ctor
+
+  } // end of class C
+
+  .method private hidebysig static int32
+          Main() cil managed
+  {
+    .entrypoint
+    // Code size       47 (0x2f)
+    .maxstack  4
+    IL_0000:  newobj     instance void Runtime_70259/C::.ctor()
+    IL_0005:  dup
+    IL_0006:  ldtoken    Runtime_70259/IFace
+    IL_000b:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_0010:  ldstr      "Method"
+    IL_0015:  call       instance class [System.Runtime]System.Reflection.MethodInfo [System.Runtime]System.Type::GetMethod(string)
+    IL_001a:  callvirt   instance !!0 [System.Runtime]System.Reflection.MethodInfo::CreateDelegate<class [System.Runtime]System.Func`3<class Runtime_70259/IFace,int32,int32>>()
+    IL_001f:  stfld      class [System.Runtime]System.Func`3<class Runtime_70259/IFace,int32,int32> Runtime_70259/C::Delegate
+    IL_0024:  ldc.i4     0x186a0
+    IL_0029:  call       instance int32 Runtime_70259/C::Method(int32)
+    IL_002e:  ret
+  } // end of method Runtime_70259::Main
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method Runtime_70259::.ctor
+
+} // end of class Runtime_70259
+
+
+// =============================================================
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70259/Runtime_70259.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70259/Runtime_70259.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1496,7 +1496,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/ShiftOperations/*">
           <Issue>There is a known undefined behavior with shifts and 0xFFFFFFFF overflows, so skip the test for mono.</Issue>
         </ExcludeList>
-      
+
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTestWithMcj/*">
             <Issue>Tests features specific to coreclr</Issue>
         </ExcludeList>
@@ -2215,6 +2215,9 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/Assembly_True_False/Assembly_True_False/*">
             <Issue>Mono doesn't support interop BestFitMapping and ThrowOnUnmappableChar attributes</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_70259/Runtime_70259/*">
+            <Issue>https://github.com/dotnet/runtime/issues/70279</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
It is rare but possible to have delegates that point to VSD stubs. Since
VSD stubs on x86 may disassemble the call-site we cannot allow tail
calling these with the old mechanism.

Fix #70259