### PR TITLE
Set `UnusedValue` correctly for the operands of `ARR_ADDR`/`BOX`

### DIFF
--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -556,13 +556,6 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
             RewriteAssignment(use);
             break;
 
-        case GT_BOX:
-        case GT_ARR_ADDR:
-            // BOX/ARR_ADDR at this level are just NOPs.
-            use.ReplaceWith(node->gtGetOp1());
-            BlockRange().Remove(node);
-            break;
-
         case GT_ADDR:
             RewriteAddress(use);
             break;
@@ -594,9 +587,11 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
             break;
 
         case GT_NOP:
-            // fgMorph sometimes inserts NOP nodes between defs and uses
-            // supposedly 'to prevent constant folding'. In this case, remove the
-            // NOP.
+        case GT_BOX:
+        case GT_ARR_ADDR:
+            // "optNarrowTree" sometimes inserts NOP nodes between defs and uses.
+            // In this case, remove the NOP. BOX/ARR_ADDR are such "passthrough"
+            // nodes by design, and at this point we no longer need them.
             if (node->gtGetOp1() != nullptr)
             {
                 use.ReplaceWith(node->gtGetOp1());

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70466/Runtime_70466.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70466/Runtime_70466.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Runtime_70466
+{
+    public static int Main()
+    {
+        Problem(1, 0);
+        return 100;
+    }
+
+    // This method is carefully crafted such that we end up with an unused ARR_ADDR node by rationalization
+    // time, of which the child operand will need to be explicitly marked "unused value" for LIR purposes.
+    //
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Problem(byte b, int idx)
+    {
+        var a = new byte[] { b };
+        var a1 = new byte[] { b, b };
+        var a2 = new byte[] { b, b, b };
+
+        if (idx == 0)
+        {
+            if (a[idx] == 1)
+            {
+                Use(1);
+            }
+            JitUse(a1[idx] + a2[idx]);
+        }
+    }
+
+    public static void Use<T>(T arg) { }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void JitUse<T>(T arg) { }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70466/Runtime_70466.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70466/Runtime_70466.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
#70398 exposed a previously unseen case of a top-level `ARR_ADDR` node:
```scala
***** BB05
STMT00032 ( ??? ... 0x0E9 )
N010 ( 10,  9) [001316] -A---------                         *  ARR_ADDR  byref ubyte[] $301
N009 ( 10,  9) [001317] -A-----N---                         \--*  ADD       byref  $2ca
N007 ( 10,  9) [002064] -A---------                            +--*  COMMA     byref  $2c0
N005 (  7,  7) [002062] -A------R--                            |  +--*  ASG       byref  $VN.Void
N004 (  3,  2) [002061] D------N---                            |  |  +--*  LCL_VAR   byref  V70 cse3         d:1 $2c0
N003 (  3,  4) [001318] -----------                            |  |  \--*  ADD       byref  $2c0
N001 (  1,  1) [001319] -----------                            |  |     +--*  LCL_VAR   ref    V03 loc3         u:2 $241
N002 (  1,  2) [001320] -----------                            |  |     \--*  CNS_INT   long   16 $1c1
N006 (  3,  2) [002063] -----------                            |  \--*  LCL_VAR   byref  V70 cse3         u:1 $2c0
N008 (  1,  2) [002085] -----------                            \--*  CNS_INT   long   1 $1c4
```
When we rationalize these nodes, we replace them with their operands. That handling was not quite complete, resulting in some missed `UnusedValue` flags.

Fixes #70466.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1815901&view=ms.vss-build-web.run-extensions-tab) as expected.