### PR TITLE
[Android] Fix failing LocalTzIsNotUtc test

### DIFF
--- a/eng/pipelines/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/runtime-extra-platforms-other.yml
@@ -197,7 +197,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true $(_runSmokeTestsOnlyArg) /p:BuildTestsOnHelix=true /p:UsePortableRuntimePack=true /p:BuildDarwinFrameworks=true
+      buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true $(_runSmokeTestsOnlyArg) /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=true /p:BuildDarwinFrameworks=true
       timeoutInMinutes: 180
       condition: >-
         or(
@@ -361,7 +361,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg)
+      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg) /p:EnableAdditionalTimezoneChecks=true
       timeoutInMinutes: 180
       condition: >-
         or(

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -433,7 +433,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:BuildTestsOnHelix=true /p:UsePortableRuntimePack=true /p:BuildDarwinFrameworks=true
+      buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=true /p:BuildDarwinFrameworks=true
       timeoutInMinutes: 180
       condition: >-
         or(

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetsDevices Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS' or ('$(TargetOS)' == 'Android' and '$(TargetArchitecture)' == 'arm64')">true</TargetsDevices>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <RunAOTCompilation Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">true</RunAOTCompilation>
   </PropertyGroup>
 
@@ -53,12 +49,6 @@
     <!-- Pass the -m or -c flag along to the app bundle, note that due to the double hyphen this needs to be the last argument -->
     <AdditionalXHarnessArguments Condition="'$(XUnitMethodName)' != ''">$(AdditionalXHarnessArguments) -- -m=$(XUnitMethodName)</AdditionalXHarnessArguments>
     <AdditionalXHarnessArguments Condition="'$(XUnitClassName)' != ''">$(AdditionalXHarnessArguments) -- -c=$(XUnitClassName)</AdditionalXHarnessArguments>
-  </PropertyGroup>
-
-  <!-- Add special trait to run local timezone validation test on devices -->
-  <PropertyGroup>
-    <_withCategories Condition="'$(TargetsDevices)' == 'true'">$(_withCategories);ValidTimeZone</_withCategories>
-    <_withoutCategories Condition="'$(TargetsDevices)' != 'true'">$(_withoutCategories);ValidTimeZone</_withoutCategories>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(XUnitUseRandomizedTestOrderer)' == 'true'">

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <TargetsDevices Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS' or ('$(TargetOS)' == 'Android' and '$(TargetArchitecture)' == 'arm64')">true</TargetsDevices>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <RunAOTCompilation Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">true</RunAOTCompilation>
   </PropertyGroup>
 
@@ -49,6 +53,12 @@
     <!-- Pass the -m or -c flag along to the app bundle, note that due to the double hyphen this needs to be the last argument -->
     <AdditionalXHarnessArguments Condition="'$(XUnitMethodName)' != ''">$(AdditionalXHarnessArguments) -- -m=$(XUnitMethodName)</AdditionalXHarnessArguments>
     <AdditionalXHarnessArguments Condition="'$(XUnitClassName)' != ''">$(AdditionalXHarnessArguments) -- -c=$(XUnitClassName)</AdditionalXHarnessArguments>
+  </PropertyGroup>
+
+  <!-- Add special trait to run local timezone validation test on devices -->
+  <PropertyGroup>
+    <_withCategories Condition="'$(TargetsDevices)' == 'true'">$(_withCategories);ValidTimeZone</_withCategories>
+    <_withoutCategories Condition="'$(TargetsDevices)' != 'true'">$(_withoutCategories);ValidTimeZone</_withoutCategories>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(XUnitUseRandomizedTestOrderer)' == 'true'">

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -10,6 +10,13 @@
     <Features>$(Features.Replace('nullablePublicOnly', '')</Features>
   </PropertyGroup>
 
+  <!-- 
+    Add special trait to run local timezone validation test on devices.  We want to make sure the local timezone is correct and not UTC
+  -->
+  <PropertyGroup>
+    <WithoutCategories Condition="'$(EnableAdditionalTimezoneChecks)' != 'true'">$(WithoutCategories);AdditionalTimezoneChecks</WithoutCategories>
+  </PropertyGroup>
+
   <ItemGroup>
     <RdXmlFile Include="default.rd.xml" />
   </ItemGroup>

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <!-- 
-    Add special trait to run local timezone validation test on devices.  We want to make sure the local timezone is correct and not UTC
+    Add special trait for running local timezone validation tests on certain devices e.g. in CI to make sure the local timezone is correct and not UTC. Disable these tests otherwise.
   -->
   <PropertyGroup>
     <WithoutCategories Condition="'$(EnableAdditionalTimezoneChecks)' != 'true'">$(WithoutCategories);AdditionalTimezoneChecks</WithoutCategories>

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2949,7 +2949,7 @@ namespace System.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Android | TestPlatforms.iOS | TestPlatforms.tvOS)]
-        [Trait(XunitConstants.Category, "validtimezone")]
+        [Trait(XunitConstants.Category, "additionaltimezonechecks")]
         public static void LocalTzIsNotUtc()
         {
             Assert.NotEqual(TimeZoneInfo.Utc.StandardName, TimeZoneInfo.Local.StandardName);

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text.RegularExpressions;
 using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Tests
@@ -2948,6 +2949,7 @@ namespace System.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Android | TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [Trait(XunitConstants.Category, "validtimezone")]
         public static void LocalTzIsNotUtc()
         {
             Assert.NotEqual(TimeZoneInfo.Utc.StandardName, TimeZoneInfo.Local.StandardName);

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2949,7 +2949,7 @@ namespace System.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Android | TestPlatforms.iOS | TestPlatforms.tvOS)]
-        [Trait(XunitConstants.Category, "additionaltimezonechecks")]
+        [Trait(XunitConstants.Category, "AdditionalTimezoneChecks")]
         public static void LocalTzIsNotUtc()
         {
             Assert.NotEqual(TimeZoneInfo.Utc.StandardName, TimeZoneInfo.Local.StandardName);


### PR DESCRIPTION
Add a trait to control when the test executes as we don't have a good way to differentiate between Android emulators and devices.

Fixes https://github.com/dotnet/runtime/issues/70482