### PR TITLE
Tweak NonBacktracking condition used to employ RegexFindOptimizations

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
@@ -206,6 +206,11 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>true iff <see cref="TryFindNextStartingPosition"/> might advance the position.</summary>
+        public bool IsUseful =>
+            FindMode != FindNextStartingPositionMode.NoSearch || // there's a searching scheme available
+            LeadingAnchor == RegexNodeKind.Bol; // there's a leading BOL anchor we can otherwise search for
+
         /// <summary>Gets the selected mode for performing the next <see cref="TryFindNextStartingPosition"/> operation</summary>
         public FindNextStartingPositionMode FindMode { get; } = FindNextStartingPositionMode.NoSearch;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -164,8 +164,11 @@ namespace System.Text.RegularExpressions.Symbolic
                 _fixedMatchLength = findOptimizations.MinRequiredLength;
             }
 
-            if (findOptimizations.FindMode != FindNextStartingPositionMode.NoSearch &&
-                findOptimizations.LeadingAnchor == 0) // If there are any anchors, we're better off letting the DFA quickly do its job of determining whether there's a match.
+            // Store the find optimizations that can be used to jump ahead to the next possible starting location.
+            // If there's a leading beginning anchor, the find optimizations are unnecessary on top of the DFA's
+            // handling for beginning anchors.
+            if (findOptimizations.IsUseful &&
+                findOptimizations.LeadingAnchor is not RegexNodeKind.Beginning)
             {
                 _findOpts = findOptimizations;
             }


### PR DESCRIPTION
Rather than excluding all anchors, only exclude beginning anchors.

Fixes https://github.com/dotnet/runtime/issues/69060