### PR TITLE
Fix trimmability of various System.Runtime tests

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -17,8 +17,7 @@ namespace System.Reflection.Tests
         private static readonly NullabilityInfoContext nullabilityContext = new NullabilityInfoContext();
         private static readonly Type testType = typeof(TypeWithNotNullContext);
         private static readonly Type genericType = typeof(GenericTest<TypeWithNotNullContext>);
-        private static readonly Type stringType = typeof(string);
-        private static readonly BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+        private const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
 
         public static IEnumerable<object[]> FieldTestData()
         {
@@ -705,7 +704,7 @@ namespace System.Reflection.Tests
         [MemberData(nameof(StringTypeTestData))]
         public void NullablePublicOnlyStringTypeTest(string methodName, NullabilityState param1State, NullabilityState param2State, NullabilityState param3State, Type[] types)
         {
-            ParameterInfo[] parameters = stringType.GetMethod(methodName, flags, types)!.GetParameters();
+            ParameterInfo[] parameters = typeof(string).GetMethod(methodName, flags, types)!.GetParameters();
             NullabilityInfo param1 = nullabilityContext.Create(parameters[0]);
             NullabilityInfo param2 = nullabilityContext.Create(parameters[1]);
             NullabilityInfo param3 = nullabilityContext.Create(parameters[2]);

--- a/src/libraries/System.Runtime/tests/System/Text/ASCIIUtilityTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/ASCIIUtilityTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -427,9 +428,10 @@ namespace System.Text.Tests
             }
         }
 
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
         private static Type GetAsciiUtilityType()
         {
-            return typeof(object).Assembly.GetType("System.Text.ASCIIUtility");
+            return Type.GetType("System.Text.ASCIIUtility");
         }
 
         private sealed class UnsafeLazyDelegate<TDelegate> where TDelegate : Delegate

--- a/src/libraries/System.Runtime/tests/System/Text/ASCIIUtilityTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/ASCIIUtilityTests.cs
@@ -431,7 +431,7 @@ namespace System.Text.Tests
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
         private static Type GetAsciiUtilityType()
         {
-            return Type.GetType("System.Text.ASCIIUtility");
+            return Type.GetType("System.Text.ASCIIUtility, System.Private.CoreLib");
         }
 
         private sealed class UnsafeLazyDelegate<TDelegate> where TDelegate : Delegate

--- a/src/libraries/System.Runtime/tests/System/Text/Latin1UtilityTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/Latin1UtilityTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -325,9 +326,10 @@ namespace System.Text.Tests
             }
         }
 
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
         private static Type GetLatin1UtilityType()
         {
-            return typeof(object).Assembly.GetType("System.Text.Latin1Utility");
+            return Type.GetType("System.Text.Latin1Utility");
         }
 
         private sealed class UnsafeLazyDelegate<TDelegate> where TDelegate : class

--- a/src/libraries/System.Runtime/tests/System/Text/Latin1UtilityTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/Latin1UtilityTests.cs
@@ -329,7 +329,7 @@ namespace System.Text.Tests
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
         private static Type GetLatin1UtilityType()
         {
-            return Type.GetType("System.Text.Latin1Utility");
+            return Type.GetType("System.Text.Latin1Utility, System.Private.CoreLib");
         }
 
         private sealed class UnsafeLazyDelegate<TDelegate> where TDelegate : class

--- a/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf16UtilityTests.ValidateChars.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf16UtilityTests.ValidateChars.cs
@@ -248,7 +248,7 @@ namespace System.Text.Unicode.Tests
         {
             return new Lazy<GetPointerToFirstInvalidCharDel>(() =>
             {
-                Type utf16UtilityType = typeof(Utf8).Assembly.GetType("System.Text.Unicode.Utf16Utility");
+                Type utf16UtilityType = Type.GetType("System.Text.Unicode.Utf16Utility");
 
                 if (utf16UtilityType is null)
                 {

--- a/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf16UtilityTests.ValidateChars.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf16UtilityTests.ValidateChars.cs
@@ -248,7 +248,7 @@ namespace System.Text.Unicode.Tests
         {
             return new Lazy<GetPointerToFirstInvalidCharDel>(() =>
             {
-                Type utf16UtilityType = Type.GetType("System.Text.Unicode.Utf16Utility");
+                Type utf16UtilityType = Type.GetType("System.Text.Unicode.Utf16Utility, System.Private.CoreLib");
 
                 if (utf16UtilityType is null)
                 {

--- a/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf8UtilityTests.ValidateBytes.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf8UtilityTests.ValidateBytes.cs
@@ -396,7 +396,7 @@ namespace System.Text.Unicode.Tests
         {
             return new Lazy<GetPointerToFirstInvalidByteDel>(() =>
             {
-                Type utf8UtilityType = Type.GetType("System.Text.Unicode.Utf8Utility");
+                Type utf8UtilityType = Type.GetType("System.Text.Unicode.Utf8Utility, System.Private.CoreLib");
 
                 if (utf8UtilityType is null)
                 {

--- a/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf8UtilityTests.ValidateBytes.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf8UtilityTests.ValidateBytes.cs
@@ -396,7 +396,7 @@ namespace System.Text.Unicode.Tests
         {
             return new Lazy<GetPointerToFirstInvalidByteDel>(() =>
             {
-                Type utf8UtilityType = typeof(Utf8).Assembly.GetType("System.Text.Unicode.Utf8Utility");
+                Type utf8UtilityType = Type.GetType("System.Text.Unicode.Utf8Utility");
 
                 if (utf8UtilityType is null)
                 {


### PR DESCRIPTION
The reflection patterns couldn't be statically analyzed.

Needed to unblock #70201. NativeAOT trims by default and CoreLib is marked trimmable.