### PR TITLE
Avoid calling into resource manager from the type loader

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -105,6 +105,10 @@ namespace Internal.Runtime.TypeLoader
         // Helper exception to abort type building if we do not find the generic type template
         internal class MissingTemplateException : Exception
         {
+            public MissingTemplateException()
+                // Cannot afford calling into resource manager from here, even to get the default message for System.Exception.
+                // This exception is always caught and rethrown as something more user friendly.
+                : base("Template is missing") { }
         }
 
 


### PR DESCRIPTION
Sample stack:

```
 	System.Runtime.Tests.exe!S_P_CoreLib_System_SR__GetResourceString() Line 29	Unknown
 	System.Runtime.Tests.exe!S_P_CoreLib_System_Exception__get_Message() Line 57	Unknown
 	System.Runtime.Tests.exe!S_P_CoreLib_System_Exception__AppendExceptionStackFrame() Line 134	Unknown
 	System.Runtime.Tests.exe!S_P_CoreLib_System_Runtime_EH__AppendExceptionStackFrameViaClasslib() Line 234	Unknown
 	System.Runtime.Tests.exe!S_P_CoreLib_System_Runtime_EH__UpdateStackTrace() Line 735	Unknown
 	System.Runtime.Tests.exe!S_P_CoreLib_System_Runtime_EH__DispatchEx() Line 630	Unknown
 	System.Runtime.Tests.exe!S_P_CoreLib_System_Runtime_EH__RhThrowEx() Line 571	Unknown
 	System.Runtime.Tests.exe!RhpThrowEx�()	Unknown
 	System.Runtime.Tests.exe!S_P_TypeLoader_Internal_TypeSystem_TypeDesc__ComputeTemplate_0() Line 241	Unknown
 	System.Runtime.Tests.exe!S_P_TypeLoader_Internal_TypeSystem_TypeDesc__ComputeTemplate() Line 233	Unknown
```