### PR TITLE
Harden for null byrefs

### DIFF
--- a/src/coreclr/pal/src/safecrt/input.inl
+++ b/src/coreclr/pal/src/safecrt/input.inl
@@ -665,7 +665,7 @@ scanit:
                                     } else
 #else  /* _UNICODE */
                                     if (fl_wchar_arg) {
-                                        *(char16_t UNALIGNED *)pointer = (char16_t)ch;
+                                        *(char16_t UNALIGNED *)pointer = ch;
                                         pointer = (char16_t *)pointer + 1;
 #ifdef _SECURE_SCANF
                                         --array_width;

--- a/src/coreclr/pal/src/safecrt/input.inl
+++ b/src/coreclr/pal/src/safecrt/input.inl
@@ -665,7 +665,7 @@ scanit:
                                     } else
 #else  /* _UNICODE */
                                     if (fl_wchar_arg) {
-                                        *(char16_t UNALIGNED *)pointer = ch;
+                                        *(char16_t UNALIGNED *)pointer = (char16_t)ch;
                                         pointer = (char16_t *)pointer + 1;
 #ifdef _SECURE_SCANF
                                         --array_width;

--- a/src/coreclr/vm/amd64/JitHelpers_InlineGetThread.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_InlineGetThread.asm
@@ -60,15 +60,9 @@ LEAF_END JIT_TrialAllocSFastMP_InlineGetThread, _TEXT
 
 ; HCIMPL2(Object*, JIT_Box, CORINFO_CLASS_HANDLE type, void* unboxedData)
 NESTED_ENTRY JIT_BoxFastMP_InlineGetThread, _TEXT
-        mov     rax, [rcx + OFFSETOF__MethodTable__m_pWriteableData]
-
-        ; Check whether the class has not been initialized
-        test    dword ptr [rax + OFFSETOF__MethodTableWriteableData__m_dwFlags], MethodTableWriteableData__enum_flag_Unrestored
-        jnz     ClassNotInited
-
-        mov     r8d, [rcx + OFFSET__MethodTable__m_BaseSize]
 
         ; m_BaseSize is guaranteed to be a multiple of 8.
+        mov     r8d, [rcx + OFFSET__MethodTable__m_BaseSize]
 
         INLINE_GETTHREAD r11
         mov     r10, [r11 + OFFSET__Thread__m_alloc_context__alloc_limit]
@@ -116,7 +110,6 @@ align 16
         pop     rax
         ret
 
-    ClassNotInited:
     AllocFailed:
     NullRef:
         jmp     JIT_Box

--- a/src/coreclr/vm/amd64/JitHelpers_InlineGetThread.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_InlineGetThread.asm
@@ -79,6 +79,9 @@ NESTED_ENTRY JIT_BoxFastMP_InlineGetThread, _TEXT
         cmp     r8, r10
         ja      AllocFailed
 
+        test    rdx, rdx
+        je      NullRef
+
         mov     [r11 + OFFSET__Thread__m_alloc_context__alloc_ptr], r8
         mov     [rax], rcx
 
@@ -115,6 +118,7 @@ align 16
 
     ClassNotInited:
     AllocFailed:
+    NullRef:
         jmp     JIT_Box
 NESTED_END JIT_BoxFastMP_InlineGetThread, _TEXT
 

--- a/src/coreclr/vm/amd64/JitHelpers_Slow.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_Slow.asm
@@ -205,15 +205,8 @@ LEAF_END JIT_TrialAllocSFastSP, _TEXT
 ; HCIMPL2(Object*, JIT_Box, CORINFO_CLASS_HANDLE type, void* unboxedData)
 NESTED_ENTRY JIT_BoxFastUP, _TEXT
 
-        mov     rax, [rcx + OFFSETOF__MethodTable__m_pWriteableData]
-
-        ; Check whether the class has not been initialized
-        test    dword ptr [rax + OFFSETOF__MethodTableWriteableData__m_dwFlags], MethodTableWriteableData__enum_flag_Unrestored
-        jnz     JIT_Box
-
-        mov     r8d, [rcx + OFFSET__MethodTable__m_BaseSize]
-
         ; m_BaseSize is guaranteed to be a multiple of 8.
+        mov     r8d, [rcx + OFFSET__MethodTable__m_BaseSize]
 
         inc     [g_global_alloc_lock]
         jnz     JIT_Box

--- a/src/coreclr/vm/amd64/JitHelpers_Slow.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_Slow.asm
@@ -226,6 +226,8 @@ NESTED_ENTRY JIT_BoxFastUP, _TEXT
         cmp     r8, r10
         ja      NoAlloc
 
+        test    rdx, rdx
+        je      NullRef
 
         mov     qword ptr [g_global_alloc_context + OFFSETOF__gc_alloc_context__alloc_ptr], r8     ; update the alloc ptr
         mov     [rax], rcx
@@ -265,6 +267,7 @@ NESTED_ENTRY JIT_BoxFastUP, _TEXT
         ret
 
     NoAlloc:
+    NullRef:
         mov     [g_global_alloc_lock], -1
         jmp     JIT_Box
 NESTED_END JIT_BoxFastUP, _TEXT

--- a/src/coreclr/vm/amd64/asmconstants.h
+++ b/src/coreclr/vm/amd64/asmconstants.h
@@ -163,10 +163,6 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__MethodTable__m_wNumInterfaces
 ASMCONSTANTS_C_ASSERT(OFFSETOF__MethodTable__m_pParentMethodTable
                     == offsetof(MethodTable, m_pParentMethodTable));
 
-#define               OFFSETOF__MethodTable__m_pWriteableData       DBG_FRE(0x28, 0x20)
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MethodTable__m_pWriteableData
-                    == offsetof(MethodTable, m_pWriteableData));
-
 #define               OFFSETOF__MethodTable__m_pEEClass             DBG_FRE(0x30, 0x28)
 ASMCONSTANTS_C_ASSERT(OFFSETOF__MethodTable__m_pEEClass
                     == offsetof(MethodTable, m_pEEClass));
@@ -200,14 +196,6 @@ ASMCONSTANTS_C_ASSERT(METHODTABLE_EQUIVALENCE_FLAGS
 #define               MethodTable__enum_flag_ContainsPointers 0x01000000
 ASMCONSTANTS_C_ASSERT(MethodTable__enum_flag_ContainsPointers
                     == MethodTable::enum_flag_ContainsPointers);
-
-#define               OFFSETOF__MethodTableWriteableData__m_dwFlags 0
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MethodTableWriteableData__m_dwFlags
-                    == offsetof(MethodTableWriteableData, m_dwFlags));
-
-#define               MethodTableWriteableData__enum_flag_Unrestored 0x04
-ASMCONSTANTS_C_ASSERT(MethodTableWriteableData__enum_flag_Unrestored
-                    == MethodTableWriteableData::enum_flag_Unrestored);
 
 #define               OFFSETOF__InterfaceInfo_t__m_pMethodTable  0
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InterfaceInfo_t__m_pMethodTable

--- a/src/coreclr/vm/arm/asmconstants.h
+++ b/src/coreclr/vm/arm/asmconstants.h
@@ -76,9 +76,6 @@ ASMCONSTANTS_C_ASSERT(MethodTable__m_BaseSize == offsetof(MethodTable, m_BaseSiz
 #define MethodTable__m_dwFlags         0x0
 ASMCONSTANTS_C_ASSERT(MethodTable__m_dwFlags == offsetof(MethodTable, m_dwFlags));
 
-#define MethodTable__m_pWriteableData   DBG_FRE(0x1c, 0x18)
-ASMCONSTANTS_C_ASSERT(MethodTable__m_pWriteableData == offsetof(MethodTable, m_pWriteableData));
-
 #define MethodTable__enum_flag_ContainsPointers 0x01000000
 ASMCONSTANTS_C_ASSERT(MethodTable__enum_flag_ContainsPointers == MethodTable::enum_flag_ContainsPointers);
 
@@ -87,12 +84,6 @@ ASMCONSTANTS_C_ASSERT(MethodTable__m_ElementType == offsetof(MethodTable, m_pMul
 
 #define SIZEOF__MethodTable             DBG_FRE(0x2c, 0x28)
 ASMCONSTANTS_C_ASSERT(SIZEOF__MethodTable == sizeof(MethodTable));
-
-#define MethodTableWriteableData__m_dwFlags 0x00
-ASMCONSTANTS_C_ASSERT(MethodTableWriteableData__m_dwFlags == offsetof(MethodTableWriteableData, m_dwFlags));
-
-#define MethodTableWriteableData__enum_flag_Unrestored 0x04
-ASMCONSTANTS_C_ASSERT(MethodTableWriteableData__enum_flag_Unrestored == MethodTableWriteableData::enum_flag_Unrestored);
 
 #define ArrayBase__m_NumComponents     0x4
 ASMCONSTANTS_C_ASSERT(ArrayBase__m_NumComponents == offsetof(ArrayBase, m_NumComponents));

--- a/src/coreclr/vm/i386/gmsx86.cpp
+++ b/src/coreclr/vm/i386/gmsx86.cpp
@@ -897,6 +897,7 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
             case 0x03:
             case 0x11:                           // ADC mod/rm
             case 0x13:
+            case 0x21:                           // AND mod/rm
             case 0x29:                           // SUB mod/rm
             case 0x2B:
                 datasize = 0;

--- a/src/coreclr/vm/i386/jitinterfacex86.cpp
+++ b/src/coreclr/vm/i386/jitinterfacex86.cpp
@@ -426,23 +426,6 @@ void *JIT_TrialAlloc::GenBox(Flags flags)
     sl.X86EmitPushReg(kEBX);
     sl.Emit16(0xda8b);
 
-    // Save the MethodTable ptr
-    sl.X86EmitPushReg(kECX);
-
-    // mov             ecx, [ecx]MethodTable.m_pWriteableData
-    sl.X86EmitOffsetModRM(0x8b, kECX, kECX, offsetof(MethodTable, m_pWriteableData));
-
-    // Check whether the class has not been initialized
-    // test [ecx]MethodTableWriteableData.m_dwFlags,MethodTableWriteableData::enum_flag_Unrestored
-    sl.X86EmitOffsetModRM(0xf7, (X86Reg)0x0, kECX, offsetof(MethodTableWriteableData, m_dwFlags));
-    sl.Emit32(MethodTableWriteableData::enum_flag_Unrestored);
-
-    // Restore the MethodTable ptr in ecx
-    sl.X86EmitPopReg(kECX);
-
-    // jne              noAlloc
-    sl.X86EmitCondJump(noAlloc, X86CondCode::kJNE);
-
     // Check for null ref
     // test edx, edx
     sl.X86EmitR2ROp(0x85, kEDX, kEDX);

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -2691,6 +2691,10 @@ HCIMPL2(Object*, JIT_Box, CORINFO_CLASS_HANDLE type, void* unboxedData)
     GCPROTECT_BEGININTERIOR(unboxedData);
     HELPER_METHOD_POLL();
 
+    // A null can be passed for boxing of a null ref.
+    if (unboxedData == NULL)
+        COMPlusThrow(kNullReferenceException);
+
     TypeHandle clsHnd(type);
 
     _ASSERTE(!clsHnd.IsTypeDesc());  // boxable types have method tables

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -2060,13 +2060,28 @@ ves_icall_System_Threading_Thread_Join_internal (MonoThreadObjectHandle thread_h
 	return FALSE;
 }
 
+static size_t
+set_pending_null_reference_exception ()
+{
+	ERROR_DECL (error);
+	mono_error_set_null_reference (error);
+	mono_error_set_pending_exception (error);
+	return 0;
+}
+
 gint32 ves_icall_System_Threading_Interlocked_Increment_Int (gint32 *location)
 {
+	if (!location)
+		return (gint32)set_pending_null_reference_exception ();
+
 	return mono_atomic_inc_i32 (location);
 }
 
 gint64 ves_icall_System_Threading_Interlocked_Increment_Long (gint64 *location)
 {
+	if (!location)
+		return (gint64)set_pending_null_reference_exception ();
+
 #if SIZEOF_VOID_P == 4
 	if (G_UNLIKELY ((size_t)location & 0x7)) {
 		gint64 ret;
@@ -2082,11 +2097,17 @@ gint64 ves_icall_System_Threading_Interlocked_Increment_Long (gint64 *location)
 
 gint32 ves_icall_System_Threading_Interlocked_Decrement_Int (gint32 *location)
 {
+	if (!location)
+		return (gint32)set_pending_null_reference_exception ();
+
 	return mono_atomic_dec_i32(location);
 }
 
 gint64 ves_icall_System_Threading_Interlocked_Decrement_Long (gint64 * location)
 {
+	if (!location)
+		return (gint64)set_pending_null_reference_exception ();
+
 #if SIZEOF_VOID_P == 4
 	if (G_UNLIKELY ((size_t)location & 0x7)) {
 		gint64 ret;
@@ -2102,12 +2123,21 @@ gint64 ves_icall_System_Threading_Interlocked_Decrement_Long (gint64 * location)
 
 gint32 ves_icall_System_Threading_Interlocked_Exchange_Int (gint32 *location, gint32 value)
 {
+	if (!location)
+		return (gint32)set_pending_null_reference_exception ();
+
 	return mono_atomic_xchg_i32(location, value);
 }
 
 void
 ves_icall_System_Threading_Interlocked_Exchange_Object (MonoObject *volatile*location, MonoObject *volatile*value, MonoObject *volatile*res)
 {
+	if (!location)
+	{
+		(void)set_pending_null_reference_exception ();
+		return;
+	}
+
 	// Coop-equivalency here via pointers to pointers.
 	// value and res are to managed frames, location ought to be (or member or global) but it cannot be guaranteed.
 	//
@@ -2123,6 +2153,8 @@ ves_icall_System_Threading_Interlocked_Exchange_Object (MonoObject *volatile*loc
 gfloat ves_icall_System_Threading_Interlocked_Exchange_Single (gfloat *location, gfloat value)
 {
 	IntFloatUnion val, ret;
+	if (!location)
+		return (gfloat)set_pending_null_reference_exception ();
 
 	val.fval = value;
 	ret.ival = mono_atomic_xchg_i32((gint32 *) location, val.ival);
@@ -2133,6 +2165,9 @@ gfloat ves_icall_System_Threading_Interlocked_Exchange_Single (gfloat *location,
 gint64
 ves_icall_System_Threading_Interlocked_Exchange_Long (gint64 *location, gint64 value)
 {
+	if (!location)
+		return (gint64)set_pending_null_reference_exception ();
+
 #if SIZEOF_VOID_P == 4
 	if (G_UNLIKELY ((size_t)location & 0x7)) {
 		gint64 ret;
@@ -2150,6 +2185,8 @@ gdouble
 ves_icall_System_Threading_Interlocked_Exchange_Double (gdouble *location, gdouble value)
 {
 	LongDoubleUnion val, ret;
+	if (!location)
+		return (gdouble)set_pending_null_reference_exception ();
 
 	val.fval = value;
 	ret.ival = (gint64)mono_atomic_xchg_i64((gint64 *) location, val.ival);
@@ -2159,11 +2196,17 @@ ves_icall_System_Threading_Interlocked_Exchange_Double (gdouble *location, gdoub
 
 gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int(gint32 *location, gint32 value, gint32 comparand)
 {
+	if (!location)
+		return (gint32)set_pending_null_reference_exception ();
+
 	return mono_atomic_cas_i32(location, value, comparand);
 }
 
 gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int_Success(gint32 *location, gint32 value, gint32 comparand, MonoBoolean *success)
 {
+	if (!location)
+		return (gint32)set_pending_null_reference_exception ();
+
 	gint32 r = mono_atomic_cas_i32(location, value, comparand);
 	*success = r == comparand;
 	return r;
@@ -2172,6 +2215,12 @@ gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int_Success(gint32
 void
 ves_icall_System_Threading_Interlocked_CompareExchange_Object (MonoObject *volatile*location, MonoObject *volatile*value, MonoObject *volatile*comparand, MonoObject *volatile* res)
 {
+	if (!location)
+	{
+		(void)set_pending_null_reference_exception ();
+		return;
+	}
+
 	// Coop-equivalency here via pointers to pointers.
 	// value and comparand and res are to managed frames, location ought to be (or member or global) but it cannot be guaranteed.
 	//
@@ -2187,6 +2236,8 @@ ves_icall_System_Threading_Interlocked_CompareExchange_Object (MonoObject *volat
 gfloat ves_icall_System_Threading_Interlocked_CompareExchange_Single (gfloat *location, gfloat value, gfloat comparand)
 {
 	IntFloatUnion val, ret, cmp;
+	if (!location)
+		return (gfloat)set_pending_null_reference_exception ();
 
 	val.fval = value;
 	cmp.fval = comparand;
@@ -2198,6 +2249,9 @@ gfloat ves_icall_System_Threading_Interlocked_CompareExchange_Single (gfloat *lo
 gdouble
 ves_icall_System_Threading_Interlocked_CompareExchange_Double (gdouble *location, gdouble value, gdouble comparand)
 {
+	if (!location)
+		return (gdouble)set_pending_null_reference_exception ();
+
 #if SIZEOF_VOID_P == 8
 	LongDoubleUnion val, comp, ret;
 
@@ -2222,6 +2276,9 @@ ves_icall_System_Threading_Interlocked_CompareExchange_Double (gdouble *location
 gint64
 ves_icall_System_Threading_Interlocked_CompareExchange_Long (gint64 *location, gint64 value, gint64 comparand)
 {
+	if (!location)
+		return (gint64)set_pending_null_reference_exception ();
+
 #if SIZEOF_VOID_P == 4
 	if (G_UNLIKELY ((size_t)location & 0x7)) {
 		gint64 old;
@@ -2239,12 +2296,18 @@ ves_icall_System_Threading_Interlocked_CompareExchange_Long (gint64 *location, g
 gint32
 ves_icall_System_Threading_Interlocked_Add_Int (gint32 *location, gint32 value)
 {
+	if (!location)
+		return (gint32)set_pending_null_reference_exception ();
+
 	return mono_atomic_add_i32 (location, value);
 }
 
 gint64
 ves_icall_System_Threading_Interlocked_Add_Long (gint64 *location, gint64 value)
 {
+	if (!location)
+		return (gint64)set_pending_null_reference_exception ();
+
 #if SIZEOF_VOID_P == 4
 	if (G_UNLIKELY ((size_t)location & 0x7)) {
 		gint64 ret;
@@ -2261,6 +2324,9 @@ ves_icall_System_Threading_Interlocked_Add_Long (gint64 *location, gint64 value)
 gint64
 ves_icall_System_Threading_Interlocked_Read_Long (gint64 *location)
 {
+	if (!location)
+		return (gint64)set_pending_null_reference_exception ();
+
 #if SIZEOF_VOID_P == 4
 	if (G_UNLIKELY ((size_t)location & 0x7)) {
 		gint64 ret;

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -2060,8 +2060,10 @@ ves_icall_System_Threading_Thread_Join_internal (MonoThreadObjectHandle thread_h
 	return FALSE;
 }
 
+// this is a bad idea but we're doing it anyway. we need to propagate
+// an exception out of these icalls in some way.
 static size_t
-set_pending_null_reference_exception ()
+set_pending_null_reference_exception (void)
 {
 	ERROR_DECL (error);
 	mono_error_set_null_reference (error);
@@ -2071,7 +2073,7 @@ set_pending_null_reference_exception ()
 
 gint32 ves_icall_System_Threading_Interlocked_Increment_Int (gint32 *location)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint32)set_pending_null_reference_exception ();
 
 	return mono_atomic_inc_i32 (location);
@@ -2079,7 +2081,7 @@ gint32 ves_icall_System_Threading_Interlocked_Increment_Int (gint32 *location)
 
 gint64 ves_icall_System_Threading_Interlocked_Increment_Long (gint64 *location)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint64)set_pending_null_reference_exception ();
 
 #if SIZEOF_VOID_P == 4
@@ -2097,7 +2099,7 @@ gint64 ves_icall_System_Threading_Interlocked_Increment_Long (gint64 *location)
 
 gint32 ves_icall_System_Threading_Interlocked_Decrement_Int (gint32 *location)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint32)set_pending_null_reference_exception ();
 
 	return mono_atomic_dec_i32(location);
@@ -2105,7 +2107,7 @@ gint32 ves_icall_System_Threading_Interlocked_Decrement_Int (gint32 *location)
 
 gint64 ves_icall_System_Threading_Interlocked_Decrement_Long (gint64 * location)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint64)set_pending_null_reference_exception ();
 
 #if SIZEOF_VOID_P == 4
@@ -2123,7 +2125,7 @@ gint64 ves_icall_System_Threading_Interlocked_Decrement_Long (gint64 * location)
 
 gint32 ves_icall_System_Threading_Interlocked_Exchange_Int (gint32 *location, gint32 value)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint32)set_pending_null_reference_exception ();
 
 	return mono_atomic_xchg_i32(location, value);
@@ -2132,7 +2134,7 @@ gint32 ves_icall_System_Threading_Interlocked_Exchange_Int (gint32 *location, gi
 void
 ves_icall_System_Threading_Interlocked_Exchange_Object (MonoObject *volatile*location, MonoObject *volatile*value, MonoObject *volatile*res)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 	{
 		(void)set_pending_null_reference_exception ();
 		return;
@@ -2153,7 +2155,7 @@ ves_icall_System_Threading_Interlocked_Exchange_Object (MonoObject *volatile*loc
 gfloat ves_icall_System_Threading_Interlocked_Exchange_Single (gfloat *location, gfloat value)
 {
 	IntFloatUnion val, ret;
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gfloat)set_pending_null_reference_exception ();
 
 	val.fval = value;
@@ -2165,7 +2167,7 @@ gfloat ves_icall_System_Threading_Interlocked_Exchange_Single (gfloat *location,
 gint64
 ves_icall_System_Threading_Interlocked_Exchange_Long (gint64 *location, gint64 value)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint64)set_pending_null_reference_exception ();
 
 #if SIZEOF_VOID_P == 4
@@ -2185,7 +2187,7 @@ gdouble
 ves_icall_System_Threading_Interlocked_Exchange_Double (gdouble *location, gdouble value)
 {
 	LongDoubleUnion val, ret;
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gdouble)set_pending_null_reference_exception ();
 
 	val.fval = value;
@@ -2196,7 +2198,7 @@ ves_icall_System_Threading_Interlocked_Exchange_Double (gdouble *location, gdoub
 
 gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int(gint32 *location, gint32 value, gint32 comparand)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint32)set_pending_null_reference_exception ();
 
 	return mono_atomic_cas_i32(location, value, comparand);
@@ -2204,7 +2206,7 @@ gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int(gint32 *locati
 
 gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int_Success(gint32 *location, gint32 value, gint32 comparand, MonoBoolean *success)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint32)set_pending_null_reference_exception ();
 
 	gint32 r = mono_atomic_cas_i32(location, value, comparand);
@@ -2215,7 +2217,7 @@ gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int_Success(gint32
 void
 ves_icall_System_Threading_Interlocked_CompareExchange_Object (MonoObject *volatile*location, MonoObject *volatile*value, MonoObject *volatile*comparand, MonoObject *volatile* res)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 	{
 		(void)set_pending_null_reference_exception ();
 		return;
@@ -2236,7 +2238,7 @@ ves_icall_System_Threading_Interlocked_CompareExchange_Object (MonoObject *volat
 gfloat ves_icall_System_Threading_Interlocked_CompareExchange_Single (gfloat *location, gfloat value, gfloat comparand)
 {
 	IntFloatUnion val, ret, cmp;
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gfloat)set_pending_null_reference_exception ();
 
 	val.fval = value;
@@ -2249,7 +2251,7 @@ gfloat ves_icall_System_Threading_Interlocked_CompareExchange_Single (gfloat *lo
 gdouble
 ves_icall_System_Threading_Interlocked_CompareExchange_Double (gdouble *location, gdouble value, gdouble comparand)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gdouble)set_pending_null_reference_exception ();
 
 #if SIZEOF_VOID_P == 8
@@ -2276,7 +2278,7 @@ ves_icall_System_Threading_Interlocked_CompareExchange_Double (gdouble *location
 gint64
 ves_icall_System_Threading_Interlocked_CompareExchange_Long (gint64 *location, gint64 value, gint64 comparand)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint64)set_pending_null_reference_exception ();
 
 #if SIZEOF_VOID_P == 4
@@ -2296,7 +2298,7 @@ ves_icall_System_Threading_Interlocked_CompareExchange_Long (gint64 *location, g
 gint32
 ves_icall_System_Threading_Interlocked_Add_Int (gint32 *location, gint32 value)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint32)set_pending_null_reference_exception ();
 
 	return mono_atomic_add_i32 (location, value);
@@ -2305,7 +2307,7 @@ ves_icall_System_Threading_Interlocked_Add_Int (gint32 *location, gint32 value)
 gint64
 ves_icall_System_Threading_Interlocked_Add_Long (gint64 *location, gint64 value)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint64)set_pending_null_reference_exception ();
 
 #if SIZEOF_VOID_P == 4
@@ -2324,7 +2326,7 @@ ves_icall_System_Threading_Interlocked_Add_Long (gint64 *location, gint64 value)
 gint64
 ves_icall_System_Threading_Interlocked_Read_Long (gint64 *location)
 {
-	if (!location)
+	if (G_UNLIKELY (!location))
 		return (gint64)set_pending_null_reference_exception ();
 
 #if SIZEOF_VOID_P == 4

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -6681,6 +6681,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gboolean flag = FALSE;
 			gint64 *dest = LOCAL_VAR (ip [2], gint64*);
 			gint64 exch = LOCAL_VAR (ip [3], gint64);
+			NULL_CHECK(dest);
 #if SIZEOF_VOID_P == 4
 			if (G_UNLIKELY (((size_t)dest) & 0x7)) {
 				gint64 result;

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -1363,6 +1363,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			if (is_ref && !mini_debug_options.weak_memory_model)
 				mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
 
+			MONO_EMIT_NULL_CHECK (cfg, args [0]->dreg, FALSE);
 			MONO_INST_NEW (cfg, ins, opcode);
 			ins->dreg = is_ref ? mono_alloc_ireg_ref (cfg) : mono_alloc_ireg (cfg);
 			ins->inst_basereg = args [0]->dreg;

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -1238,6 +1238,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				ins_iconst->dreg = mono_alloc_ireg (cfg);
 				MONO_ADD_INS (cfg->cbb, ins_iconst);
 
+				MONO_EMIT_NULL_CHECK (cfg, args [0]->dreg, FALSE);
 				MONO_INST_NEW (cfg, ins, opcode);
 				ins->dreg = mono_alloc_ireg (cfg);
 				ins->inst_basereg = args [0]->dreg;
@@ -1266,6 +1267,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				ins_iconst->dreg = mono_alloc_ireg (cfg);
 				MONO_ADD_INS (cfg->cbb, ins_iconst);
 
+				MONO_EMIT_NULL_CHECK (cfg, args [0]->dreg, FALSE);
 				MONO_INST_NEW (cfg, ins, opcode);
 				ins->dreg = mono_alloc_ireg (cfg);
 				ins->inst_basereg = args [0]->dreg;
@@ -1304,6 +1306,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 
 			// For now, only Add is supported in non-LLVM back-ends
 			if (opcode && (COMPILE_LLVM (cfg) || mono_arch_opcode_supported (opcode))) {
+				MONO_EMIT_NULL_CHECK (cfg, args [0]->dreg, FALSE);
 				MONO_INST_NEW (cfg, ins, opcode);
 				ins->dreg = mono_alloc_ireg (cfg);
 				ins->inst_basereg = args [0]->dreg;
@@ -1467,6 +1470,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			if (is_ref && !mini_debug_options.weak_memory_model)
 				mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
 
+			MONO_EMIT_NULL_CHECK (cfg, args [0]->dreg, FALSE);
 			MONO_INST_NEW (cfg, ins, opcode);
 			ins->dreg = is_ref ? alloc_ireg_ref (cfg) : alloc_ireg (cfg);
 			ins->sreg1 = args [0]->dreg;

--- a/src/tests/baseservices/invalid_operations/InvalidOperations.csproj
+++ b/src/tests/baseservices/invalid_operations/InvalidOperations.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ManagedPointers.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/invalid_operations/ManagedPointers.cs
+++ b/src/tests/baseservices/invalid_operations/ManagedPointers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 using Xunit;
 
@@ -49,5 +50,35 @@ public unsafe class ManagedPointers
 
         [UnmanagedCallersOnly]
         static nint PassByRef(void* a) => (nint)a;
+    }
+
+    [Fact]
+    public static void Validate_IntrinsicMethodsWithByRef_NullByRef()
+    {
+        Console.WriteLine($"Running {nameof(Validate_IntrinsicMethodsWithByRef_NullByRef)}...");
+
+        Assert.Throws<NullReferenceException>(() => Interlocked.Increment(ref Unsafe.NullRef<int>()));
+        Assert.Throws<NullReferenceException>(() => Interlocked.Increment(ref Unsafe.NullRef<long>()));
+        Assert.Throws<NullReferenceException>(() => Interlocked.Decrement(ref Unsafe.NullRef<int>()));
+        Assert.Throws<NullReferenceException>(() => Interlocked.Decrement(ref Unsafe.NullRef<long>()));
+
+        Assert.Throws<NullReferenceException>(() => Interlocked.And(ref Unsafe.NullRef<int>(), 0));
+        Assert.Throws<NullReferenceException>(() => Interlocked.And(ref Unsafe.NullRef<long>(), 0));
+        Assert.Throws<NullReferenceException>(() => Interlocked.Or(ref Unsafe.NullRef<int>(), 0));
+        Assert.Throws<NullReferenceException>(() => Interlocked.Or(ref Unsafe.NullRef<long>(), 0));
+
+        Assert.Throws<NullReferenceException>(() => Interlocked.Exchange(ref Unsafe.NullRef<int>(), 0));
+        Assert.Throws<NullReferenceException>(() => Interlocked.Exchange(ref Unsafe.NullRef<long>(), 0));
+        Assert.Throws<NullReferenceException>(() => Interlocked.Exchange(ref Unsafe.NullRef<float>(), 0));
+        Assert.Throws<NullReferenceException>(() => Interlocked.Exchange(ref Unsafe.NullRef<double>(), 0));
+        Assert.Throws<NullReferenceException>(() => Interlocked.Exchange(ref Unsafe.NullRef<object>(), new object()));
+        Assert.Throws<NullReferenceException>(() => Interlocked.Exchange<object>(ref Unsafe.NullRef<object>(), new object()));
+
+        Assert.Throws<NullReferenceException>(() => Interlocked.CompareExchange(ref Unsafe.NullRef<int>(), 0, 0));
+        Assert.Throws<NullReferenceException>(() => Interlocked.CompareExchange(ref Unsafe.NullRef<long>(), 0, 0));
+        Assert.Throws<NullReferenceException>(() => Interlocked.CompareExchange(ref Unsafe.NullRef<float>(), 0, 0));
+        Assert.Throws<NullReferenceException>(() => Interlocked.CompareExchange(ref Unsafe.NullRef<double>(), 0, 0));
+        Assert.Throws<NullReferenceException>(() => Interlocked.CompareExchange(ref Unsafe.NullRef<object>(), new object(), new object()));
+        Assert.Throws<NullReferenceException>(() => Interlocked.CompareExchange<object>(ref Unsafe.NullRef<object>(), new object(), new object()));
     }
 }

--- a/src/tests/baseservices/invalid_operations/ManagedPointers.cs
+++ b/src/tests/baseservices/invalid_operations/ManagedPointers.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using Xunit;
+
+public unsafe class ManagedPointers
+{
+    [Fact]
+    public static void Validate_BoxingHelpers_NullByRef()
+    {
+        Console.WriteLine($"Running {nameof(Validate_BoxingHelpers_NullByRef)}...");
+        Assert.Throws<NullReferenceException>(() =>
+        {
+            object boxed = Unsafe.NullRef<int>();
+        });
+        Assert.Throws<NullReferenceException>(() =>
+        {
+            object boxed = Unsafe.NullRef<Guid>();
+        });
+        Assert.Throws<NullReferenceException>(() =>
+        {
+            object boxed = Unsafe.NullRef<string>();
+        });
+    }
+
+    [Fact]
+    public static void Validate_GeneratedILStubs_NullByRef()
+    {
+        Console.WriteLine($"Running {nameof(Validate_GeneratedILStubs_NullByRef)}...");
+        {
+            var fptr = (delegate*unmanaged<ref int, nint>)(delegate*unmanaged<void*, nint>)&PassByRef;
+            Assert.Equal(0, fptr(ref Unsafe.NullRef<int>()));
+        }
+
+        {
+            var fptr = (delegate*unmanaged<ref Guid, nint>)(delegate*unmanaged<void*, nint>)&PassByRef;
+            Assert.Equal(0, fptr(ref Unsafe.NullRef<Guid>()));
+        }
+
+        Assert.Throws<NullReferenceException>(() =>
+        {
+            var fptr = (delegate*unmanaged<ref string, nint>)(delegate*unmanaged<void*, nint>)&PassByRef;
+            fptr(ref Unsafe.NullRef<string>());
+        });
+
+        [UnmanagedCallersOnly]
+        static nint PassByRef(void* a) => (nint)a;
+    }
+}

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1499,7 +1499,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/ShiftOperations/*">
           <Issue>There is a known undefined behavior with shifts and 0xFFFFFFFF overflows, so skip the test for mono.</Issue>
         </ExcludeList>
-      
+
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTestWithMcj/*">
             <Issue>Tests features specific to coreclr</Issue>
         </ExcludeList>
@@ -3129,6 +3129,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/generics/Pointers/**">
             <Issue>Doesn't compile with LLVM AOT.</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/baseservices/invalid_operations/**">
+            <Issue>Doesn't compile with LLVM AOT.</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and ('$(RuntimeVariant)' == 'llvmfullaot' or '$(RuntimeVariant)' == 'llvmaot') and '$(TargetArchitecture)' == 'arm64'">
@@ -3305,6 +3308,9 @@
             <Issue>https://github.com/dotnet/runtime/issues/54122</Issue>
         </ExcludeList>
 
+        <ExcludeList Include = "$(XunitTestBinBase)/baseservices/invalid_operations/**">
+            <Issue>Function mismatch</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/baseservices/threading/DeadThreads/DeadThreads/**">
             <Issue>https://github.com/dotnet/runtime/issues/41472</Issue>
         </ExcludeList>


### PR DESCRIPTION
Verified this on coreclr, mono, and added testing.

Fixes https://github.com/dotnet/runtime/issues/70268