### PR TITLE
Updating the various generic math functions to have default implementations

### DIFF
--- a/src/libraries/Common/tests/System/GenericMathHelpers.cs
+++ b/src/libraries/Common/tests/System/GenericMathHelpers.cs
@@ -113,7 +113,7 @@ namespace System
     }
 
     public static class ExponentialFunctionsHelper<TSelf>
-        where TSelf : IExponentialFunctions<TSelf>
+        where TSelf : IExponentialFunctions<TSelf>, INumberBase<TSelf>
     {
         public static TSelf Exp(TSelf x) => TSelf.Exp(x);
 
@@ -223,7 +223,7 @@ namespace System
     }
 
     public static class HyperbolicFunctionsHelper<TSelf>
-        where TSelf : IHyperbolicFunctions<TSelf>
+        where TSelf : IHyperbolicFunctions<TSelf>, INumberBase<TSelf>
     {
         public static TSelf Acosh(TSelf x) => TSelf.Acosh(x);
 
@@ -247,7 +247,7 @@ namespace System
     }
 
     public static class LogarithmicFunctionsHelper<TSelf>
-        where TSelf : ILogarithmicFunctions<TSelf>
+        where TSelf : ILogarithmicFunctions<TSelf>, INumberBase<TSelf>
     {
         public static TSelf Log(TSelf x) => TSelf.Log(x);
 
@@ -390,13 +390,13 @@ namespace System
     }
 
     public static class PowerFunctionsHelper<TSelf>
-        where TSelf : IPowerFunctions<TSelf>
+        where TSelf : IPowerFunctions<TSelf>, INumberBase<TSelf>
     {
         public static TSelf Pow(TSelf x, TSelf y) => TSelf.Pow(x, y);
     }
 
     public static class RootFunctionsHelper<TSelf>
-        where TSelf : IRootFunctions<TSelf>
+        where TSelf : IRootFunctions<TSelf>, INumberBase<TSelf>
     {
         public static TSelf Cbrt(TSelf x) => TSelf.Cbrt(x);
 
@@ -436,7 +436,7 @@ namespace System
     }
 
     public static class TrigonometricFunctionsHelper<TSelf>
-        where TSelf : ITrigonometricFunctions<TSelf>
+        where TSelf : ITrigonometricFunctions<TSelf>, INumberBase<TSelf>
     {
         public static TSelf Acos(TSelf x) => TSelf.Acos(x);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -433,9 +433,6 @@ namespace System
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static byte IDivisionOperators<byte, byte, byte>.operator /(byte left, byte right) => (byte)(left / right);
 
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static byte IDivisionOperators<byte, byte, byte>.operator checked /(byte left, byte right) => (byte)(left / right);
-
         //
         // IEqualityOperators
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -1165,9 +1165,6 @@ namespace System
         // IBinaryInteger
         //
 
-        /// <inheritdoc cref="IBinaryInteger{TSelf}.DivRem(TSelf, TSelf)" />
-        static (char Quotient, char Remainder) IBinaryInteger<char>.DivRem(char left, char right) => ((char, char))Math.DivRem(left, right);
-
         /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
         static char IBinaryInteger<char>.LeadingZeroCount(char value) => (char)(BitOperations.LeadingZeroCount(value) - 16);
 
@@ -1284,9 +1281,6 @@ namespace System
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static char IDivisionOperators<char, char, char>.operator /(char left, char right) => (char)(left / right);
 
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static char IDivisionOperators<char, char, char>.operator checked /(char left, char right) => (char)(left / right);
-
         //
         // IEqualityOperators
         //
@@ -1340,31 +1334,6 @@ namespace System
 
         /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
         static char IMultiplyOperators<char, char, char>.operator checked *(char left, char right) => checked((char)(left * right));
-
-        //
-        // INumber
-        //
-
-        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
-        static char INumber<char>.Clamp(char value, char min, char max) => (char)Math.Clamp(value, min, max);
-
-        /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
-        static char INumber<char>.CopySign(char value, char sign) => value;
-
-        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        static char INumber<char>.Max(char x, char y) => (char)Math.Max(x, y);
-
-        /// <inheritdoc cref="INumber{TSelf}.MaxNumber(TSelf, TSelf)" />
-        static char INumber<char>.MaxNumber(char x, char y) => (char)Math.Max(x, y);
-
-        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        static char INumber<char>.Min(char x, char y) => (char)Math.Min(x, y);
-
-        /// <inheritdoc cref="INumber{TSelf}.MinNumber(TSelf, TSelf)" />
-        static char INumber<char>.MinNumber(char x, char y) => (char)Math.Min(x, y);
-
-        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        static int INumber<char>.Sign(char value) => (value == 0) ? 0 : 1;
 
         //
         // INumberBase

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
@@ -1119,32 +1119,11 @@ namespace System
         }
 
         //
-        // IAdditionOperators
-        //
-
-        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
-        static decimal IAdditionOperators<decimal, decimal, decimal>.operator checked +(decimal left, decimal right) => left + right;
-
-        //
         // IAdditiveIdentity
         //
 
         /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
         static decimal IAdditiveIdentity<decimal, decimal>.AdditiveIdentity => AdditiveIdentity;
-
-        //
-        // IDecrementOperators
-        //
-
-        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_CheckedDecrement(TSelf)" />
-        static decimal IDecrementOperators<decimal>.operator checked --(decimal value) => --value;
-
-        //
-        // IDivisionOperators
-        //
-
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static decimal IDivisionOperators<decimal, decimal, decimal>.operator checked /(decimal left, decimal right) => left / right;
 
         //
         // IFloatingPoint
@@ -1261,13 +1240,6 @@ namespace System
         }
 
         //
-        // IIncrementOperators
-        //
-
-        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
-        static decimal IIncrementOperators<decimal>.operator checked ++(decimal value) => ++value;
-
-        //
         // IMinMaxValue
         //
 
@@ -1283,13 +1255,6 @@ namespace System
 
         /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
         static decimal IMultiplicativeIdentity<decimal, decimal>.MultiplicativeIdentity => MultiplicativeIdentity;
-
-        //
-        // IMultiplyOperators
-        //
-
-        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
-        public static decimal operator checked *(decimal left, decimal right) => left * right;
 
         //
         // INumber
@@ -1792,19 +1757,5 @@ namespace System
 
         /// <inheritdoc cref="ISpanParsable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out decimal result) => TryParse(s, NumberStyles.Number, provider, out result);
-
-        //
-        // ISubtractionOperators
-        //
-
-        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
-        static decimal ISubtractionOperators<decimal, decimal, decimal>.operator checked -(decimal left, decimal right) => left - right;
-
-        //
-        // IUnaryNegationOperators
-        //
-
-        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
-        static decimal IUnaryNegationOperators<decimal, decimal>.operator checked -(decimal value) => -value;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -532,9 +532,6 @@ namespace System
         /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
         static double IAdditionOperators<double, double, double>.operator +(double left, double right) => left + right;
 
-        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
-        static double IAdditionOperators<double, double, double>.operator checked +(double left, double right) => left + right;
-
         //
         // IAdditiveIdentity
         //
@@ -601,18 +598,12 @@ namespace System
         /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
         static double IDecrementOperators<double>.operator --(double value) => --value;
 
-        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_CheckedDecrement(TSelf)" />
-        static double IDecrementOperators<double>.operator checked --(double value) => --value;
-
         //
         // IDivisionOperators
         //
 
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static double IDivisionOperators<double, double, double>.operator /(double left, double right) => left / right;
-
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static double IDivisionOperators<double, double, double>.operator checked /(double left, double right) => left / right;
 
         //
         // IExponentialFunctions
@@ -865,9 +856,6 @@ namespace System
         /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
         static double IIncrementOperators<double>.operator ++(double value) => ++value;
 
-        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
-        static double IIncrementOperators<double>.operator checked ++(double value) => ++value;
-
         //
         // ILogarithmicFunctions
         //
@@ -920,9 +908,6 @@ namespace System
 
         /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
         static double IMultiplyOperators<double, double, double>.operator *(double left, double right) => left * right;
-
-        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
-        static double IMultiplyOperators<double, double, double>.operator checked *(double left, double right) => left * right;
 
         //
         // INumber
@@ -1401,9 +1386,6 @@ namespace System
         /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
         static double ISubtractionOperators<double, double, double>.operator -(double left, double right) => left - right;
 
-        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
-        static double ISubtractionOperators<double, double, double>.operator checked -(double left, double right) => left - right;
-
         //
         // ITrigonometricFunctions
         //
@@ -1459,9 +1441,6 @@ namespace System
 
         /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
         static double IUnaryNegationOperators<double, double>.operator -(double value) => -value;
-
-        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
-        static double IUnaryNegationOperators<double, double>.operator checked -(double value) => -value;
 
         //
         // IUnaryPlusOperators

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -998,9 +998,6 @@ namespace System
         /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
         public static Half operator +(Half left, Half right) => (Half)((float)left + (float)right);
 
-        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
-        static Half IAdditionOperators<Half, Half, Half>.operator checked +(Half left, Half right) => left + right;
-
         //
         // IAdditiveIdentity
         //
@@ -1072,18 +1069,12 @@ namespace System
             return (Half)tmp;
         }
 
-        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_CheckedDecrement(TSelf)" />
-        static Half IDecrementOperators<Half>.operator checked --(Half value) => --value;
-
         //
         // IDivisionOperators
         //
 
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         public static Half operator /(Half left, Half right) => (Half)((float)left / (float)right);
-
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static Half IDivisionOperators<Half, Half, Half>.operator checked /(Half left, Half right) => left / right;
 
         //
         // IExponentialFunctions
@@ -1317,9 +1308,6 @@ namespace System
             return (Half)tmp;
         }
 
-        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
-        static Half IIncrementOperators<Half>.operator checked ++(Half value) => ++value;
-
         //
         // ILogarithmicFunctions
         //
@@ -1362,9 +1350,6 @@ namespace System
 
         /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
         public static Half operator *(Half left, Half right) => (Half)((float)left * (float)right);
-
-        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
-        static Half IMultiplyOperators<Half, Half, Half>.operator checked *(Half left, Half right) => left * right;
 
         //
         // INumber
@@ -1836,9 +1821,6 @@ namespace System
         /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
         public static Half operator -(Half left, Half right) => (Half)((float)left - (float)right);
 
-        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
-        static Half ISubtractionOperators<Half, Half, Half>.operator checked -(Half left, Half right) => left - right;
-
         //
         // ITrigonometricFunctions
         //
@@ -1898,9 +1880,6 @@ namespace System
 
         /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
         public static Half operator -(Half value) => (Half)(-(float)value);
-
-        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
-        static Half IUnaryNegationOperators<Half, Half>.operator checked -(Half value) => -value;
 
         //
         // IUnaryPlusOperators

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -459,9 +459,6 @@ namespace System
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static short IDivisionOperators<short, short, short>.operator /(short left, short right) => (short)(left / right);
 
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static short IDivisionOperators<short, short, short>.operator checked /(short left, short right) => (short)(left / right);
-
         //
         // IEqualityOperators
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -451,9 +451,6 @@ namespace System
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static int IDivisionOperators<int, int, int>.operator /(int left, int right) => left / right;
 
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static int IDivisionOperators<int, int, int>.operator checked /(int left, int right) => left / right;
-
         //
         // IEqualityOperators
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -438,9 +438,6 @@ namespace System
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static long IDivisionOperators<long, long, long>.operator /(long left, long right) => left / right;
 
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static long IDivisionOperators<long, long, long>.operator checked /(long left, long right) => left / right;
-
         //
         // IEqualityOperators
         //

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -421,9 +421,6 @@ namespace System
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static nint IDivisionOperators<nint, nint, nint>.operator /(nint left, nint right) => left / right;
 
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static nint IDivisionOperators<nint, nint, nint>.operator checked /(nint left, nint right) => left / right;
-
         //
         // IIncrementOperators
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IAdditionOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IAdditionOperators.cs
@@ -21,6 +21,6 @@ namespace System.Numerics
         /// <param name="right">The value which is added to <paramref name="left" />.</param>
         /// <returns>The sum of <paramref name="left" /> and <paramref name="right" />.</returns>
         /// <exception cref="OverflowException">The sum of <paramref name="left" /> and <paramref name="right" /> is not representable by <typeparamref name="TResult" />.</exception>
-        static abstract TResult operator checked +(TSelf left, TOther right);
+        static virtual TResult operator checked +(TSelf left, TOther right) => left + right;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IBinaryInteger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IBinaryInteger.cs
@@ -14,12 +14,26 @@ namespace System.Numerics
         /// <param name="left">The value which <paramref name="right" /> divides.</param>
         /// <param name="right">The value which divides <paramref name="left" />.</param>
         /// <returns>The quotient and remainder of <paramref name="left" /> divided-by <paramref name="right" />.</returns>
-        static abstract (TSelf Quotient, TSelf Remainder) DivRem(TSelf left, TSelf right);
+        static virtual (TSelf Quotient, TSelf Remainder) DivRem(TSelf left, TSelf right)
+        {
+            TSelf quotient = left / right;
+            return (quotient, (left - (quotient * right)));
+        }
 
         /// <summary>Computes the number of leading zeros in a value.</summary>
         /// <param name="value">The value whose leading zeroes are to be counted.</param>
         /// <returns>The number of leading zeros in <paramref name="value" />.</returns>
-        static abstract TSelf LeadingZeroCount(TSelf value);
+        static virtual TSelf LeadingZeroCount(TSelf value)
+        {
+            TSelf bitCount = TSelf.CreateChecked(value.GetByteCount() * 8L);
+
+            if (value == TSelf.Zero)
+            {
+                return TSelf.CreateChecked(bitCount);
+            }
+
+            return (bitCount - TSelf.One) ^ TSelf.Log2(value);
+        }
 
         /// <summary>Computes the number of bits that are set in a value.</summary>
         /// <param name="value">The value whose set bits are to be counted.</param>
@@ -30,13 +44,21 @@ namespace System.Numerics
         /// <param name="value">The value which is rotated left by <paramref name="rotateAmount" />.</param>
         /// <param name="rotateAmount">The amount by which <paramref name="value" /> is rotated left.</param>
         /// <returns>The result of rotating <paramref name="value" /> left by <paramref name="rotateAmount" />.</returns>
-        static abstract TSelf RotateLeft(TSelf value, int rotateAmount);
+        static virtual TSelf RotateLeft(TSelf value, int rotateAmount)
+        {
+            int bitCount = checked(value.GetByteCount() * 8);
+            return (value << rotateAmount) | (value >> (bitCount - rotateAmount));
+        }
 
         /// <summary>Rotates a value right by a given amount.</summary>
         /// <param name="value">The value which is rotated right by <paramref name="rotateAmount" />.</param>
         /// <param name="rotateAmount">The amount by which <paramref name="value" /> is rotated right.</param>
         /// <returns>The result of rotating <paramref name="value" /> right by <paramref name="rotateAmount" />.</returns>
-        static abstract TSelf RotateRight(TSelf value, int rotateAmount);
+        static virtual TSelf RotateRight(TSelf value, int rotateAmount)
+        {
+            int bitCount = checked(value.GetByteCount() * 8);
+            return (value >> rotateAmount) | (value << (bitCount - rotateAmount));
+        }
 
         /// <summary>Computes the number of trailing zeros in a value.</summary>
         /// <param name="value">The value whose trailing zeroes are to be counted.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IDecrementOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IDecrementOperators.cs
@@ -17,6 +17,6 @@ namespace System.Numerics
         /// <param name="value">The value to decrement.</param>
         /// <returns>The result of decrementing <paramref name="value" />.</returns>
         /// <exception cref="OverflowException">The result of decrementing <paramref name="value" /> is not representable by <typeparamref name="TSelf" />.</exception>
-        static abstract TSelf operator checked --(TSelf value);
+        static virtual TSelf operator checked --(TSelf value) => --value;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IDivisionOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IDivisionOperators.cs
@@ -21,6 +21,6 @@ namespace System.Numerics
         /// <param name="right">The value which divides <paramref name="left" />.</param>
         /// <returns>The quotient of <paramref name="left" /> divided-by <paramref name="right" />.</returns>
         /// <exception cref="OverflowException">The quotient of <paramref name="left" /> divided-by <paramref name="right" /> is not representable by <typeparamref name="TResult" />.</exception>
-        static abstract TResult operator checked /(TSelf left, TOther right);
+        static virtual TResult operator checked /(TSelf left, TOther right) => left / right;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IExponentialFunctions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IExponentialFunctions.cs
@@ -6,7 +6,7 @@ namespace System.Numerics
     /// <summary>Defines support for exponential functions.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     public interface IExponentialFunctions<TSelf>
-        where TSelf : IExponentialFunctions<TSelf>
+        where TSelf : IExponentialFunctions<TSelf>, INumberBase<TSelf>
     {
         /// <summary>Computes <c>E</c> raised to a given power.</summary>
         /// <param name="x">The power to which <c>E</c> is raised.</param>
@@ -16,7 +16,7 @@ namespace System.Numerics
         /// <summary>Computes <c>E</c> raised to a given power and subtracts one.</summary>
         /// <param name="x">The power to which <c>E</c> is raised.</param>
         /// <returns><c>E<sup><paramref name="x" /></sup> - 1</c></returns>
-        static abstract TSelf ExpM1(TSelf x);
+        static virtual TSelf ExpM1(TSelf x) => TSelf.Exp(x) - TSelf.One;
 
         /// <summary>Computes <c>2</c> raised to a given power.</summary>
         /// <param name="x">The power to which <c>2</c> is raised.</param>
@@ -26,7 +26,7 @@ namespace System.Numerics
         /// <summary>Computes <c>2</c> raised to a given power and subtracts one.</summary>
         /// <param name="x">The power to which <c>2</c> is raised.</param>
         /// <returns><c>2<sup><paramref name="x" /></sup> - 1</c></returns>
-        static abstract TSelf Exp2M1(TSelf x);
+        static virtual TSelf Exp2M1(TSelf x) => TSelf.Exp2(x) - TSelf.One;
 
         /// <summary>Computes <c>10</c> raised to a given power.</summary>
         /// <param name="x">The power to which <c>10</c> is raised.</param>
@@ -36,6 +36,6 @@ namespace System.Numerics
         /// <summary>Computes <c>10</c> raised to a given power and subtracts one.</summary>
         /// <param name="x">The power to which <c>10</c> is raised.</param>
         /// <returns><c>10<sup><paramref name="x" /></sup> - 1</c></returns>
-        static abstract TSelf Exp10M1(TSelf x);
+        static virtual TSelf Exp10M1(TSelf x) => TSelf.Exp10M1(x) - TSelf.One;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPoint.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPoint.cs
@@ -13,29 +13,29 @@ namespace System.Numerics
         /// <summary>Computes the ceiling of a value.</summary>
         /// <param name="x">The value whose ceiling is to be computed.</param>
         /// <returns>The ceiling of <paramref name="x" />.</returns>
-        static abstract TSelf Ceiling(TSelf x);
+        static virtual TSelf Ceiling(TSelf x) => TSelf.Round(x, digits: 0, MidpointRounding.ToPositiveInfinity);
 
         /// <summary>Computes the floor of a value.</summary>
         /// <param name="x">The value whose floor is to be computed.</param>
         /// <returns>The floor of <paramref name="x" />.</returns>
-        static abstract TSelf Floor(TSelf x);
+        static virtual TSelf Floor(TSelf x) => TSelf.Round(x, digits: 0, MidpointRounding.ToNegativeInfinity);
 
         /// <summary>Rounds a value to the nearest integer using the default rounding mode (<see cref="MidpointRounding.ToEven" />).</summary>
         /// <param name="x">The value to round.</param>
         /// <returns>The result of rounding <paramref name="x" /> to the nearest integer using the default rounding mode.</returns>
-        static abstract TSelf Round(TSelf x);
+        static virtual TSelf Round(TSelf x) => TSelf.Round(x, digits: 0, MidpointRounding.ToEven);
 
         /// <summary>Rounds a value to a specified number of fractional-digits using the default rounding mode (<see cref="MidpointRounding.ToEven" />).</summary>
         /// <param name="x">The value to round.</param>
         /// <param name="digits">The number of fractional digits to which <paramref name="x" /> should be rounded.</param>
         /// <returns>The result of rounding <paramref name="x" /> to <paramref name="digits" /> fractional-digits using the default rounding mode.</returns>
-        static abstract TSelf Round(TSelf x, int digits);
+        static virtual TSelf Round(TSelf x, int digits) => TSelf.Round(x, digits, MidpointRounding.ToEven);
 
         /// <summary>Rounds a value to the nearest integer using the specified rounding mode.</summary>
         /// <param name="x">The value to round.</param>
         /// <param name="mode">The mode under which <paramref name="x" /> should be rounded.</param>
         /// <returns>The result of rounding <paramref name="x" /> to the nearest integer using <paramref name="mode" />.</returns>
-        static abstract TSelf Round(TSelf x, MidpointRounding mode);
+        static virtual TSelf Round(TSelf x, MidpointRounding mode) => TSelf.Round(x, digits: 0, MidpointRounding.ToEven);
 
         /// <summary>Rounds a value to a specified number of fractional-digits using the default rounding mode (<see cref="MidpointRounding.ToEven" />).</summary>
         /// <param name="x">The value to round.</param>
@@ -47,7 +47,7 @@ namespace System.Numerics
         /// <summary>Truncates a value.</summary>
         /// <param name="x">The value to truncate.</param>
         /// <returns>The truncation of <paramref name="x" />.</returns>
-        static abstract TSelf Truncate(TSelf x);
+        static virtual TSelf Truncate(TSelf x) => TSelf.Round(x, digits: 0, MidpointRounding.ToZero);
 
         /// <summary>Gets the number of bytes that will be written as part of <see cref="TryWriteExponentLittleEndian(Span{byte}, out int)" />.</summary>
         /// <returns>The number of bytes that will be written as part of <see cref="TryWriteExponentLittleEndian(Span{byte}, out int)" />.</returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPointIeee754.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPointIeee754.cs
@@ -70,12 +70,12 @@ namespace System.Numerics
         /// <summary>Computes an estimate of the reciprocal of a value.</summary>
         /// <param name="x">The value whose estimate of the reciprocal is to be computed.</param>
         /// <returns>An estimate of the reciprocal of <paramref name="x" />.</returns>
-        static abstract TSelf ReciprocalEstimate(TSelf x);
+        static virtual TSelf ReciprocalEstimate(TSelf x) => TSelf.One / x;
 
         /// <summary>Computes an estimate of the reciprocal square root of a value.</summary>
         /// <param name="x">The value whose estimate of the reciprocal square root is to be computed.</param>
         /// <returns>An estimate of the reciprocal square root of <paramref name="x" />.</returns>
-        static abstract TSelf ReciprocalSqrtEstimate(TSelf x);
+        static virtual TSelf ReciprocalSqrtEstimate(TSelf x) => TSelf.One / TSelf.Sqrt(x);
 
         /// <summary>Computes the product of a value and its base-radix raised to the specified power.</summary>
         /// <param name="x">The value which base-radix raised to the power of <paramref name="n" /> multiplies.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IHyperbolicFunctions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IHyperbolicFunctions.cs
@@ -6,7 +6,7 @@ namespace System.Numerics
     /// <summary>Defines support for hyperbolic functions.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     public interface IHyperbolicFunctions<TSelf>
-        where TSelf : IHyperbolicFunctions<TSelf>
+        where TSelf : IHyperbolicFunctions<TSelf>, INumberBase<TSelf>
     {
         /// <summary>Computes the hyperbolic arc-cosine of a value.</summary>
         /// <param name="x">The value, in radians, whose hyperbolic arc-cosine is to be computed.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IIncrementOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IIncrementOperators.cs
@@ -17,6 +17,6 @@ namespace System.Numerics
         /// <param name="value">The value to increment.</param>
         /// <returns>The result of incrementing <paramref name="value" />.</returns>
         /// <exception cref="OverflowException">The result of incrementing <paramref name="value" /> is not representable by <typeparamref name="TSelf" />.</exception>
-        static abstract TSelf operator checked ++(TSelf value);
+        static virtual TSelf operator checked ++(TSelf value) => ++value;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/ILogarithmicFunctions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/ILogarithmicFunctions.cs
@@ -6,7 +6,7 @@ namespace System.Numerics
     /// <summary>Defines support for logarithmic functions.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     public interface ILogarithmicFunctions<TSelf>
-        where TSelf : ILogarithmicFunctions<TSelf>
+        where TSelf : ILogarithmicFunctions<TSelf>, INumberBase<TSelf>
     {
         /// <summary>Computes the natural (<c>base-E</c>) logarithm of a value.</summary>
         /// <param name="x">The value whose natural logarithm is to be computed.</param>
@@ -22,7 +22,7 @@ namespace System.Numerics
         /// <summary>Computes the natural (<c>base-E</c>) logarithm of a value plus one.</summary>
         /// <param name="x">The value to which one is added before computing the natural logarithm.</param>
         /// <returns><c>log<sub>e</sub>(<paramref name="x" /> + 1)</c></returns>
-        static abstract TSelf LogP1(TSelf x);
+        static virtual TSelf LogP1(TSelf x) => TSelf.Log(x + TSelf.One);
 
         /// <summary>Computes the base-2 logarithm of a value.</summary>
         /// <param name="x">The value whose base-2 logarithm is to be computed.</param>
@@ -32,7 +32,7 @@ namespace System.Numerics
         /// <summary>Computes the base-2 logarithm of a value plus one.</summary>
         /// <param name="x">The value to which one is added before computing the base-2 logarithm.</param>
         /// <returns><c>log<sub>2</sub>(<paramref name="x" /> + 1)</c></returns>
-        static abstract TSelf Log2P1(TSelf x);
+        static virtual TSelf Log2P1(TSelf x) => TSelf.Log2(x + TSelf.One);
 
         /// <summary>Computes the base-10 logarithm of a value.</summary>
         /// <param name="x">The value whose base-10 logarithm is to be computed.</param>
@@ -42,6 +42,6 @@ namespace System.Numerics
         /// <summary>Computes the base-10 logarithm of a value plus one.</summary>
         /// <param name="x">The value to which one is added before computing the base-10 logarithm.</param>
         /// <returns><c>log<sub>10</sub>(<paramref name="x" /> + 1)</c></returns>
-        static abstract TSelf Log10P1(TSelf x);
+        static virtual TSelf Log10P1(TSelf x) => TSelf.Log10(x + TSelf.One);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IMultiplyOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IMultiplyOperators.cs
@@ -21,6 +21,6 @@ namespace System.Numerics
         /// <param name="right">The value which multiplies <paramref name="left" />.</param>
         /// <returns>The product of <paramref name="left" /> divided-by <paramref name="right" />.</returns>
         /// <exception cref="OverflowException">The product of <paramref name="left" /> multiplied-by <paramref name="right" /> is not representable by <typeparamref name="TResult" />.</exception>
-        static abstract TResult operator checked *(TSelf left, TOther right);
+        static virtual TResult operator checked *(TSelf left, TOther right) => left * right;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/INumber.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/INumber.cs
@@ -20,46 +20,147 @@ namespace System.Numerics
         /// <param name="max">The inclusive maximum to which <paramref name="value" /> should clamp.</param>
         /// <returns>The result of clamping <paramref name="value" /> to the inclusive range of <paramref name="min" /> and <paramref name="max" />.</returns>
         /// <exception cref="ArgumentException"><paramref name="min" /> is greater than <paramref name="max" />.</exception>
-        static abstract TSelf Clamp(TSelf value, TSelf min, TSelf max);
+        static virtual TSelf Clamp(TSelf value, TSelf min, TSelf max)
+        {
+            if (min > max)
+            {
+                Math.ThrowMinMaxException(min, max);
+            }
+
+            TSelf result = value;
+
+            result = TSelf.Max(result, min);
+            result = TSelf.Min(result, max);
+
+            return result;
+        }
 
         /// <summary>Copies the sign of a value to the sign of another value..</summary>
         /// <param name="value">The value whose magnitude is used in the result.</param>
         /// <param name="sign">The value whose sign is used in the result.</param>
         /// <returns>A value with the magnitude of <paramref name="value" /> and the sign of <paramref name="sign" />.</returns>
-        static abstract TSelf CopySign(TSelf value, TSelf sign);
+        static virtual TSelf CopySign(TSelf value, TSelf sign)
+        {
+            TSelf result = value;
+
+            if (TSelf.IsNegative(value) != TSelf.IsNegative(sign))
+            {
+                result = checked(-result);
+            }
+
+            return result;
+        }
 
         /// <summary>Compares two values to compute which is greater.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
         /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>maximum</c> function. This requires NaN inputs to be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
-        static abstract TSelf Max(TSelf x, TSelf y);
+        static virtual TSelf Max(TSelf x, TSelf y)
+        {
+            // This matches the IEEE 754:2019 `maximum` function
+            //
+            // It propagates NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!TSelf.IsNaN(x))
+                {
+                    return y < x ? x : y;
+                }
+
+                return x;
+            }
+
+            return TSelf.IsNegative(y) ? x : y;
+        }
 
         /// <summary>Compares two values to compute which is greater and returning the other value if an input is <c>NaN</c>.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
         /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
-        static abstract TSelf MaxNumber(TSelf x, TSelf y);
+        static virtual TSelf MaxNumber(TSelf x, TSelf y)
+        {
+            // This matches the IEEE 754:2019 `maximumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!TSelf.IsNaN(y))
+                {
+                    return y < x ? x : y;
+                }
+
+                return x;
+            }
+
+            return TSelf.IsNegative(y) ? x : y;
+        }
 
         /// <summary>Compares two values to compute which is lesser.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
         /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>minimum</c> function. This requires NaN inputs to be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
-        static abstract TSelf Min(TSelf x, TSelf y);
+        static virtual TSelf Min(TSelf x, TSelf y)
+        {
+            // This matches the IEEE 754:2019 `minimum` function
+            //
+            // It propagates NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if ((x != y) && !TSelf.IsNaN(x))
+            {
+                return x < y ? x : y;
+            }
+
+            return TSelf.IsNegative(x) ? x : y;
+        }
 
         /// <summary>Compares two values to compute which is lesser and returning the other value if an input is <c>NaN</c>.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
         /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
-        static abstract TSelf MinNumber(TSelf x, TSelf y);
+        static virtual TSelf MinNumber(TSelf x, TSelf y)
+        {
+            // This matches the IEEE 754:2019 `minimumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!TSelf.IsNaN(y))
+                {
+                    return x < y ? x : y;
+                }
+
+                return x;
+            }
+
+            return TSelf.IsNegative(x) ? x : y;
+        }
 
         /// <summary>Computes the sign of a value.</summary>
         /// <param name="value">The value whose sign is to be computed.</param>
         /// <returns>A positive value if <paramref name="value" /> is positive, <see cref="INumberBase{TSelf}.Zero" /> if <paramref name="value" /> is zero, and a negative value if <paramref name="value" /> is negative.</returns>
         /// <remarks>It is recommended that a function return <c>1</c>, <c>0</c>, and <c>-1</c>, respectively.</remarks>
-        static abstract int Sign(TSelf value);
+        static virtual int Sign(TSelf value)
+        {
+            if (value != TSelf.Zero)
+            {
+                return TSelf.IsNegative(value) ? -1 : +1;
+            }
+            return 0;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
@@ -47,7 +47,7 @@ namespace System.Numerics
         /// <exception cref="NotSupportedException"><typeparamref name="TOther" /> is not supported.</exception>
         /// <exception cref="OverflowException"><paramref name="value" /> is not representable by <typeparamref name="TSelf" />.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static virtual TSelf CreateChecked<TOther>(TOther value)
+        static virtual TSelf CreateChecked<TOther>(TOther value)
             where TOther : INumberBase<TOther>
         {
             TSelf? result;
@@ -70,7 +70,7 @@ namespace System.Numerics
         /// <returns>An instance of <typeparamref name="TSelf" /> created from <paramref name="value" />, saturating if <paramref name="value" /> falls outside the representable range of <typeparamref name="TSelf" />.</returns>
         /// <exception cref="NotSupportedException"><typeparamref name="TOther" /> is not supported.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static virtual TSelf CreateSaturating<TOther>(TOther value)
+        static virtual TSelf CreateSaturating<TOther>(TOther value)
             where TOther : INumberBase<TOther>
         {
             TSelf? result;
@@ -93,7 +93,7 @@ namespace System.Numerics
         /// <returns>An instance of <typeparamref name="TSelf" /> created from <paramref name="value" />, truncating if <paramref name="value" /> falls outside the representable range of <typeparamref name="TSelf" />.</returns>
         /// <exception cref="NotSupportedException"><typeparamref name="TOther" /> is not supported.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static virtual TSelf CreateTruncating<TOther>(TOther value)
+        static virtual TSelf CreateTruncating<TOther>(TOther value)
             where TOther : INumberBase<TOther>
         {
             TSelf? result;

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IPowerFunctions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IPowerFunctions.cs
@@ -6,7 +6,7 @@ namespace System.Numerics
     /// <summary>Defines support for power functions.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     public interface IPowerFunctions<TSelf>
-        where TSelf : IPowerFunctions<TSelf>
+        where TSelf : IPowerFunctions<TSelf>, INumberBase<TSelf>
     {
         /// <summary>Computes a value raised to a given power.</summary>
         /// <param name="x">The value which is raised to the power of <paramref name="x" />.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IRootFunctions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IRootFunctions.cs
@@ -6,7 +6,7 @@ namespace System.Numerics
     /// <summary>Defines support for root functions.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     public interface IRootFunctions<TSelf>
-        where TSelf : IRootFunctions<TSelf>
+        where TSelf : IRootFunctions<TSelf>, INumberBase<TSelf>
     {
         /// <summary>Computes the cube-root of a value.</summary>
         /// <param name="x">The value whose cube-root is to be computed.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/ISubtractionOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/ISubtractionOperators.cs
@@ -21,6 +21,6 @@ namespace System.Numerics
         /// <param name="right">The value which is subtracted from <paramref name="left" />.</param>
         /// <returns>The difference of <paramref name="right" /> subtracted from <paramref name="left" />.</returns>
         /// <exception cref="OverflowException">The difference of <paramref name="right" /> subtracted from <paramref name="left" /> is not representable by <typeparamref name="TResult" />.</exception>
-        static abstract TResult operator checked -(TSelf left, TOther right);
+        static virtual TResult operator checked -(TSelf left, TOther right) => left - right;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/ITrigonometricFunctions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/ITrigonometricFunctions.cs
@@ -6,7 +6,7 @@ namespace System.Numerics
     /// <summary>Defines support for trigonometric functions.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     public interface ITrigonometricFunctions<TSelf>
-        where TSelf : ITrigonometricFunctions<TSelf>
+        where TSelf : ITrigonometricFunctions<TSelf>, INumberBase<TSelf>
     {
         /// <summary>Computes the arc-cosine of a value.</summary>
         /// <param name="x">The value, in radians, whose arc-cosine is to be computed.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IUnaryNegationOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IUnaryNegationOperators.cs
@@ -18,6 +18,6 @@ namespace System.Numerics
         /// <param name="value">The value for which to compute its unary negation.</param>
         /// <returns>The unary negation of <paramref name="value" />.</returns>
         /// <exception cref="OverflowException">The unary negation of <paramref name="value" /> is not representable by <typeparamref name="TResult" />.</exception>
-        static abstract TResult operator checked -(TSelf value);
+        static virtual TResult operator checked -(TSelf value) => -value;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
@@ -860,13 +860,6 @@ namespace System.Runtime.InteropServices
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null) => _value.TryFormat(destination, out charsWritten, format, provider);
 
         //
-        // IAdditionOperators
-        //
-
-        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
-        static NFloat IAdditionOperators<NFloat, NFloat, NFloat>.operator checked +(NFloat left, NFloat right) => left + right;
-
-        //
         // IAdditiveIdentity
         //
 
@@ -942,20 +935,6 @@ namespace System.Runtime.InteropServices
             return new NFloat(result);
 #endif
         }
-
-        //
-        // IDecrementOperators
-        //
-
-        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
-        static NFloat IDecrementOperators<NFloat>.operator checked --(NFloat value) => --value;
-
-        //
-        // IDivisionOperators
-        //
-
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static NFloat IDivisionOperators<NFloat, NFloat, NFloat>.operator checked /(NFloat left, NFloat right) => left / right;
 
         //
         // IExponentialFunctions
@@ -1197,13 +1176,6 @@ namespace System.Runtime.InteropServices
         public static NFloat Tanh(NFloat x) => new NFloat(NativeType.Tanh(x._value));
 
         //
-        // IIncrementOperators
-        //
-
-        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
-        static NFloat IIncrementOperators<NFloat>.operator checked ++(NFloat value) => ++value;
-
-        //
         // ILogarithmicFunctions
         //
 
@@ -1231,13 +1203,6 @@ namespace System.Runtime.InteropServices
 
         /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
         static NFloat IMultiplicativeIdentity<NFloat, NFloat>.MultiplicativeIdentity => new NFloat(NativeType.MultiplicativeIdentity);
-
-        //
-        // IMultiplyOperators
-        //
-
-        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
-        static NFloat IMultiplyOperators<NFloat, NFloat, NFloat>.operator checked *(NFloat left, NFloat right) => left * right;
 
         //
         // INumber
@@ -1761,13 +1726,6 @@ namespace System.Runtime.InteropServices
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out NFloat result) => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
 
         //
-        // ISubtractionOperators
-        //
-
-        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
-        static NFloat ISubtractionOperators<NFloat, NFloat, NFloat>.operator checked -(NFloat left, NFloat right) => left - right;
-
-        //
         // ITrigonometricFunctions
         //
 
@@ -1819,12 +1777,5 @@ namespace System.Runtime.InteropServices
 
         // /// <inheritdoc cref="ITrigonometricFunctions{TSelf}.TanPi(TSelf)" />
         // public static NFloat TanPi(NFloat x) => new NFloat(NativeType.TanPi(x._value, y._value));
-
-        //
-        // IUnaryNegationOperators
-        //
-
-        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
-        static NFloat IUnaryNegationOperators<NFloat, NFloat>.operator checked -(NFloat value) => -value;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -466,9 +466,6 @@ namespace System
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static sbyte IDivisionOperators<sbyte, sbyte, sbyte>.operator /(sbyte left, sbyte right) => (sbyte)(left / right);
 
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static sbyte IDivisionOperators<sbyte, sbyte, sbyte>.operator checked /(sbyte left, sbyte right) => (sbyte)(left / right);
-
         //
         // IEqualityOperators
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -527,9 +527,6 @@ namespace System
         /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
         static float IAdditionOperators<float, float, float>.operator +(float left, float right) => left + right;
 
-        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
-        static float IAdditionOperators<float, float, float>.operator checked +(float left, float right) => left + right;
-
         //
         // IAdditiveIdentity
         //
@@ -596,18 +593,12 @@ namespace System
         /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
         static float IDecrementOperators<float>.operator --(float value) => --value;
 
-        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
-        static float IDecrementOperators<float>.operator checked --(float value) => --value;
-
         //
         // IDivisionOperators
         //
 
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static float IDivisionOperators<float, float, float>.operator /(float left, float right) => left / right;
-
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static float IDivisionOperators<float, float, float>.operator checked /(float left, float right) => left / right;
 
         //
         // IExponentialFunctions
@@ -848,9 +839,6 @@ namespace System
         /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
         static float IIncrementOperators<float>.operator ++(float value) => ++value;
 
-        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
-        static float IIncrementOperators<float>.operator checked ++(float value) => ++value;
-
         //
         // ILogarithmicFunctions
         //
@@ -903,9 +891,6 @@ namespace System
 
         /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
         static float IMultiplyOperators<float, float, float>.operator *(float left, float right) => left * right;
-
-        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
-        static float IMultiplyOperators<float, float, float>.operator checked *(float left, float right) => left * right;
 
         //
         // INumber
@@ -1384,9 +1369,6 @@ namespace System
         /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
         static float ISubtractionOperators<float, float, float>.operator -(float left, float right) => left - right;
 
-        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
-        static float ISubtractionOperators<float, float, float>.operator checked -(float left, float right) => left - right;
-
         //
         // ITrigonometricFunctions
         //
@@ -1442,9 +1424,6 @@ namespace System
 
         /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
         static float IUnaryNegationOperators<float, float>.operator -(float value) => -value;
-
-        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
-        static float IUnaryNegationOperators<float, float>.operator checked -(float value) => -value;
 
         //
         // IUnaryPlusOperators

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -428,9 +428,6 @@ namespace System
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static ushort IDivisionOperators<ushort, ushort, ushort>.operator /(ushort left, ushort right) => (ushort)(left / right);
 
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static ushort IDivisionOperators<ushort, ushort, ushort>.operator checked /(ushort left, ushort right) => (ushort)(left / right);
-
         //
         // IEqualityOperators
         //

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -414,9 +414,6 @@ namespace System
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static uint IDivisionOperators<uint, uint, uint>.operator /(uint left, uint right) => left / right;
 
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static uint IDivisionOperators<uint, uint, uint>.operator checked /(uint left, uint right) => left / right;
-
         //
         // IEqualityOperators
         //

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -413,9 +413,6 @@ namespace System
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static ulong IDivisionOperators<ulong, ulong, ulong>.operator /(ulong left, ulong right) => left / right;
 
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static ulong IDivisionOperators<ulong, ulong, ulong>.operator checked /(ulong left, ulong right) => left / right;
-
         //
         // IEqualityOperators
         //

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -399,9 +399,6 @@ namespace System
         /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         static nuint IDivisionOperators<nuint, nuint, nuint>.operator /(nuint left, nuint right) => left / right;
 
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static nuint IDivisionOperators<nuint, nuint, nuint>.operator checked /(nuint left, nuint right) => left / right;
-
         //
         // IIncrementOperators
         //

--- a/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
+++ b/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
@@ -98,7 +98,7 @@ namespace System.Numerics
         public static explicit operator short (System.Numerics.BigInteger value) { throw null; }
         public static explicit operator int (System.Numerics.BigInteger value) { throw null; }
         public static explicit operator long (System.Numerics.BigInteger value) { throw null; }
-        public static explicit operator System.IntPtr (System.Numerics.BigInteger value) { throw null; }
+        public static explicit operator nint (System.Numerics.BigInteger value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static explicit operator sbyte (System.Numerics.BigInteger value) { throw null; }
         public static explicit operator float (System.Numerics.BigInteger value) { throw null; }
@@ -111,7 +111,7 @@ namespace System.Numerics
         [System.CLSCompliantAttribute(false)]
         public static explicit operator ulong (System.Numerics.BigInteger value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static explicit operator System.UIntPtr (System.Numerics.BigInteger value) { throw null; }
+        public static explicit operator nuint (System.Numerics.BigInteger value) { throw null; }
         public static explicit operator System.Numerics.BigInteger (System.Numerics.Complex value) { throw null; }
         public static explicit operator System.Numerics.BigInteger (float value) { throw null; }
         public static bool operator >(long left, System.Numerics.BigInteger right) { throw null; }
@@ -134,7 +134,7 @@ namespace System.Numerics
         public static implicit operator System.Numerics.BigInteger (short value) { throw null; }
         public static implicit operator System.Numerics.BigInteger (int value) { throw null; }
         public static implicit operator System.Numerics.BigInteger (long value) { throw null; }
-        public static implicit operator System.Numerics.BigInteger (System.IntPtr value) { throw null; }
+        public static implicit operator System.Numerics.BigInteger (nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static implicit operator System.Numerics.BigInteger (sbyte value) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -146,7 +146,7 @@ namespace System.Numerics
         [System.CLSCompliantAttribute(false)]
         public static implicit operator System.Numerics.BigInteger (ulong value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static implicit operator System.Numerics.BigInteger (System.UIntPtr value) { throw null; }
+        public static implicit operator System.Numerics.BigInteger (nuint value) { throw null; }
         public static System.Numerics.BigInteger operator ++(System.Numerics.BigInteger value) { throw null; }
         public static bool operator !=(long left, System.Numerics.BigInteger right) { throw null; }
         public static bool operator !=(System.Numerics.BigInteger left, long right) { throw null; }
@@ -190,15 +190,10 @@ namespace System.Numerics
         public static System.Numerics.BigInteger RotateLeft(System.Numerics.BigInteger value, int rotateAmount) { throw null; }
         public static System.Numerics.BigInteger RotateRight(System.Numerics.BigInteger value, int rotateAmount) { throw null; }
         public static System.Numerics.BigInteger Subtract(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
-        static System.Numerics.BigInteger System.Numerics.IAdditionOperators<System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger>.operator checked +(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         int System.Numerics.IBinaryInteger<System.Numerics.BigInteger>.GetByteCount() { throw null; }
         int System.Numerics.IBinaryInteger<System.Numerics.BigInteger>.GetShortestBitLength() { throw null; }
         bool System.Numerics.IBinaryInteger<System.Numerics.BigInteger>.TryWriteBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IBinaryInteger<System.Numerics.BigInteger>.TryWriteLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
-        static System.Numerics.BigInteger System.Numerics.IDecrementOperators<System.Numerics.BigInteger>.operator checked --(System.Numerics.BigInteger value) { throw null; }
-        static System.Numerics.BigInteger System.Numerics.IDivisionOperators<System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger>.operator checked /(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
-        static System.Numerics.BigInteger System.Numerics.IIncrementOperators<System.Numerics.BigInteger>.operator checked ++(System.Numerics.BigInteger value) { throw null; }
-        static System.Numerics.BigInteger System.Numerics.IMultiplyOperators<System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger>.operator checked *(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsCanonical(System.Numerics.BigInteger value) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsComplexNumber(System.Numerics.BigInteger value) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.BigInteger>.IsFinite(System.Numerics.BigInteger value) { throw null; }
@@ -223,8 +218,6 @@ namespace System.Numerics
         static System.Numerics.BigInteger System.Numerics.INumber<System.Numerics.BigInteger>.MaxNumber(System.Numerics.BigInteger x, System.Numerics.BigInteger y) { throw null; }
         static System.Numerics.BigInteger System.Numerics.INumber<System.Numerics.BigInteger>.MinNumber(System.Numerics.BigInteger x, System.Numerics.BigInteger y) { throw null; }
         static int System.Numerics.INumber<System.Numerics.BigInteger>.Sign(System.Numerics.BigInteger value) { throw null; }
-        static System.Numerics.BigInteger System.Numerics.ISubtractionOperators<System.Numerics.BigInteger, System.Numerics.BigInteger, System.Numerics.BigInteger>.operator checked -(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
-        static System.Numerics.BigInteger System.Numerics.IUnaryNegationOperators<System.Numerics.BigInteger, System.Numerics.BigInteger>.operator checked -(System.Numerics.BigInteger value) { throw null; }
         public byte[] ToByteArray() { throw null; }
         public byte[] ToByteArray(bool isUnsigned = false, bool isBigEndian = false) { throw null; }
         public override string ToString() { throw null; }
@@ -322,7 +315,7 @@ namespace System.Numerics
         public static implicit operator System.Numerics.Complex (short value) { throw null; }
         public static implicit operator System.Numerics.Complex (int value) { throw null; }
         public static implicit operator System.Numerics.Complex (long value) { throw null; }
-        public static implicit operator System.Numerics.Complex (System.IntPtr value) { throw null; }
+        public static implicit operator System.Numerics.Complex (nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static implicit operator System.Numerics.Complex (sbyte value) { throw null; }
         public static implicit operator System.Numerics.Complex (float value) { throw null; }
@@ -333,7 +326,7 @@ namespace System.Numerics
         [System.CLSCompliantAttribute(false)]
         public static implicit operator System.Numerics.Complex (ulong value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static implicit operator System.Numerics.Complex (System.UIntPtr value) { throw null; }
+        public static implicit operator System.Numerics.Complex (nuint value) { throw null; }
         public static System.Numerics.Complex operator ++(System.Numerics.Complex value) { throw null; }
         public static bool operator !=(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         public static System.Numerics.Complex operator *(double left, System.Numerics.Complex right) { throw null; }
@@ -357,11 +350,6 @@ namespace System.Numerics
         public static System.Numerics.Complex Subtract(double left, System.Numerics.Complex right) { throw null; }
         public static System.Numerics.Complex Subtract(System.Numerics.Complex left, double right) { throw null; }
         public static System.Numerics.Complex Subtract(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
-        static System.Numerics.Complex System.Numerics.IAdditionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>.operator checked +(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
-        static System.Numerics.Complex System.Numerics.IDecrementOperators<System.Numerics.Complex>.operator checked --(System.Numerics.Complex value) { throw null; }
-        static System.Numerics.Complex System.Numerics.IDivisionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>.operator checked /(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
-        static System.Numerics.Complex System.Numerics.IIncrementOperators<System.Numerics.Complex>.operator checked ++(System.Numerics.Complex value) { throw null; }
-        static System.Numerics.Complex System.Numerics.IMultiplyOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>.operator checked *(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
         static System.Numerics.Complex System.Numerics.INumberBase<System.Numerics.Complex>.Abs(System.Numerics.Complex value) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsCanonical(System.Numerics.Complex value) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.Complex>.IsZero(System.Numerics.Complex value) { throw null; }
@@ -373,8 +361,6 @@ namespace System.Numerics
         static bool System.Numerics.INumberBase<System.Numerics.Complex>.TryConvertToChecked<TOther>(System.Numerics.Complex value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.Complex>.TryConvertToSaturating<TOther>(System.Numerics.Complex value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
         static bool System.Numerics.INumberBase<System.Numerics.Complex>.TryConvertToTruncating<TOther>(System.Numerics.Complex value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
-        static System.Numerics.Complex System.Numerics.ISubtractionOperators<System.Numerics.Complex, System.Numerics.Complex, System.Numerics.Complex>.operator checked -(System.Numerics.Complex left, System.Numerics.Complex right) { throw null; }
-        static System.Numerics.Complex System.Numerics.IUnaryNegationOperators<System.Numerics.Complex, System.Numerics.Complex>.operator checked -(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex Tan(System.Numerics.Complex value) { throw null; }
         public static System.Numerics.Complex Tanh(System.Numerics.Complex value) { throw null; }
         public override string ToString() { throw null; }

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -3114,13 +3114,6 @@ namespace System.Numerics
         }
 
         //
-        // IAdditionOperators
-        //
-
-        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
-        static BigInteger IAdditionOperators<BigInteger, BigInteger, BigInteger>.operator checked +(BigInteger left, BigInteger right) => left + right;
-
-        //
         // IAdditiveIdentity
         //
 
@@ -3850,39 +3843,11 @@ namespace System.Numerics
         }
 
         //
-        // IDecrementOperators
-        //
-
-        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
-        static BigInteger IDecrementOperators<BigInteger>.operator checked --(BigInteger value) => --value;
-
-        //
-        // IDivisionOperators
-        //
-
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static BigInteger IDivisionOperators<BigInteger, BigInteger, BigInteger>.operator checked /(BigInteger left, BigInteger right) => left / right;
-
-        //
-        // IIncrementOperators
-        //
-
-        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
-        static BigInteger IIncrementOperators<BigInteger>.operator checked ++(BigInteger value) => ++value;
-
-        //
         // IMultiplicativeIdentity
         //
 
         /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
         static BigInteger IMultiplicativeIdentity<BigInteger, BigInteger>.MultiplicativeIdentity => One;
-
-        //
-        // IMultiplyOperators
-        //
-
-        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
-        static BigInteger IMultiplyOperators<BigInteger, BigInteger, BigInteger>.operator checked *(BigInteger left, BigInteger right) => left * right;
 
         //
         // INumber
@@ -5255,19 +5220,5 @@ namespace System.Numerics
 
         /// <inheritdoc cref="ISpanParsable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out BigInteger result) => TryParse(s, NumberStyles.Integer, provider, out result);
-
-        //
-        // ISubtractionOperators
-        //
-
-        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
-        static BigInteger ISubtractionOperators<BigInteger, BigInteger, BigInteger>.operator checked -(BigInteger left, BigInteger right) => left - right;
-
-        //
-        // IUnaryNegationOperators
-        //
-
-        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
-        static BigInteger IUnaryNegationOperators<BigInteger, BigInteger>.operator checked -(BigInteger value) => -value;
     }
 }

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -923,13 +923,6 @@ namespace System.Numerics
         }
 
         //
-        // IAdditionOperators
-        //
-
-        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
-        static Complex IAdditionOperators<Complex, Complex, Complex>.operator checked +(Complex left, Complex right) => left + right;
-
-        //
         // IAdditiveIdentity
         //
 
@@ -943,16 +936,6 @@ namespace System.Numerics
         /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
         public static Complex operator --(Complex value) => value - One;
 
-        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
-        static Complex IDecrementOperators<Complex>.operator checked --(Complex value) => --value;
-
-        //
-        // IDivisionOperators
-        //
-
-        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
-        static Complex IDivisionOperators<Complex, Complex, Complex>.operator checked /(Complex left, Complex right) => left / right;
-
         //
         // IIncrementOperators
         //
@@ -960,22 +943,12 @@ namespace System.Numerics
         /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
         public static Complex operator ++(Complex value) => value + One;
 
-        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
-        static Complex IIncrementOperators<Complex>.operator checked ++(Complex value) => ++value;
-
         //
         // IMultiplicativeIdentity
         //
 
         /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
         static Complex IMultiplicativeIdentity<Complex, Complex>.MultiplicativeIdentity => new Complex(1.0, 0.0);
-
-        //
-        // IMultiplyOperators
-        //
-
-        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
-        static Complex IMultiplyOperators<Complex, Complex, Complex>.operator checked *(Complex left, Complex right) => left * right;
 
         //
         // INumberBase
@@ -2230,20 +2203,6 @@ namespace System.Numerics
 
         /// <inheritdoc cref="ISpanParsable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Complex result) => TryParse(s, DefaultNumberStyle, provider, out result);
-
-        //
-        // ISubtractionOperators
-        //
-
-        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
-        static Complex ISubtractionOperators<Complex, Complex, Complex>.operator checked -(Complex left, Complex right) => left - right;
-
-        //
-        // IUnaryNegationOperators
-        //
-
-        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
-        static Complex IUnaryNegationOperators<Complex, Complex>.operator checked -(Complex value) => -value;
 
         //
         // IUnaryPlusOperators

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -781,7 +781,6 @@ namespace System
         static bool System.Numerics.IComparisonOperators<byte, byte>.operator <=(byte left, byte right) { throw null; }
         static byte System.Numerics.IDecrementOperators<byte>.operator checked --(byte value) { throw null; }
         static byte System.Numerics.IDecrementOperators<byte>.operator --(byte value) { throw null; }
-        static byte System.Numerics.IDivisionOperators<byte, byte, byte>.operator checked /(byte left, byte right) { throw null; }
         static byte System.Numerics.IDivisionOperators<byte, byte, byte>.operator /(byte left, byte right) { throw null; }
         static bool System.Numerics.IEqualityOperators<byte, byte>.operator ==(byte left, byte right) { throw null; }
         static bool System.Numerics.IEqualityOperators<byte, byte>.operator !=(byte left, byte right) { throw null; }
@@ -936,7 +935,6 @@ namespace System
         static bool System.ISpanParsable<char>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out char result) { throw null; }
         static char System.Numerics.IAdditionOperators<char, char, char>.operator +(char left, char right) { throw null; }
         static char System.Numerics.IAdditionOperators<char, char, char>.operator checked +(char left, char right) { throw null; }
-        static (char Quotient, char Remainder) System.Numerics.IBinaryInteger<char>.DivRem(char left, char right) { throw null; }
         int System.Numerics.IBinaryInteger<char>.GetByteCount() { throw null; }
         int System.Numerics.IBinaryInteger<char>.GetShortestBitLength() { throw null; }
         static char System.Numerics.IBinaryInteger<char>.LeadingZeroCount(char value) { throw null; }
@@ -958,7 +956,6 @@ namespace System
         static bool System.Numerics.IComparisonOperators<char, char>.operator <=(char left, char right) { throw null; }
         static char System.Numerics.IDecrementOperators<char>.operator checked --(char value) { throw null; }
         static char System.Numerics.IDecrementOperators<char>.operator --(char value) { throw null; }
-        static char System.Numerics.IDivisionOperators<char, char, char>.operator checked /(char left, char right) { throw null; }
         static char System.Numerics.IDivisionOperators<char, char, char>.operator /(char left, char right) { throw null; }
         static bool System.Numerics.IEqualityOperators<char, char>.operator ==(char left, char right) { throw null; }
         static bool System.Numerics.IEqualityOperators<char, char>.operator !=(char left, char right) { throw null; }
@@ -999,13 +996,6 @@ namespace System
         static bool System.Numerics.INumberBase<char>.TryConvertToTruncating<TOther>(char value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
         static bool System.Numerics.INumberBase<char>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out char result) { throw null; }
         static bool System.Numerics.INumberBase<char>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out char result) { throw null; }
-        static char System.Numerics.INumber<char>.Clamp(char value, char min, char max) { throw null; }
-        static char System.Numerics.INumber<char>.CopySign(char value, char sign) { throw null; }
-        static char System.Numerics.INumber<char>.Max(char x, char y) { throw null; }
-        static char System.Numerics.INumber<char>.MaxNumber(char x, char y) { throw null; }
-        static char System.Numerics.INumber<char>.Min(char x, char y) { throw null; }
-        static char System.Numerics.INumber<char>.MinNumber(char x, char y) { throw null; }
-        static int System.Numerics.INumber<char>.Sign(char value) { throw null; }
         static char System.Numerics.IShiftOperators<char, char>.operator <<(char value, int shiftAmount) { throw null; }
         static char System.Numerics.IShiftOperators<char, char>.operator >>(char value, int shiftAmount) { throw null; }
         static char System.Numerics.IShiftOperators<char, char>.operator >>>(char value, int shiftAmount) { throw null; }
@@ -1915,7 +1905,6 @@ namespace System
         public static decimal Multiply(decimal d1, decimal d2) { throw null; }
         public static decimal Negate(decimal d) { throw null; }
         public static decimal operator +(decimal d1, decimal d2) { throw null; }
-        public static decimal operator checked *(decimal left, decimal right) { throw null; }
         public static decimal operator --(decimal d) { throw null; }
         public static decimal operator /(decimal d1, decimal d2) { throw null; }
         public static bool operator ==(decimal d1, decimal d2) { throw null; }
@@ -1988,9 +1977,6 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
-        static decimal System.Numerics.IAdditionOperators<decimal, decimal, decimal>.operator checked +(decimal left, decimal right) { throw null; }
-        static decimal System.Numerics.IDecrementOperators<decimal>.operator checked --(decimal value) { throw null; }
-        static decimal System.Numerics.IDivisionOperators<decimal, decimal, decimal>.operator checked /(decimal left, decimal right) { throw null; }
         int System.Numerics.IFloatingPoint<decimal>.GetExponentByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<decimal>.GetExponentShortestBitLength() { throw null; }
         int System.Numerics.IFloatingPoint<decimal>.GetSignificandBitLength() { throw null; }
@@ -1999,7 +1985,6 @@ namespace System
         bool System.Numerics.IFloatingPoint<decimal>.TryWriteExponentLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IFloatingPoint<decimal>.TryWriteSignificandBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IFloatingPoint<decimal>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
-        static decimal System.Numerics.IIncrementOperators<decimal>.operator checked ++(decimal value) { throw null; }
         static bool System.Numerics.INumberBase<decimal>.IsComplexNumber(decimal value) { throw null; }
         static bool System.Numerics.INumberBase<decimal>.IsFinite(decimal value) { throw null; }
         static bool System.Numerics.INumberBase<decimal>.IsImaginaryNumber(decimal value) { throw null; }
@@ -2021,8 +2006,6 @@ namespace System
         static bool System.Numerics.INumberBase<decimal>.TryConvertToTruncating<TOther>(decimal value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
         static decimal System.Numerics.INumber<decimal>.MaxNumber(decimal x, decimal y) { throw null; }
         static decimal System.Numerics.INumber<decimal>.MinNumber(decimal x, decimal y) { throw null; }
-        static decimal System.Numerics.ISubtractionOperators<decimal, decimal, decimal>.operator checked -(decimal left, decimal right) { throw null; }
-        static decimal System.Numerics.IUnaryNegationOperators<decimal, decimal>.operator checked -(decimal value) { throw null; }
         void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object? sender) { }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public static byte ToByte(decimal value) { throw null; }
@@ -2231,14 +2214,11 @@ namespace System
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
         static double System.Numerics.IAdditionOperators<double, double, double>.operator +(double left, double right) { throw null; }
-        static double System.Numerics.IAdditionOperators<double, double, double>.operator checked +(double left, double right) { throw null; }
         static double System.Numerics.IBitwiseOperators<double, double, double>.operator &(double left, double right) { throw null; }
         static double System.Numerics.IBitwiseOperators<double, double, double>.operator |(double left, double right) { throw null; }
         static double System.Numerics.IBitwiseOperators<double, double, double>.operator ^(double left, double right) { throw null; }
         static double System.Numerics.IBitwiseOperators<double, double, double>.operator ~(double value) { throw null; }
-        static double System.Numerics.IDecrementOperators<double>.operator checked --(double value) { throw null; }
         static double System.Numerics.IDecrementOperators<double>.operator --(double value) { throw null; }
-        static double System.Numerics.IDivisionOperators<double, double, double>.operator checked /(double left, double right) { throw null; }
         static double System.Numerics.IDivisionOperators<double, double, double>.operator /(double left, double right) { throw null; }
         int System.Numerics.IFloatingPoint<double>.GetExponentByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<double>.GetExponentShortestBitLength() { throw null; }
@@ -2248,10 +2228,8 @@ namespace System
         bool System.Numerics.IFloatingPoint<double>.TryWriteExponentLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IFloatingPoint<double>.TryWriteSignificandBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IFloatingPoint<double>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
-        static double System.Numerics.IIncrementOperators<double>.operator checked ++(double value) { throw null; }
         static double System.Numerics.IIncrementOperators<double>.operator ++(double value) { throw null; }
         static double System.Numerics.IModulusOperators<double, double, double>.operator %(double left, double right) { throw null; }
-        static double System.Numerics.IMultiplyOperators<double, double, double>.operator checked *(double left, double right) { throw null; }
         static double System.Numerics.IMultiplyOperators<double, double, double>.operator *(double left, double right) { throw null; }
         static bool System.Numerics.INumberBase<double>.IsCanonical(double value) { throw null; }
         static bool System.Numerics.INumberBase<double>.IsComplexNumber(double value) { throw null; }
@@ -2263,9 +2241,7 @@ namespace System
         static bool System.Numerics.INumberBase<double>.TryConvertToChecked<TOther>(double value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
         static bool System.Numerics.INumberBase<double>.TryConvertToSaturating<TOther>(double value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
         static bool System.Numerics.INumberBase<double>.TryConvertToTruncating<TOther>(double value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
-        static double System.Numerics.ISubtractionOperators<double, double, double>.operator checked -(double left, double right) { throw null; }
         static double System.Numerics.ISubtractionOperators<double, double, double>.operator -(double left, double right) { throw null; }
-        static double System.Numerics.IUnaryNegationOperators<double, double>.operator checked -(double value) { throw null; }
         static double System.Numerics.IUnaryNegationOperators<double, double>.operator -(double value) { throw null; }
         static double System.Numerics.IUnaryPlusOperators<double, double>.operator +(double value) { throw null; }
         public static double Tan(double x) { throw null; }
@@ -2911,13 +2887,10 @@ namespace System
         public static (System.Half Sin, System.Half Cos) SinCos(System.Half x) { throw null; }
         public static System.Half Sinh(System.Half x) { throw null; }
         public static System.Half Sqrt(System.Half x) { throw null; }
-        static System.Half System.Numerics.IAdditionOperators<System.Half, System.Half, System.Half>.operator checked +(System.Half left, System.Half right) { throw null; }
         static System.Half System.Numerics.IBitwiseOperators<System.Half, System.Half, System.Half>.operator &(System.Half left, System.Half right) { throw null; }
         static System.Half System.Numerics.IBitwiseOperators<System.Half, System.Half, System.Half>.operator |(System.Half left, System.Half right) { throw null; }
         static System.Half System.Numerics.IBitwiseOperators<System.Half, System.Half, System.Half>.operator ^(System.Half left, System.Half right) { throw null; }
         static System.Half System.Numerics.IBitwiseOperators<System.Half, System.Half, System.Half>.operator ~(System.Half value) { throw null; }
-        static System.Half System.Numerics.IDecrementOperators<System.Half>.operator checked --(System.Half value) { throw null; }
-        static System.Half System.Numerics.IDivisionOperators<System.Half, System.Half, System.Half>.operator checked /(System.Half left, System.Half right) { throw null; }
         int System.Numerics.IFloatingPoint<System.Half>.GetExponentByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<System.Half>.GetExponentShortestBitLength() { throw null; }
         int System.Numerics.IFloatingPoint<System.Half>.GetSignificandBitLength() { throw null; }
@@ -2926,8 +2899,6 @@ namespace System
         bool System.Numerics.IFloatingPoint<System.Half>.TryWriteExponentLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IFloatingPoint<System.Half>.TryWriteSignificandBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IFloatingPoint<System.Half>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
-        static System.Half System.Numerics.IIncrementOperators<System.Half>.operator checked ++(System.Half value) { throw null; }
-        static System.Half System.Numerics.IMultiplyOperators<System.Half, System.Half, System.Half>.operator checked *(System.Half left, System.Half right) { throw null; }
         static bool System.Numerics.INumberBase<System.Half>.IsCanonical(System.Half value) { throw null; }
         static bool System.Numerics.INumberBase<System.Half>.IsComplexNumber(System.Half value) { throw null; }
         static bool System.Numerics.INumberBase<System.Half>.IsImaginaryNumber(System.Half value) { throw null; }
@@ -2938,8 +2909,6 @@ namespace System
         static bool System.Numerics.INumberBase<System.Half>.TryConvertToChecked<TOther>(System.Half value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
         static bool System.Numerics.INumberBase<System.Half>.TryConvertToSaturating<TOther>(System.Half value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
         static bool System.Numerics.INumberBase<System.Half>.TryConvertToTruncating<TOther>(System.Half value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
-        static System.Half System.Numerics.ISubtractionOperators<System.Half, System.Half, System.Half>.operator checked -(System.Half left, System.Half right) { throw null; }
-        static System.Half System.Numerics.IUnaryNegationOperators<System.Half, System.Half>.operator checked -(System.Half value) { throw null; }
         public static System.Half Tan(System.Half x) { throw null; }
         public static System.Half Tanh(System.Half x) { throw null; }
         public override string ToString() { throw null; }
@@ -3138,7 +3107,7 @@ namespace System
         public static explicit operator checked System.UInt128 (System.Int128 value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static explicit operator checked nuint (System.Int128 value) { throw null; }
-        public static explicit operator checked System.Int128(float value) { throw null; }
+        public static explicit operator checked System.Int128 (float value) { throw null; }
         public static System.Int128 operator checked ++(System.Int128 value) { throw null; }
         public static System.Int128 operator checked *(System.Int128 left, System.Int128 right) { throw null; }
         public static System.Int128 operator checked -(System.Int128 left, System.Int128 right) { throw null; }
@@ -3328,7 +3297,6 @@ namespace System
         static bool System.Numerics.IComparisonOperators<short, short>.operator <=(short left, short right) { throw null; }
         static short System.Numerics.IDecrementOperators<short>.operator checked --(short value) { throw null; }
         static short System.Numerics.IDecrementOperators<short>.operator --(short value) { throw null; }
-        static short System.Numerics.IDivisionOperators<short, short, short>.operator checked /(short left, short right) { throw null; }
         static short System.Numerics.IDivisionOperators<short, short, short>.operator /(short left, short right) { throw null; }
         static bool System.Numerics.IEqualityOperators<short, short>.operator ==(short left, short right) { throw null; }
         static bool System.Numerics.IEqualityOperators<short, short>.operator !=(short left, short right) { throw null; }
@@ -3456,7 +3424,6 @@ namespace System
         static bool System.Numerics.IComparisonOperators<int, int>.operator <=(int left, int right) { throw null; }
         static int System.Numerics.IDecrementOperators<int>.operator checked --(int value) { throw null; }
         static int System.Numerics.IDecrementOperators<int>.operator --(int value) { throw null; }
-        static int System.Numerics.IDivisionOperators<int, int, int>.operator checked /(int left, int right) { throw null; }
         static int System.Numerics.IDivisionOperators<int, int, int>.operator /(int left, int right) { throw null; }
         static bool System.Numerics.IEqualityOperators<int, int>.operator ==(int left, int right) { throw null; }
         static bool System.Numerics.IEqualityOperators<int, int>.operator !=(int left, int right) { throw null; }
@@ -3584,7 +3551,6 @@ namespace System
         static bool System.Numerics.IComparisonOperators<long, long>.operator <=(long left, long right) { throw null; }
         static long System.Numerics.IDecrementOperators<long>.operator checked --(long value) { throw null; }
         static long System.Numerics.IDecrementOperators<long>.operator --(long value) { throw null; }
-        static long System.Numerics.IDivisionOperators<long, long, long>.operator checked /(long left, long right) { throw null; }
         static long System.Numerics.IDivisionOperators<long, long, long>.operator /(long left, long right) { throw null; }
         static bool System.Numerics.IEqualityOperators<long, long>.operator ==(long left, long right) { throw null; }
         static bool System.Numerics.IEqualityOperators<long, long>.operator !=(long left, long right) { throw null; }
@@ -3716,7 +3682,6 @@ namespace System
         static bool System.Numerics.IComparisonOperators<nint, nint>.operator <=(nint left, nint right) { throw null; }
         static nint System.Numerics.IDecrementOperators<nint>.operator checked --(nint value) { throw null; }
         static nint System.Numerics.IDecrementOperators<nint>.operator --(nint value) { throw null; }
-        static nint System.Numerics.IDivisionOperators<nint, nint, nint>.operator checked /(nint left, nint right) { throw null; }
         static nint System.Numerics.IDivisionOperators<nint, nint, nint>.operator /(nint left, nint right) { throw null; }
         static nint System.Numerics.IIncrementOperators<nint>.operator checked ++(nint value) { throw null; }
         static nint System.Numerics.IIncrementOperators<nint>.operator ++(nint value) { throw null; }
@@ -4652,7 +4617,6 @@ namespace System
         static bool System.Numerics.IComparisonOperators<sbyte, sbyte>.operator <=(sbyte left, sbyte right) { throw null; }
         static sbyte System.Numerics.IDecrementOperators<sbyte>.operator checked --(sbyte value) { throw null; }
         static sbyte System.Numerics.IDecrementOperators<sbyte>.operator --(sbyte value) { throw null; }
-        static sbyte System.Numerics.IDivisionOperators<sbyte, sbyte, sbyte>.operator checked /(sbyte left, sbyte right) { throw null; }
         static sbyte System.Numerics.IDivisionOperators<sbyte, sbyte, sbyte>.operator /(sbyte left, sbyte right) { throw null; }
         static bool System.Numerics.IEqualityOperators<sbyte, sbyte>.operator ==(sbyte left, sbyte right) { throw null; }
         static bool System.Numerics.IEqualityOperators<sbyte, sbyte>.operator !=(sbyte left, sbyte right) { throw null; }
@@ -4841,14 +4805,11 @@ namespace System
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
         static float System.Numerics.IAdditionOperators<float, float, float>.operator +(float left, float right) { throw null; }
-        static float System.Numerics.IAdditionOperators<float, float, float>.operator checked +(float left, float right) { throw null; }
         static float System.Numerics.IBitwiseOperators<float, float, float>.operator &(float left, float right) { throw null; }
         static float System.Numerics.IBitwiseOperators<float, float, float>.operator |(float left, float right) { throw null; }
         static float System.Numerics.IBitwiseOperators<float, float, float>.operator ^(float left, float right) { throw null; }
         static float System.Numerics.IBitwiseOperators<float, float, float>.operator ~(float value) { throw null; }
-        static float System.Numerics.IDecrementOperators<float>.operator checked --(float value) { throw null; }
         static float System.Numerics.IDecrementOperators<float>.operator --(float value) { throw null; }
-        static float System.Numerics.IDivisionOperators<float, float, float>.operator checked /(float left, float right) { throw null; }
         static float System.Numerics.IDivisionOperators<float, float, float>.operator /(float left, float right) { throw null; }
         int System.Numerics.IFloatingPoint<float>.GetExponentByteCount() { throw null; }
         int System.Numerics.IFloatingPoint<float>.GetExponentShortestBitLength() { throw null; }
@@ -4858,10 +4819,8 @@ namespace System
         bool System.Numerics.IFloatingPoint<float>.TryWriteExponentLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IFloatingPoint<float>.TryWriteSignificandBigEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
         bool System.Numerics.IFloatingPoint<float>.TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
-        static float System.Numerics.IIncrementOperators<float>.operator checked ++(float value) { throw null; }
         static float System.Numerics.IIncrementOperators<float>.operator ++(float value) { throw null; }
         static float System.Numerics.IModulusOperators<float, float, float>.operator %(float left, float right) { throw null; }
-        static float System.Numerics.IMultiplyOperators<float, float, float>.operator checked *(float left, float right) { throw null; }
         static float System.Numerics.IMultiplyOperators<float, float, float>.operator *(float left, float right) { throw null; }
         static bool System.Numerics.INumberBase<float>.IsCanonical(float value) { throw null; }
         static bool System.Numerics.INumberBase<float>.IsComplexNumber(float value) { throw null; }
@@ -4873,9 +4832,7 @@ namespace System
         static bool System.Numerics.INumberBase<float>.TryConvertToChecked<TOther>(float value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
         static bool System.Numerics.INumberBase<float>.TryConvertToSaturating<TOther>(float value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
         static bool System.Numerics.INumberBase<float>.TryConvertToTruncating<TOther>(float value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TOther result) { throw null; }
-        static float System.Numerics.ISubtractionOperators<float, float, float>.operator checked -(float left, float right) { throw null; }
         static float System.Numerics.ISubtractionOperators<float, float, float>.operator -(float left, float right) { throw null; }
-        static float System.Numerics.IUnaryNegationOperators<float, float>.operator checked -(float value) { throw null; }
         static float System.Numerics.IUnaryNegationOperators<float, float>.operator -(float value) { throw null; }
         static float System.Numerics.IUnaryPlusOperators<float, float>.operator +(float value) { throw null; }
         public static float Tan(float x) { throw null; }
@@ -6308,7 +6265,6 @@ namespace System
         static bool System.Numerics.IComparisonOperators<ushort, ushort>.operator <=(ushort left, ushort right) { throw null; }
         static ushort System.Numerics.IDecrementOperators<ushort>.operator checked --(ushort value) { throw null; }
         static ushort System.Numerics.IDecrementOperators<ushort>.operator --(ushort value) { throw null; }
-        static ushort System.Numerics.IDivisionOperators<ushort, ushort, ushort>.operator checked /(ushort left, ushort right) { throw null; }
         static ushort System.Numerics.IDivisionOperators<ushort, ushort, ushort>.operator /(ushort left, ushort right) { throw null; }
         static bool System.Numerics.IEqualityOperators<ushort, ushort>.operator ==(ushort left, ushort right) { throw null; }
         static bool System.Numerics.IEqualityOperators<ushort, ushort>.operator !=(ushort left, ushort right) { throw null; }
@@ -6436,7 +6392,6 @@ namespace System
         static bool System.Numerics.IComparisonOperators<uint, uint>.operator <=(uint left, uint right) { throw null; }
         static uint System.Numerics.IDecrementOperators<uint>.operator checked --(uint value) { throw null; }
         static uint System.Numerics.IDecrementOperators<uint>.operator --(uint value) { throw null; }
-        static uint System.Numerics.IDivisionOperators<uint, uint, uint>.operator checked /(uint left, uint right) { throw null; }
         static uint System.Numerics.IDivisionOperators<uint, uint, uint>.operator /(uint left, uint right) { throw null; }
         static bool System.Numerics.IEqualityOperators<uint, uint>.operator ==(uint left, uint right) { throw null; }
         static bool System.Numerics.IEqualityOperators<uint, uint>.operator !=(uint left, uint right) { throw null; }
@@ -6564,7 +6519,6 @@ namespace System
         static bool System.Numerics.IComparisonOperators<ulong, ulong>.operator <=(ulong left, ulong right) { throw null; }
         static ulong System.Numerics.IDecrementOperators<ulong>.operator checked --(ulong value) { throw null; }
         static ulong System.Numerics.IDecrementOperators<ulong>.operator --(ulong value) { throw null; }
-        static ulong System.Numerics.IDivisionOperators<ulong, ulong, ulong>.operator checked /(ulong left, ulong right) { throw null; }
         static ulong System.Numerics.IDivisionOperators<ulong, ulong, ulong>.operator /(ulong left, ulong right) { throw null; }
         static bool System.Numerics.IEqualityOperators<ulong, ulong>.operator ==(ulong left, ulong right) { throw null; }
         static bool System.Numerics.IEqualityOperators<ulong, ulong>.operator !=(ulong left, ulong right) { throw null; }
@@ -6626,7 +6580,7 @@ namespace System
     [System.CLSCompliantAttribute(false)]
     public readonly partial struct UIntPtr : System.IComparable, System.IComparable<nuint>, System.IEquatable<nuint>, System.IFormattable, System.IParsable<nuint>, System.ISpanFormattable, System.ISpanParsable<nuint>, System.Numerics.IAdditionOperators<nuint, nuint, nuint>, System.Numerics.IAdditiveIdentity<nuint, nuint>, System.Numerics.IBinaryInteger<nuint>, System.Numerics.IBinaryNumber<nuint>, System.Numerics.IBitwiseOperators<nuint, nuint, nuint>, System.Numerics.IComparisonOperators<nuint, nuint>, System.Numerics.IDecrementOperators<nuint>, System.Numerics.IDivisionOperators<nuint, nuint, nuint>, System.Numerics.IEqualityOperators<nuint, nuint>, System.Numerics.IIncrementOperators<nuint>, System.Numerics.IMinMaxValue<nuint>, System.Numerics.IModulusOperators<nuint, nuint, nuint>, System.Numerics.IMultiplicativeIdentity<nuint, nuint>, System.Numerics.IMultiplyOperators<nuint, nuint, nuint>, System.Numerics.INumber<nuint>, System.Numerics.INumberBase<nuint>, System.Numerics.IShiftOperators<nuint, nuint>, System.Numerics.ISubtractionOperators<nuint, nuint, nuint>, System.Numerics.IUnaryNegationOperators<nuint, nuint>, System.Numerics.IUnaryPlusOperators<nuint, nuint>, System.Numerics.IUnsignedNumber<nuint>, System.Runtime.Serialization.ISerializable
     {
-        private readonly unsafe void*_dummyPrimitive;
+        private readonly unsafe void* _dummyPrimitive;
         public static readonly nuint Zero;
         public UIntPtr(uint value) { throw null; }
         public UIntPtr(ulong value) { throw null; }
@@ -6693,7 +6647,6 @@ namespace System
         static bool System.Numerics.IComparisonOperators<nuint, nuint>.operator <=(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.IDecrementOperators<nuint>.operator checked --(nuint value) { throw null; }
         static nuint System.Numerics.IDecrementOperators<nuint>.operator --(nuint value) { throw null; }
-        static nuint System.Numerics.IDivisionOperators<nuint, nuint, nuint>.operator checked /(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.IDivisionOperators<nuint, nuint, nuint>.operator /(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.IIncrementOperators<nuint>.operator checked ++(nuint value) { throw null; }
         static nuint System.Numerics.IIncrementOperators<nuint>.operator ++(nuint value) { throw null; }
@@ -10286,12 +10239,12 @@ namespace System.Numerics
     public static partial class BitOperations
     {
         public static bool IsPow2(int value) { throw null; }
+        public static bool IsPow2(long value) { throw null; }
+        public static bool IsPow2(nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static bool IsPow2(uint value) { throw null; }
-        public static bool IsPow2(long value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static bool IsPow2(ulong value) { throw null; }
-        public static bool IsPow2(nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static bool IsPow2(nuint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -10332,18 +10285,18 @@ namespace System.Numerics
         public static nuint RoundUpToPowerOf2(nuint value) { throw null; }
         public static int TrailingZeroCount(int value) { throw null; }
         public static int TrailingZeroCount(long value) { throw null; }
+        public static int TrailingZeroCount(nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static int TrailingZeroCount(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static int TrailingZeroCount(ulong value) { throw null; }
-        public static int TrailingZeroCount(nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static int TrailingZeroCount(nuint value) { throw null; }
     }
     public partial interface IAdditionOperators<TSelf, TOther, TResult> where TSelf : System.Numerics.IAdditionOperators<TSelf, TOther, TResult>
     {
         static abstract TResult operator +(TSelf left, TOther right);
-        static abstract TResult operator checked +(TSelf left, TOther right);
+        static virtual TResult operator checked +(TSelf left, TOther right) { throw null; }
     }
     public partial interface IAdditiveIdentity<TSelf, TResult> where TSelf : System.Numerics.IAdditiveIdentity<TSelf, TResult>
     {
@@ -10354,13 +10307,13 @@ namespace System.Numerics
     }
     public partial interface IBinaryInteger<TSelf> : System.IComparable, System.IComparable<TSelf>, System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IBinaryNumber<TSelf>, System.Numerics.IBitwiseOperators<TSelf, TSelf, TSelf>, System.Numerics.IComparisonOperators<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IModulusOperators<TSelf, TSelf, TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.INumber<TSelf>, System.Numerics.INumberBase<TSelf>, System.Numerics.IShiftOperators<TSelf, TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf> where TSelf : System.Numerics.IBinaryInteger<TSelf>
     {
-        static abstract (TSelf Quotient, TSelf Remainder) DivRem(TSelf left, TSelf right);
+        static virtual (TSelf Quotient, TSelf Remainder) DivRem(TSelf left, TSelf right) { throw null; }
         int GetByteCount();
         int GetShortestBitLength();
-        static abstract TSelf LeadingZeroCount(TSelf value);
+        static virtual TSelf LeadingZeroCount(TSelf value) { throw null; }
         static abstract TSelf PopCount(TSelf value);
-        static abstract TSelf RotateLeft(TSelf value, int rotateAmount);
-        static abstract TSelf RotateRight(TSelf value, int rotateAmount);
+        static virtual TSelf RotateLeft(TSelf value, int rotateAmount) { throw null; }
+        static virtual TSelf RotateRight(TSelf value, int rotateAmount) { throw null; }
         static abstract TSelf TrailingZeroCount(TSelf value);
         bool TryWriteBigEndian(System.Span<byte> destination, out int bytesWritten);
         bool TryWriteLittleEndian(System.Span<byte> destination, out int bytesWritten);
@@ -10392,12 +10345,12 @@ namespace System.Numerics
     }
     public partial interface IDecrementOperators<TSelf> where TSelf : System.Numerics.IDecrementOperators<TSelf>
     {
-        static abstract TSelf operator checked --(TSelf value);
+        static virtual TSelf operator checked --(TSelf value) { throw null; }
         static abstract TSelf operator --(TSelf value);
     }
     public partial interface IDivisionOperators<TSelf, TOther, TResult> where TSelf : System.Numerics.IDivisionOperators<TSelf, TOther, TResult>
     {
-        static abstract TResult operator checked /(TSelf left, TOther right);
+        static virtual TResult operator checked /(TSelf left, TOther right) { throw null; }
         static abstract TResult operator /(TSelf left, TOther right);
     }
     public partial interface IEqualityOperators<TSelf, TOther> : System.IEquatable<TOther> where TSelf : System.Numerics.IEqualityOperators<TSelf, TOther>
@@ -10405,14 +10358,14 @@ namespace System.Numerics
         static abstract bool operator ==(TSelf left, TOther right);
         static abstract bool operator !=(TSelf left, TOther right);
     }
-    public partial interface IExponentialFunctions<TSelf> where TSelf : System.Numerics.IExponentialFunctions<TSelf>
+    public partial interface IExponentialFunctions<TSelf> where TSelf : System.Numerics.IExponentialFunctions<TSelf>, System.Numerics.INumberBase<TSelf>
     {
         static abstract TSelf Exp(TSelf x);
         static abstract TSelf Exp10(TSelf x);
-        static abstract TSelf Exp10M1(TSelf x);
+        static virtual TSelf Exp10M1(TSelf x) { throw null; }
         static abstract TSelf Exp2(TSelf x);
-        static abstract TSelf Exp2M1(TSelf x);
-        static abstract TSelf ExpM1(TSelf x);
+        static virtual TSelf Exp2M1(TSelf x) { throw null; }
+        static virtual TSelf ExpM1(TSelf x) { throw null; }
     }
     public partial interface IFloatingPointIeee754<TSelf> : System.IComparable, System.IComparable<TSelf>, System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IComparisonOperators<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf>, System.Numerics.IExponentialFunctions<TSelf>, System.Numerics.IFloatingPoint<TSelf>, System.Numerics.IHyperbolicFunctions<TSelf>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.ILogarithmicFunctions<TSelf>, System.Numerics.IModulusOperators<TSelf, TSelf, TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.INumber<TSelf>, System.Numerics.INumberBase<TSelf>, System.Numerics.IPowerFunctions<TSelf>, System.Numerics.IRootFunctions<TSelf>, System.Numerics.ISignedNumber<TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.ITrigonometricFunctions<TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf> where TSelf : System.Numerics.IFloatingPointIeee754<TSelf>
     {
@@ -10429,27 +10382,27 @@ namespace System.Numerics
         static abstract TSelf FusedMultiplyAdd(TSelf left, TSelf right, TSelf addend);
         static abstract TSelf Ieee754Remainder(TSelf left, TSelf right);
         static abstract int ILogB(TSelf x);
-        static abstract TSelf ReciprocalEstimate(TSelf x);
-        static abstract TSelf ReciprocalSqrtEstimate(TSelf x);
+        static virtual TSelf ReciprocalEstimate(TSelf x) { throw null; }
+        static virtual TSelf ReciprocalSqrtEstimate(TSelf x) { throw null; }
         static abstract TSelf ScaleB(TSelf x, int n);
     }
     public partial interface IFloatingPoint<TSelf> : System.IComparable, System.IComparable<TSelf>, System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IComparisonOperators<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IModulusOperators<TSelf, TSelf, TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.INumber<TSelf>, System.Numerics.INumberBase<TSelf>, System.Numerics.ISignedNumber<TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf> where TSelf : System.Numerics.IFloatingPoint<TSelf>
     {
-        static abstract TSelf Ceiling(TSelf x);
-        static abstract TSelf Floor(TSelf x);
+        static virtual TSelf Ceiling(TSelf x) { throw null; }
+        static virtual TSelf Floor(TSelf x) { throw null; }
         int GetExponentByteCount();
         int GetExponentShortestBitLength();
-        int GetSignificandByteCount();
         int GetSignificandBitLength();
-        static abstract TSelf Round(TSelf x);
-        static abstract TSelf Round(TSelf x, int digits);
+        int GetSignificandByteCount();
+        static virtual TSelf Round(TSelf x) { throw null; }
+        static virtual TSelf Round(TSelf x, int digits) { throw null; }
         static abstract TSelf Round(TSelf x, int digits, System.MidpointRounding mode);
-        static abstract TSelf Round(TSelf x, System.MidpointRounding mode);
-        static abstract TSelf Truncate(TSelf x);
-        bool TryWriteExponentBigEndian(Span<byte> destination, out int bytesWritten);
-        bool TryWriteExponentLittleEndian(Span<byte> destination, out int bytesWritten);
-        bool TryWriteSignificandBigEndian(Span<byte> destination, out int bytesWritten);
-        bool TryWriteSignificandLittleEndian(Span<byte> destination, out int bytesWritten);
+        static virtual TSelf Round(TSelf x, System.MidpointRounding mode) { throw null; }
+        static virtual TSelf Truncate(TSelf x) { throw null; }
+        bool TryWriteExponentBigEndian(System.Span<byte> destination, out int bytesWritten);
+        bool TryWriteExponentLittleEndian(System.Span<byte> destination, out int bytesWritten);
+        bool TryWriteSignificandBigEndian(System.Span<byte> destination, out int bytesWritten);
+        bool TryWriteSignificandLittleEndian(System.Span<byte> destination, out int bytesWritten);
         int WriteExponentBigEndian(byte[] destination) { throw null; }
         int WriteExponentBigEndian(byte[] destination, int startIndex) { throw null; }
         int WriteExponentBigEndian(System.Span<byte> destination) { throw null; }
@@ -10463,7 +10416,7 @@ namespace System.Numerics
         int WriteSignificandLittleEndian(byte[] destination, int startIndex) { throw null; }
         int WriteSignificandLittleEndian(System.Span<byte> destination) { throw null; }
     }
-    public partial interface IHyperbolicFunctions<TSelf> where TSelf : System.Numerics.IHyperbolicFunctions<TSelf>
+    public partial interface IHyperbolicFunctions<TSelf> where TSelf : System.Numerics.IHyperbolicFunctions<TSelf>, System.Numerics.INumberBase<TSelf>
     {
         static abstract TSelf Acosh(TSelf x);
         static abstract TSelf Asinh(TSelf x);
@@ -10474,18 +10427,18 @@ namespace System.Numerics
     }
     public partial interface IIncrementOperators<TSelf> where TSelf : System.Numerics.IIncrementOperators<TSelf>
     {
-        static abstract TSelf operator checked ++(TSelf value);
+        static virtual TSelf operator checked ++(TSelf value) { throw null; }
         static abstract TSelf operator ++(TSelf value);
     }
-    public partial interface ILogarithmicFunctions<TSelf> where TSelf : System.Numerics.ILogarithmicFunctions<TSelf>
+    public partial interface ILogarithmicFunctions<TSelf> where TSelf : System.Numerics.ILogarithmicFunctions<TSelf>, System.Numerics.INumberBase<TSelf>
     {
         static abstract TSelf Log(TSelf x);
         static abstract TSelf Log(TSelf x, TSelf newBase);
         static abstract TSelf Log10(TSelf x);
-        static abstract TSelf Log10P1(TSelf x);
+        static virtual TSelf Log10P1(TSelf x) { throw null; }
         static abstract TSelf Log2(TSelf x);
-        static abstract TSelf Log2P1(TSelf x);
-        static abstract TSelf LogP1(TSelf x);
+        static virtual TSelf Log2P1(TSelf x) { throw null; }
+        static virtual TSelf LogP1(TSelf x) { throw null; }
     }
     public partial interface IMinMaxValue<TSelf> where TSelf : System.Numerics.IMinMaxValue<TSelf>
     {
@@ -10502,7 +10455,7 @@ namespace System.Numerics
     }
     public partial interface IMultiplyOperators<TSelf, TOther, TResult> where TSelf : System.Numerics.IMultiplyOperators<TSelf, TOther, TResult>
     {
-        static abstract TResult operator checked *(TSelf left, TOther right);
+        static virtual TResult operator checked *(TSelf left, TOther right) { throw null; }
         static abstract TResult operator *(TSelf left, TOther right);
     }
     public partial interface INumberBase<TSelf> : System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf> where TSelf : System.Numerics.INumberBase<TSelf>
@@ -10548,19 +10501,19 @@ namespace System.Numerics
     }
     public partial interface INumber<TSelf> : System.IComparable, System.IComparable<TSelf>, System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IComparisonOperators<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IModulusOperators<TSelf, TSelf, TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.INumberBase<TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf> where TSelf : System.Numerics.INumber<TSelf>
     {
-        static abstract TSelf Clamp(TSelf value, TSelf min, TSelf max);
-        static abstract TSelf CopySign(TSelf value, TSelf sign);
-        static abstract TSelf Max(TSelf x, TSelf y);
-        static abstract TSelf MaxNumber(TSelf x, TSelf y);
-        static abstract TSelf Min(TSelf x, TSelf y);
-        static abstract TSelf MinNumber(TSelf x, TSelf y);
-        static abstract int Sign(TSelf value);
+        static virtual TSelf Clamp(TSelf value, TSelf min, TSelf max) { throw null; }
+        static virtual TSelf CopySign(TSelf value, TSelf sign) { throw null; }
+        static virtual TSelf Max(TSelf x, TSelf y) { throw null; }
+        static virtual TSelf MaxNumber(TSelf x, TSelf y) { throw null; }
+        static virtual TSelf Min(TSelf x, TSelf y) { throw null; }
+        static virtual TSelf MinNumber(TSelf x, TSelf y) { throw null; }
+        static virtual int Sign(TSelf value) { throw null; }
     }
-    public partial interface IPowerFunctions<TSelf> where TSelf : System.Numerics.IPowerFunctions<TSelf>
+    public partial interface IPowerFunctions<TSelf> where TSelf : System.Numerics.IPowerFunctions<TSelf>, System.Numerics.INumberBase<TSelf>
     {
         static abstract TSelf Pow(TSelf x, TSelf y);
     }
-    public partial interface IRootFunctions<TSelf> where TSelf : System.Numerics.IRootFunctions<TSelf>
+    public partial interface IRootFunctions<TSelf> where TSelf : System.Numerics.IRootFunctions<TSelf>, System.Numerics.INumberBase<TSelf>
     {
         static abstract TSelf Cbrt(TSelf x);
         static abstract TSelf Sqrt(TSelf x);
@@ -10577,10 +10530,10 @@ namespace System.Numerics
     }
     public partial interface ISubtractionOperators<TSelf, TOther, TResult> where TSelf : System.Numerics.ISubtractionOperators<TSelf, TOther, TResult>
     {
-        static abstract TResult operator checked -(TSelf left, TOther right);
+        static virtual TResult operator checked -(TSelf left, TOther right) { throw null; }
         static abstract TResult operator -(TSelf left, TOther right);
     }
-    public partial interface ITrigonometricFunctions<TSelf> where TSelf : System.Numerics.ITrigonometricFunctions<TSelf>
+    public partial interface ITrigonometricFunctions<TSelf> where TSelf : System.Numerics.ITrigonometricFunctions<TSelf>, System.Numerics.INumberBase<TSelf>
     {
         static abstract TSelf Acos(TSelf x);
         static abstract TSelf Asin(TSelf x);
@@ -10593,7 +10546,7 @@ namespace System.Numerics
     }
     public partial interface IUnaryNegationOperators<TSelf, TResult> where TSelf : System.Numerics.IUnaryNegationOperators<TSelf, TResult>
     {
-        static abstract TResult operator checked -(TSelf value);
+        static virtual TResult operator checked -(TSelf value) { throw null; }
         static abstract TResult operator -(TSelf value);
     }
     public partial interface IUnaryPlusOperators<TSelf, TResult> where TSelf : System.Numerics.IUnaryPlusOperators<TSelf, TResult>


### PR DESCRIPTION
This simplifies the amount of work required for other types to implement the interfaces.

Unfortunately, if you want to both implement the interface and have a member of the corresponding name publicly visible, you cannot currently use the DIM. Because of this, various in-box types can't reduce code duplication. Likewise, there are a few cases where the default implementation does "more" than may be necessary for all types and so for the built-in types we still want an explicit implementation so we can do a more efficient thing.

This does allow some code duplication removal around `operator checked /` and all `checked` operators on the floating-point types.