### PR TITLE
make SslStream_UnifiedHello_Ok test conditional

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -1019,7 +1019,7 @@ namespace System.Net.Security.Tests
 
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls10))]
         [InlineData(true)]
         [InlineData(false)]
         [PlatformSpecific(TestPlatforms.Windows)]


### PR DESCRIPTION
The unified  test frame uses Tls 1.0 and it will fail if not supported by the server.  

fixes #70470