### PR TITLE
Rename TarFormat to TarEntryFormat

### DIFF
--- a/src/libraries/System.Formats.Tar/ref/System.Formats.Tar.cs
+++ b/src/libraries/System.Formats.Tar/ref/System.Formats.Tar.cs
@@ -42,6 +42,14 @@ namespace System.Formats.Tar
         public void ExtractToFile(string destinationFileName, bool overwrite) { }
         public override string ToString() { throw null; }
     }
+    public enum TarEntryFormat
+    {
+        Unknown = 0,
+        V7 = 1,
+        Ustar = 2,
+        Pax = 3,
+        Gnu = 4,
+    }
     public enum TarEntryType : byte
     {
         V7RegularFile = (byte)0,
@@ -87,18 +95,10 @@ namespace System.Formats.Tar
         GroupSpecial = 1024,
         UserSpecial = 2048,
     }
-    public enum TarFormat
-    {
-        Unknown = 0,
-        V7 = 1,
-        Ustar = 2,
-        Pax = 3,
-        Gnu = 4,
-    }
     public sealed partial class TarReader : System.IDisposable
     {
         public TarReader(System.IO.Stream archiveStream, bool leaveOpen = false) { }
-        public System.Formats.Tar.TarFormat Format { get { throw null; } }
+        public System.Formats.Tar.TarEntryFormat Format { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string>? GlobalExtendedAttributes { get { throw null; } }
         public void Dispose() { }
         public System.Formats.Tar.TarEntry? GetNextEntry(bool copyData = false) { throw null; }
@@ -106,8 +106,8 @@ namespace System.Formats.Tar
     public sealed partial class TarWriter : System.IDisposable
     {
         public TarWriter(System.IO.Stream archiveStream, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>? globalExtendedAttributes = null, bool leaveOpen = false) { }
-        public TarWriter(System.IO.Stream archiveStream, System.Formats.Tar.TarFormat archiveFormat, bool leaveOpen = false) { }
-        public System.Formats.Tar.TarFormat Format { get { throw null; } }
+        public TarWriter(System.IO.Stream archiveStream, System.Formats.Tar.TarEntryFormat archiveFormat, bool leaveOpen = false) { }
+        public System.Formats.Tar.TarEntryFormat Format { get { throw null; } }
         public void Dispose() { }
         public void WriteEntry(System.Formats.Tar.TarEntry entry) { }
         public void WriteEntry(string fileName, string? entryName) { }

--- a/src/libraries/System.Formats.Tar/src/System.Formats.Tar.csproj
+++ b/src/libraries/System.Formats.Tar/src/System.Formats.Tar.csproj
@@ -21,12 +21,12 @@
     <Compile Include="System\Formats\Tar\TarHeader.Write.cs" />
     <Compile Include="System\Formats\Tar\TarHelpers.cs" />
     <Compile Include="System\Formats\Tar\TarEntry.cs" />
+    <Compile Include="System\Formats\Tar\TarEntryFormat.cs" />
     <Compile Include="System\Formats\Tar\UstarTarEntry.cs" />
     <Compile Include="System\Formats\Tar\GnuTarEntry.cs" />
     <Compile Include="System\Formats\Tar\PaxTarEntry.cs" />
     <Compile Include="System\Formats\Tar\TarEntryType.cs" />
     <Compile Include="System\Formats\Tar\TarFile.cs" />
-    <Compile Include="System\Formats\Tar\TarFormat.cs" />
     <Compile Include="System\Formats\Tar\TarReader.cs" />
     <Compile Include="System\Formats\Tar\TarWriter.cs" />
     <Compile Include="System\Formats\Tar\SubReadStream.cs" />

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
@@ -6,7 +6,7 @@ namespace System.Formats.Tar
     /// <summary>
     /// Represents a tar entry from an archive of the GNU format.
     /// </summary>
-    /// <remarks>Even though the <see cref="TarFormat.Gnu"/> format is not POSIX compatible, it implements and supports the Unix-specific fields that were defined in the POSIX IEEE P1003.1 standard from 1988: <c>devmajor</c>, <c>devminor</c>, <c>gname</c> and <c>uname</c>.</remarks>
+    /// <remarks>Even though the <see cref="TarEntryFormat.Gnu"/> format is not POSIX compatible, it implements and supports the Unix-specific fields that were defined in the POSIX IEEE P1003.1 standard from 1988: <c>devmajor</c>, <c>devminor</c>, <c>gname</c> and <c>uname</c>.</remarks>
     public sealed class GnuTarEntry : PosixTarEntry
     {
         // Constructor used when reading an existing archive.
@@ -29,7 +29,7 @@ namespace System.Formats.Tar
         /// </list>
         /// </remarks>
         public GnuTarEntry(TarEntryType entryType, string entryName)
-            : base(entryType, entryName, TarFormat.Gnu)
+            : base(entryType, entryName, TarEntryFormat.Gnu)
         {
         }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxTarEntry.cs
@@ -50,7 +50,7 @@ namespace System.Formats.Tar
         /// </list>
         /// </remarks>
         public PaxTarEntry(TarEntryType entryType, string entryName)
-            : base(entryType, entryName, TarFormat.Pax)
+            : base(entryType, entryName, TarEntryFormat.Pax)
         {
         }
 
@@ -84,7 +84,7 @@ namespace System.Formats.Tar
         /// </list>
         /// </remarks>
         public PaxTarEntry(TarEntryType entryType, string entryName, IEnumerable<KeyValuePair<string, string>> extendedAttributes)
-            : base(entryType, entryName, TarFormat.Pax)
+            : base(entryType, entryName, TarEntryFormat.Pax)
         {
             ArgumentNullException.ThrowIfNull(extendedAttributes);
             _header.ReplaceNormalAttributesWithExtended(extendedAttributes);

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
@@ -4,10 +4,10 @@
 namespace System.Formats.Tar
 {
     /// <summary>
-    /// Abstract class that represents a tar entry from an archive of a format that is based on the POSIX IEEE P1003.1 standard from 1988. This includes the formats <see cref="TarFormat.Ustar"/> (represented by the <see cref="UstarTarEntry"/> class), <see cref="TarFormat.Pax"/> (represented by the <see cref="PaxTarEntry"/> class) and <see cref="TarFormat.Gnu"/> (represented by the <see cref="GnuTarEntry"/> class).
+    /// Abstract class that represents a tar entry from an archive of a format that is based on the POSIX IEEE P1003.1 standard from 1988. This includes the formats <see cref="TarEntryFormat.Ustar"/> (represented by the <see cref="UstarTarEntry"/> class), <see cref="TarEntryFormat.Pax"/> (represented by the <see cref="PaxTarEntry"/> class) and <see cref="TarEntryFormat.Gnu"/> (represented by the <see cref="GnuTarEntry"/> class).
     /// </summary>
     /// <remarks>Formats that implement the POSIX IEEE P1003.1 standard from 1988, support the following header fields: <c>devmajor</c>, <c>devminor</c>, <c>gname</c> and <c>uname</c>.
-    /// Even though the <see cref="TarFormat.Gnu"/> format is not POSIX compatible, it implements and supports the Unix-specific fields that were defined in that POSIX standard.</remarks>
+    /// Even though the <see cref="TarEntryFormat.Gnu"/> format is not POSIX compatible, it implements and supports the Unix-specific fields that were defined in that POSIX standard.</remarks>
     public abstract partial class PosixTarEntry : TarEntry
     {
         // Constructor used when reading an existing archive.
@@ -17,7 +17,7 @@ namespace System.Formats.Tar
         }
 
         // Constructor called when creating a new 'TarEntry*' instance that can be passed to a TarWriter.
-        internal PosixTarEntry(TarEntryType entryType, string entryName, TarFormat format)
+        internal PosixTarEntry(TarEntryType entryType, string entryName, TarEntryFormat format)
             : base(entryType, entryName, format)
         {
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -11,7 +11,7 @@ namespace System.Formats.Tar
     /// <summary>
     /// Abstract class that represents a tar entry from an archive.
     /// </summary>
-    /// <remarks>All the properties exposed by this class are supported by the <see cref="TarFormat.V7"/>, <see cref="TarFormat.Ustar"/>, <see cref="TarFormat.Pax"/> and <see cref="TarFormat.Gnu"/> formats.</remarks>
+    /// <remarks>All the properties exposed by this class are supported by the <see cref="TarEntryFormat.V7"/>, <see cref="TarEntryFormat.Ustar"/>, <see cref="TarEntryFormat.Pax"/> and <see cref="TarEntryFormat.Gnu"/> formats.</remarks>
     public abstract partial class TarEntry
     {
         internal TarHeader _header;
@@ -26,7 +26,7 @@ namespace System.Formats.Tar
         }
 
         // Constructor called when creating a new 'TarEntry*' instance that can be passed to a TarWriter.
-        internal TarEntry(TarEntryType entryType, string entryName, TarFormat format)
+        internal TarEntry(TarEntryType entryType, string entryName, TarEntryFormat format)
         {
             ArgumentException.ThrowIfNullOrEmpty(entryName);
 
@@ -93,7 +93,7 @@ namespace System.Formats.Tar
         /// <summary>
         /// When the <see cref="EntryType"/> indicates an entry that can contain data, this property returns the length in bytes of such data.
         /// </summary>
-        /// <remarks>The entry type that commonly contains data is <see cref="TarEntryType.RegularFile"/> (or <see cref="TarEntryType.V7RegularFile"/> in the <see cref="TarFormat.V7"/> format). Other uncommon entry types that can also contain data are: <see cref="TarEntryType.ContiguousFile"/>, <see cref="TarEntryType.DirectoryList"/>, <see cref="TarEntryType.MultiVolume"/> and <see cref="TarEntryType.SparseFile"/>.</remarks>
+        /// <remarks>The entry type that commonly contains data is <see cref="TarEntryType.RegularFile"/> (or <see cref="TarEntryType.V7RegularFile"/> in the <see cref="TarEntryFormat.V7"/> format). Other uncommon entry types that can also contain data are: <see cref="TarEntryType.ContiguousFile"/>, <see cref="TarEntryType.DirectoryList"/>, <see cref="TarEntryType.MultiVolume"/> and <see cref="TarEntryType.SparseFile"/>.</remarks>
         public long Length => _header._dataStream != null ? _header._dataStream.Length : _header._size;
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace System.Formats.Tar
         /// <value><para>Gets a stream that represents the data section of this entry.</para>
         /// <para>Sets a new stream that represents the data section, if it makes sense for the <see cref="EntryType"/> to contain data; if a stream already existed, the old stream gets disposed before substituting it with the new stream. Setting a <see langword="null"/> stream is allowed.</para></value>
         /// <remarks>If you write data to this data stream, make sure to rewind it to the desired start position before writing this entry into an archive using <see cref="TarWriter.WriteEntry(TarEntry)"/>.</remarks>
-        /// <exception cref="InvalidOperationException">Setting a data section is not supported because the <see cref="EntryType"/> is not <see cref="TarEntryType.RegularFile"/> (or <see cref="TarEntryType.V7RegularFile"/> for an archive of <see cref="TarFormat.V7"/> format).</exception>
+        /// <exception cref="InvalidOperationException">Setting a data section is not supported because the <see cref="EntryType"/> is not <see cref="TarEntryType.RegularFile"/> (or <see cref="TarEntryType.V7RegularFile"/> for an archive of <see cref="TarEntryFormat.V7"/> format).</exception>
         /// <exception cref="IOException"><para>Cannot set an unreadable stream.</para>
         /// <para>-or-</para>
         /// <para>An I/O problem occurred.</para></exception>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntryFormat.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntryFormat.cs
@@ -4,28 +4,28 @@
 namespace System.Formats.Tar
 {
     /// <summary>
-    /// Specifies the supported Tar formats.
+    /// Specifies the supported formats that tar entries can use.
     /// </summary>
-    public enum TarFormat
+    public enum TarEntryFormat
     {
         /// <summary>
-        /// Tar format undetermined.
+        /// Tar entry format undetermined.
         /// </summary>
         Unknown,
         /// <summary>
-        /// 1979 Version 7 AT&amp;T Unix Tar Command Format (v7).
+        /// 1979 Version 7 AT&amp;T Unix tar entry format.
         /// </summary>
         V7,
         /// <summary>
-        /// POSIX IEEE 1003.1-1988 Unix Standard Tar Format (ustar).
+        /// POSIX IEEE 1003.1-1988 Unix Standard tar entry format.
         /// </summary>
         Ustar,
         /// <summary>
-        /// POSIX IEEE 1003.1-2001 ("POSIX.1") Pax Interchange Tar Format (pax).
+        /// POSIX IEEE 1003.1-2001 ("POSIX.1") Pax Interchange tar entry format.
         /// </summary>
         Pax,
         /// <summary>
-        /// GNU Tar Format (gnu).
+        /// GNU tar entry format (gnu).
         /// </summary>
         Gnu,
     }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntryType.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntryType.cs
@@ -11,7 +11,7 @@ namespace System.Formats.Tar
     {
         /// <summary>
         /// <para>Regular file.</para>
-        /// <para>This entry type is specific to the <see cref="TarFormat.Ustar"/>, <see cref="TarFormat.Pax"/> and <see cref="TarFormat.Gnu"/> formats.</para>
+        /// <para>This entry type is specific to the <see cref="TarEntryFormat.Ustar"/>, <see cref="TarEntryFormat.Pax"/> and <see cref="TarEntryFormat.Gnu"/> formats.</para>
         /// </summary>
         RegularFile = (byte)'0',
         /// <summary>
@@ -43,7 +43,7 @@ namespace System.Formats.Tar
         Fifo = (byte)'6',
         /// <summary>
         /// <para>GNU contiguous file</para>
-        /// <para>This entry type is specific to the <see cref="TarFormat.Gnu"/> format, and is treated as a <see cref="RegularFile"/> entry type.</para>
+        /// <para>This entry type is specific to the <see cref="TarEntryFormat.Gnu"/> format, and is treated as a <see cref="RegularFile"/> entry type.</para>
         /// </summary>
         // According to the GNU spec, it's extremely rare to encounter a contiguous entry.
         ContiguousFile = (byte)'7',
@@ -59,7 +59,7 @@ namespace System.Formats.Tar
         GlobalExtendedAttributes = (byte)'g',
         /// <summary>
         /// <para>GNU directory with a list of entries.</para>
-        /// <para>This entry type is specific to the <see cref="TarFormat.Gnu"/> format, and is treated as a <see cref="Directory"/> entry type that contains a data section.</para>
+        /// <para>This entry type is specific to the <see cref="TarEntryFormat.Gnu"/> format, and is treated as a <see cref="Directory"/> entry type that contains a data section.</para>
         /// </summary>
         DirectoryList = (byte)'D',
         /// <summary>
@@ -74,27 +74,27 @@ namespace System.Formats.Tar
         LongPath = (byte)'L',
         /// <summary>
         /// <para>GNU multi-volume file.</para>
-        /// <para>This entry type is specific to the <see cref="TarFormat.Gnu"/> format and is not supported for writing.</para>
+        /// <para>This entry type is specific to the <see cref="TarEntryFormat.Gnu"/> format and is not supported for writing.</para>
         /// </summary>
         MultiVolume = (byte)'M',
         /// <summary>
         /// <para>V7 Regular file.</para>
-        /// <para>This entry type is specific to the <see cref="TarFormat.V7"/> format.</para>
+        /// <para>This entry type is specific to the <see cref="TarEntryFormat.V7"/> format.</para>
         /// </summary>
         V7RegularFile = (byte)'\0',
         /// <summary>
         /// <para>GNU file to be renamed/symlinked.</para>
-        /// <para>This entry type is specific to the <see cref="TarFormat.Gnu"/> format. It is considered unsafe and is ignored by other tools.</para>
+        /// <para>This entry type is specific to the <see cref="TarEntryFormat.Gnu"/> format. It is considered unsafe and is ignored by other tools.</para>
         /// </summary>
         RenamedOrSymlinked = (byte)'N',
         /// <summary>
         /// <para>GNU sparse file.</para>
-        /// <para>This entry type is specific to the <see cref="TarFormat.Gnu"/> format and is not supported for writing.</para>
+        /// <para>This entry type is specific to the <see cref="TarEntryFormat.Gnu"/> format and is not supported for writing.</para>
         /// </summary>
         SparseFile = (byte)'S',
         /// <summary>
         /// <para>GNU tape volume.</para>
-        /// <para>This entry type is specific to the <see cref="TarFormat.Gnu"/> format and is not supported for writing.</para>
+        /// <para>This entry type is specific to the <see cref="TarEntryFormat.Gnu"/> format and is not supported for writing.</para>
         /// </summary>
         TapeVolume = (byte)'V',
     }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
@@ -196,7 +196,7 @@ namespace System.Formats.Tar
             Debug.Assert(Path.IsPathFullyQualified(sourceDirectoryName));
             Debug.Assert(destination.CanWrite);
 
-            using (TarWriter writer = new TarWriter(destination, TarFormat.Pax, leaveOpen))
+            using (TarWriter writer = new TarWriter(destination, TarEntryFormat.Pax, leaveOpen))
             {
                 bool baseDirectoryIsEmpty = true;
                 DirectoryInfo di = new(sourceDirectoryName);

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -48,7 +48,7 @@ namespace System.Formats.Tar
         internal void WriteAsV7(Stream archiveStream, Span<byte> buffer)
         {
             long actualLength = GetTotalDataBytesToWrite();
-            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarFormat.V7);
+            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarEntryFormat.V7);
 
             int checksum = WriteName(buffer, out _);
             checksum += WriteCommonFields(buffer, actualLength, actualEntryType);
@@ -66,7 +66,7 @@ namespace System.Formats.Tar
         internal void WriteAsUstar(Stream archiveStream, Span<byte> buffer)
         {
             long actualLength = GetTotalDataBytesToWrite();
-            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarFormat.Ustar);
+            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarEntryFormat.Ustar);
 
             int checksum = WritePosixName(buffer);
             checksum += WriteCommonFields(buffer, actualLength, actualEntryType);
@@ -153,7 +153,7 @@ namespace System.Formats.Tar
             _gnuUnusedBytes ??= new byte[FieldLengths.AllGnuUnused];
 
             long actualLength = GetTotalDataBytesToWrite();
-            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarFormat.Gnu);
+            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarEntryFormat.Gnu);
 
             int checksum = WriteName(buffer, out _);
             checksum += WriteCommonFields(buffer, actualLength, actualEntryType);
@@ -194,7 +194,7 @@ namespace System.Formats.Tar
         private void WriteAsPaxInternal(Stream archiveStream, Span<byte> buffer)
         {
             long actualLength = GetTotalDataBytesToWrite();
-            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarFormat.Pax);
+            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarEntryFormat.Pax);
 
             int checksum = WritePosixName(buffer);
             checksum += WriteCommonFields(buffer, actualLength, actualEntryType);
@@ -275,9 +275,9 @@ namespace System.Formats.Tar
         // When writing an entry that came from an archive of a different format, if its entry type happens to
         // be an incompatible regular file entry type, convert it to the compatible one.
         // No change for all other entry types.
-        private TarEntryType GetCorrectTypeFlagForFormat(TarFormat format)
+        private TarEntryType GetCorrectTypeFlagForFormat(TarEntryFormat format)
         {
-            if (format is TarFormat.V7)
+            if (format is TarEntryFormat.V7)
             {
                 if (_typeFlag is TarEntryType.RegularFile)
                 {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -43,7 +43,7 @@ namespace System.Formats.Tar
         // Position in the stream where the data ends in this header.
         internal long _endOfHeaderAndDataAndBlockAlignment;
 
-        internal TarFormat _format;
+        internal TarEntryFormat _format;
 
         // Common attributes
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -179,11 +179,11 @@ namespace System.Formats.Tar
 
         // Throws if the specified entry type is not supported for the specified format.
         // If 'forWriting' is true, an incompatible 'Regular File' entry type is allowed. It will be converted to the compatible version before writing.
-        internal static void VerifyEntryTypeIsSupported(TarEntryType entryType, TarFormat archiveFormat, bool forWriting)
+        internal static void VerifyEntryTypeIsSupported(TarEntryType entryType, TarEntryFormat archiveFormat, bool forWriting)
         {
             switch (archiveFormat)
             {
-                case TarFormat.V7:
+                case TarEntryFormat.V7:
                     if (entryType is
                         TarEntryType.Directory or
                         TarEntryType.HardLink or
@@ -198,7 +198,7 @@ namespace System.Formats.Tar
                     }
                     break;
 
-                case TarFormat.Ustar:
+                case TarEntryFormat.Ustar:
                     if (entryType is
                         TarEntryType.BlockDevice or
                         TarEntryType.CharacterDevice or
@@ -216,7 +216,7 @@ namespace System.Formats.Tar
                     }
                     break;
 
-                case TarFormat.Pax:
+                case TarEntryFormat.Pax:
                     if (entryType is
                         TarEntryType.BlockDevice or
                         TarEntryType.CharacterDevice or
@@ -237,7 +237,7 @@ namespace System.Formats.Tar
                     }
                     break;
 
-                case TarFormat.Gnu:
+                case TarEntryFormat.Gnu:
                     if (entryType is
                         TarEntryType.BlockDevice or
                         TarEntryType.CharacterDevice or
@@ -266,7 +266,7 @@ namespace System.Formats.Tar
                     }
                     break;
 
-                case TarFormat.Unknown:
+                case TarEntryFormat.Unknown:
                 default:
                     throw new FormatException(string.Format(SR.TarInvalidFormat, archiveFormat));
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
@@ -29,7 +29,7 @@ namespace System.Formats.Tar
                 Interop.Sys.FileTypes.S_IFCHR => TarEntryType.CharacterDevice,
                 Interop.Sys.FileTypes.S_IFIFO => TarEntryType.Fifo,
                 Interop.Sys.FileTypes.S_IFLNK => TarEntryType.SymbolicLink,
-                Interop.Sys.FileTypes.S_IFREG => Format is TarFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile,
+                Interop.Sys.FileTypes.S_IFREG => Format is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile,
                 Interop.Sys.FileTypes.S_IFDIR => TarEntryType.Directory,
                 _ => throw new IOException(string.Format(SR.TarUnsupportedFile, fullPath)),
             };
@@ -38,10 +38,10 @@ namespace System.Formats.Tar
 
             TarEntry entry = Format switch
             {
-                TarFormat.V7 => new V7TarEntry(entryType, entryName),
-                TarFormat.Ustar => new UstarTarEntry(entryType, entryName),
-                TarFormat.Pax => new PaxTarEntry(entryType, entryName),
-                TarFormat.Gnu => new GnuTarEntry(entryType, entryName),
+                TarEntryFormat.V7 => new V7TarEntry(entryType, entryName),
+                TarEntryFormat.Ustar => new UstarTarEntry(entryType, entryName),
+                TarEntryFormat.Pax => new PaxTarEntry(entryType, entryName),
+                TarEntryFormat.Gnu => new GnuTarEntry(entryType, entryName),
                 _ => throw new FormatException(string.Format(SR.TarInvalidFormat, Format)),
             };
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
@@ -28,7 +28,7 @@ namespace System.Formats.Tar
             }
             else if (attributes.HasFlag(FileAttributes.Normal) || attributes.HasFlag(FileAttributes.Archive))
             {
-                entryType = Format is TarFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+                entryType = Format is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
             }
             else
             {
@@ -37,10 +37,10 @@ namespace System.Formats.Tar
 
             TarEntry entry = Format switch
             {
-                TarFormat.V7 => new V7TarEntry(entryType, entryName),
-                TarFormat.Ustar => new UstarTarEntry(entryType, entryName),
-                TarFormat.Pax => new PaxTarEntry(entryType, entryName),
-                TarFormat.Gnu => new GnuTarEntry(entryType, entryName),
+                TarEntryFormat.V7 => new V7TarEntry(entryType, entryName),
+                TarEntryFormat.Ustar => new UstarTarEntry(entryType, entryName),
+                TarEntryFormat.Pax => new PaxTarEntry(entryType, entryName),
+                TarEntryFormat.Gnu => new GnuTarEntry(entryType, entryName),
                 _ => throw new FormatException(string.Format(SR.TarInvalidFormat, Format)),
             };
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -21,13 +21,13 @@ namespace System.Formats.Tar
         private readonly IEnumerable<KeyValuePair<string, string>>? _globalExtendedAttributes;
 
         /// <summary>
-        /// Initializes a <see cref="TarWriter"/> instance that can write tar entries to the specified stream, optionally leave the stream open upon disposal of this instance, and can optionally add a Global Extended Attributes entry at the beginning of the archive. When using this constructor, the format of the resulting archive is <see cref="TarFormat.Pax"/>.
+        /// Initializes a <see cref="TarWriter"/> instance that can write tar entries to the specified stream, optionally leave the stream open upon disposal of this instance, and can optionally add a Global Extended Attributes entry at the beginning of the archive. When using this constructor, the format of the resulting archive is <see cref="TarEntryFormat.Pax"/>.
         /// </summary>
         /// <param name="archiveStream">The stream to write to.</param>
         /// <param name="globalExtendedAttributes">An optional enumeration of string key-value pairs that represent Global Extended Attributes metadata that should apply to all subsquent entries. If <see langword="null"/>, then no Global Extended Attributes entry is written. If an empty instance is passed, a Global Extended Attributes entry is written with default values.</param>
         /// <param name="leaveOpen"><see langword="false"/> to dispose the <paramref name="archiveStream"/> when this instance is disposed; <see langword="true"/> to leave the stream open.</param>
         public TarWriter(Stream archiveStream, IEnumerable<KeyValuePair<string, string>>? globalExtendedAttributes = null, bool leaveOpen = false)
-            : this(archiveStream, TarFormat.Pax, leaveOpen)
+            : this(archiveStream, TarEntryFormat.Pax, leaveOpen)
         {
             _globalExtendedAttributes = globalExtendedAttributes;
         }
@@ -38,12 +38,12 @@ namespace System.Formats.Tar
         /// <param name="archiveStream">The stream to write to.</param>
         /// <param name="archiveFormat">The format of the archive.</param>
         /// <param name="leaveOpen"><see langword="false"/> to dispose the <paramref name="archiveStream"/> when this instance is disposed; <see langword="true"/> to leave the stream open.</param>
-        /// <remarks><para>If the selected <paramref name="archiveFormat"/> is <see cref="TarFormat.Pax"/>, no Global Extended Attributes entry is written. To write a PAX archive with a Global Extended Attributes entry inserted at the beginning of the archive, use the <see cref="TarWriter(Stream, IEnumerable{KeyValuePair{string, string}}?, bool)"/> constructor instead.</para>
-        /// <para>The recommended format is <see cref="TarFormat.Pax"/> for its flexibility.</para></remarks>
+        /// <remarks><para>If the selected <paramref name="archiveFormat"/> is <see cref="TarEntryFormat.Pax"/>, no Global Extended Attributes entry is written. To write a PAX archive with a Global Extended Attributes entry inserted at the beginning of the archive, use the <see cref="TarWriter(Stream, IEnumerable{KeyValuePair{string, string}}?, bool)"/> constructor instead.</para>
+        /// <para>The recommended format is <see cref="TarEntryFormat.Pax"/> for its flexibility.</para></remarks>
         /// <exception cref="ArgumentNullException"><paramref name="archiveStream"/> is <see langword="null"/>.</exception>
         /// <exception cref="IOException"><paramref name="archiveStream"/> is unwritable.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="archiveFormat"/> is either <see cref="TarFormat.Unknown"/>, or not one of the other enum values.</exception>
-        public TarWriter(Stream archiveStream, TarFormat archiveFormat, bool leaveOpen = false)
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="archiveFormat"/> is either <see cref="TarEntryFormat.Unknown"/>, or not one of the other enum values.</exception>
+        public TarWriter(Stream archiveStream, TarEntryFormat archiveFormat, bool leaveOpen = false)
         {
             ArgumentNullException.ThrowIfNull(archiveStream);
 
@@ -52,7 +52,7 @@ namespace System.Formats.Tar
                 throw new IOException(SR.IO_NotSupported_UnwritableStream);
             }
 
-            if (archiveFormat is not TarFormat.V7 and not TarFormat.Ustar and not TarFormat.Pax and not TarFormat.Gnu)
+            if (archiveFormat is not TarEntryFormat.V7 and not TarEntryFormat.Ustar and not TarEntryFormat.Pax and not TarEntryFormat.Gnu)
             {
                 throw new ArgumentOutOfRangeException(nameof(archiveFormat));
             }
@@ -69,7 +69,7 @@ namespace System.Formats.Tar
         /// <summary>
         /// The format of the archive.
         /// </summary>
-        public TarFormat Format { get; private set; }
+        public TarEntryFormat Format { get; private set; }
 
         /// <summary>
         /// Disposes the current <see cref="TarWriter"/> instance, and closes the archive stream if the <c>leaveOpen</c> argument was set to <see langword="false"/> in the constructor.
@@ -109,7 +109,7 @@ namespace System.Formats.Tar
                 entryName = Path.GetFileName(fileName);
             }
 
-            if (Format is TarFormat.Pax)
+            if (Format is TarEntryFormat.Pax)
             {
                 WriteGlobalExtendedAttributesEntryIfNeeded();
             }
@@ -136,7 +136,7 @@ namespace System.Formats.Tar
         /// <para>These are the entry types supported for writing on each format:</para>
         /// <list type="bullet">
         /// <item>
-        /// <para><see cref="TarFormat.V7"/></para>
+        /// <para><see cref="TarEntryFormat.V7"/></para>
         /// <list type="bullet">
         /// <item><see cref="TarEntryType.Directory"/></item>
         /// <item><see cref="TarEntryType.HardLink"/></item>
@@ -145,7 +145,7 @@ namespace System.Formats.Tar
         /// </list>
         /// </item>
         /// <item>
-        /// <para><see cref="TarFormat.Ustar"/>, <see cref="TarFormat.Pax"/> and <see cref="TarFormat.Gnu"/></para>
+        /// <para><see cref="TarEntryFormat.Ustar"/>, <see cref="TarEntryFormat.Pax"/> and <see cref="TarEntryFormat.Gnu"/></para>
         /// <list type="bullet">
         /// <item><see cref="TarEntryType.BlockDevice"/></item>
         /// <item><see cref="TarEntryType.CharacterDevice"/></item>
@@ -176,19 +176,19 @@ namespace System.Formats.Tar
             {
                 switch (Format)
                 {
-                    case TarFormat.V7:
+                    case TarEntryFormat.V7:
                         entry._header.WriteAsV7(_archiveStream, buffer);
                         break;
-                    case TarFormat.Ustar:
+                    case TarEntryFormat.Ustar:
                         entry._header.WriteAsUstar(_archiveStream, buffer);
                         break;
-                    case TarFormat.Pax:
+                    case TarEntryFormat.Pax:
                         entry._header.WriteAsPax(_archiveStream, buffer);
                         break;
-                    case TarFormat.Gnu:
+                    case TarEntryFormat.Gnu:
                         entry._header.WriteAsGnu(_archiveStream, buffer);
                         break;
-                    case TarFormat.Unknown:
+                    case TarEntryFormat.Unknown:
                     default:
                         throw new FormatException(string.Format(SR.TarInvalidFormat, Format));
                 }
@@ -210,7 +210,7 @@ namespace System.Formats.Tar
         // /// <para>These are the entry types supported for writing on each format:</para>
         // /// <list type="bullet">
         // /// <item>
-        // /// <para><see cref="TarFormat.V7"/></para>
+        // /// <para><see cref="TarEntryFormat.V7"/></para>
         // /// <list type="bullet">
         // /// <item><see cref="TarEntryType.Directory"/></item>
         // /// <item><see cref="TarEntryType.HardLink"/></item>
@@ -219,7 +219,7 @@ namespace System.Formats.Tar
         // /// </list>
         // /// </item>
         // /// <item>
-        // /// <para><see cref="TarFormat.Ustar"/>, <see cref="TarFormat.Pax"/> and <see cref="TarFormat.Gnu"/></para>
+        // /// <para><see cref="TarEntryFormat.Ustar"/>, <see cref="TarEntryFormat.Pax"/> and <see cref="TarEntryFormat.Gnu"/></para>
         // /// <list type="bullet">
         // /// <item><see cref="TarEntryType.BlockDevice"/></item>
         // /// <item><see cref="TarEntryType.CharacterDevice"/></item>
@@ -279,7 +279,7 @@ namespace System.Formats.Tar
         {
             Debug.Assert(!_isDisposed);
 
-            if (_wroteGEA || Format != TarFormat.Pax)
+            if (_wroteGEA || Format != TarEntryFormat.Pax)
             {
                 return;
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/UstarTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/UstarTarEntry.cs
@@ -28,7 +28,7 @@ namespace System.Formats.Tar
         /// </list>
         /// </remarks>
         public UstarTarEntry(TarEntryType entryType, string entryName)
-            : base(entryType, entryName, TarFormat.Ustar)
+            : base(entryType, entryName, TarEntryFormat.Ustar)
         {
         }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/V7TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/V7TarEntry.cs
@@ -23,7 +23,7 @@ namespace System.Formats.Tar
         /// <exception cref="InvalidOperationException">The entry type is not supported for creating an entry.</exception>
         /// <remarks>When creating an instance using the <see cref="V7TarEntry(TarEntryType, string)"/> constructor, only the following entry types are supported: <see cref="TarEntryType.Directory"/>, <see cref="TarEntryType.HardLink"/>, <see cref="TarEntryType.SymbolicLink"/> and <see cref="TarEntryType.V7RegularFile"/>.</remarks>
         public V7TarEntry(TarEntryType entryType, string entryName)
-            : base(entryType, entryName, TarFormat.V7)
+            : base(entryType, entryName, TarEntryFormat.V7)
         {
         }
 

--- a/src/libraries/System.Formats.Tar/tests/CompressedTar.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/CompressedTar.Tests.cs
@@ -37,7 +37,7 @@ namespace System.Formats.Tar.Tests
                 using GZipStream decompressorStream = new GZipStream(streamToDecompress, CompressionMode.Decompress);
                 using TarReader reader = new TarReader(decompressorStream);
                 TarEntry entry = reader.GetNextEntry();
-                Assert.Equal(TarFormat.Pax, reader.Format);
+                Assert.Equal(TarEntryFormat.Pax, reader.Format);
                 Assert.Equal(fileName, entry.Name);
                 Assert.Null(reader.GetNextEntry());
             }

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -52,7 +52,7 @@ namespace System.Formats.Tar.Tests
             string fileWithTwoSegments = Path.Join(secondSegment, "c.txt");
 
             using MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 // No preceding directory entries for the segments
                 UstarTarEntry entry = new UstarTarEntry(TarEntryType.RegularFile, fileWithTwoSegments);
@@ -78,7 +78,7 @@ namespace System.Formats.Tar.Tests
         public void Extract_LinkEntry_TargetOutsideDirectory(TarEntryType entryType)
         {
             using MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry entry = new UstarTarEntry(entryType, "link");
                 entry.LinkName = PlatformDetection.IsWindows ? @"C:\Windows\System32\notepad.exe" : "/usr/bin/nano";
@@ -112,7 +112,7 @@ namespace System.Formats.Tar.Tests
             File.Create(targetPath).Dispose();
 
             using MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry entry = new UstarTarEntry(entryType, linkName);
                 entry.LinkName = targetPath;

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -12,13 +12,13 @@ namespace System.Formats.Tar.Tests
     public class TarReader_File_Tests : TarTestsBase
     {
         [Theory]
-        [InlineData(TarFormat.V7, TestTarFormat.v7)]
-        [InlineData(TarFormat.Ustar, TestTarFormat.ustar)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_File(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.V7, TestTarFormat.v7)]
+        [InlineData(TarEntryFormat.Ustar, TestTarFormat.ustar)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_File(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "file";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -32,7 +32,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             TarEntry file = reader.GetNextEntry();
 
             Assert.Equal(format, reader.Format);
@@ -50,13 +50,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData(TarFormat.V7, TestTarFormat.v7)]
-        [InlineData(TarFormat.Ustar, TestTarFormat.ustar)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_File_HardLink(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.V7, TestTarFormat.v7)]
+        [InlineData(TarEntryFormat.Ustar, TestTarFormat.ustar)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_File_HardLink(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "file_hardlink";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -69,7 +69,7 @@ namespace System.Formats.Tar.Tests
                 Assert.Null(reader.GlobalExtendedAttributes);
             }
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             TarEntry file = reader.GetNextEntry();
 
             Assert.Equal(format, reader.Format);
@@ -91,13 +91,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData(TarFormat.V7, TestTarFormat.v7)]
-        [InlineData(TarFormat.Ustar, TestTarFormat.ustar)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_File_SymbolicLink(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.V7, TestTarFormat.v7)]
+        [InlineData(TarEntryFormat.Ustar, TestTarFormat.ustar)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_File_SymbolicLink(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "file_symlink";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -111,7 +111,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             TarEntry file = reader.GetNextEntry();
 
             Assert.Equal(format, reader.Format);
@@ -133,13 +133,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData(TarFormat.V7, TestTarFormat.v7)]
-        [InlineData(TarFormat.Ustar, TestTarFormat.ustar)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_Folder_File(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.V7, TestTarFormat.v7)]
+        [InlineData(TarEntryFormat.Ustar, TestTarFormat.ustar)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_Folder_File(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "folder_file";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -153,7 +153,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             TarEntry directory = reader.GetNextEntry();
 
             Assert.Equal(format, reader.Format);
@@ -174,13 +174,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData(TarFormat.V7, TestTarFormat.v7)]
-        [InlineData(TarFormat.Ustar, TestTarFormat.ustar)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_Folder_File_Utf8(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.V7, TestTarFormat.v7)]
+        [InlineData(TarEntryFormat.Ustar, TestTarFormat.ustar)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_Folder_File_Utf8(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "folder_file_utf8";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -193,7 +193,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             TarEntry directory = reader.GetNextEntry();
 
             Assert.Equal(format, reader.Format);
@@ -214,13 +214,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData(TarFormat.V7, TestTarFormat.v7)]
-        [InlineData(TarFormat.Ustar, TestTarFormat.ustar)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_Folder_Subfolder_File(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.V7, TestTarFormat.v7)]
+        [InlineData(TarEntryFormat.Ustar, TestTarFormat.ustar)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_Folder_Subfolder_File(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "folder_subfolder_file";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -233,7 +233,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             TarEntry parent = reader.GetNextEntry();
 
             Assert.Equal(format, reader.Format);
@@ -257,13 +257,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData(TarFormat.V7, TestTarFormat.v7)]
-        [InlineData(TarFormat.Ustar, TestTarFormat.ustar)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_FolderSymbolicLink_Folder_Subfolder_File(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.V7, TestTarFormat.v7)]
+        [InlineData(TarEntryFormat.Ustar, TestTarFormat.ustar)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_FolderSymbolicLink_Folder_Subfolder_File(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "foldersymlink_folder_subfolder_file";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -276,7 +276,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             TarEntry childlink = reader.GetNextEntry();
 
             Assert.Equal(format, reader.Format);
@@ -303,13 +303,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData(TarFormat.V7, TestTarFormat.v7)]
-        [InlineData(TarFormat.Ustar, TestTarFormat.ustar)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_Many_Small_Files(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.V7, TestTarFormat.v7)]
+        [InlineData(TarEntryFormat.Ustar, TestTarFormat.ustar)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_Many_Small_Files(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "many_small_files";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -322,7 +322,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
 
             List<TarEntry> entries = new List<TarEntry>();
             TarEntry entry;
@@ -348,7 +348,7 @@ namespace System.Formats.Tar.Tests
             int directoriesCount = entries.Count(e => e.EntryType == TarEntryType.Directory);
             Assert.Equal(10, directoriesCount);
 
-            TarEntryType regularFileEntryType = format == TarFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+            TarEntryType regularFileEntryType = format == TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
             for (int i = 0; i < 10; i++)
             {
                 int filesCount = entries.Count(e => e.EntryType == regularFileEntryType && e.Name.StartsWith($"{i}/"));
@@ -358,12 +358,12 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         // V7 does not support longer filenames
-        [InlineData(TarFormat.Ustar, TestTarFormat.ustar)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_LongPath_Splitable_Under255(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.Ustar, TestTarFormat.ustar)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_LongPath_Splitable_Under255(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "longpath_splitable_under255";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -376,7 +376,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             TarEntry directory = reader.GetNextEntry();
 
             Assert.Equal(format, reader.Format);
@@ -398,12 +398,12 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         // V7 does not support block devices, character devices or fifos
-        [InlineData(TarFormat.Ustar, TestTarFormat.ustar)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_SpecialFiles(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.Ustar, TestTarFormat.ustar)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_SpecialFiles(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "specialfiles";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -416,7 +416,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             PosixTarEntry blockDevice = reader.GetNextEntry() as PosixTarEntry;
 
             Assert.Equal(format, reader.Format);
@@ -441,11 +441,11 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         // Neither V7 not Ustar can handle links with long target filenames
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_File_LongSymbolicLink(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_File_LongSymbolicLink(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "file_longsymlink";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -458,7 +458,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             TarEntry directory = reader.GetNextEntry();
 
             Assert.Equal(format, reader.Format);
@@ -483,11 +483,11 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         // Neither V7 not Ustar can handle a path that does not have separators that can be split under 100 bytes
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_LongFileName_Over100_Under255(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_LongFileName_Over100_Under255(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "longfilename_over100_under255";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -500,7 +500,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             TarEntry file = reader.GetNextEntry();
 
             Assert.Equal(format, reader.Format);
@@ -519,11 +519,11 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         // Neither V7 not Ustar can handle path lenghts waaaay beyond name+prefix length
-        [InlineData(TarFormat.Pax, TestTarFormat.pax)]
-        [InlineData(TarFormat.Pax, TestTarFormat.pax_gea)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.gnu)]
-        [InlineData(TarFormat.Gnu, TestTarFormat.oldgnu)]
-        public void Read_Archive_LongPath_Over255(TarFormat format, TestTarFormat testFormat)
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax)]
+        [InlineData(TarEntryFormat.Pax, TestTarFormat.pax_gea)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.gnu)]
+        [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
+        public void Read_Archive_LongPath_Over255(TarEntryFormat format, TestTarFormat testFormat)
         {
             string testCaseName = "longpath_over255";
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, testFormat, testCaseName);
@@ -536,7 +536,7 @@ namespace System.Formats.Tar.Tests
             }
 
             // Format is determined after reading the first entry, not on the constructor
-            Assert.Equal(TarFormat.Unknown, reader.Format);
+            Assert.Equal(TarEntryFormat.Unknown, reader.Format);
             TarEntry directory = reader.GetNextEntry();
 
             Assert.Equal(format, reader.Format);
@@ -556,7 +556,7 @@ namespace System.Formats.Tar.Tests
             Assert.Null(reader.GetNextEntry());
         }
 
-        private void Verify_Archive_RegularFile(TarEntry file, TarFormat format, IReadOnlyDictionary<string, string> gea, string expectedFileName, string expectedContents)
+        private void Verify_Archive_RegularFile(TarEntry file, TarEntryFormat format, IReadOnlyDictionary<string, string> gea, string expectedFileName, string expectedContents)
         {
             Assert.NotNull(file);
 
@@ -572,7 +572,7 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(expectedContents, contents);
             }
 
-            TarEntryType expectedEntryType = format == TarFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+            TarEntryType expectedEntryType = format == TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
             Assert.Equal(expectedEntryType, file.EntryType);
 
             Assert.Equal(AssetGid, file.Gid);

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
@@ -48,7 +48,7 @@ namespace System.Formats.Tar.Tests
         {
             using MemoryStream archive = new MemoryStream();
 
-            using (TarWriter writer = new TarWriter(archive, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry entry = new UstarTarEntry(TarEntryType.Directory, "dir");
                 writer.WriteEntry(entry);
@@ -72,7 +72,7 @@ namespace System.Formats.Tar.Tests
         {
             string expectedText = "Hello world!";
             MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry entry1 = new UstarTarEntry(TarEntryType.RegularFile, "file.txt");
                 entry1.DataStream = new MemoryStream();
@@ -118,7 +118,7 @@ namespace System.Formats.Tar.Tests
         {
             string expectedText = "Hello world!";
             MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry entry1 = new UstarTarEntry(TarEntryType.RegularFile, "file.txt");
                 entry1.DataStream = new MemoryStream();
@@ -165,7 +165,7 @@ namespace System.Formats.Tar.Tests
         public void GetNextEntry_CopyDataFalse_UnseekableArchive_Exceptions()
         {
             MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry entry1 = new UstarTarEntry(TarEntryType.RegularFile, "file.txt");
                 entry1.DataStream = new MemoryStream();
@@ -208,7 +208,7 @@ namespace System.Formats.Tar.Tests
         public void GetNextEntry_UnseekableArchive_ReplaceDataStream_ExcludeFromDisposing(bool copyData)
         {
             MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry entry1 = new UstarTarEntry(TarEntryType.RegularFile, "file.txt");
                 entry1.DataStream = new MemoryStream();

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
@@ -13,7 +13,7 @@ namespace System.Formats.Tar.Tests
         public void Constructors_NullStream()
         {
             Assert.Throws<ArgumentNullException>(() => new TarWriter(archiveStream: null));
-            Assert.Throws<ArgumentNullException>(() => new TarWriter(archiveStream: null, TarFormat.V7));
+            Assert.Throws<ArgumentNullException>(() => new TarWriter(archiveStream: null, TarEntryFormat.V7));
         }
 
         [Fact]
@@ -36,29 +36,29 @@ namespace System.Formats.Tar.Tests
             using MemoryStream archiveStream = new MemoryStream();
 
             using TarWriter writerDefault = new TarWriter(archiveStream, leaveOpen: true);
-            Assert.Equal(TarFormat.Pax, writerDefault.Format);
+            Assert.Equal(TarEntryFormat.Pax, writerDefault.Format);
 
-            using TarWriter writerV7 = new TarWriter(archiveStream, TarFormat.V7, leaveOpen: true);
-            Assert.Equal(TarFormat.V7, writerV7.Format);
+            using TarWriter writerV7 = new TarWriter(archiveStream, TarEntryFormat.V7, leaveOpen: true);
+            Assert.Equal(TarEntryFormat.V7, writerV7.Format);
 
-            using TarWriter writerUstar = new TarWriter(archiveStream, TarFormat.Ustar, leaveOpen: true);
-            Assert.Equal(TarFormat.Ustar, writerUstar.Format);
+            using TarWriter writerUstar = new TarWriter(archiveStream, TarEntryFormat.Ustar, leaveOpen: true);
+            Assert.Equal(TarEntryFormat.Ustar, writerUstar.Format);
 
-            using TarWriter writerPax = new TarWriter(archiveStream, TarFormat.Pax, leaveOpen: true);
-            Assert.Equal(TarFormat.Pax, writerPax.Format);
+            using TarWriter writerPax = new TarWriter(archiveStream, TarEntryFormat.Pax, leaveOpen: true);
+            Assert.Equal(TarEntryFormat.Pax, writerPax.Format);
 
-            using TarWriter writerGnu = new TarWriter(archiveStream, TarFormat.Gnu, leaveOpen: true);
-            Assert.Equal(TarFormat.Gnu, writerGnu.Format);
+            using TarWriter writerGnu = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true);
+            Assert.Equal(TarEntryFormat.Gnu, writerGnu.Format);
 
             using TarWriter writerNullGeaDefaultPax = new TarWriter(archiveStream, leaveOpen: true, globalExtendedAttributes: null);
-            Assert.Equal(TarFormat.Pax, writerNullGeaDefaultPax.Format);
+            Assert.Equal(TarEntryFormat.Pax, writerNullGeaDefaultPax.Format);
 
             using TarWriter writerValidGeaDefaultPax = new TarWriter(archiveStream, leaveOpen: true, globalExtendedAttributes: new Dictionary<string, string>());
-            Assert.Equal(TarFormat.Pax, writerValidGeaDefaultPax.Format);
+            Assert.Equal(TarEntryFormat.Pax, writerValidGeaDefaultPax.Format);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new TarWriter(archiveStream, TarFormat.Unknown));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new TarWriter(archiveStream, (TarFormat)int.MinValue));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new TarWriter(archiveStream, (TarFormat)int.MaxValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new TarWriter(archiveStream, TarEntryFormat.Unknown));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new TarWriter(archiveStream, (TarEntryFormat)int.MinValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new TarWriter(archiveStream, (TarEntryFormat)int.MaxValue));
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace System.Formats.Tar.Tests
             using MemoryStream archiveStream = new MemoryStream();
             using WrappedStream wrappedStream = new WrappedStream(archiveStream, canRead: true, canWrite: false, canSeek: false);
             Assert.Throws<IOException>(() => new TarWriter(wrappedStream));
-            Assert.Throws<IOException>(() => new TarWriter(wrappedStream, TarFormat.V7));
+            Assert.Throws<IOException>(() => new TarWriter(wrappedStream, TarEntryFormat.V7));
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace System.Formats.Tar.Tests
             using (TarReader reader = new TarReader(wrapped))
             {
                 TarEntry entry = reader.GetNextEntry();
-                Assert.Equal(TarFormat.Pax, reader.Format);
+                Assert.Equal(TarEntryFormat.Pax, reader.Format);
                 Assert.Equal(TarEntryType.RegularFile, entry.EntryType);
                 Assert.Null(reader.GetNextEntry());
             }
@@ -106,7 +106,7 @@ namespace System.Formats.Tar.Tests
         public void VerifyChecksumV7()
         {
             using MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, TarFormat.V7, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.V7, leaveOpen: true))
             {
                 V7TarEntry entry = new V7TarEntry(
                     // '\0' = 0

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Gnu.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Gnu.Tests.cs
@@ -13,7 +13,7 @@ namespace System.Formats.Tar.Tests
         public void Write_V7RegularFileEntry_As_RegularFileEntry()
         {
             using MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, archiveFormat: TarFormat.Gnu, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, archiveFormat: TarEntryFormat.Gnu, leaveOpen: true))
             {
                 V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
 
@@ -36,7 +36,7 @@ namespace System.Formats.Tar.Tests
         public void WriteRegularFile()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Gnu, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry regularFile = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 SetRegularFile(regularFile);
@@ -56,7 +56,7 @@ namespace System.Formats.Tar.Tests
         public void WriteHardLink()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Gnu, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry hardLink = new GnuTarEntry(TarEntryType.HardLink, InitialEntryName);
                 SetHardLink(hardLink);
@@ -76,7 +76,7 @@ namespace System.Formats.Tar.Tests
         public void WriteSymbolicLink()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Gnu, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry symbolicLink = new GnuTarEntry(TarEntryType.SymbolicLink, InitialEntryName);
                 SetSymbolicLink(symbolicLink);
@@ -96,7 +96,7 @@ namespace System.Formats.Tar.Tests
         public void WriteDirectory()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Gnu, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry directory = new GnuTarEntry(TarEntryType.Directory, InitialEntryName);
                 SetDirectory(directory);
@@ -116,7 +116,7 @@ namespace System.Formats.Tar.Tests
         public void WriteCharacterDevice()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Gnu, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry charDevice = new GnuTarEntry(TarEntryType.CharacterDevice, InitialEntryName);
                 SetCharacterDevice(charDevice);
@@ -136,7 +136,7 @@ namespace System.Formats.Tar.Tests
         public void WriteBlockDevice()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Gnu, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry blockDevice = new GnuTarEntry(TarEntryType.BlockDevice, InitialEntryName);
                 SetBlockDevice(blockDevice);
@@ -156,7 +156,7 @@ namespace System.Formats.Tar.Tests
         public void WriteFifo()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Gnu, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry fifo = new GnuTarEntry(TarEntryType.Fifo, InitialEntryName);
                 SetFifo(fifo);
@@ -183,7 +183,7 @@ namespace System.Formats.Tar.Tests
             string longName = new string('a', 101);
 
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Gnu, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry entry = new GnuTarEntry(entryType, longName);
                 writer.WriteEntry(entry);
@@ -207,7 +207,7 @@ namespace System.Formats.Tar.Tests
             string longLinkName = new string('a', 101);
 
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Gnu, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry entry = new GnuTarEntry(entryType, "file.txt");
                 entry.LinkName = longLinkName;
@@ -234,7 +234,7 @@ namespace System.Formats.Tar.Tests
             string longLinkName = new string('a', 101);
 
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Gnu, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry entry = new GnuTarEntry(entryType, longName);
                 entry.LinkName = longLinkName;

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
@@ -15,7 +15,7 @@ namespace System.Formats.Tar.Tests
         public void Write_V7RegularFileEntry_As_RegularFileEntry()
         {
             using MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, archiveFormat: TarFormat.Pax, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, archiveFormat: TarEntryFormat.Pax, leaveOpen: true))
             {
                 V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
 
@@ -38,7 +38,7 @@ namespace System.Formats.Tar.Tests
         public void WriteRegularFile()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Pax, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Pax, leaveOpen: true))
             {
                 PaxTarEntry regularFile = new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 SetRegularFile(regularFile);
@@ -58,7 +58,7 @@ namespace System.Formats.Tar.Tests
         public void WriteHardLink()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Pax, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Pax, leaveOpen: true))
             {
                 PaxTarEntry hardLink = new PaxTarEntry(TarEntryType.HardLink, InitialEntryName);
                 SetHardLink(hardLink);
@@ -78,7 +78,7 @@ namespace System.Formats.Tar.Tests
         public void WriteSymbolicLink()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Pax, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Pax, leaveOpen: true))
             {
                 PaxTarEntry symbolicLink = new PaxTarEntry(TarEntryType.SymbolicLink, InitialEntryName);
                 SetSymbolicLink(symbolicLink);
@@ -98,7 +98,7 @@ namespace System.Formats.Tar.Tests
         public void WriteDirectory()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Pax, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Pax, leaveOpen: true))
             {
                 PaxTarEntry directory = new PaxTarEntry(TarEntryType.Directory, InitialEntryName);
                 SetDirectory(directory);
@@ -118,7 +118,7 @@ namespace System.Formats.Tar.Tests
         public void WriteCharacterDevice()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Pax, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Pax, leaveOpen: true))
             {
                 PaxTarEntry charDevice = new PaxTarEntry(TarEntryType.CharacterDevice, InitialEntryName);
                 SetCharacterDevice(charDevice);
@@ -138,7 +138,7 @@ namespace System.Formats.Tar.Tests
         public void WriteBlockDevice()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Pax, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Pax, leaveOpen: true))
             {
                 PaxTarEntry blockDevice = new PaxTarEntry(TarEntryType.BlockDevice, InitialEntryName);
                 SetBlockDevice(blockDevice);
@@ -158,7 +158,7 @@ namespace System.Formats.Tar.Tests
         public void WriteFifo()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Pax, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Pax, leaveOpen: true))
             {
                 PaxTarEntry fifo = new PaxTarEntry(TarEntryType.Fifo, InitialEntryName);
                 SetFifo(fifo);
@@ -184,7 +184,7 @@ namespace System.Formats.Tar.Tests
             extendedAttributes.Add(expectedKey, expectedValue);
 
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Pax, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Pax, leaveOpen: true))
             {
                 PaxTarEntry regularFile = new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName, extendedAttributes);
                 SetRegularFile(regularFile);
@@ -221,7 +221,7 @@ namespace System.Formats.Tar.Tests
             extendedAttributes.Add("ctime", ConvertDateTimeOffsetToDouble(TestChangeTime).ToString("F6", CultureInfo.InvariantCulture));
 
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Pax, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Pax, leaveOpen: true))
             {
                 PaxTarEntry regularFile = new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName, extendedAttributes);
                 SetRegularFile(regularFile);
@@ -252,7 +252,7 @@ namespace System.Formats.Tar.Tests
             string groupName = "IAmAGroupNameWhoseLengthIsWayBeyondTheThirtyTwoByteLimit";
 
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Pax, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Pax, leaveOpen: true))
             {
                 PaxTarEntry regularFile = new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 SetRegularFile(regularFile);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Ustar.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Ustar.Tests.cs
@@ -13,7 +13,7 @@ namespace System.Formats.Tar.Tests
         public void Write_V7RegularFileEntry_As_RegularFileEntry()
         {
             using MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, archiveFormat: TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, archiveFormat: TarEntryFormat.Ustar, leaveOpen: true))
             {
                 V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
 
@@ -36,7 +36,7 @@ namespace System.Formats.Tar.Tests
         public void WriteRegularFile()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry regularFile = new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName);
                 SetRegularFile(regularFile);
@@ -56,7 +56,7 @@ namespace System.Formats.Tar.Tests
         public void WriteHardLink()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry hardLink = new UstarTarEntry(TarEntryType.HardLink, InitialEntryName);
                 SetHardLink(hardLink);
@@ -76,7 +76,7 @@ namespace System.Formats.Tar.Tests
         public void WriteSymbolicLink()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry symbolicLink = new UstarTarEntry(TarEntryType.SymbolicLink, InitialEntryName);
                 SetSymbolicLink(symbolicLink);
@@ -96,7 +96,7 @@ namespace System.Formats.Tar.Tests
         public void WriteDirectory()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry directory = new UstarTarEntry(TarEntryType.Directory, InitialEntryName);
                 SetDirectory(directory);
@@ -116,7 +116,7 @@ namespace System.Formats.Tar.Tests
         public void WriteCharacterDevice()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry charDevice = new UstarTarEntry(TarEntryType.CharacterDevice, InitialEntryName);
                 SetCharacterDevice(charDevice);
@@ -136,7 +136,7 @@ namespace System.Formats.Tar.Tests
         public void WriteBlockDevice()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry blockDevice = new UstarTarEntry(TarEntryType.BlockDevice, InitialEntryName);
                 SetBlockDevice(blockDevice);
@@ -156,7 +156,7 @@ namespace System.Formats.Tar.Tests
         public void WriteFifo()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.Ustar, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Ustar, leaveOpen: true))
             {
                 UstarTarEntry fifo = new UstarTarEntry(TarEntryType.Fifo, InitialEntryName);
                 SetFifo(fifo);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.V7.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.V7.Tests.cs
@@ -14,7 +14,7 @@ namespace System.Formats.Tar.Tests
         {
             // Verify that entry types that can be manually constructed in other types, cannot be inserted in a v7 writer
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, archiveFormat: TarFormat.V7, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, archiveFormat: TarEntryFormat.V7, leaveOpen: true))
             {
                 // Entry types supported in ustar but not in v7
                 Assert.Throws<InvalidOperationException>(() => writer.WriteEntry(new UstarTarEntry(TarEntryType.BlockDevice, InitialEntryName)));
@@ -36,19 +36,19 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData(TarFormat.Ustar)]
-        [InlineData(TarFormat.Pax)]
-        [InlineData(TarFormat.Gnu)]
-        public void Write_RegularFileEntry_As_V7RegularFileEntry(TarFormat entryFormat)
+        [InlineData(TarEntryFormat.Ustar)]
+        [InlineData(TarEntryFormat.Pax)]
+        [InlineData(TarEntryFormat.Gnu)]
+        public void Write_RegularFileEntry_As_V7RegularFileEntry(TarEntryFormat entryFormat)
         {
             using MemoryStream archive = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archive, archiveFormat: TarFormat.V7, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archive, archiveFormat: TarEntryFormat.V7, leaveOpen: true))
             {
                 TarEntry entry = entryFormat switch
                 {
-                    TarFormat.Ustar => new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName),
-                    TarFormat.Pax => new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName),
-                    TarFormat.Gnu => new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName),
+                    TarEntryFormat.Ustar => new UstarTarEntry(TarEntryType.RegularFile, InitialEntryName),
+                    TarEntryFormat.Pax => new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName),
+                    TarEntryFormat.Gnu => new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName),
                     _ => throw new FormatException()
                 };
 
@@ -72,7 +72,7 @@ namespace System.Formats.Tar.Tests
         public void WriteRegularFile()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.V7, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.V7, leaveOpen: true))
             {
                 V7TarEntry oldRegularFile = new V7TarEntry(TarEntryType.V7RegularFile, InitialEntryName);
                 SetRegularFile(oldRegularFile);
@@ -92,7 +92,7 @@ namespace System.Formats.Tar.Tests
         public void WriteHardLink()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.V7, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.V7, leaveOpen: true))
             {
                 V7TarEntry hardLink = new V7TarEntry(TarEntryType.HardLink, InitialEntryName);
                 SetHardLink(hardLink);
@@ -112,7 +112,7 @@ namespace System.Formats.Tar.Tests
         public void WriteSymbolicLink()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.V7, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.V7, leaveOpen: true))
             {
                 V7TarEntry symbolicLink = new V7TarEntry(TarEntryType.SymbolicLink, InitialEntryName);
                 SetSymbolicLink(symbolicLink);
@@ -132,7 +132,7 @@ namespace System.Formats.Tar.Tests
         public void WriteDirectory()
         {
             using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, TarFormat.V7, leaveOpen: true))
+            using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.V7, leaveOpen: true))
             {
                 V7TarEntry directory = new V7TarEntry(TarEntryType.Directory, InitialEntryName);
                 SetDirectory(directory);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
@@ -12,14 +12,14 @@ namespace System.Formats.Tar.Tests
         private static bool IsRemoteExecutorSupportedAndOnUnixAndSuperUser => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndSuperUser;
 
         [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndSuperUser))]
-        [InlineData(TarFormat.Ustar)]
-        [InlineData(TarFormat.Pax)]
-        [InlineData(TarFormat.Gnu)]
-        public void Add_Fifo(TarFormat format)
+        [InlineData(TarEntryFormat.Ustar)]
+        [InlineData(TarEntryFormat.Pax)]
+        [InlineData(TarEntryFormat.Gnu)]
+        public void Add_Fifo(TarEntryFormat format)
         {
             RemoteExecutor.Invoke((string strFormat) =>
             {
-                TarFormat expectedFormat = Enum.Parse<TarFormat>(strFormat);
+                TarEntryFormat expectedFormat = Enum.Parse<TarEntryFormat>(strFormat);
 
                 using TempDirectory root = new TempDirectory();
                 string fifoName = "fifofile";
@@ -36,7 +36,7 @@ namespace System.Formats.Tar.Tests
                 archive.Seek(0, SeekOrigin.Begin);
                 using (TarReader reader = new TarReader(archive))
                 {
-                    Assert.Equal(TarFormat.Unknown, reader.Format);
+                    Assert.Equal(TarEntryFormat.Unknown, reader.Format);
                     PosixTarEntry entry = reader.GetNextEntry() as PosixTarEntry;
                     Assert.Equal(expectedFormat, reader.Format);
 
@@ -55,14 +55,14 @@ namespace System.Formats.Tar.Tests
         }
 
         [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndSuperUser))]
-        [InlineData(TarFormat.Ustar)]
-        [InlineData(TarFormat.Pax)]
-        [InlineData(TarFormat.Gnu)]
-        public void Add_BlockDevice(TarFormat format)
+        [InlineData(TarEntryFormat.Ustar)]
+        [InlineData(TarEntryFormat.Pax)]
+        [InlineData(TarEntryFormat.Gnu)]
+        public void Add_BlockDevice(TarEntryFormat format)
         {
             RemoteExecutor.Invoke((string strFormat) =>
             {
-                TarFormat expectedFormat = Enum.Parse<TarFormat>(strFormat);
+                TarEntryFormat expectedFormat = Enum.Parse<TarEntryFormat>(strFormat);
 
                 using TempDirectory root = new TempDirectory();
                 string blockDevicePath = Path.Join(root.Path, AssetBlockDeviceFileName);
@@ -79,7 +79,7 @@ namespace System.Formats.Tar.Tests
                 archive.Seek(0, SeekOrigin.Begin);
                 using (TarReader reader = new TarReader(archive))
                 {
-                    Assert.Equal(TarFormat.Unknown, reader.Format);
+                    Assert.Equal(TarEntryFormat.Unknown, reader.Format);
                     PosixTarEntry entry = reader.GetNextEntry() as PosixTarEntry;
                     Assert.Equal(expectedFormat, reader.Format);
 
@@ -101,14 +101,14 @@ namespace System.Formats.Tar.Tests
         }
 
         [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndSuperUser))]
-        [InlineData(TarFormat.Ustar)]
-        [InlineData(TarFormat.Pax)]
-        [InlineData(TarFormat.Gnu)]
-        public void Add_CharacterDevice(TarFormat format)
+        [InlineData(TarEntryFormat.Ustar)]
+        [InlineData(TarEntryFormat.Pax)]
+        [InlineData(TarEntryFormat.Gnu)]
+        public void Add_CharacterDevice(TarEntryFormat format)
         {
             RemoteExecutor.Invoke((string strFormat) =>
             {
-                TarFormat expectedFormat = Enum.Parse<TarFormat>(strFormat);
+                TarEntryFormat expectedFormat = Enum.Parse<TarEntryFormat>(strFormat);
                 using TempDirectory root = new TempDirectory();
                 string characterDevicePath = Path.Join(root.Path, AssetCharacterDeviceFileName);
 
@@ -124,7 +124,7 @@ namespace System.Formats.Tar.Tests
                 archive.Seek(0, SeekOrigin.Begin);
                 using (TarReader reader = new TarReader(archive))
                 {
-                    Assert.Equal(TarFormat.Unknown, reader.Format);
+                    Assert.Equal(TarEntryFormat.Unknown, reader.Format);
                     PosixTarEntry entry = reader.GetNextEntry() as PosixTarEntry;
                     Assert.Equal(expectedFormat, reader.Format);
 

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
@@ -67,11 +67,11 @@ namespace System.Formats.Tar.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/69474", TestPlatforms.Linux)]
         [Theory]
-        [InlineData(TarFormat.V7)]
-        [InlineData(TarFormat.Ustar)]
-        [InlineData(TarFormat.Pax)]
-        [InlineData(TarFormat.Gnu)]
-        public void Add_File(TarFormat format)
+        [InlineData(TarEntryFormat.V7)]
+        [InlineData(TarEntryFormat.Ustar)]
+        [InlineData(TarEntryFormat.Pax)]
+        [InlineData(TarEntryFormat.Gnu)]
+        public void Add_File(TarEntryFormat format)
         {
             using TempDirectory root = new TempDirectory();
             string fileName = "file.txt";
@@ -92,12 +92,12 @@ namespace System.Formats.Tar.Tests
             archive.Seek(0, SeekOrigin.Begin);
             using (TarReader reader = new TarReader(archive))
             {
-                Assert.Equal(TarFormat.Unknown, reader.Format);
+                Assert.Equal(TarEntryFormat.Unknown, reader.Format);
                 TarEntry entry = reader.GetNextEntry();
                 Assert.NotNull(entry);
                 Assert.Equal(format, reader.Format);
                 Assert.Equal(fileName, entry.Name);
-                TarEntryType expectedEntryType = format is TarFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+                TarEntryType expectedEntryType = format is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
                 Assert.Equal(expectedEntryType, entry.EntryType);
                 Assert.True(entry.Length > 0);
                 Assert.NotNull(entry.DataStream);
@@ -115,15 +115,15 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData(TarFormat.V7, false)]
-        [InlineData(TarFormat.V7, true)]
-        [InlineData(TarFormat.Ustar, false)]
-        [InlineData(TarFormat.Ustar, true)]
-        [InlineData(TarFormat.Pax, false)]
-        [InlineData(TarFormat.Pax, true)]
-        [InlineData(TarFormat.Gnu, false)]
-        [InlineData(TarFormat.Gnu, true)]
-        public void Add_Directory(TarFormat format, bool withContents)
+        [InlineData(TarEntryFormat.V7, false)]
+        [InlineData(TarEntryFormat.V7, true)]
+        [InlineData(TarEntryFormat.Ustar, false)]
+        [InlineData(TarEntryFormat.Ustar, true)]
+        [InlineData(TarEntryFormat.Pax, false)]
+        [InlineData(TarEntryFormat.Pax, true)]
+        [InlineData(TarEntryFormat.Gnu, false)]
+        [InlineData(TarEntryFormat.Gnu, true)]
+        public void Add_Directory(TarEntryFormat format, bool withContents)
         {
             using TempDirectory root = new TempDirectory();
             string dirName = "dir";
@@ -146,7 +146,7 @@ namespace System.Formats.Tar.Tests
             archive.Seek(0, SeekOrigin.Begin);
             using (TarReader reader = new TarReader(archive))
             {
-                Assert.Equal(TarFormat.Unknown, reader.Format);
+                Assert.Equal(TarEntryFormat.Unknown, reader.Format);
                 TarEntry entry = reader.GetNextEntry();
                 Assert.Equal(format, reader.Format);
 
@@ -162,15 +162,15 @@ namespace System.Formats.Tar.Tests
         }
 
         [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
-        [InlineData(TarFormat.V7, false)]
-        [InlineData(TarFormat.V7, true)]
-        [InlineData(TarFormat.Ustar, false)]
-        [InlineData(TarFormat.Ustar, true)]
-        [InlineData(TarFormat.Pax, false)]
-        [InlineData(TarFormat.Pax, true)]
-        [InlineData(TarFormat.Gnu, false)]
-        [InlineData(TarFormat.Gnu, true)]
-        public void Add_SymbolicLink(TarFormat format, bool createTarget)
+        [InlineData(TarEntryFormat.V7, false)]
+        [InlineData(TarEntryFormat.V7, true)]
+        [InlineData(TarEntryFormat.Ustar, false)]
+        [InlineData(TarEntryFormat.Ustar, true)]
+        [InlineData(TarEntryFormat.Pax, false)]
+        [InlineData(TarEntryFormat.Pax, true)]
+        [InlineData(TarEntryFormat.Gnu, false)]
+        [InlineData(TarEntryFormat.Gnu, true)]
+        public void Add_SymbolicLink(TarEntryFormat format, bool createTarget)
         {
             using TempDirectory root = new TempDirectory();
             string targetName = "file.txt";
@@ -195,7 +195,7 @@ namespace System.Formats.Tar.Tests
             archive.Seek(0, SeekOrigin.Begin);
             using (TarReader reader = new TarReader(archive))
             {
-                Assert.Equal(TarFormat.Unknown, reader.Format);
+                Assert.Equal(TarEntryFormat.Unknown, reader.Format);
                 TarEntry entry = reader.GetNextEntry();
                 Assert.Equal(format, reader.Format);
 
@@ -233,12 +233,12 @@ namespace System.Formats.Tar.Tests
             using (TarReader reader = new TarReader(archive))
             {
                 // Unknown until reading first entry
-                Assert.Equal(TarFormat.Unknown, reader.Format);
+                Assert.Equal(TarEntryFormat.Unknown, reader.Format);
                 Assert.Null(reader.GlobalExtendedAttributes);
 
                 Assert.Null(reader.GetNextEntry());
 
-                Assert.Equal(TarFormat.Pax, reader.Format);
+                Assert.Equal(TarEntryFormat.Pax, reader.Format);
                 Assert.NotNull(reader.GlobalExtendedAttributes);
 
                 int expectedCount = withAttributes ? 1 : 0;

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
@@ -35,7 +35,7 @@ namespace System.Formats.Tar.Tests
                 Assert.NotNull(entry.DataStream);
                 entry.DataStream.ReadByte(); // Advance one byte, now the expected string would be "ello file"
 
-                using (TarWriter writer = new TarWriter(destination, TarFormat.Ustar, leaveOpen: true))
+                using (TarWriter writer = new TarWriter(destination, TarEntryFormat.Ustar, leaveOpen: true))
                 {
                     writer.WriteEntry(entry);
                 }


### PR DESCRIPTION
Partially addresses approved proposal: https://github.com/dotnet/runtime/issues/69935#issuecomment-1142455260

No behavior modification in this PR, only API rename, to make future PRs cleaner.