### PR TITLE
Modify thread pool thread counting to be a bit more defensive

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.ThreadCounts.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.ThreadCounts.cs
@@ -31,28 +31,17 @@ namespace System.Threading
             /// </summary>
             public short NumProcessingWork
             {
-                get => GetInt16Value(NumProcessingWorkShift);
+                get
+                {
+                    short value = GetInt16Value(NumProcessingWorkShift);
+                    Debug.Assert(value >= 0);
+                    return value;
+                }
                 set
                 {
                     Debug.Assert(value >= 0);
-                    SetInt16Value(value, NumProcessingWorkShift);
+                    SetInt16Value(Math.Max((short)0, value), NumProcessingWorkShift);
                 }
-            }
-
-            public void SubtractNumProcessingWork(short value)
-            {
-                Debug.Assert(value >= 0);
-                Debug.Assert(value <= NumProcessingWork);
-
-                _data -= (ulong)(ushort)value << NumProcessingWorkShift;
-            }
-
-            public void InterlockedDecrementNumProcessingWork()
-            {
-                Debug.Assert(NumProcessingWorkShift == 0);
-
-                ThreadCounts counts = new ThreadCounts(Interlocked.Decrement(ref _data));
-                Debug.Assert(counts.NumProcessingWork >= 0);
             }
 
             /// <summary>
@@ -60,20 +49,17 @@ namespace System.Threading
             /// </summary>
             public short NumExistingThreads
             {
-                get => GetInt16Value(NumExistingThreadsShift);
+                get
+                {
+                    short value = GetInt16Value(NumExistingThreadsShift);
+                    Debug.Assert(value >= 0);
+                    return value;
+                }
                 set
                 {
                     Debug.Assert(value >= 0);
-                    SetInt16Value(value, NumExistingThreadsShift);
+                    SetInt16Value(Math.Max((short)0, value), NumExistingThreadsShift);
                 }
-            }
-
-            public void SubtractNumExistingThreads(short value)
-            {
-                Debug.Assert(value >= 0);
-                Debug.Assert(value <= NumExistingThreads);
-
-                _data -= (ulong)(ushort)value << NumExistingThreadsShift;
             }
 
             /// <summary>
@@ -81,11 +67,16 @@ namespace System.Threading
             /// </summary>
             public short NumThreadsGoal
             {
-                get => GetInt16Value(NumThreadsGoalShift);
+                get
+                {
+                    short value = GetInt16Value(NumThreadsGoalShift);
+                    Debug.Assert(value > 0);
+                    return value;
+                }
                 set
                 {
                     Debug.Assert(value > 0);
-                    SetInt16Value(value, NumThreadsGoalShift);
+                    SetInt16Value(Math.Max((short)1, value), NumThreadsGoalShift);
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -128,16 +128,14 @@ namespace System.Threading
                             // Since this thread is currently registered as an existing thread, if more work comes in meanwhile,
                             // this thread would be expected to satisfy the new work. Ensure that NumExistingThreads is not
                             // decreased below NumProcessingWork, as that would be indicative of such a case.
-                            short numExistingThreads = counts.NumExistingThreads;
-                            if (numExistingThreads <= counts.NumProcessingWork)
+                            if (counts.NumExistingThreads <= counts.NumProcessingWork)
                             {
                                 // In this case, enough work came in that this thread should not time out and should go back to work.
                                 break;
                             }
 
                             ThreadCounts newCounts = counts;
-                            newCounts.SubtractNumExistingThreads(1);
-                            short newNumExistingThreads = (short)(numExistingThreads - 1);
+                            short newNumExistingThreads = --newCounts.NumExistingThreads;
                             short newNumThreadsGoal =
                                 Math.Max(
                                     threadPoolInstance.MinThreadsGoal,
@@ -173,7 +171,21 @@ namespace System.Threading
             /// </summary>
             private static void RemoveWorkingWorker(PortableThreadPool threadPoolInstance)
             {
-                threadPoolInstance._separated.counts.InterlockedDecrementNumProcessingWork();
+                ThreadCounts counts = threadPoolInstance._separated.counts;
+                while (true)
+                {
+                    ThreadCounts newCounts = counts;
+                    newCounts.NumProcessingWork--;
+
+                    ThreadCounts countsBeforeUpdate =
+                        threadPoolInstance._separated.counts.InterlockedCompareExchange(newCounts, counts);
+                    if (countsBeforeUpdate == counts)
+                    {
+                        break;
+                    }
+
+                    counts = countsBeforeUpdate;
+                }
 
                 // It's possible that we decided we had thread requests just before a request came in,
                 // but reduced the worker count *after* the request came in.  In this case, we might
@@ -235,8 +247,8 @@ namespace System.Threading
                     while (true)
                     {
                         ThreadCounts newCounts = counts;
-                        newCounts.SubtractNumProcessingWork((short)toCreate);
-                        newCounts.SubtractNumExistingThreads((short)toCreate);
+                        newCounts.NumProcessingWork -= (short)toCreate;
+                        newCounts.NumExistingThreads -= (short)toCreate;
 
                         ThreadCounts oldCounts = threadPoolInstance._separated.counts.InterlockedCompareExchange(newCounts, counts);
                         if (oldCounts == counts)
@@ -273,7 +285,7 @@ namespace System.Threading
                     }
 
                     ThreadCounts newCounts = counts;
-                    newCounts.SubtractNumProcessingWork(1);
+                    newCounts.NumProcessingWork--;
 
                     ThreadCounts oldCounts = threadPoolInstance._separated.counts.InterlockedCompareExchange(newCounts, counts);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -171,6 +171,8 @@ namespace System.Threading
             /// </summary>
             private static void RemoveWorkingWorker(PortableThreadPool threadPoolInstance)
             {
+                // A compare-exchange loop is used instead of Interlocked.Decrement or Interlocked.Add to defensively prevent
+                // NumProcessingWork from underflowing. See the setter for NumProcessingWork.
                 ThreadCounts counts = threadPoolInstance._separated.counts;
                 while (true)
                 {


### PR DESCRIPTION
- An unexpected underflow in one or more thread counts can lead to a large number of threads to be created continually
- Prevented underflows in changes to thread counts, such that following an unexpected underflow, subsequent paired increments and decrements would avoid repeating the underflow
- Verified by creating an unexpected underflow in the debugger