### PR TITLE
fixed a bug in DFA to NFA mode alternative branch generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -2224,17 +2224,11 @@ namespace System.Text.RegularExpressions.Symbolic
                     // The recursive call is to make sure that cases such as ((A|B)C)D are also handled,
                     // because right associative form of concatenations is not always guaranteed
                     Debug.Assert(_left is not null && _right is not null);
-                    foreach (SymbolicRegexNode<TSet> left_alt in _left.EnumerateAlternationBranches())
+                    foreach (SymbolicRegexNode<TSet> branch in _left.EnumerateAlternationBranches())
                     {
-                        if (left_alt == _left)
-                        {
-                            // There were no initial alternatives in this concatenation
-                            yield return this;
-                        }
-                        else
-                        {
-                            yield return CreateConcat(_builder, left_alt, _right);
-                        }
+                        yield return branch == _left ?
+                            this : // no initial alternation
+                            CreateConcat(_builder, branch, _right);
                     }
                     break;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -2219,10 +2219,10 @@ namespace System.Text.RegularExpressions.Symbolic
                     break;
 
                 case SymbolicRegexNodeKind.Concat:
-                    // Extract possible alternations present in the initial element of the concatenation
-                    // Typical case would be that (A|B)C is treated the same as (AC|BC)
+                    // Extract possible alternations present in the initial element of the concatenation.
+                    // Typical case would be that (A|B)C is treated the same as (AC|BC).
                     // The recursive call is to make sure that cases such as ((A|B)C)D are also handled,
-                    // because right associative form of concatenations is not always guaranteed
+                    // because a right associative form of concatenations is not always guaranteed.
                     Debug.Assert(_left is not null && _right is not null);
                     foreach (SymbolicRegexNode<TSet> branch in _left.EnumerateAlternationBranches())
                     {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -2181,7 +2181,6 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <returns>an enumeration of the elements of the alternation, or just the node itself if there is no alternation</returns>
         internal IEnumerable<SymbolicRegexNode<TSet>> EnumerateAlternationBranches()
         {
-            // Guard against stack overflow due to deep recursion, that should not arise in any normal situation
             if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 foreach (SymbolicRegexNode<TSet> elem in StackHelper.CallOnEmptyStack(EnumerateAlternationBranches))

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/SymbolicRegexTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/SymbolicRegexTests.cs
@@ -81,7 +81,7 @@ namespace System.Text.RegularExpressions.Tests
                 ("(a{2147483647,})", 2),
                 // typical case that blows up the DFA size to 2^100 when .* is added at the beginnig (below)
                 ("a.{100}b", 103),
-                // these patterns are regression tests to make sure that right concatenations are propagated over alternations
+                // make sure that right concatenations are propagated over alternations
                 ("a.{10}|bb", 14),
                 ("(a.{10}|bb)c", 15),
                 ("((a.{10}|bb)c)d", 16),


### PR DESCRIPTION
Added a missing case to `SymbolicRegexNode.EnumerateAlternationBranches` that is responsible for propagating right concatenations over left alternations: in situations when a derivative looks like `(A|B)C` exposing the top level alternatives `AC` and `BC` as separate NFA states. Otherwise, not all top-level alternations were discovered in NFA mode which then fell back partially into DFA mode for those cases. Found this bug when I wanted to add more unit tests to the safe size limit calculation, in order to more comprehensively cover all constructs -- that should be the case now.  I added more unit test patterns into the `SafeThresholdTests` test that would have failed prior to this change.

In that context also ended up calling into `SymbolicRegexNode.EnumerateAlternationBranches` that was prior to this PR reimplemented in the unit test class itself, and thus now covers this behavior more accurately also.

Also updated `Singleton` nodes when `IsNothing` holds to contribute 0 NFA states, in that sense made the NFA state count limit even more strict.