### PR TITLE
Enable HMAC on Browser WASM

### DIFF
--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1352,7 +1352,6 @@ namespace System.Security.Cryptography
         public static bool TryHashData(System.ReadOnlySpan<byte> key, System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
-    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class HMACSHA1 : System.Security.Cryptography.HMAC
     {
         public const int HashSizeInBits = 160;
@@ -1380,7 +1379,6 @@ namespace System.Security.Cryptography
         public static bool TryHashData(System.ReadOnlySpan<byte> key, System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
-    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class HMACSHA256 : System.Security.Cryptography.HMAC
     {
         public const int HashSizeInBits = 256;
@@ -1405,7 +1403,6 @@ namespace System.Security.Cryptography
         public static bool TryHashData(System.ReadOnlySpan<byte> key, System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
-    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class HMACSHA384 : System.Security.Cryptography.HMAC
     {
         public const int HashSizeInBits = 384;
@@ -1432,7 +1429,6 @@ namespace System.Security.Cryptography
         public static bool TryHashData(System.ReadOnlySpan<byte> key, System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
-    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class HMACSHA512 : System.Security.Cryptography.HMAC
     {
         public const int HashSizeInBits = 512;
@@ -1483,9 +1479,7 @@ namespace System.Security.Cryptography
         public void AppendData(byte[] data, int offset, int count) { }
         public void AppendData(System.ReadOnlySpan<byte> data) { }
         public static System.Security.Cryptography.IncrementalHash CreateHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
-        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] key) { throw null; }
-        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.ReadOnlySpan<byte> key) { throw null; }
         public void Dispose() { }
         public byte[] GetCurrentHash() { throw null; }

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -556,6 +556,7 @@
     <Compile Include="System\Security\Cryptography\ECDiffieHellman.Create.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\ECDsa.Create.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\HashProviderDispenser.Browser.cs" />
+    <Compile Include="System\Security\Cryptography\HMACHashProvider.Browser.Managed.cs" />
     <Compile Include="System\Security\Cryptography\LiteHash.Browser.cs" />
     <Compile Include="System\Security\Cryptography\OidLookup.NoFallback.cs" />
     <Compile Include="System\Security\Cryptography\OpenSsl.NotSupported.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoConfig.cs
@@ -357,7 +357,6 @@ namespace System.Security.Cryptography
                     return new SHA512Managed();
 #pragma warning restore SYSLIB0021
 
-                case "HMAC":
                 case "System.Security.Cryptography.HMAC":
                 case "HMACSHA1":
                 case "System.Security.Cryptography.HMACSHA1":

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoConfig.cs
@@ -338,7 +338,7 @@ namespace System.Security.Cryptography
             switch (name)
             {
 #pragma warning disable SYSLIB0021 // Obsolete: derived cryptographic types
-                // hardcode mapping for SHA* algorithm names from https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.cryptoconfig?view=net-5.0#remarks
+                // hardcode mapping for SHA* and HMAC* algorithm names from https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.cryptoconfig?view=net-5.0#remarks
                 case "SHA":
                 case "SHA1":
                 case "System.Security.Cryptography.SHA1":
@@ -356,6 +356,22 @@ namespace System.Security.Cryptography
                 case "System.Security.Cryptography.SHA512":
                     return new SHA512Managed();
 #pragma warning restore SYSLIB0021
+
+                case "HMAC":
+                case "System.Security.Cryptography.HMAC":
+                case "HMACSHA1":
+                case "System.Security.Cryptography.HMACSHA1":
+                case "System.Security.Cryptography.KeyedHashAlgorithm":
+                    return new HMACSHA1();
+                case "HMACSHA256":
+                case "System.Security.Cryptography.HMACSHA256":
+                    return new HMACSHA256();
+                case "HMACSHA384":
+                case "System.Security.Cryptography.HMACSHA384":
+                    return new HMACSHA384();
+                case "HMACSHA512":
+                case "System.Security.Cryptography.HMACSHA512":
+                    return new HMACSHA512();
             }
 
             return null;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACHashProvider.Browser.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACHashProvider.Browser.Managed.cs
@@ -121,8 +121,9 @@ namespace System.Security.Cryptography
             {
                 _hash1.Dispose();
                 _hash2.Dispose();
-                Array.Clear(_inner, 0, _inner.Length);
-                Array.Clear(_outer, 0, _outer.Length);
+                Array.Clear(_inner);
+                Array.Clear(_outer);
+                Array.Clear(_key);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACHashProvider.Browser.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACHashProvider.Browser.Managed.cs
@@ -1,0 +1,139 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Security.Cryptography
+{
+    // ported from https://github.com/microsoft/referencesource/blob/5697c29004a34d80acdaf5742d7e699022c64ecd/mscorlib/system/security/cryptography/hmac.cs
+    internal sealed class HMACManagedHashProvider : HashProvider
+    {
+        private bool _hashing;
+        private readonly int _blockSizeValue;
+        private readonly int _hashSizeValue;
+
+        private readonly byte[] _key;
+        private readonly HashProvider _hash1;
+        private readonly HashProvider _hash2;
+
+        // _inner = PaddedKey ^ {0x36,...,0x36}
+        // _outer = PaddedKey ^ {0x5C,...,0x5C}
+        private readonly byte[] _inner;
+        private readonly byte[] _outer;
+
+        public HMACManagedHashProvider(string hashAlgorithmId, ReadOnlySpan<byte> key)
+        {
+            _hash1 = HashProviderDispenser.CreateHashProvider(hashAlgorithmId);
+            _hash2 = HashProviderDispenser.CreateHashProvider(hashAlgorithmId);
+
+            (_blockSizeValue, _hashSizeValue) = hashAlgorithmId switch
+            {
+                HashAlgorithmNames.SHA1 => (64, 160 / 8),
+                HashAlgorithmNames.SHA256 => (64, 256 / 8),
+                HashAlgorithmNames.SHA384 => (128, 384 / 8),
+                HashAlgorithmNames.SHA512 => (128, 512 / 8),
+                _ => throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId)),
+            };
+
+            _key = InitializeKey(key);
+            (_inner, _outer) = UpdateIOPadBuffers();
+        }
+
+        private byte[] InitializeKey(ReadOnlySpan<byte> key)
+        {
+            if (key.Length > _blockSizeValue)
+            {
+                byte[] result = new byte[_hashSizeValue];
+                _hash1.AppendHashData(key);
+                int written = _hash1.FinalizeHashAndReset(result);
+                Debug.Assert(written == result.Length);
+
+                return result;
+            }
+
+            return key.ToArray();
+        }
+
+        private (byte[] inner, byte[] outer) UpdateIOPadBuffers()
+        {
+            byte[] inner = new byte[_blockSizeValue];
+            byte[] outer = new byte[_blockSizeValue];
+
+            int i;
+            for (i = 0; i < _blockSizeValue; i++)
+            {
+                inner[i] = 0x36;
+                outer[i] = 0x5C;
+            }
+            for (i = 0; i < _key.Length; i++)
+            {
+                inner[i] ^= _key[i];
+                outer[i] ^= _key[i];
+            }
+
+            return (inner, outer);
+        }
+
+        public override void AppendHashData(ReadOnlySpan<byte> data)
+        {
+            if (_hashing == false)
+            {
+                _hash1.AppendHashData(_inner);
+                _hashing = true;
+            }
+
+            _hash1.AppendHashData(data);
+        }
+
+        public override int FinalizeHashAndReset(Span<byte> destination)
+        {
+            int written = GetCurrentHash(destination);
+            Reset();
+            return written;
+        }
+
+        public override int GetCurrentHash(Span<byte> destination)
+        {
+            if (_hashing == false)
+            {
+                _hash1.AppendHashData(_inner);
+                _hashing = true;
+            }
+
+            // finalize the original hash
+            Span<byte> hashValue1 = stackalloc byte[_hashSizeValue];
+            int hash1Written = _hash1.GetCurrentHash(hashValue1);
+            Debug.Assert(hash1Written == hashValue1.Length);
+
+            // write the outer array
+            _hash2.AppendHashData(_outer);
+            // write the inner hash and finalize the hash
+            _hash2.AppendHashData(hashValue1);
+            return _hash2.FinalizeHashAndReset(destination);
+        }
+
+        public override int HashSizeInBytes => _hashSizeValue;
+
+        public override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _hash1.Dispose();
+                _hash2.Dispose();
+                Array.Clear(_inner, 0, _inner.Length);
+                Array.Clear(_outer, 0, _outer.Length);
+            }
+        }
+
+        public override void Reset()
+        {
+            if (_hashing)
+            {
+                _hash1.Reset();
+                _hash2.Reset();
+                _hashing = false;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA1.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA1.cs
@@ -16,7 +16,6 @@ namespace System.Security.Cryptography
     // preexisting contract from the .NET Framework locks all of these into deriving directly from HMAC, it can't be helped.
     //
 
-    [UnsupportedOSPlatform("browser")]
     public class HMACSHA1 : HMAC
     {
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA256.cs
@@ -15,7 +15,6 @@ namespace System.Security.Cryptography
     // preexisting contract from the .NET Framework locks all of these into deriving directly from HMAC, it can't be helped.
     //
 
-    [UnsupportedOSPlatform("browser")]
     public class HMACSHA256 : HMAC
     {
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA384.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA384.cs
@@ -15,7 +15,6 @@ namespace System.Security.Cryptography
     // preexisting contract from the .NET Framework locks all of these into deriving directly from HMAC, it can't be helped.
     //
 
-    [UnsupportedOSPlatform("browser")]
     public class HMACSHA384 : HMAC
     {
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA512.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA512.cs
@@ -15,7 +15,6 @@ namespace System.Security.Cryptography
     // preexisting contract from the .NET Framework locks all of these into deriving directly from HMAC, it can't be helped.
     //
 
-    [UnsupportedOSPlatform("browser")]
     public class HMACSHA512 : HMAC
     {
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
@@ -32,7 +32,9 @@ namespace System.Security.Cryptography
                 ReadOnlySpan<byte> source,
                 Span<byte> destination)
             {
-                throw new PlatformNotSupportedException(SR.SystemSecurityCryptography_PlatformNotSupported);
+                HashProvider provider = CreateMacProvider(hashAlgorithmId, key);
+                provider.AppendHashData(source);
+                return provider.FinalizeHashAndReset(destination);
             }
 
             public static int HashData(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination)
@@ -45,7 +47,15 @@ namespace System.Security.Cryptography
 
         public static unsafe HashProvider CreateMacProvider(string hashAlgorithmId, ReadOnlySpan<byte> key)
         {
-            throw new PlatformNotSupportedException(SR.SystemSecurityCryptography_PlatformNotSupported);
+            switch (hashAlgorithmId)
+            {
+                case HashAlgorithmNames.SHA1:
+                case HashAlgorithmNames.SHA256:
+                case HashAlgorithmNames.SHA384:
+                case HashAlgorithmNames.SHA512:
+                    return new HMACManagedHashProvider(hashAlgorithmId, key);
+            }
+            throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/IncrementalHash.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/IncrementalHash.cs
@@ -345,7 +345,6 @@ namespace System.Security.Cryptography
         ///     the empty string.
         /// </exception>
         /// <exception cref="CryptographicException"><paramref name="hashAlgorithm"/> is not a known hash algorithm.</exception>
-        [UnsupportedOSPlatform("browser")]
         public static IncrementalHash CreateHMAC(HashAlgorithmName hashAlgorithm, byte[] key)
         {
             ArgumentNullException.ThrowIfNull(key);
@@ -375,7 +374,6 @@ namespace System.Security.Cryptography
         ///     the empty string.
         /// </exception>
         /// <exception cref="CryptographicException"><paramref name="hashAlgorithm"/> is not a known hash algorithm.</exception>
-        [UnsupportedOSPlatform("browser")]
         public static IncrementalHash CreateHMAC(HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> key)
         {
             ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));

--- a/src/libraries/System.Security.Cryptography/tests/BlockSizeValueTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/BlockSizeValueTests.cs
@@ -5,10 +5,10 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public class BlockSizeValueTests
     {
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void BlockSizeValueTest_HMACMD5()
         {
             int hmacBlockSizeValue = new HMACMD5Test().GetBlockSizeValue();

--- a/src/libraries/System.Security.Cryptography/tests/CryptoConfigTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/CryptoConfigTests.cs
@@ -342,6 +342,19 @@ namespace System.Security.Cryptography.Tests
         {
             get
             {
+                // Keyed Hash Algorithms - supported on all platforms
+                yield return new object[] { "HMAC", "System.Security.Cryptography.HMACSHA1", true };
+                yield return new object[] { "System.Security.Cryptography.HMAC", "System.Security.Cryptography.HMACSHA1", true };
+                yield return new object[] { "System.Security.Cryptography.KeyedHashAlgorithm", "System.Security.Cryptography.HMACSHA1", true };
+                yield return new object[] { "HMACSHA1", "System.Security.Cryptography.HMACSHA1", true };
+                yield return new object[] { "System.Security.Cryptography.HMACSHA1", null, true };
+                yield return new object[] { "HMACSHA256", "System.Security.Cryptography.HMACSHA256", true };
+                yield return new object[] { "System.Security.Cryptography.HMACSHA256", null, true };
+                yield return new object[] { "HMACSHA384", "System.Security.Cryptography.HMACSHA384", true };
+                yield return new object[] { "System.Security.Cryptography.HMACSHA384", null, true };
+                yield return new object[] { "HMACSHA512", "System.Security.Cryptography.HMACSHA512", true };
+                yield return new object[] { "System.Security.Cryptography.HMACSHA512", null, true };
+
                 if (PlatformDetection.IsBrowser)
                 {
                     // Hash functions
@@ -381,19 +394,9 @@ namespace System.Security.Cryptography.Tests
                     yield return new object[] { "SHA-512", typeof(SHA512Managed).FullName, true };
                     yield return new object[] { "System.Security.Cryptography.SHA512", typeof(SHA512Managed).FullName, true };
 
-                    // Keyed Hash Algorithms
-                    yield return new object[] { "System.Security.Cryptography.HMAC", "System.Security.Cryptography.HMACSHA1", true };
-                    yield return new object[] { "System.Security.Cryptography.KeyedHashAlgorithm", "System.Security.Cryptography.HMACSHA1", true };
+                    // Keyed Hash Algorithms - not supported on Browser
                     yield return new object[] { "HMACMD5", "System.Security.Cryptography.HMACMD5", true };
                     yield return new object[] { "System.Security.Cryptography.HMACMD5", null, true };
-                    yield return new object[] { "HMACSHA1", "System.Security.Cryptography.HMACSHA1", true };
-                    yield return new object[] { "System.Security.Cryptography.HMACSHA1", null, true };
-                    yield return new object[] { "HMACSHA256", "System.Security.Cryptography.HMACSHA256", true };
-                    yield return new object[] { "System.Security.Cryptography.HMACSHA256", null, true };
-                    yield return new object[] { "HMACSHA384", "System.Security.Cryptography.HMACSHA384", true };
-                    yield return new object[] { "System.Security.Cryptography.HMACSHA384", null, true };
-                    yield return new object[] { "HMACSHA512", "System.Security.Cryptography.HMACSHA512", true };
-                    yield return new object[] { "System.Security.Cryptography.HMACSHA512", null, true };
 
                     // Asymmetric algorithms
                     yield return new object[] { "RSA", "System.Security.Cryptography.RSACryptoServiceProvider", true };

--- a/src/libraries/System.Security.Cryptography/tests/CryptoConfigTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/CryptoConfigTests.cs
@@ -343,7 +343,6 @@ namespace System.Security.Cryptography.Tests
             get
             {
                 // Keyed Hash Algorithms - supported on all platforms
-                yield return new object[] { "HMAC", "System.Security.Cryptography.HMACSHA1", true };
                 yield return new object[] { "System.Security.Cryptography.HMAC", "System.Security.Cryptography.HMACSHA1", true };
                 yield return new object[] { "System.Security.Cryptography.KeyedHashAlgorithm", "System.Security.Cryptography.HMACSHA1", true };
                 yield return new object[] { "HMACSHA1", "System.Security.Cryptography.HMACSHA1", true };

--- a/src/libraries/System.Security.Cryptography/tests/HmacSha1Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacSha1Tests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public class HmacSha1Tests : Rfc2202HmacTests
     {
         private static readonly byte[][] s_testKeys2202 =

--- a/src/libraries/System.Security.Cryptography/tests/HmacSha256Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacSha256Tests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public class HmacSha256Tests : Rfc4231HmacTests
     {
         protected override int BlockSize => 64;

--- a/src/libraries/System.Security.Cryptography/tests/HmacSha384Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacSha384Tests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public class HmacSha384Tests : Rfc4231HmacTests
     {
         protected override int BlockSize => 128;

--- a/src/libraries/System.Security.Cryptography/tests/HmacSha512Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacSha512Tests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public class HmacSha512Tests : Rfc4231HmacTests
     {
         protected override int BlockSize => 128;

--- a/src/libraries/System.Security.Cryptography/tests/HmacTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public abstract class HmacTests
     {
         // RFC2202 defines the test vectors for HMACMD5 and HMACSHA1

--- a/src/libraries/System.Security.Cryptography/tests/IncrementalHashTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/IncrementalHashTests.cs
@@ -29,14 +29,14 @@ namespace System.Security.Cryptography.Tests
 
         public static IEnumerable<object[]> GetHMACs()
         {
-            return new[]
+            if (!PlatformDetection.IsBrowser)
             {
-                new object[] { new HMACMD5(), HashAlgorithmName.MD5 },
-                new object[] { new HMACSHA1(), HashAlgorithmName.SHA1 },
-                new object[] { new HMACSHA256(), HashAlgorithmName.SHA256 },
-                new object[] { new HMACSHA384(), HashAlgorithmName.SHA384 },
-                new object[] { new HMACSHA512(), HashAlgorithmName.SHA512 },
-            };
+                yield return new object[] { new HMACMD5(), HashAlgorithmName.MD5 };
+            }
+            yield return new object[] { new HMACSHA1(), HashAlgorithmName.SHA1 };
+            yield return new object[] { new HMACSHA256(), HashAlgorithmName.SHA256 };
+            yield return new object[] { new HMACSHA384(), HashAlgorithmName.SHA384 };
+            yield return new object[] { new HMACSHA512(), HashAlgorithmName.SHA512 };
         }
 
         [Fact]
@@ -81,7 +81,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [MemberData(nameof(GetHMACs))]
         public static void VerifyIncrementalHMAC(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
         {
@@ -95,7 +94,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [MemberData(nameof(GetHMACs))]
         public static void VerifyIncrementalHMAC_SpanKey(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
         {
@@ -162,7 +160,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [MemberData(nameof(GetHMACs))]
         public static void VerifyEmptyHMAC(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
         {
@@ -198,7 +195,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [MemberData(nameof(GetHMACs))]
         public static void VerifyTrivialHMAC(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
         {
@@ -229,7 +225,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void AppendDataAfterHMACClose()
         {
             using (IncrementalHash hash = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA256, s_hmacKey))
@@ -256,7 +251,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void GetHMACTwice()
         {
             using (IncrementalHash hash = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA256, s_hmacKey))
@@ -280,7 +274,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void ModifyAfterHMACDispose()
         {
             using (IncrementalHash hash = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA256, s_hmacKey))
@@ -299,7 +292,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void UnknownHmacAlgorithm()
         {
             Assert.ThrowsAny<CryptographicException>(
@@ -318,7 +310,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [MemberData(nameof(GetHMACs))]
         public static void VerifyIncrementalHMAC_Span(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
         {
@@ -395,7 +386,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [MemberData(nameof(GetHMACs))]
         public static void VerifyEmptyHMAC_Span(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
         {
@@ -433,7 +423,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [MemberData(nameof(GetHMACs))]
         public static void VerifyTrivialHMAC_Span(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
         {
@@ -474,7 +463,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [MemberData(nameof(GetHMACs))]
         public static void Dispose_HMAC_ThrowsException(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
         {
@@ -511,7 +499,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [SkipOnPlatform(TestPlatforms.Android, "Android doesn't support cloning the current state for HMAC, so it doesn't support GetCurrentHash.")]
         [MemberData(nameof(GetHMACs))]
         public static void VerifyGetCurrentHash_HMAC(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
@@ -526,7 +513,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [SkipOnPlatform(TestPlatforms.Android, "Android doesn't support cloning the current state for HMAC, so it doesn't support GetCurrentHash.")]
         [MemberData(nameof(GetHMACs))]
         public static void VerifyBounds_GetCurrentHash_HMAC(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
@@ -548,7 +534,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         [MemberData(nameof(GetHMACs))]
         public static void VerifyBounds_GetHashAndReset_HMAC(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
         {

--- a/src/libraries/System.Security.Cryptography/tests/InvalidUsageTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/InvalidUsageTests.cs
@@ -9,7 +9,6 @@ namespace System.Security.Cryptography.Tests
     public class InvalidUsageTests
     {
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public void InvalidHashCoreArgumentsFromDerivedType()
         {
             using (var hmac = new DerivedHMACSHA1())

--- a/src/libraries/System.Security.Cryptography/tests/ReusabilityTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/ReusabilityTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public class ReusabilityTests
     {
         [Theory]
@@ -25,18 +24,19 @@ namespace System.Security.Cryptography.Tests
 
         public static IEnumerable<object[]> ReusabilityHashAlgorithms()
         {
-            return new[]
+            if (!PlatformDetection.IsBrowser)
             {
-                new object[] { MD5.Create(), },
-                new object[] { SHA1.Create(), },
-                new object[] { SHA256.Create(), },
-                new object[] { SHA384.Create(), },
-                new object[] { SHA512.Create(), },
-                new object[] { new HMACSHA1(), },
-                new object[] { new HMACSHA256(), },
-                new object[] { new HMACSHA384(), },
-                new object[] { new HMACSHA512(), },
-            };
+                yield return new object[] { MD5.Create(), };
+            }
+
+            yield return new object[] { SHA1.Create(), };
+            yield return new object[] { SHA256.Create(), };
+            yield return new object[] { SHA384.Create(), };
+            yield return new object[] { SHA512.Create(), };
+            yield return new object[] { new HMACSHA1(), };
+            yield return new object[] { new HMACSHA256(), };
+            yield return new object[] { new HMACSHA384(), };
+            yield return new object[] { new HMACSHA512(), };
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/tests/Rfc2202HmacTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/Rfc2202HmacTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public abstract class Rfc2202HmacTests : HmacTests
     {
         private static readonly byte[][] s_testData2202 =

--- a/src/libraries/System.Security.Cryptography/tests/Rfc4231HmacTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/Rfc4231HmacTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public abstract class Rfc4231HmacTests : HmacTests
     {
         private static readonly byte[][] s_testKeys4231 =

--- a/src/libraries/apicompat/ApiCompatBaseline.NetCoreAppLatestStable.txt
+++ b/src/libraries/apicompat/ApiCompatBaseline.NetCoreAppLatestStable.txt
@@ -13,6 +13,10 @@ CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' on 'System.Security.Cryptography.DSA.Create(System.Security.Cryptography.DSAParameters)' changed from '[UnsupportedOSPlatformAttribute("ios")]' in the contract to '[UnsupportedOSPlatformAttribute("browser")]' in the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.DSASignatureDeformatter' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.DSASignatureFormatter' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA1' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA256' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA384' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA512' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.MaskGenerationMethod' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.PKCS1MaskGenerationMethod' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RandomNumberGenerator.Create(System.String)' in the contract but not the implementation.
@@ -65,6 +69,12 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECDiffieHellman' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECDsa' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECParameters' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA1' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA256' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA384' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA512' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.IncrementalHash.CreateHMAC(System.Security.Cryptography.HashAlgorithmName, System.Byte[])' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.IncrementalHash.CreateHMAC(System.Security.Cryptography.HashAlgorithmName, System.ReadOnlySpan<System.Byte>)' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.MaskGenerationMethod' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.PKCS1MaskGenerationMethod' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RandomNumberGenerator.Create(System.String)' in the contract but not the implementation.
@@ -93,6 +103,8 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECDiffieHellman' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECDsa' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECParameters' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.IncrementalHash.CreateHMAC(System.Security.Cryptography.HashAlgorithmName, System.Byte[])' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.IncrementalHash.CreateHMAC(System.Security.Cryptography.HashAlgorithmName, System.ReadOnlySpan<System.Byte>)' in the contract but not the implementation.
 Compat issues with assembly System.Diagnostics.Process:
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.SupportedOSPlatformAttribute' on 'System.Diagnostics.Process.MaxWorkingSet.set(System.IntPtr)' changed from '[SupportedOSPlatformAttribute("freebsd")]' in the contract to '[SupportedOSPlatformAttribute("freebsd")]' in the implementation.
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.SupportedOSPlatformAttribute' on 'System.Diagnostics.Process.MinWorkingSet.set(System.IntPtr)' changed from '[SupportedOSPlatformAttribute("freebsd")]' in the contract to '[SupportedOSPlatformAttribute("freebsd")]' in the implementation.
@@ -143,6 +155,12 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECDiffieHellman' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECDsa' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECParameters' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA1' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA256' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA384' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA512' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.IncrementalHash.CreateHMAC(System.Security.Cryptography.HashAlgorithmName, System.Byte[])' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.IncrementalHash.CreateHMAC(System.Security.Cryptography.HashAlgorithmName, System.ReadOnlySpan<System.Byte>)' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.MaskGenerationMethod' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.PKCS1MaskGenerationMethod' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RandomNumberGenerator.Create(System.String)' in the contract but not the implementation.
@@ -160,4 +178,4 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.TripleDES' in the contract but not the implementation.
 Compat issues with assembly System.Security.Cryptography.X509Certificates:
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' on 'System.Security.Cryptography.X509Certificates.PublicKey.GetDSAPublicKey()' changed from '[UnsupportedOSPlatformAttribute("ios")]' in the contract to '[UnsupportedOSPlatformAttribute("browser")]' in the implementation.
-Total Issues: 149
+Total Issues: 167


### PR DESCRIPTION
This ports the C# implementation of HMAC from https://github.com/microsoft/referencesource/blob/5697c29004a34d80acdaf5742d7e699022c64ecd/mscorlib/system/security/cryptography/hmac.cs, marks the APIs as supported on Browser, and enables HMAC tests on Browser WASM.

Contributes to #40074

The HMAC SubtleCrypto support will come in a separate PR. Currently, we don't have the ability to run both the SubtleCrypto and C# fallback implementations in CI tests. I will work on enabling that before contributing the SubtleCrypto support.