### PR TITLE
Fix lazy loop backtracking uncapture in compiled regexes

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -3379,8 +3379,9 @@ namespace System.Text.RegularExpressions.Generator
                     // and thus it needs to be pushed on to the backtracking stack.
                     bool isInLoop = rm.Analysis.IsInLoop(node);
                     EmitStackPush(
-                        !isInLoop ? new[] { "pos" } :
-                        iterationMayBeEmpty ? new[] { "pos", iterationCount, startingPos!, sawEmpty! } :
+                        !isInLoop ? (expressionHasCaptures ? new[] { "pos", "base.Crawlpos()" } : new[] { "pos" }) :
+                        iterationMayBeEmpty ? (expressionHasCaptures ? new[] { "pos", iterationCount, startingPos!, sawEmpty!, "base.Crawlpos()" } : new[] { "pos", iterationCount, startingPos!, sawEmpty! }) :
+                        expressionHasCaptures ? new[] { "pos", iterationCount, "base.Crawlpos()"} :
                         new[] { "pos", iterationCount });
 
                     string skipBacktrack = ReserveName("LazyLoopSkipBacktrack");
@@ -3395,6 +3396,10 @@ namespace System.Text.RegularExpressions.Generator
                     // We're backtracking.  Check the timeout.
                     EmitTimeoutCheckIfNeeded(writer, rm);
 
+                    if (expressionHasCaptures)
+                    {
+                        EmitUncaptureUntil(StackPop());
+                    }
                     EmitStackPop(
                         !isInLoop ? new[] { "pos" } :
                         iterationMayBeEmpty ? new[] { sawEmpty!, startingPos!, iterationCount, "pos" } :

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.KnownPattern.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.KnownPattern.Tests.cs
@@ -1378,12 +1378,6 @@ namespace System.Text.RegularExpressions.Tests
         {
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
             {
-                if (engine != RegexEngine.Interpreter)
-                {
-                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/69381")]
-                    continue;
-                }
-
                 if (RegexHelpers.IsNonBacktracking(engine))
                 {
                     // NonBacktracking doesn't support lookarounds or balancing groups
@@ -1413,6 +1407,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         [MemberData(nameof(RecreationalRegex_Rectangle_MemberData))]
+        [OuterLoop("May take several seconds")]
         public async Task RecreationalRegex_Rectangle(RegexEngine engine, string input, bool expectedMatch)
         {
             Regex r = await RegexHelpers.GetRegexAsync(engine, @"

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1476,6 +1476,49 @@ namespace System.Text.RegularExpressions.Tests
                     }
                 };
 
+                // Validate captures after backtracking constructs are uncaptured when backtracking
+                foreach (string lazy in new[] { "", "?" })
+                {
+                    yield return new object[]
+                    {
+                        engine,
+                        $"^a+{lazy}(a)$", "aaaa", RegexOptions.None, 0, 4,
+                        new CaptureData[]
+                        {
+                            new CaptureData("aaaa", 0, 4),
+                            new CaptureData("a", 3, 1)
+                        }
+                    };
+
+                    yield return new object[]
+                    {
+                        engine,
+                        $"^(a)+{lazy}(a)$", "aaaa", RegexOptions.None, 0, 4,
+                        new CaptureData[]
+                        {
+                            new CaptureData("aaaa", 0, 4),
+                            new CaptureData("a", 2, 1, new CaptureData[]
+                            {
+                                new CaptureData("a", 0, 1),
+                                new CaptureData("a", 1, 1),
+                                new CaptureData("a", 2, 1),
+                            }),
+                            new CaptureData("a", 3, 1)
+                        }
+                    };
+                }
+                yield return new object[]
+                {
+                    engine,
+                    $"^(|a)aa(a)$", "aaaa", RegexOptions.None, 0, 4,
+                    new CaptureData[]
+                    {
+                        new CaptureData("aaaa", 0, 4),
+                        new CaptureData("a", 0, 1),
+                        new CaptureData("a", 3, 1)
+                    }
+                };
+
                 if (!RegexHelpers.IsNonBacktracking(engine))
                 {
                     // Zero-width positive lookahead assertion: Actual - "abc(?=XXX)\\w+"


### PR DESCRIPTION
When a lazy loop backtracks, we should be uncapturing everything after the loop, but we're failing to do so.  As we do elsewhere, we need to store the current capture position and then uncapture until that position when backtracking.

Fixes https://github.com/dotnet/runtime/issues/69381
cc: @joperezr, @kobi