### PR TITLE
Let low cost tree nodes reach CSE phase

### DIFF
--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -3507,7 +3507,7 @@ bool Compiler::optIsCSEcandidate(GenTree* tree)
     }
 
     /* Don't bother if the potential savings are very low */
-    if (cost < MIN_CSE_COST)
+    if (cost == 0)
     {
         return false;
     }


### PR DESCRIPTION
Placeholder to prototype to check the implications of letting low cost tree nodes reach the CSE phase. Currently, they are avoided before checking their usage/refcounts/weights.