### PR TITLE
[Mono] Fix C4018 round I

### DIFF
--- a/src/mono/mono/component/debugger-state-machine.c
+++ b/src/mono/mono/component/debugger-state-machine.c
@@ -298,7 +298,7 @@ mono_debugger_state (JsonWriter *writer)
 		mono_json_writer_object_key(writer, "breakpoints");
 		mono_json_writer_array_begin (writer);
 
-		for (int i=0; i < breakpoint_copy->len; i++) {
+		for (guint i=0; i < breakpoint_copy->len; i++) {
 			MonoBreakpoint *bp = (MonoBreakpoint *) g_ptr_array_index (breakpoint_copy, i);
 
 			mono_json_writer_indent (writer);

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -62,7 +62,7 @@ hot_reload_stub_get_updated_method_ppdb (MonoImage *base_image, uint32_t idx);
 static gboolean
 hot_reload_stub_has_modified_rows (const MonoTableInfo *table);
 
-static int
+static guint32
 hot_reload_stub_table_num_rows_slow (MonoImage *image, int table_index);
 
 static uint32_t
@@ -234,7 +234,7 @@ hot_reload_stub_has_modified_rows (const MonoTableInfo *table)
 	return FALSE;
 }
 
-static int
+static guint32
 hot_reload_stub_table_num_rows_slow (MonoImage *image, int table_index)
 {
 	g_assert_not_reached (); /* should always take the fast path */

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -39,7 +39,7 @@ static void
 hot_reload_stub_cleanup_on_close (MonoImage *image);
 
 static void
-hot_reload_stub_effective_table_slow (const MonoTableInfo **t, int idx);
+hot_reload_stub_effective_table_slow (const MonoTableInfo **t, uint32_t idx);
 
 static void
 hot_reload_stub_close_except_pools_all (MonoImage *base_image);
@@ -183,7 +183,7 @@ hot_reload_stub_cleanup_on_close (MonoImage *image)
 }
 
 void
-hot_reload_stub_effective_table_slow (const MonoTableInfo **t, int idx)
+hot_reload_stub_effective_table_slow (const MonoTableInfo **t, uint32_t idx)
 {
 	g_assert_not_reached ();
 }

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -63,7 +63,7 @@ static void
 hot_reload_cleanup_on_close (MonoImage *image);
 
 static void
-hot_reload_effective_table_slow (const MonoTableInfo **t, int idx);
+hot_reload_effective_table_slow (const MonoTableInfo **t, uint32_t idx);
 
 static void
 hot_reload_apply_changes (int origin, MonoImage *base_image, gconstpointer dmeta, uint32_t dmeta_len, gconstpointer dil, uint32_t dil_len, gconstpointer dpdb_bytes_orig, uint32_t dpdb_length, MonoError *error);
@@ -1041,7 +1041,7 @@ effective_table_mutant (MonoImage *base, BaselineInfo *info, int tbl_index, cons
 }
 
 void
-hot_reload_effective_table_slow (const MonoTableInfo **t, int idx)
+hot_reload_effective_table_slow (const MonoTableInfo **t, uint32_t idx G_GNUC_UNUSED)
 {
 	/* FIXME: don't let any thread other than the updater thread see values from a delta image
 	 * with a generation past update_published

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -92,7 +92,7 @@ hot_reload_get_updated_method_ppdb (MonoImage *base_image, uint32_t idx);
 static gboolean
 hot_reload_has_modified_rows (const MonoTableInfo *table);
 
-static int
+static guint32
 hot_reload_table_num_rows_slow (MonoImage *image, int table_index);
 
 static GSList*
@@ -2678,7 +2678,7 @@ hot_reload_has_modified_rows (const MonoTableInfo *table)
 	return info->any_modified_rows[tbl_index];
 }
 
-static int
+static guint32
 hot_reload_table_num_rows_slow (MonoImage *base, int table_index)
 {
 	BaselineInfo *base_info = baseline_info_lookup (base);

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -32,7 +32,7 @@ typedef struct _MonoComponentHotReload {
 	gboolean (*delta_heap_lookup) (MonoImage *base_image, MetadataHeapGetterFunc get_heap, uint32_t orig_index, MonoImage **image_out, uint32_t *index_out);
 	gpointer (*get_updated_method_ppdb) (MonoImage *base_image, uint32_t idx);
 	gboolean (*has_modified_rows) (const MonoTableInfo *table);
-	gboolean (*table_num_rows_slow) (MonoImage *base_image, int table_index);
+	uint32_t (*table_num_rows_slow) (MonoImage *base_image, int table_index);
 	uint32_t (*method_parent) (MonoImage *base_image, uint32_t method_index);
 	void* (*metadata_linear_search) (MonoImage *base_image, MonoTableInfo *base_table, const void *key, BinarySearchComparer comparer);
 	uint32_t (*field_parent) (MonoImage *base_image, uint32_t method_index);

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -23,7 +23,7 @@ typedef struct _MonoComponentHotReload {
 	uint32_t (*thread_expose_published) (void);
 	uint32_t (*get_thread_generation) (void);
 	void (*cleanup_on_close) (MonoImage *image);
-	void (*effective_table_slow) (const MonoTableInfo **t, int idx);
+	void (*effective_table_slow) (const MonoTableInfo **t, uint32_t idx);
 	void (*apply_changes) (int origin, MonoImage *base_image, gconstpointer dmeta, uint32_t dmeta_len, gconstpointer dil, uint32_t dil_len, gconstpointer dpdb_bytes_orig, uint32_t dpdb_length, MonoError *error);
 	void (*image_close_except_pools_all) (MonoImage *base_image);
 	void (*image_close_all) (MonoImage *base_image);

--- a/src/mono/mono/eglib/garray.c
+++ b/src/mono/mono/eglib/garray.c
@@ -229,7 +229,7 @@ g_array_set_size (GArray *array, gint length)
 	if (length == priv->capacity)
 		return; // nothing to be done
 
-	if (length > priv->capacity) {
+	if (length > GUINT_TO_INT(priv->capacity)) {
 		// grow the array
 		ensure_capacity (priv, length);
 	}

--- a/src/mono/mono/eglib/garray.c
+++ b/src/mono/mono/eglib/garray.c
@@ -229,7 +229,7 @@ g_array_set_size (GArray *array, gint length)
 	if (length == priv->capacity)
 		return; // nothing to be done
 
-	if (length > GUINT_TO_INT(priv->capacity)) {
+	if (GINT_TO_UINT(length) > priv->capacity) {
 		// grow the array
 		ensure_capacity (priv, length);
 	}

--- a/src/mono/mono/eglib/gfile.c
+++ b/src/mono/mono/eglib/gfile.c
@@ -133,7 +133,7 @@ g_file_set_contents (const gchar *filename, const gchar *contents, gssize length
 	if (length < 0)
 		length = strlen (contents);
 
-	if (fwrite (contents, 1, length, fp) < length) {
+	if (fwrite (contents, 1, length, fp) < GSSIZE_TO_SIZE(length)) {
 		g_set_error (err, G_FILE_ERROR, g_file_error_from_errno (ferror (fp)), "%s", g_strerror (ferror (fp)));
 		g_unlink (path);
 		g_free (path);

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -1617,6 +1617,8 @@ __CAST_UTYPE_TO_STYPE(gunichar, gchar, CHAR_MIN, CHAR_MAX)
 #define GSSIZE_TO_INT(v)         G_CAST_TYPE_TO_TYPE(gssize, gint, v)
 #define GSSIZE_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gssize, guint, v)
 
+#define GSSIZE_TO_SIZE(v)        G_CAST_TYPE_TO_TYPE(gssize, gsize, v)
+
 #define GDOUBLE_TO_INT64(v)      G_CAST_TYPE_TO_TYPE(gdouble, gint64, v)
 #define GDOUBLE_TO_UINT64(v)     G_CAST_TYPE_TO_TYPE(gdouble, guint64, v)
 #define GDOUBLE_TO_INT32(v)      G_CAST_TYPE_TO_TYPE(gdouble, gint32, v)

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -1440,6 +1440,9 @@ __CAST_STYPE_TO_UTYPE(gssize, guint32, UINT32_MAX)
 __CAST_STYPE_TO_STYPE(gssize, gint, INT_MIN, INT_MAX)
 __CAST_STYPE_TO_UTYPE(gssize, guint, UINT_MAX)
 
+__CAST_STYPE_TO_UTYPE(gssize, gsize, SIZE_MAX)
+__CAST_UTYPE_TO_STYPE(gsize, gssize, PTRDIFF_MIN, PTRDIFF_MAX)
+
 __CAST_STYPE_TO_STYPE(gdouble, gint64, INT64_MIN, INT64_MAX)
 __CAST_STYPE_TO_UTYPE(gdouble, guint64, UINT64_MAX)
 __CAST_STYPE_TO_STYPE(gdouble, gint32, INT32_MIN, INT32_MAX)
@@ -1487,6 +1490,7 @@ __CAST_STYPE_TO_UTYPE(gint32, guint8, UINT8_MAX)
 
 __CAST_STYPE_TO_UTYPE(gint32, guint, UINT_MAX)
 
+__CAST_UTYPE_TO_UTYPE(guint32, guint, UINT_MAX)
 __CAST_UTYPE_TO_STYPE(guint32, gint32, INT32_MIN, INT32_MAX)
 __CAST_UTYPE_TO_STYPE(guint32, gint16, INT16_MIN, INT16_MAX)
 __CAST_UTYPE_TO_UTYPE(guint32, guint16, UINT16_MAX)
@@ -1673,7 +1677,7 @@ __CAST_UTYPE_TO_STYPE(gunichar, gchar, CHAR_MIN, CHAR_MAX)
 
 #define GINT32_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gint32, guint, v)
 
-#define GUINT32_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(guint32, guint, v)
+#define GUINT32_TO_UINT(v)       G_CAST_TYPE_TO_TYPE(guint32, guint, v)
 #define GUINT32_TO_INT32(v)      G_CAST_TYPE_TO_TYPE(guint32, gint32, v)
 #define GUINT32_TO_INT16(v)      G_CAST_TYPE_TO_TYPE(guint32, gint16, v)
 #define GUINT32_TO_UINT16(v)     G_CAST_TYPE_TO_TYPE(guint32, guint16, v)

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -1673,6 +1673,7 @@ __CAST_UTYPE_TO_STYPE(gunichar, gchar, CHAR_MIN, CHAR_MAX)
 
 #define GINT32_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gint32, guint, v)
 
+#define GUINT32_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(guint32, guint, v)
 #define GUINT32_TO_INT32(v)      G_CAST_TYPE_TO_TYPE(guint32, gint32, v)
 #define GUINT32_TO_INT16(v)      G_CAST_TYPE_TO_TYPE(guint32, gint16, v)
 #define GUINT32_TO_UINT16(v)     G_CAST_TYPE_TO_TYPE(guint32, guint16, v)

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -1618,6 +1618,7 @@ __CAST_UTYPE_TO_STYPE(gunichar, gchar, CHAR_MIN, CHAR_MAX)
 #define GSSIZE_TO_UINT(v)        G_CAST_TYPE_TO_TYPE(gssize, guint, v)
 
 #define GSSIZE_TO_SIZE(v)        G_CAST_TYPE_TO_TYPE(gssize, gsize, v)
+#define GSIZE_TO_SSIZE(v)        G_CAST_TYPE_TO_TYPE(gsize, gssize, v)
 
 #define GDOUBLE_TO_INT64(v)      G_CAST_TYPE_TO_TYPE(gdouble, gint64, v)
 #define GDOUBLE_TO_UINT64(v)     G_CAST_TYPE_TO_TYPE(gdouble, guint64, v)

--- a/src/mono/mono/eglib/gptrarray.c
+++ b/src/mono/mono/eglib/gptrarray.c
@@ -226,7 +226,7 @@ gboolean
 g_ptr_array_find (GPtrArray *array, gconstpointer needle, guint *index)
 {
 	g_assert (array);
-	for (int i = 0; i < array->len; i++) {
+	for (guint i = 0; i < array->len; i++) {
 		if (array->pdata [i] == needle) {
 			if (index)
 				*index = i;

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -1469,7 +1469,7 @@ eventpipe_fire_method_events (
 				il_offsets = (uint32_t*)events_data->buffer;
 				native_offsets = il_offsets + offset_entries;
 
-				for (int32_t offset_count = 0; offset_count < offset_entries; ++offset_count) {
+				for (uint32_t offset_count = 0; offset_count < offset_entries; ++offset_count) {
 					il_offsets [offset_count] = debug_info->line_numbers [offset_count].il_offset;
 					native_offsets [offset_count] = debug_info->line_numbers [offset_count].native_offset;
 				}
@@ -3106,7 +3106,7 @@ ep_rt_mono_fire_bulk_type_event (BulkTypeEventLogger *type_logger)
 
 	char *ptr = (char *)type_logger->bulk_type_event_buffer;
 
-	for (int type_value_index = 0; type_value_index < type_logger->bulk_type_value_count; type_value_index++) {
+	for (uint32_t type_value_index = 0; type_value_index < type_logger->bulk_type_value_count; type_value_index++) {
 		BulkTypeValue *target = &type_logger->bulk_type_values [type_value_index];
 
 		values_element_size += write_event_buffer_int64 (target->fixed_sized_data.type_id, ptr, &ptr);
@@ -3120,7 +3120,7 @@ ep_rt_mono_fire_bulk_type_event (BulkTypeEventLogger *type_logger)
 
 		values_element_size += write_event_buffer_int32 (target->type_parameters_count, ptr, &ptr);
 
-		for (int i = 0; i < target->type_parameters_count; i++) {
+		for (uint32_t i = 0; i < target->type_parameters_count; i++) {
 			uint64_t type_parameter = get_typeid_for_type (target->mono_type_parameters [i]);
 			values_element_size += write_event_buffer_int64 ((int64_t)type_parameter, ptr, &ptr);
 		}
@@ -3413,7 +3413,7 @@ ep_rt_mono_send_method_details_event (MonoMethod *method)
 		method_inst_parameter_types_count = method_inst->type_argc;
 
 	uint64_t *method_inst_parameters_type_ids = mono_mempool_alloc0 (type_logger->mem_pool, method_inst_parameter_types_count * sizeof (uint64_t));
-	for (int i = 0; i < method_inst_parameter_types_count; i++) {
+	for (uint32_t i = 0; i < method_inst_parameter_types_count; i++) {
 		method_inst_parameters_type_ids [i] = get_typeid_for_type (method_inst->type_argv [i]);
 
 		ep_rt_mono_log_type_and_parameters_if_necessary (type_logger, method_inst->type_argv [i]);
@@ -3524,7 +3524,7 @@ ep_rt_mono_write_event_method_il_to_native_map (
 				}
 				if (il_offsets) {
 					native_offsets = il_offsets + offset_entries;
-					for (int32_t offset_count = 0; offset_count < offset_entries; ++offset_count) {
+					for (uint32_t offset_count = 0; offset_count < offset_entries; ++offset_count) {
 						il_offsets [offset_count] = debug_info->line_numbers [offset_count].il_offset;
 						native_offsets [offset_count] = debug_info->line_numbers [offset_count].native_offset;
 					}

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1459,7 +1459,7 @@ ep_rt_temp_path_get (
 	EP_ASSERT (buffer_len > 0);
 
 	const ep_char8_t *path = g_get_tmp_dir ();
-	int32_t result = snprintf (buffer, buffer_len, "%s", path);
+	uint32_t result = snprintf (buffer, buffer_len, "%s", path);
 	if (result <= 0 || result > buffer_len)
 		ep_raise_error ();
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1459,8 +1459,8 @@ ep_rt_temp_path_get (
 	EP_ASSERT (buffer_len > 0);
 
 	const ep_char8_t *path = g_get_tmp_dir ();
-	uint32_t result = snprintf (buffer, buffer_len, "%s", path);
-	if (result <= 0 || result > buffer_len)
+	int32_t result = snprintf (buffer, buffer_len, "%s", path);
+	if (result <= 0 || GINT32_TO_UINT32(result) > buffer_len)
 		ep_raise_error ();
 
 	if (buffer [result - 1] != G_DIR_SEPARATOR) {

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -436,7 +436,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 	MonoClass *klass, *parent = NULL;
 	guint32 cols [MONO_TYPEDEF_SIZE];
 	guint32 cols_next [MONO_TYPEDEF_SIZE];
-	guint tidx = mono_metadata_token_index (type_token);
+	gint tidx = mono_metadata_token_index (type_token);
 	MonoGenericContext *context = NULL;
 	const char *name, *nspace;
 	guint icount = 0;
@@ -649,9 +649,9 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		}
 
 		if (cols [MONO_TYPEDEF_FIELD_LIST] &&
-		    cols [MONO_TYPEDEF_FIELD_LIST] <= table_info_get_rows (&image->tables [MONO_TABLE_FIELD]))
+		    GUINT32_TO_INT32(cols [MONO_TYPEDEF_FIELD_LIST]) <= table_info_get_rows (&image->tables [MONO_TABLE_FIELD]))
 			mono_class_set_field_count (klass, field_last - first_field_idx);
-		if (cols [MONO_TYPEDEF_METHOD_LIST] <= table_info_get_rows (&image->tables [MONO_TABLE_METHOD]))
+		if (GUINT32_TO_INT32(cols [MONO_TYPEDEF_METHOD_LIST]) <= table_info_get_rows (&image->tables [MONO_TABLE_METHOD]))
 			mono_class_set_method_count (klass, method_last - first_method_idx);
 	} else if (G_UNLIKELY (cols [MONO_TYPEDEF_FIELD_LIST] == 0 && cols [MONO_TYPEDEF_METHOD_LIST] == 0 && image->has_updates)) {
 		uint32_t first_field_idx, first_method_idx, field_count, method_count;
@@ -2020,7 +2020,8 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 	int i;
 	const int top = mono_class_get_field_count (klass);
 	guint32 layout = mono_class_get_flags (klass) & TYPE_ATTRIBUTE_LAYOUT_MASK;
-	guint32 pass, passes, real_size;
+	guint32 pass, passes;
+	gint32 real_size;
 	gboolean gc_aware_layout = FALSE;
 	gboolean has_static_fields = FALSE;
 	gboolean has_references = FALSE;
@@ -2270,8 +2271,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 	case TYPE_ATTRIBUTE_EXPLICIT_LAYOUT: {
 		real_size = 0;
 		for (i = 0; i < top; i++) {
-			gint32 align;
-			guint32 size;
+			gint32 align, size;
 			MonoType *ftype;
 
 			field = &klass->fields [i];
@@ -2802,7 +2802,7 @@ mono_unload_interface_id (MonoClass *klass)
 static guint32
 mono_get_unique_iid (MonoClass *klass)
 {
-	int iid;
+	guint32 iid;
 
 	g_assert (MONO_CLASS_IS_INTERFACE_INTERNAL (klass));
 
@@ -3690,8 +3690,8 @@ inflate_method_listz (MonoMethod **methods, MonoClass *klass, MonoGenericContext
 void
 mono_class_setup_events (MonoClass *klass)
 {
-	int first, count;
-	guint startm, endm, i, j;
+	int first, count, i;
+	guint startm, endm, j;
 	guint32 cols [MONO_EVENT_SIZE];
 	MonoTableInfo *msemt = &klass->image->tables [MONO_TABLE_METHODSEMANTICS];
 	guint32 last;
@@ -3749,7 +3749,7 @@ mono_class_setup_events (MonoClass *klass)
 		}
 
 		events = (MonoEvent *)mono_class_alloc0 (klass, sizeof (MonoEvent) * count);
-		for (i = first; i < last; ++i) {
+		for (i = first; i < GUINT32_TO_INT32(last); ++i) {
 			MonoEvent *event = &events [i - first];
 
 			mono_metadata_decode_table_row (klass->image, MONO_TABLE_EVENT, i, cols, MONO_EVENT_SIZE);

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -436,7 +436,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 	MonoClass *klass, *parent = NULL;
 	guint32 cols [MONO_TYPEDEF_SIZE];
 	guint32 cols_next [MONO_TYPEDEF_SIZE];
-	gint tidx = mono_metadata_token_index (type_token);
+	guint32 tidx = mono_metadata_token_index (type_token);
 	MonoGenericContext *context = NULL;
 	const char *name, *nspace;
 	guint icount = 0;
@@ -649,9 +649,9 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		}
 
 		if (cols [MONO_TYPEDEF_FIELD_LIST] &&
-		    GUINT32_TO_INT32(cols [MONO_TYPEDEF_FIELD_LIST]) <= table_info_get_rows (&image->tables [MONO_TABLE_FIELD]))
+		    cols [MONO_TYPEDEF_FIELD_LIST] <= table_info_get_rows (&image->tables [MONO_TABLE_FIELD]))
 			mono_class_set_field_count (klass, field_last - first_field_idx);
-		if (GUINT32_TO_INT32(cols [MONO_TYPEDEF_METHOD_LIST]) <= table_info_get_rows (&image->tables [MONO_TABLE_METHOD]))
+		if (cols [MONO_TYPEDEF_METHOD_LIST] <= table_info_get_rows (&image->tables [MONO_TABLE_METHOD]))
 			mono_class_set_method_count (klass, method_last - first_method_idx);
 	} else if (G_UNLIKELY (cols [MONO_TYPEDEF_FIELD_LIST] == 0 && cols [MONO_TYPEDEF_METHOD_LIST] == 0 && image->has_updates)) {
 		uint32_t first_field_idx, first_method_idx, field_count, method_count;
@@ -2802,7 +2802,7 @@ mono_unload_interface_id (MonoClass *klass)
 static guint32
 mono_get_unique_iid (MonoClass *klass)
 {
-	guint32 iid;
+	int iid;
 
 	g_assert (MONO_CLASS_IS_INTERFACE_INTERNAL (klass));
 
@@ -2815,7 +2815,7 @@ mono_get_unique_iid (MonoClass *klass)
 
 	iid = mono_bitset_find_first_unset (global_interface_bitset, -1);
 	if (iid < 0) {
-		int old_size = mono_bitset_size (global_interface_bitset);
+		guint32 old_size = mono_bitset_size (global_interface_bitset);
 		MonoBitSet *new_set = mono_bitset_clone (global_interface_bitset, old_size * 2);
 		mono_bitset_free (global_interface_bitset);
 		global_interface_bitset = new_set;
@@ -2825,7 +2825,7 @@ mono_get_unique_iid (MonoClass *klass)
 	/* set the bit also in the per-image set */
 	if (!mono_class_is_ginst (klass)) {
 		if (klass->image->interface_bitset) {
-			if (iid >= mono_bitset_size (klass->image->interface_bitset)) {
+			if (GINT_TO_UINT32(iid) >= mono_bitset_size (klass->image->interface_bitset)) {
 				MonoBitSet *new_set = mono_bitset_clone (klass->image->interface_bitset, iid + 1);
 				mono_bitset_free (klass->image->interface_bitset);
 				klass->image->interface_bitset = new_set;
@@ -3567,12 +3567,11 @@ mono_class_setup_methods (MonoClass *klass)
 void
 mono_class_setup_properties (MonoClass *klass)
 {
-	guint startm, endm, i, j;
+	guint startm, endm;
 	guint32 cols [MONO_PROPERTY_SIZE];
 	MonoTableInfo *msemt = &klass->image->tables [MONO_TABLE_METHODSEMANTICS];
 	MonoProperty *properties;
-	guint32 last;
-	int first, count;
+	guint32 first, last, count;
 	MonoClassPropertyInfo *info;
 
 	info = mono_class_get_property_info (klass);
@@ -3590,7 +3589,7 @@ mono_class_setup_properties (MonoClass *klass)
 		MonoClassPropertyInfo *ginfo = mono_class_get_property_info (gklass);
 		properties = mono_class_new0 (klass, MonoProperty, ginfo->count + 1);
 
-		for (i = 0; i < ginfo->count; i++) {
+		for (guint32 i = 0; i < ginfo->count; i++) {
 			ERROR_DECL (error);
 			MonoProperty *prop = &properties [i];
 
@@ -3611,6 +3610,7 @@ mono_class_setup_properties (MonoClass *klass)
 		count = ginfo->count;
 	} else {
 		first = mono_metadata_properties_from_typedef (klass->image, mono_metadata_token_index (klass->type_token) - 1, &last);
+		g_assert ((last - first) >= 0);
 		count = last - first;
 
 		if (count) {
@@ -3620,7 +3620,7 @@ mono_class_setup_properties (MonoClass *klass)
 		}
 
 		properties = (MonoProperty *)mono_class_alloc0 (klass, sizeof (MonoProperty) * count);
-		for (i = first; i < last; ++i) {
+		for (guint32 i = first; i < last; ++i) {
 			mono_metadata_decode_table_row (klass->image, MONO_TABLE_PROPERTY, i, cols, MONO_PROPERTY_SIZE);
 			properties [i - first].parent = klass;
 			properties [i - first].attrs = cols [MONO_PROPERTY_FLAGS];
@@ -3628,7 +3628,7 @@ mono_class_setup_properties (MonoClass *klass)
 
 			startm = mono_metadata_methods_from_property (klass->image, i, &endm);
 			int first_idx = mono_class_get_first_method_idx (klass);
-			for (j = startm; j < endm; ++j) {
+			for (guint j = startm; j < endm; ++j) {
 				MonoMethod *method;
 
 				mono_metadata_decode_row (msemt, j, cols, MONO_METHOD_SEMA_SIZE);
@@ -3690,11 +3690,10 @@ inflate_method_listz (MonoMethod **methods, MonoClass *klass, MonoGenericContext
 void
 mono_class_setup_events (MonoClass *klass)
 {
-	int first, count, i;
-	guint startm, endm, j;
+	guint32 first, last, count;
+	guint startm, endm;
 	guint32 cols [MONO_EVENT_SIZE];
 	MonoTableInfo *msemt = &klass->image->tables [MONO_TABLE_METHODSEMANTICS];
-	guint32 last;
 	MonoEvent *events;
 
 	MonoClassEventInfo *info = mono_class_get_event_info (klass);
@@ -3718,7 +3717,7 @@ mono_class_setup_events (MonoClass *klass)
 		if (count)
 			context = mono_class_get_context (klass);
 
-		for (i = 0; i < count; i++) {
+		for (guint32 i = 0; i < count; i++) {
 			ERROR_DECL (error);
 			MonoEvent *event = &events [i];
 			MonoEvent *gevent = &ginfo->events [i];
@@ -3739,6 +3738,7 @@ mono_class_setup_events (MonoClass *klass)
 		}
 	} else {
 		first = mono_metadata_events_from_typedef (klass->image, mono_metadata_token_index (klass->type_token) - 1, &last);
+		g_assert ((last - first) >= 0);
 		count = last - first;
 
 		if (count) {
@@ -3749,7 +3749,7 @@ mono_class_setup_events (MonoClass *klass)
 		}
 
 		events = (MonoEvent *)mono_class_alloc0 (klass, sizeof (MonoEvent) * count);
-		for (i = first; i < GUINT32_TO_INT32(last); ++i) {
+		for (guint32 i = first; i < last; ++i) {
 			MonoEvent *event = &events [i - first];
 
 			mono_metadata_decode_table_row (klass->image, MONO_TABLE_EVENT, i, cols, MONO_EVENT_SIZE);
@@ -3759,7 +3759,7 @@ mono_class_setup_events (MonoClass *klass)
 
 			startm = mono_metadata_methods_from_event (klass->image, i, &endm);
 			int first_idx = mono_class_get_first_method_idx (klass);
-			for (j = startm; j < endm; ++j) {
+			for (guint j = startm; j < endm; ++j) {
 				MonoMethod *method;
 
 				mono_metadata_decode_row (msemt, j, cols, MONO_METHOD_SEMA_SIZE);

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -5044,17 +5044,18 @@ static MonoArrayHandle
 mono_module_get_types (MonoImage *image, MonoArrayHandleOut exceptions, MonoBoolean exportedOnly, MonoError *error)
 {
 	MonoTableInfo *tdef = &image->tables [MONO_TABLE_TYPEDEF];
-	int rows = mono_metadata_table_num_rows (image, MONO_TABLE_TYPEDEF);
-	int i, count;
+	guint32 rows = mono_metadata_table_num_rows (image, MONO_TABLE_TYPEDEF);
+	guint32 count;
 
 	/* we start the count from 1 because we skip the special type <Module> */
 	if (exportedOnly) {
 		count = 0;
-		for (i = 1; i < rows; ++i) {
+		for (guint32 i = 1; i < rows; ++i) {
 			if (mono_module_type_is_visible (tdef, image, i + 1))
 				count++;
 		}
 	} else {
+		g_assert (rows > 0);
 		count = rows - 1;
 	}
 	MonoArrayHandle res = mono_array_new_handle (mono_defaults.runtimetype_class, count, error);
@@ -5062,7 +5063,7 @@ mono_module_get_types (MonoImage *image, MonoArrayHandleOut exceptions, MonoBool
 	MONO_HANDLE_ASSIGN (exceptions,  mono_array_new_handle (mono_defaults.exception_class, count, error));
 	return_val_if_nok (error, NULL_HANDLE_ARRAY);
 	count = 0;
-	for (i = 1; i < rows; ++i) {
+	for (guint32 i = 1; i < rows; ++i) {
 		if (!exportedOnly || mono_module_type_is_visible (tdef, image, i+1)) {
 			image_get_type (image, tdef, i + 1, count, res, exceptions, exportedOnly, error);
 			return_val_if_nok (error, NULL_HANDLE_ARRAY);
@@ -5430,8 +5431,8 @@ static gboolean
 mono_memberref_is_method (MonoImage *image, guint32 token)
 {
 	if (!image_is_dynamic (image)) {
-		int idx = mono_metadata_token_index (token);
-		if (idx <= 0 || mono_metadata_table_bounds_check (image, MONO_TABLE_MEMBERREF, idx)) {
+		uint32_t idx = mono_metadata_token_index (token);
+		if (idx == 0 || mono_metadata_table_bounds_check (image, MONO_TABLE_MEMBERREF, idx)) {
 			return FALSE;
 		}
 
@@ -5500,7 +5501,7 @@ module_resolve_type_token (MonoImage *image, guint32 token, MonoArrayHandle type
 	MonoType *result = NULL;
 	MonoClass *klass;
 	int table = mono_metadata_token_table (token);
-	int index = mono_metadata_token_index (token);
+	uint32_t index = mono_metadata_token_index (token);
 	MonoGenericContext context;
 
 	*resolve_error = ResolveTokenError_Other;
@@ -5529,7 +5530,7 @@ module_resolve_type_token (MonoImage *image, guint32 token, MonoArrayHandle type
 		goto leave;
 	}
 
-	if ((index <= 0) || mono_metadata_table_bounds_check (image, table, index)) {
+	if ((index == 0) || mono_metadata_table_bounds_check (image, table, index)) {
 		*resolve_error = ResolveTokenError_OutOfRange;
 		goto leave;
 	}
@@ -5558,7 +5559,7 @@ module_resolve_method_token (MonoImage *image, guint32 token, MonoArrayHandle ty
 	HANDLE_FUNCTION_ENTER ();
 	MonoMethod *method = NULL;
 	int table = mono_metadata_token_table (token);
-	int index = mono_metadata_token_index (token);
+	uint32_t index = mono_metadata_token_index (token);
 	MonoGenericContext context;
 
 	*resolve_error = ResolveTokenError_Other;
@@ -5590,7 +5591,7 @@ module_resolve_method_token (MonoImage *image, guint32 token, MonoArrayHandle ty
 		goto leave;
 	}
 
-	if ((index <= 0) || mono_metadata_table_bounds_check (image, table, index)) {
+	if ((index == 0) || mono_metadata_table_bounds_check (image, table, index)) {
 		*resolve_error = ResolveTokenError_OutOfRange;
 		goto leave;
 	}
@@ -5649,7 +5650,7 @@ module_resolve_field_token (MonoImage *image, guint32 token, MonoArrayHandle typ
 	HANDLE_FUNCTION_ENTER ();
 	MonoClass *klass;
 	int table = mono_metadata_token_table (token);
-	int index = mono_metadata_token_index (token);
+	uint32_t index = mono_metadata_token_index (token);
 	MonoGenericContext context;
 	MonoClassField *field = NULL;
 
@@ -5681,7 +5682,7 @@ module_resolve_field_token (MonoImage *image, guint32 token, MonoArrayHandle typ
 		goto leave;
 	}
 
-	if ((index <= 0) || mono_metadata_table_bounds_check (image, table, index)) {
+	if ((index == 0) || mono_metadata_table_bounds_check (image, table, index)) {
 		*resolve_error = ResolveTokenError_OutOfRange;
 		goto leave;
 	}
@@ -5766,7 +5767,7 @@ MonoArrayHandle
 ves_icall_System_Reflection_RuntimeModule_ResolveSignature (MonoImage *image, guint32 token, MonoResolveTokenError *resolve_error, MonoError *error)
 {
 	int table = mono_metadata_token_table (token);
-	int idx = mono_metadata_token_index (token);
+	uint32_t idx = mono_metadata_token_index (token);
 	MonoTableInfo *tables = image->tables;
 	guint32 sig, len;
 	const char *ptr;

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -790,13 +790,13 @@ gboolean
 mono_metadata_has_updates_api (void);
 
 void
-mono_image_effective_table_slow (const MonoTableInfo **t, int idx);
+mono_image_effective_table_slow (const MonoTableInfo **t, uint32_t idx);
 
 gboolean
 mono_metadata_update_has_modified_rows (const MonoTableInfo *t);
 
 static inline void
-mono_image_effective_table (const MonoTableInfo **t, int idx)
+mono_image_effective_table (const MonoTableInfo **t, uint32_t idx)
 {
 	if (G_UNLIKELY (mono_metadata_has_updates ())) {
 		if (G_UNLIKELY (idx >= table_info_get_rows ((*t)) || mono_metadata_update_has_modified_rows (*t))) {

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -844,10 +844,10 @@ mono_metadata_clean_generic_classes_for_image (MonoImage *image);
 gboolean
 mono_metadata_table_bounds_check_slow (MonoImage *image, int table_index, int token_index);
 
-int
+guint32
 mono_metadata_table_num_rows_slow (MonoImage *image, int table_index);
 
-static inline int
+static inline guint32
 mono_metadata_table_num_rows (MonoImage *image, int table_index)
 {
 	if (G_LIKELY (!image->has_updates))

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -833,7 +833,7 @@ void
 mono_metadata_decode_row_raw (const MonoTableInfo *t, int idx, uint32_t *res, int res_size);
 
 gboolean
-mono_metadata_decode_row_dynamic_checked (const MonoDynamicImage *image, const MonoDynamicTable *t, int idx, guint32 *res, int res_size, MonoError *error);
+mono_metadata_decode_row_dynamic_checked (const MonoDynamicImage *image, const MonoDynamicTable *t, guint idx, guint32 *res, int res_size, MonoError *error);
 
 MonoType*
 mono_metadata_get_shared_type (MonoType *type);
@@ -902,7 +902,7 @@ MonoMethodSignature  *mono_metadata_parse_signature_checked (MonoImage *image,
 gboolean
 mono_method_get_header_summary (MonoMethod *method, MonoMethodHeaderSummary *summary);
 
-int* mono_metadata_get_param_attrs          (MonoImage *m, int def, int param_count);
+int* mono_metadata_get_param_attrs          (MonoImage *m, int def, guint32 param_count);
 gboolean mono_metadata_method_has_param_attrs (MonoImage *m, int def);
 
 guint

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -694,7 +694,7 @@ assembly_is_dynamic (MonoAssembly *assembly)
 #endif
 }
 
-static inline int
+static inline uint32_t
 table_info_get_rows (const MonoTableInfo *table)
 {
 	return table->rows_;
@@ -799,7 +799,7 @@ static inline void
 mono_image_effective_table (const MonoTableInfo **t, uint32_t idx)
 {
 	if (G_UNLIKELY (mono_metadata_has_updates ())) {
-		if (G_UNLIKELY (idx >= table_info_get_rows ((*t)) || mono_metadata_update_has_modified_rows (*t))) {
+		if (G_UNLIKELY (idx >= table_info_get_rows (*t) || mono_metadata_update_has_modified_rows (*t))) {
 			mono_image_effective_table_slow (t, idx);
 		}
 	}
@@ -861,7 +861,7 @@ static inline gboolean
 mono_metadata_table_bounds_check (MonoImage *image, int table_index, int token_index)
 {
 	/* returns true if given index is not in bounds with provided table/index pair */
-	if (G_LIKELY (token_index <= table_info_get_rows (&image->tables [table_index])))
+	if (G_LIKELY (GINT_TO_UINT32(token_index) <= table_info_get_rows (&image->tables [table_index])))
 		return FALSE;
         if (G_LIKELY (!image->has_updates))
                 return TRUE;

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -62,7 +62,7 @@ mono_metadata_update_cleanup_on_close (MonoImage *base_image)
 }
 
 void
-mono_image_effective_table_slow (const MonoTableInfo **t, int idx)
+mono_image_effective_table_slow (const MonoTableInfo **t, uint32_t idx)
 {
 	mono_component_hot_reload ()->effective_table_slow (t, idx);
 }

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -143,7 +143,7 @@ mono_metadata_has_updates_api (void)
  * Returns the number of rows from the specified table that the current thread can see.
  * If there's a EnC metadata update, this number may change.
  */
-int
+guint32
 mono_metadata_table_num_rows_slow (MonoImage *base_image, int table_index)
 {
 	return mono_component_hot_reload()->table_num_rows_slow (base_image, table_index);

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -6390,7 +6390,8 @@ mono_metadata_methods_from_event   (MonoImage *meta, guint32 index, guint *end_i
 			break;
 	}
 	end = start + 1;
-	while (end < mono_metadata_table_num_rows (meta, MONO_TABLE_METHODSEMANTICS)) {
+	guint32 rows = mono_metadata_table_num_rows (meta, MONO_TABLE_METHODSEMANTICS);
+	while (end < rows) {
 		mono_metadata_decode_row (msemt, end, cols, MONO_METHOD_SEMA_SIZE);
 		if (cols [MONO_METHOD_SEMA_ASSOCIATION] != loc.idx)
 			break;
@@ -6502,7 +6503,8 @@ mono_metadata_methods_from_property   (MonoImage *meta, guint32 index, guint *en
 			break;
 	}
 	end = start + 1;
-	while (end < mono_metadata_table_num_rows (meta, MONO_TABLE_METHODSEMANTICS)) {
+	guint32 rows = mono_metadata_table_num_rows (meta, MONO_TABLE_METHODSEMANTICS);
+	while (end < rows) {
 		mono_metadata_decode_row (msemt, end, cols, MONO_METHOD_SEMA_SIZE);
 		if (cols [MONO_METHOD_SEMA_ASSOCIATION] != loc.idx)
 			break;
@@ -7034,7 +7036,8 @@ mono_class_get_overrides_full (MonoImage *image, guint32 type_token, MonoMethod 
 		else
 			break;
 	}
-	while (end < table_info_get_rows (tdef)) {
+	guint32 rows = table_info_get_rows (tdef);
+	while (end < rows) {
 		if (loc.idx == mono_metadata_decode_row_col (tdef, end, MONO_METHODIMPL_CLASS))
 			end++;
 		else
@@ -7116,7 +7119,8 @@ get_constraints (MonoImage *image, int owner, MonoClass ***constraints, MonoGene
 	*constraints = NULL;
 	found = 0;
 	/* FIXME: metadata-update */
-	for (i = 0; i < table_info_get_rows (tdef); ++i) {
+	guint32 rows = table_info_get_rows (tdef);
+	for (i = 0; i < rows; ++i) {
 		mono_metadata_decode_row (tdef, i, cols, MONO_GENPARCONSTRAINT_SIZE);
 		if (cols [MONO_GENPARCONSTRAINT_GENERICPAR] == owner) {
 			token = mono_metadata_token_from_dor (cols [MONO_GENPARCONSTRAINT_CONSTRAINT]);

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1303,6 +1303,7 @@ mono_metadata_decode_row (const MonoTableInfo *t, int idx, guint32 *res, int res
 void
 mono_metadata_decode_row_slow (const MonoTableInfo *t, int idx, guint32 *res, int res_size)
 {
+	g_assert (idx >= 0);
 	mono_image_effective_table (&t, idx);
 	mono_metadata_decode_row_raw (t, idx, res, res_size);
 }
@@ -1359,6 +1360,7 @@ mono_metadata_decode_row_checked (const MonoImage *image, const MonoTableInfo *t
 {
 	const char *image_name = image && image->name ? image->name : "unknown image";
 
+	g_assert (idx >= 0);
 	mono_image_effective_table (&t, idx);
 
 	guint32 bitfield = t->size_bitfield;
@@ -1448,6 +1450,7 @@ mono_metadata_decode_row_col (const MonoTableInfo *t, int idx, guint col)
 guint32
 mono_metadata_decode_row_col_slow (const MonoTableInfo *t, int idx, guint col)
 {
+	g_assert (idx >= 0);
 	mono_image_effective_table (&t, idx);
 	return mono_metadata_decode_row_col_raw (t, idx, col);
 }

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2323,8 +2323,7 @@ mono_metadata_get_param_attrs (MonoImage *m, int def, guint32 param_count)
 		return NULL;
 
 	/* FIXME: metadata-update */
-	guint32 rows = mono_metadata_table_num_rows (m, MONO_TABLE_METHOD);
-	if (GINT_TO_UINT32(def) < rows)
+	if (GINT_TO_UINT32(def) < mono_metadata_table_num_rows (m, MONO_TABLE_METHOD))
 		lastp = mono_metadata_decode_row_col (methodt, def, MONO_METHOD_PARAMLIST);
 	else
 		lastp = table_info_get_rows (paramt) + 1;
@@ -4648,7 +4647,7 @@ mono_metadata_token_from_dor (guint32 dor_index)
 typedef struct {
 	guint32 idx;			/* The index that we are trying to locate */
 	guint32 col_idx;		/* The index in the row where idx may be stored */
-	MonoTableInfo *t;	/* pointer to the table */
+	MonoTableInfo *t;		/* pointer to the table */
 	guint32 result;
 } locator_t;
 
@@ -4805,7 +4804,7 @@ mono_metadata_typedef_from_field (MonoImage *meta, guint32 index)
 		loc.idx = search_ptr_table (meta, MONO_TABLE_FIELD_POINTER, loc.idx);
 
 	/* if it's not in the base image, look in the hot reload table */
-	gboolean added = (loc.idx > GINT_TO_UINT32(table_info_get_rows (&meta->tables [MONO_TABLE_FIELD])));
+	gboolean added = (loc.idx > table_info_get_rows (&meta->tables [MONO_TABLE_FIELD]));
 	if (added) {
 		uint32_t res = mono_component_hot_reload()->field_parent (meta, loc.idx);
 		return res; /* 0 if not found, otherwise 1-based */
@@ -4842,7 +4841,7 @@ mono_metadata_typedef_from_method (MonoImage *meta, guint32 index)
 		loc.idx = search_ptr_table (meta, MONO_TABLE_METHOD_POINTER, loc.idx);
 
 	/* if it's not in the base image, look in the hot reload table */
-	gboolean added = (loc.idx > GINT_TO_UINT32(table_info_get_rows (&meta->tables [MONO_TABLE_METHOD])));
+	gboolean added = (loc.idx > table_info_get_rows (&meta->tables [MONO_TABLE_METHOD]));
 	if (added) {
 		uint32_t res = mono_component_hot_reload ()->method_parent (meta, loc.idx);
 		return res; /* 0 if not found, otherwise 1-based */
@@ -6391,8 +6390,7 @@ mono_metadata_methods_from_event   (MonoImage *meta, guint32 index, guint *end_i
 			break;
 	}
 	end = start + 1;
-	guint32 rows = mono_metadata_table_num_rows (meta, MONO_TABLE_METHODSEMANTICS);
-	while (end < rows) {
+	while (end < mono_metadata_table_num_rows (meta, MONO_TABLE_METHODSEMANTICS)) {
 		mono_metadata_decode_row (msemt, end, cols, MONO_METHOD_SEMA_SIZE);
 		if (cols [MONO_METHOD_SEMA_ASSOCIATION] != loc.idx)
 			break;
@@ -6504,8 +6502,7 @@ mono_metadata_methods_from_property   (MonoImage *meta, guint32 index, guint *en
 			break;
 	}
 	end = start + 1;
-	guint32 rows = mono_metadata_table_num_rows (meta, MONO_TABLE_METHODSEMANTICS);
-	while (end < rows) {
+	while (end < mono_metadata_table_num_rows (meta, MONO_TABLE_METHODSEMANTICS)) {
 		mono_metadata_decode_row (msemt, end, cols, MONO_METHOD_SEMA_SIZE);
 		if (cols [MONO_METHOD_SEMA_ASSOCIATION] != loc.idx)
 			break;
@@ -7037,8 +7034,7 @@ mono_class_get_overrides_full (MonoImage *image, guint32 type_token, MonoMethod 
 		else
 			break;
 	}
-	guint32 rows = table_info_get_rows (tdef);
-	while (end < rows) {
+	while (end < table_info_get_rows (tdef)) {
 		if (loc.idx == mono_metadata_decode_row_col (tdef, end, MONO_METHODIMPL_CLASS))
 			end++;
 		else
@@ -7120,8 +7116,7 @@ get_constraints (MonoImage *image, int owner, MonoClass ***constraints, MonoGene
 	*constraints = NULL;
 	found = 0;
 	/* FIXME: metadata-update */
-	guint32 rows = table_info_get_rows (tdef);
-	for (i = 0; i < rows; ++i) {
+	for (i = 0; i < table_info_get_rows (tdef); ++i) {
 		mono_metadata_decode_row (tdef, i, cols, MONO_GENPARCONSTRAINT_SIZE);
 		if (cols [MONO_GENPARCONSTRAINT_GENERICPAR] == owner) {
 			token = mono_metadata_token_from_dor (cols [MONO_GENPARCONSTRAINT_CONSTRAINT]);

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -1271,7 +1271,7 @@ mono_arch_get_native_call_context_args (CallContext *ccontext, gpointer frame, M
 	gpointer storage;
 	ArgInfo *ainfo;
 
-	for (guint16 i = 0; i < sig->param_count + sig->hasthis; i++) {
+	for (guint i = 0; i < sig->param_count + sig->hasthis; i++) {
 		ainfo = &cinfo->args [i];
 
 		if (ainfo->storage == ArgValuetypeAddrInIReg || ainfo->storage == ArgValuetypeAddrOnStack) {
@@ -7854,7 +7854,7 @@ MONO_RESTORE_WARNING
 	}
 
 	/* Keep this in sync with emit_load_volatile_arguments */
-	for (guint16 i = 0; i < sig->param_count + sig->hasthis; ++i) {
+	for (guint i = 0; i < sig->param_count + sig->hasthis; ++i) {
 		ArgInfo *ainfo = cinfo->args + i;
 
 		ins = cfg->args [i];
@@ -7974,7 +7974,7 @@ MONO_RESTORE_WARNING
 		if (first_bb->in_count > 1)
 			next = NULL;
 
-		for (guint16 i = 0; next && i < sig->param_count + sig->hasthis; ++i) {
+		for (guint i = 0; next && i < sig->param_count + sig->hasthis; ++i) {
 			ArgInfo *ainfo = cinfo->args + i;
 			gboolean match = FALSE;
 

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -310,7 +310,7 @@ merge_argument_class_from_type (MonoType *type, ArgumentClass class1)
 		/* fall through */
 	case MONO_TYPE_VALUETYPE: {
 		MonoMarshalType *info = mono_marshal_load_type_info (ptype->data.klass);
-		int i;
+		guint32 i;
 
 		for (i = 0; i < info->num_fields; ++i) {
 			class2 = class1;
@@ -339,7 +339,7 @@ merge_argument_class_from_type (MonoType *type, ArgumentClass class1)
 
 typedef struct {
 	MonoType *type;
-	int size, offset;
+	guint32 size, offset;
 } StructFieldInfo;
 
 /*
@@ -351,7 +351,7 @@ static void
 collect_field_info_nested (MonoClass *klass, GArray *fields_array, int offset, gboolean pinvoke, gboolean unicode)
 {
 	MonoMarshalType *info;
-	int i;
+	guint32 i;
 
 	if (pinvoke) {
 		info = mono_marshal_load_type_info (klass);
@@ -417,7 +417,7 @@ collect_field_info_nested (MonoClass *klass, GArray *fields_array, int offset, g
 #define MONO_WIN64_VALUE_TYPE_FITS_REG(arg_size) (arg_size <= SIZEOF_REGISTER && (arg_size == 1 || arg_size == 2 || arg_size == 4 || arg_size == 8))
 
 static gboolean
-allocate_register_for_valuetype_win64 (ArgInfo *arg_info, ArgumentClass arg_class, guint32 arg_size, const AMD64_Reg_No int_regs [], int int_reg_count, const AMD64_XMM_Reg_No float_regs [], int float_reg_count, guint32 *current_int_reg, guint32 *current_float_reg)
+allocate_register_for_valuetype_win64 (ArgInfo *arg_info, ArgumentClass arg_class, guint32 arg_size, const AMD64_Reg_No int_regs [], guint32 int_reg_count, const AMD64_XMM_Reg_No float_regs [], guint32 float_reg_count, guint32 *current_int_reg, guint32 *current_float_reg)
 {
 	gboolean result = FALSE;
 
@@ -1274,7 +1274,7 @@ mono_arch_get_native_call_context_args (CallContext *ccontext, gpointer frame, M
 	gpointer storage;
 	ArgInfo *ainfo;
 
-	for (int i = 0; i < sig->param_count + sig->hasthis; i++) {
+	for (guint16 i = 0; i < sig->param_count + sig->hasthis; i++) {
 		ainfo = &cinfo->args [i];
 
 		if (ainfo->storage == ArgValuetypeAddrInIReg || ainfo->storage == ArgValuetypeAddrOnStack) {
@@ -1503,7 +1503,7 @@ GList *
 mono_arch_get_allocatable_int_vars (MonoCompile *cfg)
 {
 	GList *vars = NULL;
-	int i;
+	guint i;
 
 	for (i = 0; i < cfg->num_varinfo; i++) {
 		MonoInst *ins = cfg->varinfo [i];
@@ -1538,7 +1538,7 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 {
 	MonoMethodSignature *sig;
 	MonoMethodHeader *header;
-	int i;
+	guint16 i;
 	CallInfo *cinfo;
 
 	if (cfg->arch.omit_fp_computed)
@@ -1644,7 +1644,7 @@ mono_arch_fill_argument_info (MonoCompile *cfg)
 {
 	MonoMethodSignature *sig;
 	MonoInst *ins;
-	int i;
+	guint16 i;
 	CallInfo *cinfo;
 
 	sig = mono_method_signature_internal (cfg->method);
@@ -1708,7 +1708,8 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 	MonoType *sig_ret;
 	MonoMethodSignature *sig;
 	MonoInst *ins;
-	int i, offset;
+	int offset;
+	guint i;
 	guint32 locals_stack_size, locals_stack_align;
 	gint32 *offsets;
 	CallInfo *cinfo;
@@ -5418,7 +5419,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_TAILCALL_REG:
 		case OP_TAILCALL_MEMBASE: {
 			call = (MonoCallInst*)ins;
-			int i, save_area_offset;
+			int save_area_offset;
+			guint i;
 			gboolean tailcall_membase = (ins->opcode == OP_TAILCALL_MEMBASE);
 			gboolean tailcall_reg = (ins->opcode == OP_TAILCALL_REG);
 
@@ -8439,7 +8441,7 @@ get_delegate_invoke_impl (MonoTrampInfo **info, gboolean has_target, guint32 par
 {
 	guint8 *code, *start;
 	GSList *unwind_ops = NULL;
-	int i;
+	guint32 i;
 
 	unwind_ops = mono_arch_get_cie_program ();
 

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -310,9 +310,7 @@ merge_argument_class_from_type (MonoType *type, ArgumentClass class1)
 		/* fall through */
 	case MONO_TYPE_VALUETYPE: {
 		MonoMarshalType *info = mono_marshal_load_type_info (ptype->data.klass);
-		guint32 i;
-
-		for (i = 0; i < info->num_fields; ++i) {
+		for (guint32 i = 0; i < info->num_fields; ++i) {
 			class2 = class1;
 			class2 = merge_argument_class_from_type (info->fields [i].field->type, class2);
 		}
@@ -351,12 +349,11 @@ static void
 collect_field_info_nested (MonoClass *klass, GArray *fields_array, int offset, gboolean pinvoke, gboolean unicode)
 {
 	MonoMarshalType *info;
-	guint32 i;
 
 	if (pinvoke) {
 		info = mono_marshal_load_type_info (klass);
 		g_assert(info);
-		for (i = 0; i < info->num_fields; ++i) {
+		for (guint32 i = 0; i < info->num_fields; ++i) {
 			if (MONO_TYPE_ISSTRUCT (info->fields [i].field->type)) {
 				collect_field_info_nested (mono_class_from_mono_type_internal (info->fields [i].field->type), fields_array, info->fields [i].offset, pinvoke, unicode);
 			} else {
@@ -1503,9 +1500,8 @@ GList *
 mono_arch_get_allocatable_int_vars (MonoCompile *cfg)
 {
 	GList *vars = NULL;
-	guint i;
 
-	for (i = 0; i < cfg->num_varinfo; i++) {
+	for (guint i = 0; i < cfg->num_varinfo; i++) {
 		MonoInst *ins = cfg->varinfo [i];
 		MonoMethodVar *vmv = MONO_VARINFO (cfg, i);
 
@@ -1538,7 +1534,6 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 {
 	MonoMethodSignature *sig;
 	MonoMethodHeader *header;
-	guint16 i;
 	CallInfo *cinfo;
 
 	if (cfg->arch.omit_fp_computed)
@@ -1575,7 +1570,7 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 		cfg->arch.omit_fp = FALSE;
 	if (!sig->pinvoke && (sig->call_convention == MONO_CALL_VARARG))
 		cfg->arch.omit_fp = FALSE;
-	for (i = 0; i < sig->param_count + sig->hasthis; ++i) {
+	for (guint i = 0; i < sig->param_count + sig->hasthis; ++i) {
 		ArgInfo *ainfo = &cinfo->args [i];
 
 		if (ainfo->storage == ArgOnStack || ainfo->storage == ArgValuetypeAddrInIReg || ainfo->storage == ArgValuetypeAddrOnStack) {
@@ -1644,7 +1639,6 @@ mono_arch_fill_argument_info (MonoCompile *cfg)
 {
 	MonoMethodSignature *sig;
 	MonoInst *ins;
-	guint16 i;
 	CallInfo *cinfo;
 
 	sig = mono_method_signature_internal (cfg->method);
@@ -1675,7 +1669,7 @@ mono_arch_fill_argument_info (MonoCompile *cfg)
 		g_assert_not_reached ();
 	}
 
-	for (i = 0; i < sig->param_count + sig->hasthis; ++i) {
+	for (guint i = 0; i < sig->param_count + sig->hasthis; ++i) {
 		ArgInfo *ainfo = &cinfo->args [i];
 
 		ins = cfg->args [i];
@@ -1709,7 +1703,6 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 	MonoMethodSignature *sig;
 	MonoInst *ins;
 	int offset;
-	guint i;
 	guint32 locals_stack_size, locals_stack_align;
 	gint32 *offsets;
 	CallInfo *cinfo;
@@ -1757,7 +1750,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 	if (cfg->arch.omit_fp)
 		cfg->arch.reg_save_area_offset = offset;
 	/* Reserve space for callee saved registers */
-	for (i = 0; i < AMD64_NREG; ++i)
+	for (guint i = 0; i < AMD64_NREG; ++i)
 		if (AMD64_IS_CALLEE_SAVED_REG (i) && (cfg->arch.saved_iregs & (1 << i))) {
 			offset += sizeof (target_mgreg_t);
 		}
@@ -1821,7 +1814,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 		cfg->locals_max_stack_offset = - offset;
 	}
 
-	for (i = cfg->locals_start; i < cfg->num_varinfo; i++) {
+	for (guint i = cfg->locals_start; i < cfg->num_varinfo; i++) {
 		if (offsets [i] != -1) {
 			ins = cfg->varinfo [i];
 			ins->opcode = OP_REGOFFSET;
@@ -1841,7 +1834,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 		cfg->sig_cookie = cinfo->sig_cookie.offset + ARGS_OFFSET;
 	}
 
-	for (i = 0; i < sig->param_count + sig->hasthis; ++i) {
+	for (guint i = 0; i < sig->param_count + sig->hasthis; ++i) {
 		ins = cfg->args [i];
 		if (ins->opcode != OP_REGVAR) {
 			ArgInfo *ainfo = &cinfo->args [i];
@@ -5420,7 +5413,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_TAILCALL_MEMBASE: {
 			call = (MonoCallInst*)ins;
 			int save_area_offset;
-			guint i;
 			gboolean tailcall_membase = (ins->opcode == OP_TAILCALL_MEMBASE);
 			gboolean tailcall_reg = (ins->opcode == OP_TAILCALL_REG);
 
@@ -5457,7 +5449,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 			/* Restore callee saved registers */
 			save_area_offset = cfg->arch.reg_save_area_offset;
-			for (i = 0; i < AMD64_NREG; ++i)
+			for (guint i = 0; i < AMD64_NREG; ++i)
 				if (AMD64_IS_CALLEE_SAVED_REG (i) && (cfg->used_int_regs & ((regmask_t)1 << i))) {
 					amd64_mov_reg_membase (code, i, cfg->frame_reg, save_area_offset, 8);
 					save_area_offset += 8;
@@ -5474,7 +5466,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				/* Copy arguments on the stack to our argument area */
 				// FIXME use rep mov for constant code size, before nonvolatiles
 				// restored, first saving rsi, rdi into volatiles
-				for (i = 0; i < call->stack_usage; i += sizeof (target_mgreg_t)) {
+				for (guint i = 0; i < call->stack_usage; i += sizeof (target_mgreg_t)) {
 					amd64_mov_reg_membase (code, AMD64_RAX, AMD64_RSP, i + 8, sizeof (target_mgreg_t));
 					amd64_mov_membase_reg (code, AMD64_RBP, ARGS_OFFSET + i, AMD64_RAX, sizeof (target_mgreg_t));
 				}
@@ -8441,7 +8433,6 @@ get_delegate_invoke_impl (MonoTrampInfo **info, gboolean has_target, guint32 par
 {
 	guint8 *code, *start;
 	GSList *unwind_ops = NULL;
-	guint32 i;
 
 	unwind_ops = mono_arch_get_cie_program ();
 
@@ -8462,7 +8453,7 @@ get_delegate_invoke_impl (MonoTrampInfo **info, gboolean has_target, guint32 par
 		} else {
 			/* We have to shift the arguments left */
 			amd64_mov_reg_reg (code, AMD64_RAX, AMD64_ARG_REG1, 8);
-			for (i = 0; i < param_count; ++i) {
+			for (guint32 i = 0; i < param_count; ++i) {
 #ifdef TARGET_WIN32
 				if (i < 3)
 					amd64_mov_reg_reg (code, param_regs [i], param_regs [i + 1], 8);

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1282,7 +1282,7 @@ typedef enum {
 #define MONO_REGION_FLAGS(region) ((region) & 0x7)
 #define MONO_REGION_CLAUSE_INDEX(region) (((region) >> 8) - 1)
 
-#define get_vreg_to_inst(cfg, vreg) ((vreg) < (cfg)->vreg_to_inst_len ? (cfg)->vreg_to_inst [(vreg)] : NULL)
+#define get_vreg_to_inst(cfg, vreg) ((vreg) < GUINT32_TO_INT32((cfg)->vreg_to_inst_len) ? (cfg)->vreg_to_inst [(vreg)] : NULL)
 
 #define vreg_is_volatile(cfg, vreg) (G_UNLIKELY (get_vreg_to_inst ((cfg), (vreg)) && (get_vreg_to_inst ((cfg), (vreg))->flags & (MONO_INST_VOLATILE|MONO_INST_INDIRECT))))
 

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1282,7 +1282,7 @@ typedef enum {
 #define MONO_REGION_FLAGS(region) ((region) & 0x7)
 #define MONO_REGION_CLAUSE_INDEX(region) (((region) >> 8) - 1)
 
-#define get_vreg_to_inst(cfg, vreg) ((vreg) < GUINT32_TO_INT32((cfg)->vreg_to_inst_len) ? (cfg)->vreg_to_inst [(vreg)] : NULL)
+#define get_vreg_to_inst(cfg, vreg) (GINT32_TO_UINT32(vreg) < (cfg)->vreg_to_inst_len ? (cfg)->vreg_to_inst [(vreg)] : NULL)
 
 #define vreg_is_volatile(cfg, vreg) (G_UNLIKELY (get_vreg_to_inst ((cfg), (vreg)) && (get_vreg_to_inst ((cfg), (vreg))->flags & (MONO_INST_VOLATILE|MONO_INST_INDIRECT))))
 


### PR DESCRIPTION
Fixes part of C4018 warnings on Mono runtime x86/x64 Windows build, aligning with SDL requirements (https://github.com/dotnet/runtime/issues/66154).

First of all, this PR eliminated C4018 warnings from the following files and made sure that no new C4244 warnings were introduced.

- src\mono\mono\metadata\metadata.c
- src\mono\mono\mini\mini-amd64.c
- src\mono\mono\metadata\class-init.c
- src\mono\mono\eventpipe\ep-rt-mono.c
- src\mono\mono\mini\simd-intrinsics.c
- src\mono\mono\eglib\gfile.c
- src\mono\mono\eventpipe\ep-rt-mono.h
- src\mono\mono\eglib\gptrarray.c
- src\mono\mono\component\debugger-state-machine.c
- src\mono\mono\eglib\garray.c

Secondly, some existing code has been refactored, which was to use the more accurate datatype. Mostly, I was changing the type of index parameter from signed to unsigned. As a result, the signature of the following methods have changed

- `*effective_table_slow`
- `*table_num_rows*`
-  `mono_image_effective_table`
-  `mono_metadata_decode_row_dynamic_checked`
-  `mono_metadata_get_param_attrs`
-  `allocate_register_for_valuetype_win64`
- `table_info_get_rows`

While working on this PR, I've also observed more methods also have the above issue, which were used more broadly and more often in the codebase, which deserve a dedicated PR to ensure the accuracy of changing the signedness. Thus, I opened a new issue to track it. (https://github.com/dotnet/runtime/issues/70495)