### PR TITLE
CMake support in VS open folder for coreclr

### DIFF
--- a/src/coreclr/CMakeSettings.json
+++ b/src/coreclr/CMakeSettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "configurations": [
+    {
+      "name": "windows.x64.Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64" ],
+      "buildRoot": "${projectDir}\\..\\..\\artifacts\\obj\\coreclr\\${name}",
+      "installRoot": "${projectDir}\\..\\..\\artifacts\\bin\\coreclr\\${name}",
+      "cmakeCommandArgs": "-DCLR_CMAKE_HOST_ARCH=x64",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    }
+  ]
+}

--- a/src/coreclr/CMakeSettings.json
+++ b/src/coreclr/CMakeSettings.json
@@ -1,15 +1,101 @@
 ﻿{
+  "environments": [
+    {
+      "artifactsBin": "${projectDir}\\..\\..\\artifacts\\bin\\coreclr",
+      "artifactsObj": "${projectDir}\\..\\..\\artifacts\\obj\\coreclr"
+    }
+  ],
   "configurations": [
     {
       "name": "windows.x64.Debug",
       "generator": "Ninja",
       "configurationType": "Debug",
-      "inheritEnvironments": [ "msvc_x64" ],
-      "buildRoot": "${projectDir}\\..\\..\\artifacts\\obj\\coreclr\\${name}",
-      "installRoot": "${projectDir}\\..\\..\\artifacts\\bin\\coreclr\\${name}",
+      "buildRoot": "${env.artifactsObj}\\${name}",
+      "installRoot": "${env.artifactsBin}\\${name}",
       "cmakeCommandArgs": "-DCLR_CMAKE_HOST_ARCH=x64",
       "buildCommandArgs": "",
-      "ctestCommandArgs": ""
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64" ]
+    },
+    {
+      "name": "windows.x64.Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${env.artifactsObj}\\${name}",
+      "installRoot": "${env.artifactsBin}\\${name}",
+      "cmakeCommandArgs": "-DCLR_CMAKE_HOST_ARCH=x64",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64" ]
+    },
+    {
+      "name": "windows.x86.Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${env.artifactsObj}\\${name}",
+      "installRoot": "${env.artifactsBin}\\${name}",
+      "cmakeCommandArgs": "-DCLR_CMAKE_HOST_ARCH=x86",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x86" ]
+    },
+    {
+      "name": "windows.x86.Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${env.artifactsObj}\\${name}",
+      "installRoot": "${env.artifactsBin}\\${name}",
+      "cmakeCommandArgs": "-DCLR_CMAKE_HOST_ARCH=x86",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x86" ]
+    },
+    {
+      "name": "windows.arm.Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${env.artifactsObj}\\${name}",
+      "installRoot": "${env.artifactsBin}\\${name}",
+      "cmakeCommandArgs": "-DCLR_CMAKE_HOST_ARCH=arm",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_arm" ]
+    },
+    {
+      "name": "windows.arm.Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${env.artifactsObj}\\${name}",
+      "installRoot": "${env.artifactsBin}\\${name}",
+      "cmakeCommandArgs": "-DCLR_CMAKE_HOST_ARCH=arm",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_arm" ],
+      "variables": []
+    },
+    {
+      "name": "windows.arm64.Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${env.artifactsObj}\\${name}",
+      "installRoot": "${env.artifactsBin}\\${name}",
+      "cmakeCommandArgs": "-DCLR_CMAKE_HOST_ARCH=arm64",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_arm64" ],
+      "variables": []
+    },
+    {
+      "name": "windows.arm64.Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${env.artifactsObj}\\${name}",
+      "installRoot": "${env.artifactsBin}\\${name}",
+      "cmakeCommandArgs": "-DCLR_CMAKE_HOST_ARCH=arm64",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_arm64" ],
+      "variables": []
     }
   ]
 }


### PR DESCRIPTION
#40049

I don't add remote Linux support because I don't have the environment set.

Making it build is quite easy at least for Windows MSVC. Making debugger works is somehow complicated.

Note: after playing with CMake a while and deleting coreclr artifacts for some times, `build.cmd clr` is failing for can't find `bin\coreclr\Windows.x64.Debug\dotnet-pgo\shims\...`. Is it caused by some build steps not included?