### PR TITLE
Fix emitDispJumpList for Arm64

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3910,7 +3910,12 @@ void emitter::emitDispJumpList()
         printf("IG%02u IN%04x %3s[%u] -> IG%02u %s\n", jmp->idjIG->igNum, jmp->idDebugOnlyInfo()->idNum,
                codeGen->genInsDisplayName(jmp), jmp->idCodeSize(),
                ((insGroup*)emitCodeGetCookie(jmp->idAddr()->iiaBBlabel))->igNum,
-               jmp->idjIsRemovableJmpCandidate ? " ; removal candidate" : "");
+#if defined(TARGET_XARCH)
+               jmp->idjIsRemovableJmpCandidate ? " ; removal candidate" : ""
+#else
+               ""
+#endif
+        );
 #endif
         jmpCount += 1;
     }

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3894,15 +3894,24 @@ void emitter::emitDispJumpList()
     unsigned int jmpCount = 0;
     for (instrDescJmp* jmp = emitJumpList; jmp != nullptr; jmp = jmp->idjNext)
     {
+#if defined(TARGET_ARM64)
+        if ((jmp->idInsFmt() == IF_LARGEADR) || (jmp->idInsFmt() == IF_LARGELDC))
+        {
+            printf("IG%02u IN%04x %3s[%u] -> %s\n", jmp->idjIG->igNum, jmp->idDebugOnlyInfo()->idNum,
+                   codeGen->genInsDisplayName(jmp), jmp->idCodeSize(), getRegName(jmp->idReg1()));
+        }
+        else
+        {
+            printf("IG%02u IN%04x %3s[%u] -> IG%02u\n", jmp->idjIG->igNum, jmp->idDebugOnlyInfo()->idNum,
+                   codeGen->genInsDisplayName(jmp), jmp->idCodeSize(),
+                   ((insGroup*)emitCodeGetCookie(jmp->idAddr()->iiaBBlabel))->igNum);
+        }
+#else
         printf("IG%02u IN%04x %3s[%u] -> IG%02u %s\n", jmp->idjIG->igNum, jmp->idDebugOnlyInfo()->idNum,
                codeGen->genInsDisplayName(jmp), jmp->idCodeSize(),
                ((insGroup*)emitCodeGetCookie(jmp->idAddr()->iiaBBlabel))->igNum,
-#if defined(TARGET_XARCH)
-               jmp->idjIsRemovableJmpCandidate ? " ; removal candidate" : ""
-#else
-               ""
+               jmp->idjIsRemovableJmpCandidate ? " ; removal candidate" : "");
 #endif
-               );
         jmpCount += 1;
     }
     printf("  total jump count: %u\n", jmpCount);

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3915,7 +3915,7 @@ void emitter::emitDispJumpList()
 #else
                ""
 #endif
-        );
+               );
 #endif
         jmpCount += 1;
     }


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/69041 added `emitDispJumpList()` which breaks for arm64 because it has jump formats using `ldr` where destination is in register. 

cc: @Wraith2 