### PR TITLE
[wasm] Fix Wasm.Build.Tests test failures on windows

### DIFF
--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -91,6 +91,7 @@
         See https://github.com/dotnet/runtime/issues/53367 for the motivating issue
       -->
       <EmscriptenEnvVars Include="PYTHONUTF8=1" />
+      <EmscriptenEnvVars Include="EM_WORKAROUND_PYTHON_BUG_34780=1" />
     </ItemGroup>
   </Target>
 

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildEnvironment.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildEnvironment.cs
@@ -97,6 +97,7 @@ namespace Wasm.Build.Tests
             EnvVars["_WasmStrictVersionMatch"] = "true";
             EnvVars["MSBuildSDKsPath"] = string.Empty;
             EnvVars["PATH"] = $"{sdkForWorkloadPath}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}";
+            EnvVars["EM_WORKAROUND_PYTHON_BUG_34780"] = "1";
 
             // helps with debugging
             EnvVars["WasmNativeStrip"] = "false";

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/data/RunScriptTemplate.cmd
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/data/RunScriptTemplate.cmd
@@ -95,13 +95,13 @@ REM Functions
 :SetEnvVars
 if [%TEST_USING_WORKLOADS%] == [true] (
     set SDK_HAS_WORKLOAD_INSTALLED=true
-    robocopy /e %BASE_DIR%\dotnet-workload %EXECUTION_DIR%\dotnet-workload
+    robocopy /np /nfl /e %BASE_DIR%\dotnet-workload %EXECUTION_DIR%\dotnet-workload
     set "SDK_FOR_WORKLOAD_TESTING_PATH=%EXECUTION_DIR%\dotnet-workload"
     set "PATH=%EXECUTION_DIR%\dotnet-workload;%PATH%"
     set "AppRefDir=%BASE_DIR%\microsoft.netcore.app.ref"
 ) else (
     set SDK_HAS_WORKLOAD_INSTALLED=false
-    robocopy /e %BASE_DIR%\sdk-no-workload %EXECUTION_DIR%\sdk-no-workload
+    robocopy /np /nfl /e %BASE_DIR%\sdk-no-workload %EXECUTION_DIR%\sdk-no-workload
     set "SDK_FOR_WORKLOAD_TESTING_PATH=%EXECUTION_DIR%\sdk-no-workload"
     set "PATH=%EXECUTION_DIR%\sdk-no-workload;%PATH%"
     set "AppRefDir=%BASE_DIR%\microsoft.netcore.app.ref"

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/data/RunScriptTemplate.cmd
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/data/RunScriptTemplate.cmd
@@ -94,14 +94,16 @@ exit /b %EXIT_CODE%
 REM Functions
 :SetEnvVars
 if [%TEST_USING_WORKLOADS%] == [true] (
-    set "PATH=%BASE_DIR%\dotnet-workload;%PATH%"
     set SDK_HAS_WORKLOAD_INSTALLED=true
-    set "SDK_FOR_WORKLOAD_TESTING_PATH=%BASE_DIR%\dotnet-workload"
+    robocopy /e %BASE_DIR%\dotnet-workload %EXECUTION_DIR%\dotnet-workload
+    set "SDK_FOR_WORKLOAD_TESTING_PATH=%EXECUTION_DIR%\dotnet-workload"
+    set "PATH=%EXECUTION_DIR%\dotnet-workload;%PATH%"
     set "AppRefDir=%BASE_DIR%\microsoft.netcore.app.ref"
 ) else (
-    set "PATH=%BASE_DIR%\sdk-no-workload;%PATH%"
     set SDK_HAS_WORKLOAD_INSTALLED=false
-    set "SDK_FOR_WORKLOAD_TESTING_PATH=%BASE_DIR%\sdk-no-workload"
+    robocopy /e %BASE_DIR%\sdk-no-workload %EXECUTION_DIR%\sdk-no-workload
+    set "SDK_FOR_WORKLOAD_TESTING_PATH=%EXECUTION_DIR%\sdk-no-workload"
+    set "PATH=%EXECUTION_DIR%\sdk-no-workload;%PATH%"
     set "AppRefDir=%BASE_DIR%\microsoft.netcore.app.ref"
 )
 EXIT /b 0

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/data/RunScriptTemplate.sh
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/data/RunScriptTemplate.sh
@@ -67,14 +67,16 @@ echo XHARNESS_ARGS=$XHARNESS_ARGS
 function set_env_vars()
 {
     if [ "x$TEST_USING_WORKLOADS" = "xtrue" ]; then
-        export PATH=$BASE_DIR/dotnet-workload:$PATH
+        cp -r $BASE_DIR/dotnet-workload $EXECUTION_DIR
+        export PATH=$EXECUTION_DIR/dotnet-workload:$PATH
         export SDK_HAS_WORKLOAD_INSTALLED=true
-        export SDK_FOR_WORKLOAD_TESTING_PATH=$BASE_DIR/dotnet-workload
+        export SDK_FOR_WORKLOAD_TESTING_PATH=$EXECUTION_DIR/dotnet-workload
         export AppRefDir=$BASE_DIR/microsoft.netcore.app.ref
     else
-        export PATH=$BASE_DIR/sdk-no-workload:$PATH
+        cp -r $BASE_DIR/sdk-no-workload $EXECUTION_DIR
+        export PATH=$EXECUTION_DIR/sdk-no-workload:$PATH
         export SDK_HAS_WORKLOAD_INSTALLED=false
-        export SDK_FOR_WORKLOAD_TESTING_PATH=$BASE_DIR/sdk-no-workload
+        export SDK_FOR_WORKLOAD_TESTING_PATH=$EXECUTION_DIR/sdk-no-workload
         export AppRefDir=$BASE_DIR/microsoft.netcore.app.ref
     fi
 }


### PR DESCRIPTION
- Enable workaround for a python issue - `EM_WORKAROUND_PYTHON_BUG_34780` (https://github.com/emscripten-core/emscripten/pull/15146)
- Use a local copy of `dotnet`, to avoid interfering with other `dotnet` instances

Fixes https://github.com/dotnet/runtime/issues/69860 .