### PR TITLE
Obsolete AssemblyName.CodeBase, AssemblyName.EscapedCodeBase

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -135,8 +135,9 @@ namespace System.Reflection
             an.RawFlags = GetFlags() | AssemblyNameFlags.PublicKey;
 
 #pragma warning disable IL3000, SYSLIB0044 // System.Reflection.AssemblyName.CodeBase' always returns an empty string for assemblies embedded in a single-file app.
+                                           // AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete. Using them for loading an assembly is not supported.
             an.CodeBase = GetCodeBase();
-#pragma warning restore IL3000, SYSLIB004 // AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete, using them for loading an assembly is not supported.
+#pragma warning restore IL3000, SYSLIB0044
 
 #pragma warning disable SYSLIB0037 // AssemblyName.HashAlgorithm is obsolete
             an.HashAlgorithm = GetHashAlgorithm();

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -134,9 +134,9 @@ namespace System.Reflection
 
             an.RawFlags = GetFlags() | AssemblyNameFlags.PublicKey;
 
-#pragma warning disable IL3000 // System.Reflection.AssemblyName.CodeBase' always returns an empty string for assemblies embedded in a single-file app.
+#pragma warning disable IL3000, SYSLIB0044 // System.Reflection.AssemblyName.CodeBase' always returns an empty string for assemblies embedded in a single-file app.
             an.CodeBase = GetCodeBase();
-#pragma warning restore IL3000
+#pragma warning restore IL3000, SYSLIB004 // AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete, using them for loading an assembly is not supported.
 
 #pragma warning disable SYSLIB0037 // AssemblyName.HashAlgorithm is obsolete
             an.HashAlgorithm = GetHashAlgorithm();

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -141,5 +141,8 @@ namespace System
 
         internal const string EcDhPublicKeyBlobMessage = "ECDiffieHellmanPublicKey.ToByteArray() and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo() instead.";
         internal const string EcDhPublicKeyBlobDiagId = "SYSLIB0043";
+
+        internal const string AssemblyNameCodeBaseMessage = "AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete, using them for loading an assembly is not supported.";
+        internal const string AssemblyNameCodeBaseDiagId = "SYSLIB0044";
     }
 }

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -142,7 +142,7 @@ namespace System
         internal const string EcDhPublicKeyBlobMessage = "ECDiffieHellmanPublicKey.ToByteArray() and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo() instead.";
         internal const string EcDhPublicKeyBlobDiagId = "SYSLIB0043";
 
-        internal const string AssemblyNameCodeBaseMessage = "AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete, using them for loading an assembly is not supported.";
+        internal const string AssemblyNameCodeBaseMessage = "AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete. Using them for loading an assembly is not supported.";
         internal const string AssemblyNameCodeBaseDiagId = "SYSLIB0044";
     }
 }

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AssemblyCatalog.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AssemblyCatalog.cs
@@ -558,7 +558,9 @@ namespace System.ComponentModel.Composition.Hosting
             catch (ArgumentException)
             {
                 assemblyName = new AssemblyName();
+#pragma warning disable SYSLIB0044 // AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete, using them for loading an assembly is not supported.
                 assemblyName.CodeBase = codeBase;
+#pragma warning restore SYSLIB0044
             }
 
             try

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AssemblyCatalog.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AssemblyCatalog.cs
@@ -558,7 +558,7 @@ namespace System.ComponentModel.Composition.Hosting
             catch (ArgumentException)
             {
                 assemblyName = new AssemblyName();
-#pragma warning disable SYSLIB0044 // AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete, using them for loading an assembly is not supported.
+#pragma warning disable SYSLIB0044 // AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete. Using them for loading an assembly is not supported.
                 assemblyName.CodeBase = codeBase;
 #pragma warning restore SYSLIB0044
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -82,6 +82,7 @@ namespace System.Reflection
             set => _cultureInfo = (value == null) ? null : new CultureInfo(value);
         }
 
+        [Obsolete(Obsoletions.AssemblyNameCodeBaseMessage, DiagnosticId = Obsoletions.AssemblyNameCodeBaseDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public string? CodeBase
         {
             [RequiresAssemblyFiles("The code will return an empty string for assemblies embedded in a single-file app")]
@@ -89,6 +90,7 @@ namespace System.Reflection
             set => _codeBase = value;
         }
 
+        [Obsolete(Obsoletions.AssemblyNameCodeBaseMessage, DiagnosticId = Obsoletions.AssemblyNameCodeBaseDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [RequiresAssemblyFiles("The code will return an empty string for assemblies embedded in a single-file app")]
         public string? EscapedCodeBase
         {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -162,7 +162,6 @@ namespace System.Xml.Serialization
                     serializerName = Compiler.GetTempAssemblyName(name, defaultNamespace);
                     // use strong name
                     name.Name = serializerName;
-                    name.CodeBase = null;
                     name.CultureInfo = CultureInfo.InvariantCulture;
 
                     try

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -235,7 +235,7 @@ namespace System.Reflection.Tests
             AssemblyName an = new AssemblyName("MyAssemblyName");
             Assert.Null(an.CultureName);
         }
-
+#pragma warning disable SYSLIB0044 // AssemblyName.CodeBase .AssemblyName.EscapedCodeBase are obsolete
         [Fact]
         public void Verify_CodeBase()
         {
@@ -259,6 +259,7 @@ namespace System.Reflection.Tests
             n.CodeBase = @"file:///c:/program files/MyAssemblyName.dll";
             Assert.Equal(n.EscapedCodeBase, Uri.EscapeUriString(n.CodeBase));
         }
+#pragma warning restore SYSLIB0044
 
         [Fact]
         public static void Verify_HashAlgorithm()

--- a/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -254,7 +254,6 @@ namespace System.Tests
                 Assert.Equal(10, AppDomain.CurrentDomain.ExecuteAssemblyByName(assembly.FullName, new string[2] { "2", "3" }));
                 Assert.Throws<FormatException>(() => AppDomain.CurrentDomain.ExecuteAssemblyByName(assembly.FullName, new string[1] { "a" }));
                 AssemblyName assemblyName = assembly.GetName();
-                assemblyName.CodeBase = null;
                 Assert.Equal(105, AppDomain.CurrentDomain.ExecuteAssemblyByName(assemblyName, new string[3] { "50", "25", "25" }));
             }).Dispose();
         }
@@ -358,7 +357,6 @@ namespace System.Tests
         public void Load()
         {
             AssemblyName assemblyName = typeof(AppDomainTests).Assembly.GetName();
-            assemblyName.CodeBase = null;
             Assert.NotNull(AppDomain.CurrentDomain.Load(assemblyName));
             Assert.NotNull(AppDomain.CurrentDomain.Load(typeof(AppDomainTests).Assembly.FullName));
         }

--- a/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -115,7 +115,6 @@ namespace System.Runtime.Loader.Tests
         public static void LoadFromAssemblyName_ValidTrustedPlatformAssembly()
         {
             var asmName = typeof(System.Linq.Enumerable).Assembly.GetName();
-            asmName.CodeBase = null;
             var loadContext = new CustomTPALoadContext();
 
             // We should be able to override (and thus, load) assemblies that were
@@ -131,7 +130,6 @@ namespace System.Runtime.Loader.Tests
         public static void LoadFromAssemblyName_FallbackToDefaultContext()
         {
             var asmName = typeof(System.Linq.Enumerable).Assembly.GetName();
-            asmName.CodeBase = null;
             var loadContext = new AssemblyLoadContext("FallbackToDefaultContextTest");
 
             // This should not have any special handlers, so it should just find the version in the default context

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10828,11 +10828,13 @@ namespace System.Reflection
     {
         public AssemblyName() { }
         public AssemblyName(string assemblyName) { }
+        [System.ObsoleteAttribute("AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete, using them for loading an assembly is not supported.", DiagnosticId = "SYSLIB0044", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public string? CodeBase { [System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute("The code will return an empty string for assemblies embedded in a single-file app")] get { throw null; } set { } }
         public System.Reflection.AssemblyContentType ContentType { get { throw null; } set { } }
         public System.Globalization.CultureInfo? CultureInfo { get { throw null; } set { } }
         public string? CultureName { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute("The code will return an empty string for assemblies embedded in a single-file app")]
+        [System.ObsoleteAttribute("AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete, using them for loading an assembly is not supported.", DiagnosticId = "SYSLIB0044", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public string? EscapedCodeBase { get { throw null; } }
         public System.Reflection.AssemblyNameFlags Flags { get { throw null; } set { } }
         public string FullName { get { throw null; } }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10828,13 +10828,13 @@ namespace System.Reflection
     {
         public AssemblyName() { }
         public AssemblyName(string assemblyName) { }
-        [System.ObsoleteAttribute("AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete, using them for loading an assembly is not supported.", DiagnosticId = "SYSLIB0044", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete. Using them for loading an assembly is not supported.", DiagnosticId = "SYSLIB0044", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public string? CodeBase { [System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute("The code will return an empty string for assemblies embedded in a single-file app")] get { throw null; } set { } }
         public System.Reflection.AssemblyContentType ContentType { get { throw null; } set { } }
         public System.Globalization.CultureInfo? CultureInfo { get { throw null; } set { } }
         public string? CultureName { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute("The code will return an empty string for assemblies embedded in a single-file app")]
-        [System.ObsoleteAttribute("AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete, using them for loading an assembly is not supported.", DiagnosticId = "SYSLIB0044", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete. Using them for loading an assembly is not supported.", DiagnosticId = "SYSLIB0044", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public string? EscapedCodeBase { get { throw null; } }
         public System.Reflection.AssemblyNameFlags Flags { get { throw null; } set { } }
         public string FullName { get { throw null; } }


### PR DESCRIPTION
 AssemblyName.CodeBase is related to Assembly.CodeBase which is obsoleted in 7.0, same for AssemblyName.EscapedCodeBase

Loading assembly using this property is not supported in .Net Core which is main functional usage of this API

```cs
private static Assembly LoadAssembly(string codeBase)
{
    AssemblyName assemblyName = new AssemblyName { CodeBase = assemblyPath };
    return Assembly.Load(assemblyName);
}
```
Fixes https://github.com/dotnet/runtime/issues/42857