### PR TITLE
JIT: remove loop if `lpTop` becomes unreachable

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -443,7 +443,7 @@ void Compiler::optUpdateLoopsBeforeRemoveBlock(BasicBlock* block, bool skipUnmar
 #endif // DEBUG
         };
 
-        if (block == loop.lpEntry || block == loop.lpBottom)
+        if ((block == loop.lpEntry) || (block == loop.lpBottom) || (block == loop.lpTop))
         {
             reportBefore();
             optMarkLoopRemoved(loopNum);


### PR DESCRIPTION
We may be able to prune the backedge of a middle-entry loop (one where
`lpEntry != lpTop`). Extend `optUpdateLoopsBeforeRemoveBlock` to handle
this case.

Fixes #69938.