### PR TITLE
Make ConnectWithRevocation_StapledOcsp more resilient to being slow

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.X509Certificates.Tests.Common;
@@ -183,8 +184,36 @@ namespace System.Net.Security.Tests
 
                     if (revocationMode == X509RevocationMode.Offline)
                     {
-                        // Give the OCSP response a better chance to finish.
-                        await Task.Delay(200);
+                        if (offlineContext.GetValueOrDefault(false))
+                        {
+                            // Add a delay just to show we're not winning because of race conditions.
+                            await Task.Delay(200);
+                        }
+                        else
+                        {
+                            if (!OperatingSystem.IsLinux())
+                            {
+                                throw new InvalidOperationException(
+                                    "This test configuration uses reflection and is only defined for Linux.");
+                            }
+
+                            FieldInfo pendingDownloadTaskField = typeof(SslStreamCertificateContext).GetField(
+                                "_pendingDownload",
+                                BindingFlags.Instance | BindingFlags.NonPublic);
+
+                            if (pendingDownloadTaskField is null)
+                            {
+                                throw new InvalidOperationException("Cannot find the pending download field.");
+                            }
+
+                            Task download = (Task)pendingDownloadTaskField.GetValue(serverOpts.ServerCertificateContext);
+
+                            // If it's null, it should mean it has already finished. If not, it might not have.
+                            if (download is not null)
+                            {
+                                await download;
+                            }
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
On my Linux dev box this actually speeds up the ConnectWithRevocation_StapledOcsp(false) test from a 200ms delay to a 6ms delay (combination of reflection and await), but should also make it better handle high load and the background HTTP loopback fetch taking longer than 200ms.

Fixes #70322.