### PR TITLE
[NativeAOT] prevent reentering CreateThreadLocalContentionCountObject

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Monitor.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Monitor.NativeAot.cs
@@ -240,25 +240,13 @@ namespace System.Threading
         {
             Debug.Assert(t_ContentionCountObject == null);
 
-            // we use "s_lockContentionCounter" as a sentinel value to prevent reentrancy.
-            t_ContentionCountObject = s_lockContentionCounter;
-
             object threadLocalContentionCountObject = s_lockContentionCounter.CreateThreadLocalCountObject();
             t_ContentionCountObject = threadLocalContentionCountObject;
             return threadLocalContentionCountObject;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void IncrementLockContentionCount()
-        {
-            // CreateThreadLocalCountObject may indirectly take locks and in rare cases may have contentions.
-            // we use "s_lockContentionCounter" as a sentinel value to prevent re-entering CreateThreadLocalContentionCountObject,
-            // which would otherwise deadlock.
-            if (t_ContentionCountObject != s_lockContentionCounter)
-            {
-                ThreadInt64PersistentCounter.Increment(t_ContentionCountObject ?? CreateThreadLocalContentionCountObject());
-            }
-        }
+        internal static void IncrementLockContentionCount() => ThreadInt64PersistentCounter.Increment(t_ContentionCountObject ?? CreateThreadLocalContentionCountObject());
 
         /// <summary>
         /// Gets the number of times there was contention upon trying to take a <see cref="Monitor"/>'s lock so far.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Monitor.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Monitor.NativeAot.cs
@@ -240,13 +240,25 @@ namespace System.Threading
         {
             Debug.Assert(t_ContentionCountObject == null);
 
+            // we use "s_lockContentionCounter" as a sentinel value to prevent reentrancy.
+            t_ContentionCountObject = s_lockContentionCounter;
+
             object threadLocalContentionCountObject = s_lockContentionCounter.CreateThreadLocalCountObject();
             t_ContentionCountObject = threadLocalContentionCountObject;
             return threadLocalContentionCountObject;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void IncrementLockContentionCount() => ThreadInt64PersistentCounter.Increment(t_ContentionCountObject ?? CreateThreadLocalContentionCountObject());
+        internal static void IncrementLockContentionCount()
+        {
+            // CreateThreadLocalCountObject may indirectly take locks and in rare cases may have contentions.
+            // we use "s_lockContentionCounter" as a sentinel value to prevent re-entering CreateThreadLocalContentionCountObject,
+            // which would otherwise deadlock.
+            if (t_ContentionCountObject != s_lockContentionCounter)
+            {
+                ThreadInt64PersistentCounter.Increment(t_ContentionCountObject ?? CreateThreadLocalContentionCountObject());
+            }
+        }
 
         /// <summary>
         /// Gets the number of times there was contention upon trying to take a <see cref="Monitor"/>'s lock so far.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
@@ -15,7 +15,10 @@ namespace System.Threading
         private static List<ThreadLocalNodeFinalizationHelper>? t_nodeFinalizationHelpers;
 
         private long _overflowCount;
-        private HashSet<ThreadLocalNode> _nodes = new HashSet<ThreadLocalNode>();
+
+        // we pass comparer explicitly so that in NativeAOT case we would not end up
+        // calling into the type system when lock contention increments its counter
+        private HashSet<ThreadLocalNode> _nodes = new HashSet<ThreadLocalNode>(ObjectEqualityComparer<object>.Default);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Increment(object threadLocalCountObject)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/70453