### PR TITLE
Disable 2 FSW tests failing only on macOS 12

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
@@ -25,7 +25,7 @@ namespace System.IO.Tests
             DirectoryMove_FromWatchedToUnwatched(WatcherChangeTypes.Deleted);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [PlatformSpecific(TestPlatforms.OSX)]
         [InlineData(1)]
         [InlineData(2)]

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit;
-
+using Microsoft.DotNet.XUnitExtensions;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Xunit;
 
 namespace System.IO.Tests
 {
@@ -32,6 +32,11 @@ namespace System.IO.Tests
         [InlineData(3)]
         public void Directory_Move_Multiple_From_Watched_To_Unwatched_Mac(int filesCount)
         {
+            if (Environment.OSVersion.Version.Major == 12)
+            {
+                throw new SkipTestException("Unreliable on Monterey"); // https://github.com/dotnet/runtime/issues/70164
+            }
+
             // On Mac, the FSStream aggregate old events caused by the test setup.
             // There is no option how to get rid of it but skip it.
             DirectoryMove_Multiple_FromWatchedToUnwatched(filesCount, skipOldEvents: true);

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
@@ -30,7 +30,7 @@ namespace System.IO.Tests
             FileMove_FromWatchedToUnwatched(WatcherChangeTypes.Deleted);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [PlatformSpecific(TestPlatforms.OSX)]
         [InlineData(1)]
         [InlineData(2)]

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.XUnitExtensions;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -36,6 +37,11 @@ namespace System.IO.Tests
         [InlineData(3)]
         public void File_Move_Multiple_From_Watched_To_Unwatched_Mac(int filesCount)
         {
+            if (Environment.OSVersion.Version.Major == 12)
+            {
+                throw new SkipTestException("Unreliable on Monterey"); // https://github.com/dotnet/runtime/issues/70164
+            }
+
             // On Mac, the FSStream aggregate old events caused by the test setup.
             // There is no option how to get rid of it but skip it.
             FileMove_Multiple_FromWatchedToUnwatched(filesCount, skipOldEvents: true);


### PR DESCRIPTION
Relates to https://github.com/dotnet/runtime/issues/70164