### PR TITLE
Disable UnixDomainSocketTest.FilePathEquality test on tvOS and iOS

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
@@ -534,6 +534,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [ConditionalFact(nameof(PlatformSupportsUnixDomainSockets))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51392", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void FilePathEquality()
         {
             string path1 = "relative" + Path.DirectorySeparatorChar + "path";


### PR DESCRIPTION
Fixes #70468.

Related to #51392.

`GetRandomNonExistingFilePath` produces too long paths which cause UnixDomainSocketTest.FilePathEquality to fail on iOS and tvOS platforms., probably the reason why other tests that use the method are disabled on these platforms.

I used the same issue url as the other ActiveIssue attributes in the file.