### PR TITLE
Convert assert to exception for loading native libraries

### DIFF
--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -169,11 +169,6 @@ native_binaries_to_ignore = [
     "System.IO.Compression.Native.dll",
     "ucrtbase.dll",
     "xunit.console.exe",
-
-    # The following cause VM asserts. Disabling to attempt to fix periodic SPMI collection pipeline failures.
-    # Tracked by: https://github.com/dotnet/runtime/issues/70293
-    "System.Runtime.InteropServices.Tests.dll", # libraries test
-    "DllImportPathTest.dll", # coreclr test
 ]
 
 MAX_FILES_COUNT = 1500

--- a/src/coreclr/utilcode/longfilepathwrappers.cpp
+++ b/src/coreclr/utilcode/longfilepathwrappers.cpp
@@ -59,10 +59,6 @@ LoadLibraryExWrapper(
         if (LongFile::IsPathNotFullyQualified(path) || SUCCEEDED(LongFile::NormalizePath(path)))
         {
 #ifdef HOST_WINDOWS
-            // Ensure relative paths which are not just filenames are not used for LoadLibrary calls.
-            if (LongFile::IsPathNotFullyQualified(path) && LongFile::ContainsDirectorySeparator(path))
-                ThrowHR(HRESULT_FROM_WIN32(ERROR_BAD_PATHNAME));
-
             LongFile::NormalizeDirectorySeparators(path);
 #endif //HOST_WINDOWS
 

--- a/src/coreclr/utilcode/longfilepathwrappers.cpp
+++ b/src/coreclr/utilcode/longfilepathwrappers.cpp
@@ -54,14 +54,15 @@ LoadLibraryExWrapper(
 
     EX_TRY
     {
-
         LongPathString path(LongPathString::Literal, lpLibFileName);
 
         if (LongFile::IsPathNotFullyQualified(path) || SUCCEEDED(LongFile::NormalizePath(path)))
         {
 #ifdef HOST_WINDOWS
-            //Adding the assert to ensure relative paths which are not just filenames are not used for LoadLibrary Calls
-            _ASSERTE(!LongFile::IsPathNotFullyQualified(path) || !LongFile::ContainsDirectorySeparator(path));
+            // Ensure relative paths which are not just filenames are not used for LoadLibrary calls.
+            if (LongFile::IsPathNotFullyQualified(path) && LongFile::ContainsDirectorySeparator(path))
+                ThrowHR(HRESULT_FROM_WIN32(ERROR_BAD_PATHNAME));
+
             LongFile::NormalizeDirectorySeparators(path);
 #endif //HOST_WINDOWS
 

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
@@ -109,6 +109,15 @@ public class NativeLibraryTests : IDisposable
         EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, null), TestResult.ReturnFailure);
     }
 
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void LoadLibraryInvalidPath_Failure()
+    {
+        string libName = "../InvalidPath/InvalidPath.dll";
+        EXPECT(LoadLibrary_WithAssembly(libName, assembly, null), TestResult.DllNotFound);
+        EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, null), TestResult.ReturnFailure);
+    }
+
     public static bool HasKnownLibraryInSystemDirectory =>
         OperatingSystem.IsWindows()
         && File.Exists(Path.Combine(Environment.SystemDirectory, "url.dll"));

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
@@ -47,6 +47,23 @@ public class NativeLibraryTests : IDisposable
     }
 
     [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void LoadLibraryRelativePaths()
+    {
+        {
+            string libName = "../InvalidPath/InvalidPath.dll";
+            EXPECT(LoadLibrary_NameOnly(libName), TestResult.DllNotFound);
+            EXPECT(TryLoadLibrary_NameOnly(libName), TestResult.ReturnFailure);
+        }
+
+        {
+            string libName = $"..\\{nameof(NativeLibraryTests)}\\{NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.Name)}";
+            EXPECT(LoadLibrary_NameOnly(libName), TestResult.Success);
+            EXPECT(TryLoadLibrary_NameOnly(libName), TestResult.Success);
+        }
+    }
+
+    [Fact]
     public void LoadLibraryFullPath_WithAssembly()
     {
         string libName = libFullPath;
@@ -105,15 +122,6 @@ public class NativeLibraryTests : IDisposable
         // DllImport doesn't add a prefix if the name is preceeded by a path specification.
         // Linux and Mac need both prefix and suffix
         string libName = Path.Combine(testBinDir, NativeLibraryToLoad.Name);
-        EXPECT(LoadLibrary_WithAssembly(libName, assembly, null), TestResult.DllNotFound);
-        EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, null), TestResult.ReturnFailure);
-    }
-
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    public void LoadLibraryInvalidPath_Failure()
-    {
-        string libName = "../InvalidPath/InvalidPath.dll";
         EXPECT(LoadLibrary_WithAssembly(libName, assembly, null), TestResult.DllNotFound);
         EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, null), TestResult.ReturnFailure);
     }

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
@@ -47,17 +47,16 @@ public class NativeLibraryTests : IDisposable
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    public void LoadLibraryRelativePaths()
+    public void LoadLibraryRelativePaths_NameOnly()
     {
         {
-            string libName = "../InvalidPath/InvalidPath.dll";
+            string libName = Path.Combine("..", NativeLibraryToLoad.InvalidName, NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.InvalidName));
             EXPECT(LoadLibrary_NameOnly(libName), TestResult.DllNotFound);
             EXPECT(TryLoadLibrary_NameOnly(libName), TestResult.ReturnFailure);
         }
 
         {
-            string libName = $"..\\{nameof(NativeLibraryTests)}\\{NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.Name)}";
+            string libName = Path.Combine("..", nameof(NativeLibraryTests), NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.Name));
             EXPECT(LoadLibrary_NameOnly(libName), TestResult.Success);
             EXPECT(TryLoadLibrary_NameOnly(libName), TestResult.Success);
         }


### PR DESCRIPTION
Fixes #70293

/cc @dotnet/interop-contrib