### PR TITLE
Update libraries' building docs for native components

### DIFF
--- a/docs/workflow/building/libraries/README.md
+++ b/docs/workflow/building/libraries/README.md
@@ -119,7 +119,7 @@ The libraries build contains some native code. This includes shims over libc, op
 - Building and updating the binplace (for e.g. the testhost), which is needed when iterating on native components
 ```bash
 dotnet.sh build src/native/libraries/build-native.proj
-``` 
+```
 
 - The following example shows how you would do an arm cross-compile build
 ```bash

--- a/docs/workflow/building/libraries/README.md
+++ b/docs/workflow/building/libraries/README.md
@@ -116,6 +116,11 @@ The libraries build contains some native code. This includes shims over libc, op
 ./src/native/libs/build-native.sh debug x64
 ```
 
+- Building and updating the binplace (for e.g. the testhost), which is needed when iterating on native components
+```bash
+dotnet.sh build src/native/libraries/build-native.proj
+``` 
+
 - The following example shows how you would do an arm cross-compile build
 ```bash
 ./src/native/libs/build-native.sh debug arm cross verbose

--- a/src/native/libs/ReadMe.md
+++ b/src/native/libs/ReadMe.md
@@ -1,0 +1,3 @@
+For information on how to build, how to update the binplacing of the native artifacts please refer to 
+[How to building native components only](../../../docs/workflow/building/libraries/ReadMe.md#how-to-building-native-components-only)
+section in the libraries' building document.

--- a/src/native/libs/ReadMe.md
+++ b/src/native/libs/ReadMe.md
@@ -1,3 +1,3 @@
-For information on how to build, how to update the binplacing of the native artifacts please refer to 
+For information on how to build, how to update the binplacing of the native artifacts please refer to
 [How to building native components only](../../../docs/workflow/building/libraries/ReadMe.md#how-to-building-native-components-only)
 section in the libraries' building document.

--- a/src/native/libs/ReadMe.md
+++ b/src/native/libs/ReadMe.md
@@ -1,3 +1,3 @@
 For information on how to build, how to update the binplacing of the native artifacts please refer to
-[How to building native components only](../../../docs/workflow/building/libraries/ReadMe.md#how-to-building-native-components-only)
+[How to building native components only](../../../docs/workflow/building/libraries/README.md#how-to-building-native-components-only)
 section in the libraries' building document.


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/70134

For me this information is enough, as now I have a reference to look at on how to update the native components.
It's helpful when iterating on the native components, and to update the testhost with the new native binaries.

In the `src/native/libs` a very short ReadMe.md got added, that links to the more details libraries's build documentation.
I'm not sure if this is striclty needed, but I find it helpful, as when navigating to that folder and I see `build-native.sh` then I'd run this script, and wonder why the testhost isn't updated. With the ReadMe in place, it's a nice remainder on how to build the native side actually.

/cc: @ViktorHofer 