### PR TITLE
Dispose algorithm in SignatureSupport

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/SignatureSupport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/SignatureSupport.cs
@@ -7,50 +7,44 @@ namespace System.Security.Cryptography.Tests
     {
         internal static bool CanProduceSha1Signature(AsymmetricAlgorithm algorithm)
         {
+            using (algorithm)
+            {
 #if NETFRAMEWORK
-            algorithm.Dispose();
-            return true;
-#else
-            // We expect all non-Linux platforms to support SHA1 signatures, currently.
-            if (!OperatingSystem.IsLinux())
-            {
                 return true;
-            }
+#else
+                // We expect all non-Linux platforms to support SHA1 signatures, currently.
+                if (!OperatingSystem.IsLinux())
+                {
+                    return true;
+                }
 
-            switch (algorithm)
-            {
-                case ECDsa ecdsa:
-                    try
-                    {
-                        ecdsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1);
-                        return true;
-                    }
-                    catch (CryptographicException)
-                    {
-                        return false;
-                    }
-                    finally
-                    {
-                        algorithm.Dispose();
-                    }
-                case RSA rsa:
-                    try
-                    {
-                        rsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
-                        return true;
-                    }
-                    catch (CryptographicException)
-                    {
-                        return false;
-                    }
-                    finally
-                    {
-                        algorithm.Dispose();
-                    }
-                default:
-                    throw new NotSupportedException($"Algorithm type {algorithm.GetType()} is not supported.");
-            }
+                switch (algorithm)
+                {
+                    case ECDsa ecdsa:
+                        try
+                        {
+                            ecdsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1);
+                            return true;
+                        }
+                        catch (CryptographicException)
+                        {
+                            return false;
+                        }
+                    case RSA rsa:
+                        try
+                        {
+                            rsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
+                            return true;
+                        }
+                        catch (CryptographicException)
+                        {
+                            return false;
+                        }
+                    default:
+                        throw new NotSupportedException($"Algorithm type {algorithm.GetType()} is not supported.");
+                }
 #endif
+            }
         }
     }
 }


### PR DESCRIPTION
Minor thing I noticed looking back through this. In the `IsLinux` path we were not disposing of the algorithm instance (because this method is assumed to take ownership of the algorithm passed).

So just throw it in a `using` to avoid all of the `Dispose` calls.