### PR TITLE
Move analyzer and fixer tests into FuncionalTests project

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -285,7 +285,4 @@
   <data name="UsingSpanAPIsWithCompiledToAssembly" xml:space="preserve">
     <value>Searching an input span using a pre-compiled Regex assembly is not supported. Please use the string overloads or use a newer Regex implementation.</value>
   </data>
-  <data name="UseRegexSourceGeneratorTitle" xml:space="preserve">
-    <value>Use the RegEx source generator.</value>
-  </data>
 </root>

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/CSharpCodeFixVerifier`2.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/CSharpCodeFixVerifier`2.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 
-namespace System.Text.RegularExpressions.Unit.Tests
+namespace System.Text.RegularExpressions.Tests
 {
     public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         where TAnalyzer : DiagnosticAnalyzer, new()

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/CSharpCodeFixVerifier`2.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/CSharpCodeFixVerifier`2.cs
@@ -85,7 +85,7 @@ namespace System.Text.RegularExpressions.Tests
                     // Clear out the default reference assemblies. We explicitly add references from the live ref pack,
                     // so we don't want the Roslyn test infrastructure to resolve/add any default reference assemblies
                     ReferenceAssemblies = new ReferenceAssemblies(string.Empty);
-                    TestState.AdditionalReferences.AddRange(SourceGenerators.Tests.LiveReferencePack.GetMetadataReferences());
+                    TestState.AdditionalReferences.AddRange(RegexGeneratorHelper.References);
                 }
 
                 NumberOfFixAllIterations = numberOfIterations;

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <!-- xUnit2008 is about regexes and isn't appropriate in the test project for regexes -->
@@ -8,6 +8,7 @@
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'Browser'">true</DebuggerSupport>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IsHighAotMemoryUsageTest>true</IsHighAotMemoryUsageTest> <!-- to avoid OOMs with source generation in wasm: https://github.com/dotnet/runtime/pull/60701 -->
+    <TestRunRequiresLiveRefPack Condition="'$(TargetOS)' != 'Browser'">true</TestRunRequiresLiveRefPack>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AttRegexTests.cs" />
@@ -43,6 +44,9 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
     <Compile Include="CustomDerivedRegexScenarioTest.cs" />
+    <Compile Include="CSharpCodeFixVerifier`2.cs"/>
+    <Compile Include="UpgradeToRegexGeneratorAnalyzerTests.cs" />
+    <Compile Include="$(CommonTestPath)SourceGenerators\LiveReferencePack.cs" Link="Common\SourceGenerators\LiveReferencePack.cs" />
     <Compile Include="RegexRunnerTests.cs" />
     <Compile Include="Regex.Count.Tests.cs" />
     <Compile Include="RegexAssert.netcoreapp.cs" />
@@ -61,6 +65,9 @@
     <Compile Include="RegexExperiment.cs" />
     <Compile Include="RegexGeneratorHelper.netcoreapp.cs" />
     <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs" Link="Common\System\Diagnostics\DebuggerAttributes.cs" />
+
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(CompilerPlatformTestingVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
     <ProjectReference Include="..\..\gen\System.Text.RegularExpressions.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
   </ItemGroup>

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
@@ -8,7 +8,6 @@
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'Browser'">true</DebuggerSupport>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IsHighAotMemoryUsageTest>true</IsHighAotMemoryUsageTest> <!-- to avoid OOMs with source generation in wasm: https://github.com/dotnet/runtime/pull/60701 -->
-    <TestRunRequiresLiveRefPack Condition="'$(TargetOS)' != 'Browser'">true</TestRunRequiresLiveRefPack>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AttRegexTests.cs" />
@@ -46,7 +45,6 @@
     <Compile Include="CustomDerivedRegexScenarioTest.cs" />
     <Compile Include="CSharpCodeFixVerifier`2.cs"/>
     <Compile Include="UpgradeToRegexGeneratorAnalyzerTests.cs" />
-    <Compile Include="$(CommonTestPath)SourceGenerators\LiveReferencePack.cs" Link="Common\SourceGenerators\LiveReferencePack.cs" />
     <Compile Include="RegexRunnerTests.cs" />
     <Compile Include="Regex.Count.Tests.cs" />
     <Compile Include="RegexAssert.netcoreapp.cs" />

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToRegexGeneratorAnalyzerTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToRegexGeneratorAnalyzerTests.cs
@@ -10,15 +10,17 @@ using System.Text.RegularExpressions.Generator;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using VerifyCS = System.Text.RegularExpressions.Unit.Tests.CSharpCodeFixVerifier<
+using VerifyCS = System.Text.RegularExpressions.Tests.CSharpCodeFixVerifier<
     System.Text.RegularExpressions.Generator.UpgradeToRegexGeneratorAnalyzer,
     System.Text.RegularExpressions.Generator.UpgradeToRegexGeneratorCodeFixer>;
 
-namespace System.Text.RegularExpressions.Unit.Tests
+namespace System.Text.RegularExpressions.Tests
 {
     [ActiveIssue("https://github.com/dotnet/runtime/issues/69823", TestRuntimes.Mono)]
     public class UpgradeToRegexGeneratorAnalyzerTests
     {
+        private const string UseRegexSourceGeneratorDiagnosticId = @"SYSLIB1046";
+
         [Fact]
         public async Task NoDiagnosticsForEmpty()
             => await VerifyCS.VerifyAnalyzerAsync(source: string.Empty);
@@ -237,7 +239,7 @@ public partial class Program
         [MemberData(nameof(ConstantPatternTestData))]
         public async Task DiagnosticEmittedForConstantPattern(string test, string fixedSource)
         {
-            DiagnosticResult expectedDiagnostic = VerifyCS.Diagnostic(DiagnosticDescriptors.UseRegexSourceGeneration.Id).WithLocation(0);
+            DiagnosticResult expectedDiagnostic = VerifyCS.Diagnostic(UseRegexSourceGeneratorDiagnosticId).WithLocation(0);
             await VerifyCS.VerifyCodeFixAsync(test, expectedDiagnostic, fixedSource);
         }
 
@@ -400,7 +402,7 @@ public partial class Program
         [MemberData(nameof(ConstantOptionsTestData))]
         public async Task DiagnosticEmittedForConstantOptions(string test, string fixedSource)
         {
-            DiagnosticResult expected = VerifyCS.Diagnostic(DiagnosticDescriptors.UseRegexSourceGeneration.Id).WithLocation(0);
+            DiagnosticResult expected = VerifyCS.Diagnostic(UseRegexSourceGeneratorDiagnosticId).WithLocation(0);
             await VerifyCS.VerifyCodeFixAsync(test, expected, fixedSource);
         }
 
@@ -503,7 +505,7 @@ public partial class Program
     [RegexGenerator(""a|b"", RegexOptions.None)]
     private static partial Regex MyRegex();
 }";
-            DiagnosticResult expectedDiagnostic = VerifyCS.Diagnostic(DiagnosticDescriptors.UseRegexSourceGeneration.Id).WithLocation(0);
+            DiagnosticResult expectedDiagnostic = VerifyCS.Diagnostic(UseRegexSourceGeneratorDiagnosticId).WithLocation(0);
 
             const string testTemplateWithoutOptions = @"using System.Text.RegularExpressions;
 
@@ -600,7 +602,7 @@ public partial class Program
         [Fact]
         public async Task CodeFixSupportsNesting()
         {
-            DiagnosticResult expectedDiagnostic = VerifyCS.Diagnostic(DiagnosticDescriptors.UseRegexSourceGeneration.Id).WithLocation(0);
+            DiagnosticResult expectedDiagnostic = VerifyCS.Diagnostic(UseRegexSourceGeneratorDiagnosticId).WithLocation(0);
             string test = @"using System.Text.RegularExpressions;
 
 public class A
@@ -680,8 +682,8 @@ public class Program
 ";
             DiagnosticResult[] expectedDiagnostics = new[]
             {
-                VerifyCS.Diagnostic(DiagnosticDescriptors.UseRegexSourceGeneration.Id).WithLocation(0),
-                VerifyCS.Diagnostic(DiagnosticDescriptors.UseRegexSourceGeneration.Id).WithLocation(1)
+                VerifyCS.Diagnostic(UseRegexSourceGeneratorDiagnosticId).WithLocation(0),
+                VerifyCS.Diagnostic(UseRegexSourceGeneratorDiagnosticId).WithLocation(1)
             };
 
             string fixedSource = @"using System.Text.RegularExpressions;
@@ -716,7 +718,7 @@ class Program
         Regex r = {|#0:new Regex(options: RegexOptions.None, pattern: ""a|b"")|};
     }
 }";
-            DiagnosticResult expectedDiagnostic = VerifyCS.Diagnostic(DiagnosticDescriptors.UseRegexSourceGeneration.Id).WithLocation(0);
+            DiagnosticResult expectedDiagnostic = VerifyCS.Diagnostic(UseRegexSourceGeneratorDiagnosticId).WithLocation(0);
 
             string fixedSource = @"using System.Text.RegularExpressions;
 

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/Stubs.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/Stubs.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using Microsoft.CodeAnalysis;
 
 namespace System.Text.RegularExpressions
 {
@@ -21,19 +20,5 @@ namespace System.Text.RegularExpressions
         public const int RightPortion = -2;
         public const int LastGroup = -3;
         public const int WholeString = -4;
-    }
-}
-
-namespace System.Text.RegularExpressions.Generator
-{
-    internal static class DiagnosticDescriptors
-    {
-        public static DiagnosticDescriptor UseRegexSourceGeneration { get; } = new DiagnosticDescriptor(
-            id: "SYSLIB1046",
-            title: "Use the Regex source generator.",
-            messageFormat: "The inputs to your Regex are known at compile-time so you could be using the source generator to boost performance.",
-            category: "RegexGenerator",
-            DiagnosticSeverity.Info,
-            isEnabledByDefault: true);
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/System.Text.RegularExpressions.Unit.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/System.Text.RegularExpressions.Unit.Tests.csproj
@@ -9,13 +9,9 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DEBUG</DefineConstants> <!-- always define debug, even in release builds -->
-    <TestRunRequiresLiveRefPack Condition="'$(TargetOS)' != 'Browser'">true</TestRunRequiresLiveRefPack>
   </PropertyGroup>
   <ItemGroup>
     <DefaultReferenceExclusion Include="System.Text.RegularExpressions" />
-    <!--Include Unit tests as part of code coverage since we are compiling product code into the tests assembly-->
-    <CoverageInclude Include="$(AssemblyName)" />
-    <Compile Include="CSharpCodeFixVerifier`2.cs" />
 
     <Compile Include="RegexCharClassTests.cs" />
     <Compile Include="RegexFindOptimizationsTests.cs" />
@@ -48,9 +44,6 @@
     <Compile Include="..\..\src\System\Text\RegularExpressions\RegexTreeAnalyzer.cs" Link="Production\RegexTreeAnalyzer.cs" />
     <Compile Include="..\..\src\System\Text\RegularExpressions\RegexWriter.cs" Link="Production\RegexWriter.cs" />
     <Compile Include="..\..\src\System\Collections\HashtableExtensions.cs" Link="Production\HashtableExtensions.cs" />
-    <Compile Include="..\..\gen\UpgradeToRegexGeneratorAnalyzer.cs" Link="Production\UpgradeToRegexGeneratorAnalyzer.cs" />
-    <Compile Include="..\..\gen\UpgradeToRegexGeneratorCodeFixer.cs" Link="Production\UpgradeToRegexGeneratorCodeFixer.cs" />
-    <Compile Include="$(CommonTestPath)SourceGenerators\LiveReferencePack.cs" Link="Common\SourceGenerators\LiveReferencePack.cs" />
 
     <!-- Code included from System.Text.RegularExpressions.Symbolic -->
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\BDD.cs" Link="Production\BDD.cs" />
@@ -73,10 +66,5 @@
 
     <!-- Code used as stubs to avoid pulling in further code from System.Text.RegularExpressions -->
     <Compile Include="Stubs.cs" />
-    <Compile Include="UpgradeToRegexGeneratorAnalyzerTests.cs" />
-
-    <!-- References required for the Analyzer tests -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion_4_0)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(CompilerPlatformTestingVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
In the PR where they were added, all of the Analyzer and Fixer tests were added to the unit test project as opposed to the functional test project. Given there is no real need for that, this PR is moving them to instead be on the functional Unit test project.