### PR TITLE
[wasm] Fail stable jobs if the tests fail, even for `runtime-staging`

### DIFF
--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -8,6 +8,7 @@ parameters:
   platforms: []
   runAOT: false 
   runSmokeOnlyArg: ''
+  shouldContinueOnError: false
 
 jobs:
 
@@ -23,3 +24,4 @@ jobs:
     extraHelixArgs: /p:NeedsToBuildWasmAppsOnHelix=true ${{ parameters.extraHelixArgs }}
     alwaysRun: ${{ parameters.alwaysRun }}
     runSmokeOnlyArg: $(_runSmokeTestsOnlyArg)
+    shouldContinueOnError: ${{ parameters.shouldContinueOnError }}

--- a/eng/pipelines/common/templates/wasm-library-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-tests.yml
@@ -7,6 +7,7 @@ parameters:
   platforms: []
   runSmokeOnlyArg: ''
   scenarios: ['normal']
+  shouldContinueOnError: false
 
 jobs:
 
@@ -20,6 +21,7 @@ jobs:
     buildConfig: Release
     runtimeFlavor: mono
     platforms: ${{ parameters.platforms }}
+    shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -9,13 +9,16 @@ parameters:
   platform: ''
   targetRid: ''
   jobParameters: {}
-  shouldContinueOnError: false
+  shouldContinueOnError: '' # defaults to being true for `runtime-staging` on PRs
   variables: []
 
 jobs:
 - template: ${{ coalesce(parameters.helixQueuesTemplate, parameters.jobTemplate) }}
   parameters:
-    shouldContinueOnError: ${{ or(eq(parameters.shouldContinueOnError, true), and(endsWith(variables['Build.DefinitionName'], 'staging'), eq(variables['Build.Reason'], 'PullRequest'))) }}
+    ${{ if eq(parameters.shouldContinueOnError, '') }}:
+      shouldContinueOnError: ${{ and(endsWith(variables['Build.DefinitionName'], 'staging'), eq(variables['Build.Reason'], 'PullRequest')) }}
+    ${{ if ne(parameters.shouldContinueOnError, '') }}:
+      shouldContinueOnError: ${{ eq(parameters.shouldContinueOnError, true) }}
 
     # keep in sync with /eng/pipelines/common/variables.yml
     dependOnEvaluatePaths: ${{ and(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.DefinitionName'], 'runtime', 'runtime-staging', 'runtime-community', 'runtime-extra-platforms')) }}

--- a/eng/pipelines/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/runtime-extra-platforms-wasm.yml
@@ -60,6 +60,7 @@ jobs:
         - Browser_wasm_win
       # Don't run for rolling builds, as this is covered
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      shouldContinueOnError: false
       scenarios:
         - normal
         - WasmTestOnBrowser
@@ -107,6 +108,7 @@ jobs:
       nameSuffix: _EAT
       runAOT: false
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      shouldContinueOnError: false
 
   # AOT Library tests
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -117,6 +119,7 @@ jobs:
       nameSuffix: _AOT
       runAOT: true
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      shouldContinueOnError: false
 
   # High resource AOT Library tests
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -129,6 +132,7 @@ jobs:
       buildAOTOnHelix: false
       runAOT: true
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      shouldContinueOnError: false
 
   # Wasm.Build.Tests
   - template: /eng/pipelines/common/templates/wasm-build-tests.yml
@@ -137,6 +141,8 @@ jobs:
         - Browser_wasm
         - Browser_wasm_win
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      # override the default for runtime-staging
+      shouldContinueOnError: false
 
   # Debugger tests
   - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
@@ -145,6 +151,8 @@ jobs:
         - Browser_wasm
         - Browser_wasm_win
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      # override the default for runtime-staging
+      shouldContinueOnError: false
 
   - template: /eng/pipelines/common/templates/wasm-runtime-tests.yml
     parameters:


### PR DESCRIPTION
- For `runtime-staging` pipeline running for PRs, we default to not failing the job if the helix tests fail. But this is not always desirable, for example, in case wasm jobs that cannot be moved out of `runtime-staging`, but are stable, and thus test failures should fail the job.

- Also fix the new wasm/threading jobs failing on `runtime-extra-platforms`, and `runtime-wasm` because their tests failed, even though they are known to be unstable right now.