### PR TITLE
Stop normalizing managed calls in R2R

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -9250,15 +9250,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
     // We only need to cast the return value of pinvoke inlined calls that return small types
 
-    // TODO-AMD64-Cleanup: Remove this when we stop interoperating with JIT64, or if we decide to stop
-    // widening everything! CoreCLR does not support JIT64 interoperation so no need to widen there.
-    // The existing x64 JIT doesn't bother widening all types to int, so we have to assume for
-    // the time being that the callee might be compiled by the other JIT and thus the return
-    // value will need to be widened by us (or not widened at all...)
-
-    // ReadyToRun code sticks with default calling convention that does not widen small return types.
-
-    bool checkForSmallType  = opts.IsReadyToRun();
+    bool checkForSmallType  = false;
     bool bIntrinsicImported = false;
 
     CORINFO_SIG_INFO calliSig;


### PR DESCRIPTION
We no longer need to interop with JIT64 so clean up this TODO. We are in
fact already relying on the normalization done by the callee since we
allow tailcalling that skips the inserted normalization in R2R.

[Some small diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1810699&view=ms.vss-build-web.run-extensions-tab)