### PR TITLE
Add bool and uint to documentation for RuntimeHelpers.CreateSpan

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -95,7 +95,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="fldHandle">A field handle that specifies the location of the data to be referred to by the ReadOnlySpan{T}. The Rva of the field must be aligned on a natural boundary of type T</param>
         /// <returns>A ReadOnlySpan{T} of the data stored in the field</returns>
         /// <exception cref="ArgumentException"><paramref name="fldHandle"/> does not refer to a field which is an Rva, is misaligned, or T is of an invalid type.</exception>
-        /// <remarks>This method is intended for compiler use rather than use directly in code. T must be one of byte, sbyte, char, short, ushort, int, long, ulong, float, or double.</remarks>
+        /// <remarks>This method is intended for compiler use rather than use directly in code. T must be one of byte, sbyte, bool, char, short, ushort, int, uint, long, ulong, float, or double.</remarks>
         [Intrinsic]
         public static unsafe ReadOnlySpan<T> CreateSpan<T>(RuntimeFieldHandle fldHandle) => new ReadOnlySpan<T>(GetSpanDataFrom(fldHandle, typeof(T).TypeHandle, out int length), length);
 


### PR DESCRIPTION
The C# compiler will rely on `CreateSpan` fro the `uint` case, so that should definitely be documented.
The compiler doesn't rely on this API for `sbyte`, `byte` or `bool` cases, so we should either include all three or exclude all three.

Relates to https://github.com/dotnet/roslyn/pull/61414#discussion_r889277793 (compiler making use of this API)
Relates to https://github.com/dotnet/runtime/pull/61079 (PR introducing this API)