### PR TITLE
remove extra GC.SuppressFinalize from SslStream

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -119,7 +119,6 @@ namespace System.Net.Security
 
             _securityContext?.Dispose();
             _credentialsHandle?.Dispose();
-            GC.SuppressFinalize(this);
         }
 
         //


### PR DESCRIPTION
This was missed in #68678. This used to be separate class (`SecureChannel`) but now it is part of `SslStream` and there is separate logic in `CloseInternal` to deal with suppression.