### PR TITLE
[custom_attrs] Use the image's ALC instead of the default one (#68266)

### DIFF
--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -203,7 +203,7 @@ static MonoType*
 cattr_type_from_name (char *n, MonoImage *image, gboolean is_enum, MonoError *error)
 {
 	ERROR_DECL (inner_error);
-	MonoAssemblyLoadContext *alc = mono_alc_get_ambient ();
+	MonoAssemblyLoadContext *alc = mono_image_get_alc (image);
 	MonoType *t = mono_reflection_type_from_name_checked (n, alc, image, inner_error);
 	if (!t) {
 		mono_error_set_type_load_name (error, g_strdup(n), NULL,

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -1266,6 +1266,7 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb, M
 	return_if_nok (error);
 	image = mono_dynamic_image_create (assembly, assembly_name, g_strdup ("RefEmit_YouForgotToDefineAModule"));
 	image->initial_image = TRUE;
+	image->image.alc = alc;
 	assembly->assembly.aname.name = image->image.name;
 	assembly->assembly.image = &image->image;
 


### PR DESCRIPTION
Running ApiCompat task under Mono fails with:

    Could not load type System.Collections.Generic.IEqualityComparer`1[[Microsoft.Cci.ITypeReference, Microsoft.Cci ...

The reason is that cattr_type_from_name() uses a default ACL instead of
the image's one. This is important, because ExportCciSettings.Settings
field has the

      [Export(typeof(IEqualityComparer<ITypeReference>))]

custom attribute [1], where ITypeReference comes from the Microsoft.Cci
assembly. ApiCompat task runs under MSBuild, which provides its own
MSBuildLoadContext ALC. Microsoft.Cci is supposed to be found using
this ALC, not the default one.

[1] https://github.com/dotnet/arcade/blob/8f311fed1f2acf0ecfdfcecbc7a9fa871ed634cc/src/Microsoft.DotNet.ApiCompat/src/Microsoft.DotNet.ApiCompat.Core/ExportCciSettings.cs#L28