### PR TITLE
Fix default log color behavior when console is redirected

### DIFF
--- a/src/libraries/Common/src/System/Console/ConsoleUtils.cs
+++ b/src/libraries/Common/src/System/Console/ConsoleUtils.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace System
+{
+    internal static partial class ConsoleUtils
+    {
+        /// <summary>Whether to output ansi color strings.</summary>
+        private static volatile int s_emitAnsiColorCodes = -1;
+
+        /// <summary>Get whether to emit ANSI color codes.</summary>
+        public static bool EmitAnsiColorCodes
+        {
+            get
+            {
+                // The flag starts at -1.  If it's no longer -1, it's 0 or 1 to represent false or true.
+                int emitAnsiColorCodes = s_emitAnsiColorCodes;
+                if (emitAnsiColorCodes != -1)
+                {
+                    return Convert.ToBoolean(emitAnsiColorCodes);
+                }
+
+                // We've not yet computed whether to emit codes or not.  Do so now.  We may race with
+                // other threads, and that's ok; this is idempotent unless someone is currently changing
+                // the value of the relevant environment variables, in which case behavior here is undefined.
+
+                // By default, we emit ANSI color codes if output isn't redirected, and suppress them if output is redirected.
+                bool enabled = !Console.IsOutputRedirected;
+
+                if (enabled)
+                {
+                    // We subscribe to the informal standard from https://no-color.org/.  If we'd otherwise emit
+                    // ANSI color codes but the NO_COLOR environment variable is set, disable emitting them.
+                    enabled = Environment.GetEnvironmentVariable("NO_COLOR") is null;
+                }
+                else
+                {
+                    // We also support overriding in the other direction.  If we'd otherwise avoid emitting color
+                    // codes but the DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION environment variable is
+                    // set to 1 or true, enable color.
+                    string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION");
+                    enabled = envVar is not null && (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
+                }
+
+                // Store and return the computed answer.
+                s_emitAnsiColorCodes = Convert.ToInt32(enabled);
+                return enabled;
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -21,8 +21,7 @@ namespace Microsoft.Extensions.Logging.Console
         private readonly IOptionsMonitor<ConsoleLoggerOptions> _options;
         private readonly ConcurrentDictionary<string, ConsoleLogger> _loggers;
         private ConcurrentDictionary<string, ConsoleFormatter> _formatters;
-        // for testing
-        internal ConsoleLoggerProcessor MessageQueue;
+        private ConsoleLoggerProcessor _messageQueue;
 
         private IDisposable? _optionsReloadToken;
         private IExternalScopeProvider _scopeProvider = NullExternalScopeProvider.Instance;
@@ -61,7 +60,7 @@ namespace Microsoft.Extensions.Logging.Console
                 errorConsole = new AnsiParsingLogConsole(stdErr: true);
             }
 
-            MessageQueue = new ConsoleLoggerProcessor(console, errorConsole);
+            _messageQueue = new ConsoleLoggerProcessor(console, errorConsole);
         }
 
         [UnsupportedOSPlatformGuard("windows")]
@@ -153,7 +152,7 @@ namespace Microsoft.Extensions.Logging.Console
 
             return _loggers.TryGetValue(name, out ConsoleLogger? logger) ?
                 logger :
-                _loggers.GetOrAdd(name, new ConsoleLogger(name, MessageQueue, logFormatter, _scopeProvider, _options.CurrentValue));
+                _loggers.GetOrAdd(name, new ConsoleLogger(name, _messageQueue, logFormatter, _scopeProvider, _options.CurrentValue));
         }
 
 #pragma warning disable CS0618
@@ -189,7 +188,7 @@ namespace Microsoft.Extensions.Logging.Console
         public void Dispose()
         {
             _optionsReloadToken?.Dispose();
-            MessageQueue.Dispose();
+            _messageQueue.Dispose();
         }
 
         /// <inheritdoc />

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Extensions.Logging.Console
         private readonly IOptionsMonitor<ConsoleLoggerOptions> _options;
         private readonly ConcurrentDictionary<string, ConsoleLogger> _loggers;
         private ConcurrentDictionary<string, ConsoleFormatter> _formatters;
-        private readonly ConsoleLoggerProcessor _messageQueue;
+        // for testing
+        internal ConsoleLoggerProcessor MessageQueue;
 
         private IDisposable? _optionsReloadToken;
         private IExternalScopeProvider _scopeProvider = NullExternalScopeProvider.Instance;
@@ -59,7 +60,8 @@ namespace Microsoft.Extensions.Logging.Console
                 console = new AnsiParsingLogConsole();
                 errorConsole = new AnsiParsingLogConsole(stdErr: true);
             }
-            _messageQueue = new ConsoleLoggerProcessor(console, errorConsole);
+
+            MessageQueue = new ConsoleLoggerProcessor(console, errorConsole);
         }
 
         [UnsupportedOSPlatformGuard("windows")]
@@ -151,7 +153,7 @@ namespace Microsoft.Extensions.Logging.Console
 
             return _loggers.TryGetValue(name, out ConsoleLogger? logger) ?
                 logger :
-                _loggers.GetOrAdd(name, new ConsoleLogger(name, _messageQueue, logFormatter, _scopeProvider, _options.CurrentValue));
+                _loggers.GetOrAdd(name, new ConsoleLogger(name, MessageQueue, logFormatter, _scopeProvider, _options.CurrentValue));
         }
 
 #pragma warning disable CS0618
@@ -187,7 +189,7 @@ namespace Microsoft.Extensions.Logging.Console
         public void Dispose()
         {
             _optionsReloadToken?.Dispose();
-            _messageQueue.Dispose();
+            MessageQueue.Dispose();
         }
 
         /// <inheritdoc />

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -158,14 +158,12 @@ namespace Microsoft.Extensions.Logging.Console
 #pragma warning disable CS0618
         private static void UpdateFormatterOptions(ConsoleFormatter formatter, ConsoleLoggerOptions deprecatedFromOptions)
         {
-            bool disableColors = deprecatedFromOptions.DisableColors || System.Console.IsOutputRedirected;
-
             // kept for deprecated apis:
             if (formatter is SimpleConsoleFormatter defaultFormatter)
             {
                 defaultFormatter.FormatterOptions = new SimpleConsoleFormatterOptions()
                 {
-                    ColorBehavior = disableColors ? LoggerColorBehavior.Disabled : LoggerColorBehavior.Enabled,
+                    ColorBehavior = deprecatedFromOptions.DisableColors ? LoggerColorBehavior.Disabled : LoggerColorBehavior.Default,
                     IncludeScopes = deprecatedFromOptions.IncludeScopes,
                     TimestampFormat = deprecatedFromOptions.TimestampFormat,
                     UseUtcTimestamp = deprecatedFromOptions.UseUtcTimestamp,

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -59,7 +59,6 @@ namespace Microsoft.Extensions.Logging.Console
                 console = new AnsiParsingLogConsole();
                 errorConsole = new AnsiParsingLogConsole(stdErr: true);
             }
-
             _messageQueue = new ConsoleLoggerProcessor(console, errorConsole);
         }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Logging.Console
         private readonly IOptionsMonitor<ConsoleLoggerOptions> _options;
         private readonly ConcurrentDictionary<string, ConsoleLogger> _loggers;
         private ConcurrentDictionary<string, ConsoleFormatter> _formatters;
-        private ConsoleLoggerProcessor _messageQueue;
+        private readonly ConsoleLoggerProcessor _messageQueue;
 
         private IDisposable? _optionsReloadToken;
         private IExternalScopeProvider _scopeProvider = NullExternalScopeProvider.Instance;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -157,12 +157,14 @@ namespace Microsoft.Extensions.Logging.Console
 #pragma warning disable CS0618
         private static void UpdateFormatterOptions(ConsoleFormatter formatter, ConsoleLoggerOptions deprecatedFromOptions)
         {
+            bool disableColors = deprecatedFromOptions.DisableColors || System.Console.IsOutputRedirected;
+
             // kept for deprecated apis:
             if (formatter is SimpleConsoleFormatter defaultFormatter)
             {
                 defaultFormatter.FormatterOptions = new SimpleConsoleFormatterOptions()
                 {
-                    ColorBehavior = deprecatedFromOptions.DisableColors ? LoggerColorBehavior.Disabled : LoggerColorBehavior.Enabled,
+                    ColorBehavior = disableColors ? LoggerColorBehavior.Disabled : LoggerColorBehavior.Enabled,
                     IncludeScopes = deprecatedFromOptions.IncludeScopes,
                     TimestampFormat = deprecatedFromOptions.TimestampFormat,
                     UseUtcTimestamp = deprecatedFromOptions.UseUtcTimestamp,

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
@@ -28,6 +28,8 @@
              Link="Common\Interop\Windows\Interop.GetConsoleMode.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetStdHandle.cs"
              Link="Common\Interop\Windows\Interop.GetStdHandle.cs" />
+    <Compile Include="$(CommonPath)System\Console\ConsoleUtils.cs"
+             Link="Common\System\Console\ConsoleUtils.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Extensions.Logging.Console
 {
     internal sealed class SimpleConsoleFormatter : ConsoleFormatter, IDisposable
     {
+        /// <summary>Whether to output ansi color strings.</summary>
+        private static volatile int s_emitAnsiColorCodes = -1;
         private const string LoglevelPadding = ": ";
         private static readonly string _messagePadding = new string(' ', GetLogLevelString(LogLevel.Information).Length + LoglevelPadding.Length);
         private static readonly string _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
@@ -155,10 +157,50 @@ namespace Microsoft.Extensions.Logging.Console
             };
         }
 
+        /// <summary>Get whether to emit ANSI color codes.</summary>
+        private static bool EmitAnsiColorCodes
+        {
+            get
+            {
+                // The flag starts at -1.  If it's no longer -1, it's 0 or 1 to represent false or true.
+                int emitAnsiColorCodes = s_emitAnsiColorCodes;
+                if (emitAnsiColorCodes != -1)
+                {
+                    return Convert.ToBoolean(emitAnsiColorCodes);
+                }
+
+                // We've not yet computed whether to emit codes or not.  Do so now.  We may race with
+                // other threads, and that's ok; this is idempotent unless someone is currently changing
+                // the value of the relevant environment variables, in which case behavior here is undefined.
+
+                // By default, we emit ANSI color codes if output isn't redirected, and suppress them if output is redirected.
+                bool enabled = !System.Console.IsOutputRedirected;
+
+                if (enabled)
+                {
+                    // We subscribe to the informal standard from https://no-color.org/.  If we'd otherwise emit
+                    // ANSI color codes but the NO_COLOR environment variable is set, disable emitting them.
+                    enabled = Environment.GetEnvironmentVariable("NO_COLOR") is null;
+                }
+                else
+                {
+                    // We also support overriding in the other direction.  If we'd otherwise avoid emitting color
+                    // codes but the DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION environment variable is
+                    // set to 1 or true, enable color.
+                    string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION");
+                    enabled = envVar is not null && (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
+                }
+
+                // Store and return the computed answer.
+                s_emitAnsiColorCodes = Convert.ToInt32(enabled);
+                return enabled;
+            }
+        }
+
         private ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
         {
             bool disableColors = (FormatterOptions.ColorBehavior == LoggerColorBehavior.Disabled) ||
-                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && System.Console.IsOutputRedirected);
+                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && !EmitAnsiColorCodes);
             if (disableColors)
             {
                 return new ConsoleColors(null, null);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Extensions.Logging.Console
 {
     internal sealed class SimpleConsoleFormatter : ConsoleFormatter, IDisposable
     {
-        /// <summary>Whether to output ansi color strings.</summary>
-        private static volatile int s_emitAnsiColorCodes = -1;
         private const string LoglevelPadding = ": ";
         private static readonly string _messagePadding = new string(' ', GetLogLevelString(LogLevel.Information).Length + LoglevelPadding.Length);
         private static readonly string _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
@@ -157,50 +155,10 @@ namespace Microsoft.Extensions.Logging.Console
             };
         }
 
-        /// <summary>Get whether to emit ANSI color codes.</summary>
-        private static bool EmitAnsiColorCodes
-        {
-            get
-            {
-                // The flag starts at -1.  If it's no longer -1, it's 0 or 1 to represent false or true.
-                int emitAnsiColorCodes = s_emitAnsiColorCodes;
-                if (emitAnsiColorCodes != -1)
-                {
-                    return Convert.ToBoolean(emitAnsiColorCodes);
-                }
-
-                // We've not yet computed whether to emit codes or not.  Do so now.  We may race with
-                // other threads, and that's ok; this is idempotent unless someone is currently changing
-                // the value of the relevant environment variables, in which case behavior here is undefined.
-
-                // By default, we emit ANSI color codes if output isn't redirected, and suppress them if output is redirected.
-                bool enabled = !System.Console.IsOutputRedirected;
-
-                if (enabled)
-                {
-                    // We subscribe to the informal standard from https://no-color.org/.  If we'd otherwise emit
-                    // ANSI color codes but the NO_COLOR environment variable is set, disable emitting them.
-                    enabled = Environment.GetEnvironmentVariable("NO_COLOR") is null;
-                }
-                else
-                {
-                    // We also support overriding in the other direction.  If we'd otherwise avoid emitting color
-                    // codes but the DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION environment variable is
-                    // set to 1 or true, enable color.
-                    string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION");
-                    enabled = envVar is not null && (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
-                }
-
-                // Store and return the computed answer.
-                s_emitAnsiColorCodes = Convert.ToInt32(enabled);
-                return enabled;
-            }
-        }
-
         private ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
         {
             bool disableColors = (FormatterOptions.ColorBehavior == LoggerColorBehavior.Disabled) ||
-                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && !EmitAnsiColorCodes);
+                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && !System.ConsoleUtils.EmitAnsiColorCodes);
             if (disableColors)
             {
                 return new ConsoleColors(null, null);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Extensions.Logging.Console
         private ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
         {
             bool disableColors = (FormatterOptions.ColorBehavior == LoggerColorBehavior.Disabled) ||
-                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && !System.ConsoleUtils.EmitAnsiColorCodes);
+                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && !ConsoleUtils.EmitAnsiColorCodes);
             if (disableColors)
             {
                 return new ConsoleColors(null, null);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -440,7 +440,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 Assert.True(System.Console.IsOutputRedirected);
                 Assert.Null(logger.Options.FormatterName);
                 var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
-                Assert.Equal(LoggerColorBehavior.Disabled, formatter.FormatterOptions.ColorBehavior);
+                Assert.Equal(LoggerColorBehavior.Default, formatter.FormatterOptions.ColorBehavior);
 
             }, new RemoteInvokeOptions { StartInfo = new ProcessStartInfo() { RedirectStandardOutput = true } }).Dispose();
         }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Test.Console;
@@ -411,6 +413,49 @@ namespace Microsoft.Extensions.Logging.Console.Test
             write = sink.Writes[1];
             Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
             Assert.Equal(TestConsole.DefaultForegroundColor, write.ForegroundColor);
+        }
+
+        [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
+        public void AddConsole_IsOutputRedirected_ColorDisabled()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                // Arrange
+                var sink = new ConsoleSink();
+                var console = new TestConsole(sink);
+                var loggerOptions = new ConsoleLoggerOptions();
+                var consoleLoggerProcessor = new TestLoggerProcessor(console, null!);
+
+                var loggerProvider = new ServiceCollection()
+                    .AddLogging(builder => builder
+                        .AddConsole()
+                    )
+                    .BuildServiceProvider()
+                    .GetRequiredService<ILoggerProvider>();
+
+                var consoleLoggerProvider = Assert.IsType<ConsoleLoggerProvider>(loggerProvider);
+                consoleLoggerProvider.MessageQueue = consoleLoggerProcessor;
+                var logger = (ConsoleLogger)consoleLoggerProvider.CreateLogger("Category");
+
+                // Act
+                logger.Log(
+                    LogLevel.Information,
+                    0,
+                    "This is a test, and {curly braces} are just fine!",
+                    null,
+                    (state, exception) => state.ToString());
+
+                // Assert
+                Assert.True(System.Console.IsOutputRedirected);
+                Assert.Null(logger.Options.FormatterName);
+                var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
+                Assert.Equal(LoggerColorBehavior.Disabled, formatter.FormatterOptions.ColorBehavior);
+
+                Assert.Equal(1, sink.Writes.Count);
+                var write = sink.Writes[0];
+                Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
+                Assert.Equal(TestConsole.DefaultForegroundColor, write.ForegroundColor);
+            }, new RemoteInvokeOptions { StartInfo = new ProcessStartInfo() { RedirectStandardOutput = true } }).Dispose();
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -1365,6 +1410,9 @@ namespace Microsoft.Extensions.Logging.Console.Test
                     throw new ArgumentOutOfRangeException(nameof(format));
             }
         }
+
+        public static bool IsThreadingAndRemoteExecutorSupported =>
+            PlatformDetection.IsThreadingSupported && RemoteExecutor.IsSupported;
     }
 
     internal class TestLoggerProcessor : ConsoleLoggerProcessor

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -434,16 +434,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                     .GetRequiredService<ILoggerProvider>();
 
                 var consoleLoggerProvider = Assert.IsType<ConsoleLoggerProvider>(loggerProvider);
-                consoleLoggerProvider.MessageQueue = consoleLoggerProcessor;
                 var logger = (ConsoleLogger)consoleLoggerProvider.CreateLogger("Category");
-
-                // Act
-                logger.Log(
-                    LogLevel.Information,
-                    0,
-                    "This is a test, and {curly braces} are just fine!",
-                    null,
-                    (state, exception) => state.ToString());
 
                 // Assert
                 Assert.True(System.Console.IsOutputRedirected);
@@ -451,10 +442,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
                 Assert.Equal(LoggerColorBehavior.Disabled, formatter.FormatterOptions.ColorBehavior);
 
-                Assert.Equal(1, sink.Writes.Count);
-                var write = sink.Writes[0];
-                Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
-                Assert.Equal(TestConsole.DefaultForegroundColor, write.ForegroundColor);
             }, new RemoteInvokeOptions { StartInfo = new ProcessStartInfo() { RedirectStandardOutput = true } }).Dispose();
         }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/Microsoft.Extensions.Logging.Console.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/Microsoft.Extensions.Logging.Console.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
     <EnableDefaultItems>true</EnableDefaultItems>

--- a/src/libraries/System.Console/src/System.Console.csproj
+++ b/src/libraries/System.Console/src/System.Console.csproj
@@ -156,6 +156,8 @@
   <!-- Unix -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Unix'">
     <Compile Include="System\ConsolePal.Unix.cs" />
+    <Compile Include="$(CommonPath)System\Console\ConsoleUtils.cs"
+             Link="Common\System\Console\ConsoleUtils.cs" />
     <Compile Include="System\TermInfo.cs" />
     <Compile Include="System\IO\StdInReader.cs" />
     <Compile Include="System\IO\SyncTextReader.Unix.cs" />

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -39,9 +39,6 @@ namespace System
         private static int s_windowHeight;  // Cached WindowHeight, invalid when s_windowWidth == -1.
         private static int s_invalidateCachedSettings = 1; // Tracks whether we should invalidate the cached settings.
 
-        /// <summary>Whether to output ansi color strings.</summary>
-        private static volatile int s_emitAnsiColorCodes = -1;
-
         public static Stream OpenStandardInput()
         {
             return new UnixConsoleStream(Interop.CheckIo(Interop.Sys.Dup(Interop.Sys.FileDescriptors.STDIN_FILENO)), FileAccess.Read,
@@ -770,7 +767,7 @@ namespace System
             // Changing the color involves writing an ANSI character sequence out to the output stream.
             // We only want to do this if we know that sequence will be interpreted by the output.
             // rather than simply displayed visibly.
-            if (!EmitAnsiColorCodes)
+            if (!ConsoleUtils.EmitAnsiColorCodes)
             {
                 return;
             }
@@ -832,49 +829,9 @@ namespace System
         /// <summary>Writes out the ANSI string to reset colors.</summary>
         private static void WriteResetColorString()
         {
-            if (EmitAnsiColorCodes)
+            if (ConsoleUtils.EmitAnsiColorCodes)
             {
                 WriteStdoutAnsiString(TerminalFormatStrings.Instance.Reset);
-            }
-        }
-
-        /// <summary>Get whether to emit ANSI color codes.</summary>
-        private static bool EmitAnsiColorCodes
-        {
-            get
-            {
-                // The flag starts at -1.  If it's no longer -1, it's 0 or 1 to represent false or true.
-                int emitAnsiColorCodes = s_emitAnsiColorCodes;
-                if (emitAnsiColorCodes != -1)
-                {
-                    return Convert.ToBoolean(emitAnsiColorCodes);
-                }
-
-                // We've not yet computed whether to emit codes or not.  Do so now.  We may race with
-                // other threads, and that's ok; this is idempotent unless someone is currently changing
-                // the value of the relevant environment variables, in which case behavior here is undefined.
-
-                // By default, we emit ANSI color codes if output isn't redirected, and suppress them if output is redirected.
-                bool enabled = !Console.IsOutputRedirected;
-
-                if (enabled)
-                {
-                    // We subscribe to the informal standard from https://no-color.org/.  If we'd otherwise emit
-                    // ANSI color codes but the NO_COLOR environment variable is set, disable emitting them.
-                    enabled = Environment.GetEnvironmentVariable("NO_COLOR") is null;
-                }
-                else
-                {
-                    // We also support overriding in the other direction.  If we'd otherwise avoid emitting color
-                    // codes but the DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION environment variable is
-                    // set to 1 or true, enable color.
-                    string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION");
-                    enabled = envVar is not null && (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
-                }
-
-                // Store and return the computed answer.
-                s_emitAnsiColorCodes = Convert.ToInt32(enabled);
-                return enabled;
             }
         }
 


### PR DESCRIPTION
/cc @tdms 

Fixes behavior using default log color behavior, in kubernetes when output is redirected, then we should not get color coding.

TODO

- [x] Add test when using default `AddConsole` when `IsOutputRedirected` is true

Fixes #70156