### PR TITLE
JsonSerializer.DeserializeAsyncEnumerable should not wait until buffer is filled.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -1,14 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Converters;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
@@ -375,7 +373,7 @@ namespace System.Text.Json
             }
 
             JsonTypeInfo jsonTypeInfo = options.GetOrAddJsonTypeInfoForRootType(typeof(TValue));
-            return CreateAsyncEnumerableDeserializer<TValue>(utf8Json, jsonTypeInfo, cancellationToken);
+            return CreateAsyncEnumerableDeserializer(utf8Json, CreateQueueTypeInfo<TValue>(jsonTypeInfo), cancellationToken);
         }
 
         /// <summary>
@@ -406,28 +404,30 @@ namespace System.Text.Json
                 ThrowHelper.ThrowArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return CreateAsyncEnumerableDeserializer<TValue>(utf8Json, jsonTypeInfo, cancellationToken);
+            return CreateAsyncEnumerableDeserializer(utf8Json, CreateQueueTypeInfo<TValue>(jsonTypeInfo), cancellationToken);
+        }
+
+        private static JsonTypeInfo<Queue<TValue>> CreateQueueTypeInfo<TValue>(JsonTypeInfo jsonTypeInfo)
+        {
+            return JsonMetadataServices.CreateQueueInfo<Queue<TValue>, TValue>(
+                options: jsonTypeInfo.Options,
+                collectionInfo: new()
+                {
+                    ObjectCreator = static () => new Queue<TValue>(),
+                    ElementInfo = jsonTypeInfo,
+                    NumberHandling = jsonTypeInfo.Options.NumberHandling
+                });
         }
 
         private static async IAsyncEnumerable<TValue> CreateAsyncEnumerableDeserializer<TValue>(
             Stream utf8Json,
-            JsonTypeInfo jsonTypeInfo,
+            JsonTypeInfo<Queue<TValue>> queueTypeInfo,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            JsonSerializerOptions options = jsonTypeInfo.Options;
-            JsonTypeInfo<Queue<TValue>> queueTypeInfo =
-                JsonMetadataServices.CreateQueueInfo<Queue<TValue>, TValue>(
-                    options: options,
-                    collectionInfo: new()
-                    {
-                        ObjectCreator = () => new Queue<TValue>(),
-                        ElementInfo = jsonTypeInfo,
-                        NumberHandling = options.NumberHandling
-                    });
-
+            queueTypeInfo.EnsureConfigured();
+            JsonSerializerOptions options = queueTypeInfo.Options;
             var bufferState = new ReadBufferState(options.DefaultBufferSize);
             ReadStack readStack = default;
-            queueTypeInfo.EnsureConfigured();
             readStack.Initialize(queueTypeInfo, supportContinuation: true);
             var jsonReaderState = new JsonReaderState(options.GetReaderOptions());
 
@@ -435,7 +435,7 @@ namespace System.Text.Json
             {
                 do
                 {
-                    bufferState = await ReadFromStreamAsync(utf8Json, bufferState, cancellationToken).ConfigureAwait(false);
+                    bufferState = await bufferState.ReadFromStreamAsync(utf8Json, cancellationToken, fillBuffer: false).ConfigureAwait(false);
                     ContinueDeserialize<Queue<TValue>>(
                         ref bufferState,
                         ref jsonReaderState,
@@ -476,7 +476,7 @@ namespace System.Text.Json
             {
                 while (true)
                 {
-                    bufferState = await ReadFromStreamAsync(utf8Json, bufferState, cancellationToken).ConfigureAwait(false);
+                    bufferState = await bufferState.ReadFromStreamAsync(utf8Json, cancellationToken).ConfigureAwait(false);
                     TValue value = ContinueDeserialize<TValue>(ref bufferState, ref jsonReaderState, ref readStack, converter, options);
 
                     if (bufferState.IsFinalBlock)
@@ -507,7 +507,7 @@ namespace System.Text.Json
             {
                 while (true)
                 {
-                    bufferState = ReadFromStream(utf8Json, bufferState);
+                    bufferState.ReadFromStream(utf8Json);
                     TValue value = ContinueDeserialize<TValue>(ref bufferState, ref jsonReaderState, ref readStack, converter, options);
 
                     if (bufferState.IsFinalBlock)
@@ -522,78 +522,6 @@ namespace System.Text.Json
             }
         }
 
-        /// <summary>
-        /// Read from the stream until either our buffer is filled or we hit EOF.
-        /// Calling ReadCore is relatively expensive, so we minimize the number of times
-        /// we need to call it.
-        /// </summary>
-        internal static async ValueTask<ReadBufferState> ReadFromStreamAsync(
-            Stream utf8Json,
-            ReadBufferState bufferState,
-            CancellationToken cancellationToken)
-        {
-            while (true)
-            {
-                int bytesRead = await utf8Json.ReadAsync(
-#if BUILDING_INBOX_LIBRARY
-                    bufferState.Buffer.AsMemory(bufferState.BytesInBuffer),
-#else
-                    bufferState.Buffer, bufferState.BytesInBuffer, bufferState.Buffer.Length - bufferState.BytesInBuffer,
-#endif
-                    cancellationToken).ConfigureAwait(false);
-
-                if (bytesRead == 0)
-                {
-                    bufferState.IsFinalBlock = true;
-                    break;
-                }
-
-                bufferState.BytesInBuffer += bytesRead;
-
-                if (bufferState.BytesInBuffer == bufferState.Buffer.Length)
-                {
-                    break;
-                }
-            }
-
-            return bufferState;
-        }
-
-        /// <summary>
-        /// Read from the stream until either our buffer is filled or we hit EOF.
-        /// Calling ReadCore is relatively expensive, so we minimize the number of times
-        /// we need to call it.
-        /// </summary>
-        internal static ReadBufferState ReadFromStream(
-            Stream utf8Json,
-            ReadBufferState bufferState)
-        {
-            while (true)
-            {
-                int bytesRead = utf8Json.Read(
-#if BUILDING_INBOX_LIBRARY
-                    bufferState.Buffer.AsSpan(bufferState.BytesInBuffer));
-#else
-                    bufferState.Buffer, bufferState.BytesInBuffer, bufferState.Buffer.Length - bufferState.BytesInBuffer);
-#endif
-
-                if (bytesRead == 0)
-                {
-                    bufferState.IsFinalBlock = true;
-                    break;
-                }
-
-                bufferState.BytesInBuffer += bytesRead;
-
-                if (bufferState.BytesInBuffer == bufferState.Buffer.Length)
-                {
-                    break;
-                }
-            }
-
-            return bufferState;
-        }
-
         internal static TValue ContinueDeserialize<TValue>(
             ref ReadBufferState bufferState,
             ref JsonReaderState jsonReaderState,
@@ -601,67 +529,17 @@ namespace System.Text.Json
             JsonConverter converter,
             JsonSerializerOptions options)
         {
-            if (bufferState.BytesInBuffer > bufferState.ClearMax)
-            {
-                bufferState.ClearMax = bufferState.BytesInBuffer;
-            }
-
-            int start = 0;
-            if (bufferState.IsFirstIteration)
-            {
-                bufferState.IsFirstIteration = false;
-
-                // Handle the UTF-8 BOM if present
-                Debug.Assert(bufferState.Buffer.Length >= JsonConstants.Utf8Bom.Length);
-                if (bufferState.Buffer.AsSpan().StartsWith(JsonConstants.Utf8Bom))
-                {
-                    start += JsonConstants.Utf8Bom.Length;
-                    bufferState.BytesInBuffer -= JsonConstants.Utf8Bom.Length;
-                }
-            }
-
             // Process the data available
             TValue value = ReadCore<TValue>(
                 ref jsonReaderState,
                 bufferState.IsFinalBlock,
-                new ReadOnlySpan<byte>(bufferState.Buffer, start, bufferState.BytesInBuffer),
+                bufferState.Bytes,
                 options,
                 ref readStack,
                 converter);
 
-            Debug.Assert(readStack.BytesConsumed <= bufferState.BytesInBuffer);
-            int bytesConsumed = checked((int)readStack.BytesConsumed);
-
-            bufferState.BytesInBuffer -= bytesConsumed;
-
-            // The reader should have thrown if we have remaining bytes.
-            Debug.Assert(!bufferState.IsFinalBlock || bufferState.BytesInBuffer == 0);
-
-            if (!bufferState.IsFinalBlock)
-            {
-                // Check if we need to shift or expand the buffer because there wasn't enough data to complete deserialization.
-                if ((uint)bufferState.BytesInBuffer > ((uint)bufferState.Buffer.Length / 2))
-                {
-                    // We have less than half the buffer available, double the buffer size.
-                    byte[] oldBuffer = bufferState.Buffer;
-                    int oldClearMax = bufferState.ClearMax;
-                    byte[] newBuffer = ArrayPool<byte>.Shared.Rent((bufferState.Buffer.Length < (int.MaxValue / 2)) ? bufferState.Buffer.Length * 2 : int.MaxValue);
-
-                    // Copy the unprocessed data to the new buffer while shifting the processed bytes.
-                    Buffer.BlockCopy(oldBuffer, bytesConsumed + start, newBuffer, 0, bufferState.BytesInBuffer);
-                    bufferState.Buffer = newBuffer;
-                    bufferState.ClearMax = bufferState.BytesInBuffer;
-
-                    // Clear and return the old buffer
-                    new Span<byte>(oldBuffer, 0, oldClearMax).Clear();
-                    ArrayPool<byte>.Shared.Return(oldBuffer);
-                }
-                else if (bufferState.BytesInBuffer != 0)
-                {
-                    // Shift the processed bytes to the beginning of buffer to make more room.
-                    Buffer.BlockCopy(bufferState.Buffer, bytesConsumed + start, bufferState.Buffer, 0, bufferState.BytesInBuffer);
-                }
-            }
+            Debug.Assert(readStack.BytesConsumed <= bufferState.Bytes.Length);
+            bufferState.AdvanceBuffer((int)readStack.BytesConsumed);
 
             return value;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadBufferState.cs
@@ -2,32 +2,168 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Text.Json.Serialization
 {
     internal struct ReadBufferState : IDisposable
     {
-        public byte[] Buffer;
-        public int BytesInBuffer;
-        public int ClearMax;
-        public bool IsFirstIteration;
-        public bool IsFinalBlock;
+        private byte[] _buffer;
+        private byte _offset; // Read bytes offset typically used when skipping the UTF-8 BOM.
+        private int _count; // Number of read bytes yet to be consumed by the serializer.
+        private int _maxCount; // Number of bytes we need to clear before returning the buffer.
+        private bool _isFirstBlock;
+        private bool _isFinalBlock;
 
-        public ReadBufferState(int defaultBufferSize)
+        public ReadBufferState(int initialBufferSize)
         {
-            Buffer = ArrayPool<byte>.Shared.Rent(Math.Max(defaultBufferSize, JsonConstants.Utf8Bom.Length));
-            BytesInBuffer = ClearMax = 0;
-            IsFirstIteration = true;
-            IsFinalBlock = false;
+            _buffer = ArrayPool<byte>.Shared.Rent(Math.Max(initialBufferSize, JsonConstants.Utf8Bom.Length));
+            _maxCount = _count = _offset = 0;
+            _isFirstBlock = true;
+            _isFinalBlock = false;
+        }
+
+        public bool IsFinalBlock => _isFinalBlock;
+
+        public ReadOnlySpan<byte> Bytes => _buffer.AsSpan(_offset, _count);
+
+        /// <summary>
+        /// Read from the stream until either our buffer is filled or we hit EOF.
+        /// Calling ReadCore is relatively expensive, so we minimize the number of times
+        /// we need to call it.
+        /// </summary>
+        public readonly async ValueTask<ReadBufferState> ReadFromStreamAsync(
+            Stream utf8Json,
+            CancellationToken cancellationToken,
+            bool fillBuffer = true)
+        {
+            // Since mutable structs don't work well with async state machines,
+            // make all updates on a copy which is returned once complete.
+            ReadBufferState bufferState = this;
+
+            do
+            {
+                int bytesRead = await utf8Json.ReadAsync(
+#if BUILDING_INBOX_LIBRARY
+                    bufferState._buffer.AsMemory(bufferState._count),
+#else
+                    bufferState._buffer, bufferState._count, bufferState._buffer.Length - bufferState._count,
+#endif
+                    cancellationToken).ConfigureAwait(false);
+
+                if (bytesRead == 0)
+                {
+                    bufferState._isFinalBlock = true;
+                    break;
+                }
+
+                bufferState._count += bytesRead;
+            }
+            while (fillBuffer && bufferState._count < bufferState._buffer.Length);
+
+            bufferState.ProcessReadBytes();
+            return bufferState;
+        }
+
+        /// <summary>
+        /// Read from the stream until either our buffer is filled or we hit EOF.
+        /// Calling ReadCore is relatively expensive, so we minimize the number of times
+        /// we need to call it.
+        /// </summary>
+        public void ReadFromStream(Stream utf8Json)
+        {
+            do
+            {
+                int bytesRead = utf8Json.Read(
+#if BUILDING_INBOX_LIBRARY
+                    _buffer.AsSpan(_count));
+#else
+                    _buffer, _count, _buffer.Length - _count);
+#endif
+
+                if (bytesRead == 0)
+                {
+                    _isFinalBlock = true;
+                    break;
+                }
+
+                _count += bytesRead;
+            }
+            while (_count < _buffer.Length);
+
+            ProcessReadBytes();
+        }
+
+        /// <summary>
+        /// Advances the buffer in anticipation of a subsequent read operation.
+        /// </summary>
+        public void AdvanceBuffer(int bytesConsumed)
+        {
+            Debug.Assert(bytesConsumed <= _count);
+            Debug.Assert(!_isFinalBlock || _count == bytesConsumed, "The reader should have thrown if we have remaining bytes.");
+
+            _count -= bytesConsumed;
+
+            if (!_isFinalBlock)
+            {
+                // Check if we need to shift or expand the buffer because there wasn't enough data to complete deserialization.
+                if ((uint)_count > ((uint)_buffer.Length / 2))
+                {
+                    // We have less than half the buffer available, double the buffer size.
+                    byte[] oldBuffer = _buffer;
+                    int oldMaxCount = _maxCount;
+                    byte[] newBuffer = ArrayPool<byte>.Shared.Rent((_buffer.Length < (int.MaxValue / 2)) ? _buffer.Length * 2 : int.MaxValue);
+
+                    // Copy the unprocessed data to the new buffer while shifting the processed bytes.
+                    Buffer.BlockCopy(oldBuffer, _offset + bytesConsumed, newBuffer, 0, _count);
+                    _buffer = newBuffer;
+                    _offset = 0;
+                    _maxCount = _count;
+
+                    // Clear and return the old buffer
+                    new Span<byte>(oldBuffer, 0, oldMaxCount).Clear();
+                    ArrayPool<byte>.Shared.Return(oldBuffer);
+                }
+                else if (_count != 0)
+                {
+                    // Shift the processed bytes to the beginning of buffer to make more room.
+                    Buffer.BlockCopy(_buffer, _offset + bytesConsumed, _buffer, 0, _count);
+                    _offset = 0;
+                }
+            }
+        }
+
+        private void ProcessReadBytes()
+        {
+            if (_count > _maxCount)
+            {
+                _maxCount = _count;
+            }
+
+            if (_isFirstBlock)
+            {
+                _isFirstBlock = false;
+
+                // Handle the UTF-8 BOM if present
+                Debug.Assert(_buffer.Length >= JsonConstants.Utf8Bom.Length);
+                if (_buffer.AsSpan(0, _count).StartsWith(JsonConstants.Utf8Bom))
+                {
+                    _offset = (byte)JsonConstants.Utf8Bom.Length;
+                    _count -= JsonConstants.Utf8Bom.Length;
+                }
+            }
         }
 
         public void Dispose()
         {
             // Clear only what we used and return the buffer to the pool
-            new Span<byte>(Buffer, 0, ClearMax).Clear();
+            new Span<byte>(_buffer, 0, _maxCount).Clear();
 
-            byte[] toReturn = Buffer;
-            Buffer = null!;
+            byte[] toReturn = _buffer;
+            _buffer = null!;
 
             ArrayPool<byte>.Shared.Return(toReturn);
         }


### PR DESCRIPTION
From https://github.com/dotnet/runtime/issues/70107#issuecomment-1148808314. The current implementation of the [internal `ReadFromStreamAsync` method](https://github.com/dotnet/runtime/blob/da79dc611cba819dce6da3966dc4c7503524fa18/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs#L525-L560) will keep reading from the stream until either the internal buffer is filled or the stream EOF's, which is intended as a performance optimization to avoid redundant deserialization calls. While this makes sense in the case of `DeserializeAsync`, it can impact liveness when deserializing IAsyncEnumerable sequences in examples such as the one seen in #70107.

This PR changes the behavior of stream reading specifically in `DeserializeAsyncEnumerable` such that the deserializer is invoked as soon as the first `Stream.ReadAsync` operation returns. Moreover it makes a few more changes:

* Encapsulate the buffer management logic behind the `ReadBufferState` struct.
* Avoid allocating a new JsonTypeInfo instance on every IAsyncEnumerator initialization.

Fix #70107.