### PR TITLE
[Wasm] Add support for baseUrl and mainScriptPath

### DIFF
--- a/src/mono/wasm/runtime/crypto-worker.ts
+++ b/src/mono/wasm/runtime/crypto-worker.ts
@@ -41,7 +41,7 @@ export function init_crypto(): void {
         console.debug("MONO_WASM: Initializing Crypto WebWorker");
 
         const chan = LibraryChannel.create(1024); // 1024 is the buffer size in char units.
-        const worker = new Worker("dotnet-crypto-worker.js");
+        const worker = new Worker(`${Module.baseUrl}dotnet-crypto-worker.js`);
         mono_wasm_crypto = {
             channel: chan,
             worker: worker,

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -198,6 +198,17 @@ export type DotnetModuleConfig = {
 
     config?: MonoConfig | MonoConfigError,
     configSrc?: string,
+
+    /**
+     * Base url for the app, defaults to `./` and must contain a trailing slash
+     */
+    baseUrl?: string,
+
+    /**
+     * main script path from baseUrl, defaults to `dotnet.js`
+     */
+    mainScriptPath?: string,
+    
     onConfigLoaded?: (config: MonoConfig) => Promise<void>;
     onDotnetReady?: () => void;
 


### PR DESCRIPTION
This change allows for resources like the crypto worker or thread workers to be resolved properly when used in a generic context.