### PR TITLE
Don't call RuntimeHelper.Equals in Object.Equals

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Object.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Object.cs
@@ -47,7 +47,7 @@ namespace System
         /// <returns><c>true</c> if the specified object is equal to the current object; otherwise, <c>false</c>.</returns>
         public virtual bool Equals(object? obj)
         {
-            return RuntimeHelpers.Equals(this, obj);
+            return ReferenceEquals(this, obj);
         }
 
         public static bool Equals(object? objA, object? objB)

--- a/src/libraries/System.Private.CoreLib/src/System/Object.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Object.cs
@@ -47,7 +47,7 @@ namespace System
         /// <returns><c>true</c> if the specified object is equal to the current object; otherwise, <c>false</c>.</returns>
         public virtual bool Equals(object? obj)
         {
-            return ReferenceEquals(this, obj);
+            return this == obj;
         }
 
         public static bool Equals(object? objA, object? objB)


### PR DESCRIPTION
`RuntimeHelper.Equals` only deals value types with additional comparison, which would be handled by the override `ValueType.Equals`. The behavior of reference types is just `ReferenceEquals`.

Question: `RuntimeHelper.Equals` compares value types for value and padding, while `ValueType.Equals` (fast path) compares only fields. I looked for the purpose of `RuntimeHelper.Equals`, and found it was introduced in .NET Framework 1.1. Shouldn't padding just be an implementation detail, and the purpose of the API is comparing value bits?

Should we unify the implementation with `ValueType.Equals` then? The Mono behavior is actually wrong now (uses the full path of `ValueType.Equals`, instead of fast compare bits path).