### PR TITLE
Bump intellisense version to Preview4

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -166,7 +166,7 @@
     <!--<SdkVersionForWorkloadTesting>7.0.100-preview.3.22151.18</SdkVersionForWorkloadTesting>-->
     <CompilerPlatformTestingVersion>1.1.2-beta1.22205.2</CompilerPlatformTestingVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220429.1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220608.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>7.0.100-1.22306.1</MicrosoftNETILLinkTasksVersion>
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>


### PR DESCRIPTION
The Preview4 docs have been ported and merged: https://github.com/dotnet/dotnet-api-docs/pull/8127

The intellisense CI pipeline result is here: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=297379&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=11e7ea89-affe-5194-cdc6-0171c3394706

The generated package name is `Microsoft.Private.Intellisense.7.0.0-preview-20220608.1.nupkg`.
