### PR TITLE
Keep members on Int128 and Half for testing

### DIFF
--- a/src/libraries/System.Runtime/tests/default.rd.xml
+++ b/src/libraries/System.Runtime/tests/default.rd.xml
@@ -499,7 +499,8 @@
           <GenericArgument Name="System.Runtime.CompilerServices.Tests.RuntimeHelpersTests+TestStruct, System.Runtime.Tests" />
         </Method>
       </Type>
-
+      <Type Name="System.Int128" Dynamic="Required All" />
+      <Type Name="System.Half" Dynamic="Required All" />
     </Assembly>
   </Application>
 </Directives>


### PR DESCRIPTION
I was hitting a lot of obscure failures in #70201 that look like this:

```
  [FAIL] System.Tests.Int128Tests.Parse_Span_Valid(value: "170141183460469231731687303715884105727", offset: 0, count: 1, style: Integer, provider: null, expected: 1)
  System.ArgumentException : Object of type 'System.Int32' cannot be converted to type 'System.Int128'.
     at System.InvokeUtils.CheckArgument(Object, EETypePtr, InvokeUtils.CheckArgumentSemantics, BinderBundle, InvokeUtils.ArgSetupState&) + 0x1c0
     at System.InvokeUtils.DynamicInvokeParamHelperCore(InvokeUtils.ArgSetupState&, RuntimeTypeHandle, InvokeUtils.DynamicInvokeParamLookupType&, Int32&, InvokeUtils.DynamicInvokeParamType) + 0x228
     at System.InvokeUtils.DynamicInvokeParamHelperIn(InvokeUtils.ArgSetupState&, RuntimeTypeHandle) + 0x1b
     at System.Runtime.Tests!<BaseAddress>+0xffe015
     at System.InvokeUtils.CallDynamicInvokeMethod(Object, IntPtr, IntPtr, IntPtr, Object, Object[], BinderBundle, Boolean, Boolean) + 0x14d
     at Internal.Runtime.Augments.RuntimeAugments.CallDynamicInvokeMethod(Object, IntPtr, IntPtr, IntPtr, Object, Object[], BinderBundle, Boolean, Boolean) + 0x3e
     at Internal.Reflection.Execution.MethodInvokers.StaticMethodInvoker.Invoke(Object, Object[], BinderBundle, Boolean) + 0x4e
     at Internal.Reflection.Core.Execution.MethodInvoker.Invoke(Object, Object[], Binder, BindingFlags, CultureInfo) + 0x45
     at System.Reflection.Runtime.MethodInfos.RuntimeMethodInfo.Invoke(Object, BindingFlags, Binder, Object[], CultureInfo) + 0x58
```

This stack is showing a reflection invoke attempt by xunit (not by a test, but by xunit itself) to invoke a method taking Int128, but passing a boxed Int32 as an argument. The TestData is indeed doing that.

I was getting myself ready to debug xunit but I thought that maybe xunit has a custom binder that calls the operator methods using reflection to do the conversions. Sure enough the RD.XML fixed it, so the problem was with operators getting trimmed away.

Cc @dotnet/ilc-contrib 