### PR TITLE
[wasm] Fix passing `shouldContinueOnError` through for the library tests

### DIFF
--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -8,6 +8,7 @@ parameters:
   platforms: []
   runAOT: false 
   runSmokeOnlyArg: ''
+  shouldContinueOnError: false
 
 jobs:
 
@@ -23,3 +24,4 @@ jobs:
     extraHelixArgs: /p:NeedsToBuildWasmAppsOnHelix=true ${{ parameters.extraHelixArgs }}
     alwaysRun: ${{ parameters.alwaysRun }}
     runSmokeOnlyArg: $(_runSmokeTestsOnlyArg)
+    shouldContinueOnError: ${{ parameters.shouldContinueOnError }}

--- a/eng/pipelines/common/templates/wasm-library-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-tests.yml
@@ -7,6 +7,7 @@ parameters:
   platforms: []
   runSmokeOnlyArg: ''
   scenarios: ['normal']
+  shouldContinueOnError: false
 
 jobs:
 
@@ -20,6 +21,7 @@ jobs:
     buildConfig: Release
     runtimeFlavor: mono
     platforms: ${{ parameters.platforms }}
+    shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange


### PR DESCRIPTION
The new `Threading*` CI jobs on `runtime-wasm` use `shouldContinueOnError: false` because the tests are known to be unstable right now. But they were not getting correctly forwarded to the base templates.