### PR TITLE
Precisely track reflected on fields

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMarker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMarker.cs
@@ -161,7 +161,9 @@ namespace ILCompiler.Dataflow
         {
             if (!type.IsGenericDefinition && !type.ContainsSignatureVariables(treatGenericParameterLikeSignatureVariable: true) && type.HasStaticConstructor)
             {
-                _dependencies.Add(_factory.CanonicalEntrypoint(type.GetStaticConstructor()), "RunClassConstructor reference");
+                // Mark the GC static base - it contains a pointer to the class constructor, but also info
+                // about whether the class constructor already executed and it's what is looked at at runtime.
+                _dependencies.Add(_factory.TypeNonGCStaticsSymbol((MetadataType)type), "RunClassConstructor reference");
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
@@ -168,7 +168,8 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (decodedArgument.Kind == CustomAttributeNamedArgumentKind.Field)
                 {
-                    // This is an instance field. We don't track them right now.
+                    if (!AddDependenciesFromField(dependencies, factory, attributeType, decodedArgument.Name))
+                        return false;
                 }
                 else
                 {
@@ -183,6 +184,29 @@ namespace ILCompiler.DependencyAnalysis
                     return false;
             }
 
+            return true;
+        }
+
+        private static bool AddDependenciesFromField(DependencyList dependencies, NodeFactory factory, TypeDesc attributeType, string fieldName)
+        {
+            FieldDesc field = attributeType.GetField(fieldName);
+            if (field is not null)
+            {
+                if (factory.MetadataManager.IsReflectionBlocked(field))
+                    return false;
+
+                dependencies.Add(factory.ReflectableField(field), "Custom attribute blob");
+
+                return true;
+            }
+
+            // Haven't found it in current type. Check the base type.
+            TypeDesc baseType = attributeType.BaseType;
+
+            if (baseType != null)
+                return AddDependenciesFromField(dependencies, factory, baseType, fieldName);
+
+            // Not found. This is bad metadata that will result in a runtime failure, but we shouldn't fail the compilation.
             return true;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldMetadataNode.cs
@@ -41,7 +41,7 @@ namespace ILCompiler.DependencyAnalysis
         }
         protected override string GetName(NodeFactory factory)
         {
-            return "Reflectable field: " + _field.ToString();
+            return "Field metadata: " + _field.ToString();
         }
 
         protected override void OnMarked(NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -19,6 +19,7 @@ namespace ILCompiler.DependencyAnalysis
         public GCStaticsNode(MetadataType type, PreinitializationManager preinitManager)
         {
             Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Specific));
+            Debug.Assert(!type.IsGenericDefinition);
             _type = type;
 
             if (preinitManager.IsPreinitialized(type))

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MethodMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MethodMetadataNode.cs
@@ -49,7 +49,7 @@ namespace ILCompiler.DependencyAnalysis
         }
         protected override string GetName(NodeFactory factory)
         {
-            return "Reflectable method: " + _method.ToString();
+            return "Method metadata: " + _method.ToString();
         }
 
         protected override void OnMarked(NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -294,6 +294,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new ReflectableMethodNode(method);
             });
 
+            _reflectableFields = new NodeCache<FieldDesc, ReflectableFieldNode>(field =>
+            {
+                return new ReflectableFieldNode(field);
+            });
+
             _objectGetTypeFlowDependencies = new NodeCache<MetadataType, ObjectGetTypeFlowDependenciesNode>(type =>
             {
                 return new ObjectGetTypeFlowDependenciesNode(type);
@@ -850,6 +855,12 @@ namespace ILCompiler.DependencyAnalysis
         public ReflectableMethodNode ReflectableMethod(MethodDesc method)
         {
             return _reflectableMethods.GetOrAdd(method);
+        }
+
+        private NodeCache<FieldDesc, ReflectableFieldNode> _reflectableFields;
+        public ReflectableFieldNode ReflectableField(FieldDesc field)
+        {
+            return _reflectableFields.GetOrAdd(field);
         }
 
         private NodeCache<MetadataType, ObjectGetTypeFlowDependenciesNode> _objectGetTypeFlowDependencies;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -25,6 +25,7 @@ namespace ILCompiler.DependencyAnalysis
         public NonGCStaticsNode(MetadataType type, PreinitializationManager preinitializationManager)
         {
             Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Specific));
+            Debug.Assert(!type.IsGenericDefinition);
             _type = type;
             _preinitializationManager = preinitializationManager;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableFieldNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableFieldNode.cs
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a field that is gettable/settable from reflection.
+    /// </summary>
+    public class ReflectableFieldNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly FieldDesc _field;
+
+        public ReflectableFieldNode(FieldDesc field)
+        {
+            Debug.Assert(!field.OwningType.IsCanonicalSubtype(CanonicalFormKind.Any)
+                || field.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific) == field.OwningType);
+            _field = field;
+        }
+
+        public FieldDesc Field => _field;
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            Debug.Assert(!factory.MetadataManager.IsReflectionBlocked(_field.GetTypicalFieldDefinition()));
+
+            DependencyList dependencies = new DependencyList();
+            factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencies, factory, _field);
+
+            // No runtime artifacts needed if this is a generic definition or literal field
+            if (_field.OwningType.IsGenericDefinition || _field.IsLiteral)
+            {
+                return dependencies;
+            }
+
+            FieldDesc typicalField = _field.GetTypicalFieldDefinition();
+            if (typicalField != _field)
+            {
+                // Ensure we consistently apply reflectability to all fields sharing the same definition.
+                // Bases for different instantiations of the field have a conditional dependency on the definition node that
+                // brings a ReflectableField of the instantiated field if it's necessary for it to be reflectable.
+                dependencies.Add(factory.ReflectableField(typicalField), "Definition of the reflectable field");
+            }
+
+            // Runtime reflection stack needs to see the type handle of the owning type
+            dependencies.Add(factory.MaximallyConstructableType(_field.OwningType), "Instance base of a reflectable field");
+
+            // Root the static base of the type
+            if (_field.IsStatic && !_field.OwningType.IsCanonicalSubtype(CanonicalFormKind.Any))
+            {
+                // Infrastructure around static constructors is stashed in the NonGC static base
+                bool needsNonGcStaticBase = factory.PreinitializationManager.HasLazyStaticConstructor(Field.OwningType);
+
+                if (_field.HasRva)
+                {
+                    // No reflection access right now
+                }
+                else if (_field.IsThreadStatic)
+                {
+                    dependencies.Add(factory.TypeThreadStaticIndex((MetadataType)_field.OwningType), "Threadstatic base of a reflectable field");
+                }
+                else if (_field.HasGCStaticBase)
+                {
+                    dependencies.Add(factory.TypeGCStaticsSymbol((MetadataType)_field.OwningType), "GC static base of a reflectable field");
+                }
+                else
+                {
+                    dependencies.Add(factory.TypeNonGCStaticsSymbol((MetadataType)_field.OwningType), "NonGC static base of a reflectable field");
+                    needsNonGcStaticBase = false;
+                }
+
+                if (needsNonGcStaticBase)
+                {
+                    dependencies.Add(factory.TypeNonGCStaticsSymbol((MetadataType)_field.OwningType), "CCtor context");
+                }
+            }
+
+            // Runtime reflection stack needs to obtain the type handle of the field
+            // (but there's no type handles for function pointers)
+            if (!_field.FieldType.IsFunctionPointer)
+                dependencies.Add(factory.MaximallyConstructableType(_field.FieldType.NormalizeInstantiation()), "Type of the field");
+
+            return dependencies;
+        }
+        protected override string GetName(NodeFactory factory)
+        {
+            return "Reflectable field: " + _field.ToString();
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -19,7 +19,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public ThreadStaticsNode(MetadataType type, NodeFactory factory)
         {
-            Debug.Assert(factory.Target.Abi == TargetAbi.NativeAot || factory.Target.Abi == TargetAbi.CppCodegen);
+            Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Specific));
+            Debug.Assert(!type.IsGenericDefinition);
             _type = type;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -59,7 +59,8 @@ namespace ILCompiler.DependencyAnalysis
                 // so for enums also include their MethodTable.
                 dependencies.Add(factory.MaximallyConstructableType(_type), "Reflectable enum");
 
-                // Enums are not useful without their literal fields
+                // Enums are not useful without their literal fields. The literal fields are not referenced
+                // from anywhere (source code reference to enums compiles to the underlying numerical constants in IL).
                 foreach (FieldDesc enumField in _type.GetFields())
                 {
                     if (enumField.IsLiteral)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -58,6 +58,15 @@ namespace ILCompiler.DependencyAnalysis
                 // A lot of the enum reflection actually happens on top of the respective MethodTable (e.g. getting the underlying type),
                 // so for enums also include their MethodTable.
                 dependencies.Add(factory.MaximallyConstructableType(_type), "Reflectable enum");
+
+                // Enums are not useful without their literal fields
+                foreach (FieldDesc enumField in _type.GetFields())
+                {
+                    if (enumField.IsLiteral)
+                    {
+                        dependencies.Add(factory.FieldMetadata(enumField), "Value of a reflectable enum");
+                    }
+                }
             }
 
             // If the user asked for complete metadata to be generated for all types that are getting metadata, ensure that.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/IRootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/IRootingServiceProvider.cs
@@ -13,6 +13,7 @@ namespace ILCompiler
         void AddCompilationRoot(MethodDesc method, string reason, string exportName = null);
         void AddCompilationRoot(TypeDesc type, string reason);
         void AddReflectionRoot(MethodDesc method, string reason);
+        void AddReflectionRoot(FieldDesc field, string reason);
         void RootThreadStaticBaseForType(TypeDesc type, string reason);
         void RootGCStaticBaseForType(TypeDesc type, string reason);
         void RootNonGCStaticBaseForType(TypeDesc type, string reason);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -346,6 +346,19 @@ namespace ILCompiler
         }
 
         /// <summary>
+        /// This method is an extension point that can provide additional metadata-based dependencies to generated fields.
+        /// </summary>
+        public void GetDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
+        {
+            MetadataCategory category = GetMetadataCategory(field);
+
+            if ((category & MetadataCategory.Description) != 0)
+            {
+                GetMetadataDependenciesDueToReflectability(ref dependencies, factory, field);
+            }
+        }
+
+        /// <summary>
         /// This method is an extension point that can provide additional metadata-based dependencies on a virtual method.
         /// </summary>
         public virtual void GetDependenciesDueToVirtualMethodReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
@@ -356,6 +369,13 @@ namespace ILCompiler
         {
             // MetadataManagers can override this to provide additional dependencies caused by the emission of metadata
             // (E.g. dependencies caused by the method having custom attributes applied to it: making sure we compile the attribute constructor
+            // and property setters)
+        }
+
+        protected virtual void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
+        {
+            // MetadataManagers can override this to provide additional dependencies caused by the emission of metadata
+            // (E.g. dependencies caused by the field having custom attributes applied to it: making sure we compile the attribute constructor
             // and property setters)
         }
 
@@ -371,15 +391,6 @@ namespace ILCompiler
                 GetMetadataDependenciesDueToReflectability(ref dependencies, factory, type);
             }
 
-            if ((category & MetadataCategory.RuntimeMapping) != 0)
-            {
-                // We're going to generate a mapping table entry for this. Collect dependencies.
-
-                // Nothing special is needed for the mapping table (we only emit the MethodTable and we already
-                // have one, since we got this callback). But check if a child wants to do something extra.
-                GetRuntimeMappingDependenciesDueToReflectability(ref dependencies, factory, type);
-            }
-
             GetDependenciesDueToEETypePresence(ref dependencies, factory, type);
         }
 
@@ -388,12 +399,6 @@ namespace ILCompiler
             // MetadataManagers can override this to provide additional dependencies caused by the emission of metadata
             // (E.g. dependencies caused by the type having custom attributes applied to it: making sure we compile the attribute constructor
             // and property setters)
-        }
-
-        protected virtual void GetRuntimeMappingDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
-        {
-            // MetadataManagers can override this to provide additional dependencies caused by the emission of a runtime
-            // mapping for a type.
         }
 
         protected virtual void GetDependenciesDueToEETypePresence(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
@@ -46,6 +46,12 @@ namespace ILCompiler
                 _rootAdder(_factory.ReflectableMethod(method), reason);
         }
 
+        public void AddReflectionRoot(FieldDesc field, string reason)
+        {
+            if (!_factory.MetadataManager.IsReflectionBlocked(field))
+                _rootAdder(_factory.ReflectableField(field), reason);
+        }
+
         public void RootThreadStaticBaseForType(TypeDesc type, string reason)
         {
             Debug.Assert(!type.IsGenericDefinition);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -40,7 +40,6 @@ namespace ILCompiler
         private readonly CompilationModuleGroup _compilationModuleGroup;
 
         internal readonly UsageBasedMetadataGenerationOptions _generationOptions;
-        private readonly bool _hasPreciseFieldUsageInformation;
 
         private readonly FeatureSwitchHashtable _featureSwitchHashtable;
 
@@ -48,6 +47,7 @@ namespace ILCompiler
         private readonly List<FieldDesc> _fieldsWithMetadata = new List<FieldDesc>();
         private readonly List<MethodDesc> _methodsWithMetadata = new List<MethodDesc>();
         private readonly List<MetadataType> _typesWithMetadata = new List<MetadataType>();
+        private readonly List<FieldDesc> _fieldsWithRuntimeMapping = new List<FieldDesc>();
         private readonly List<ReflectableCustomAttribute> _customAttributesWithMetadata = new List<ReflectableCustomAttribute>();
 
         private readonly HashSet<ModuleDesc> _rootEntireAssembliesExaminedModules = new HashSet<ModuleDesc>();
@@ -75,8 +75,6 @@ namespace ILCompiler
             IEnumerable<string> trimmedAssemblies)
             : base(typeSystemContext, blockingPolicy, resourceBlockingPolicy, logFile, stackTracePolicy, invokeThunkGenerationPolicy)
         {
-            // We use this to mark places that would behave differently if we tracked exact fields used. 
-            _hasPreciseFieldUsageInformation = false;
             _compilationModuleGroup = group;
             _generationOptions = generationOptions;
 
@@ -121,6 +119,22 @@ namespace ILCompiler
             if (customAttributeMetadataNode != null)
             {
                 _customAttributesWithMetadata.Add(customAttributeMetadataNode.CustomAttribute);
+            }
+
+            var reflectableFieldNode = obj as ReflectableFieldNode;
+            if (reflectableFieldNode != null)
+            {
+                FieldDesc field = reflectableFieldNode.Field;
+                TypeDesc fieldOwningType = field.OwningType;
+
+                // Filter out to those that make sense to have in the mapping tables
+                if (!fieldOwningType.IsGenericDefinition
+                    && !field.IsLiteral
+                    && (!fieldOwningType.IsCanonicalSubtype(CanonicalFormKind.Specific) || !field.IsStatic))
+                {
+                    Debug.Assert((GetMetadataCategory(field) & MetadataCategory.RuntimeMapping) != 0);
+                    _fieldsWithRuntimeMapping.Add(field);
+                }
             }
         }
 
@@ -192,25 +206,15 @@ namespace ILCompiler
             dependencies.Add(factory.MethodMetadata(method.GetTypicalMethodDefinition()), "Reflectable method");
         }
 
+        protected override void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
+        {
+            dependencies = dependencies ?? new DependencyList();
+            dependencies.Add(factory.FieldMetadata(field.GetTypicalFieldDefinition()), "Reflectable field");
+        }
+
         protected override void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
         {
             TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, type, "Reflectable type");
-
-            // If we don't have precise field usage information, apply policy that all fields that
-            // are eligible to have metadata get metadata.
-            if (!_hasPreciseFieldUsageInformation)
-            {
-                TypeDesc typeDefinition = type.GetTypeDefinition();
-
-                foreach (FieldDesc field in typeDefinition.GetFields())
-                {
-                    if ((GetMetadataCategory(field) & MetadataCategory.Description) != 0)
-                    {
-                        dependencies = dependencies ?? new DependencyList();
-                        dependencies.Add(factory.FieldMetadata(field), "Field of a reflectable type");
-                    }
-                }
-            }
 
             MetadataType mdType = type as MetadataType;
 
@@ -338,48 +342,19 @@ namespace ILCompiler
             return false;
         }
 
-        protected override void GetRuntimeMappingDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
-        {
-            // If we precisely track field usage, we don't need the logic below.
-            if (_hasPreciseFieldUsageInformation)
-                return;
-
-            const string reason = "Reflection";
-
-            // This logic is applying policy: if a type is reflectable (has a runtime mapping), all of it's fields
-            // are reflectable (with a runtime mapping) as well.
-            // This is potentially overly broad (we don't know if any of the fields will actually be eligile
-            // for metadata - e.g. they could all be reflection blocked). This is fine since lack of
-            // precise field usage information is already not ideal from a size on disk perspective.
-            // The more precise way to do this would be to go over each field, check that it's eligible for RuntimeMapping
-            // according to the policy (e.g. it's not blocked), and only then root the base of the field.
-            if (type is MetadataType metadataType && !type.IsGenericDefinition)
-            {
-                Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Any));
-
-                if (metadataType.GCStaticFieldSize.AsInt > 0)
-                {
-                    dependencies.Add(factory.TypeGCStaticsSymbol(metadataType), reason);
-                }
-
-                if (metadataType.NonGCStaticFieldSize.AsInt > 0 || factory.PreinitializationManager.HasLazyStaticConstructor(metadataType))
-                {
-                    dependencies.Add(factory.TypeNonGCStaticsSymbol(metadataType), reason);
-                }
-
-                if (metadataType.ThreadGcStaticFieldSize.AsInt > 0)
-                {
-                    dependencies.Add(factory.TypeThreadStaticIndex(metadataType), reason);
-                }
-
-                Debug.Assert(metadataType.ThreadNonGcStaticFieldSize.AsInt == 0);
-            }
-        }
-
         public override bool HasConditionalDependenciesDueToEETypePresence(TypeDesc type)
         {
-            // Note: duplicated with the check in GetConditionalDependenciesDueToEETypePresence
-            return type.IsDefType && !type.IsInterface && FlowAnnotations.GetTypeAnnotation(type) != default;
+            // Note: these are duplicated with the checks in GetConditionalDependenciesDueToEETypePresence
+
+            // If there's dataflow annotations on the type, we have conditional dependencies
+            if (type.IsDefType && !type.IsInterface && FlowAnnotations.GetTypeAnnotation(type) != default)
+                return true;
+
+            // If we need to ensure fields are consistently reflectable on various generic instances
+            if (type.HasInstantiation && !type.IsGenericDefinition && !IsReflectionBlocked(type))
+                return true;
+
+            return false;
         }
 
         public override void GetConditionalDependenciesDueToEETypePresence(ref CombinedDependencyList dependencies, NodeFactory factory, TypeDesc type)
@@ -435,16 +410,34 @@ namespace ILCompiler
                 // of the bases/interfaces are annotated.
                 // ObjectGetTypeFlowDependencies don't need to be conditional in that case. They'll be added as needed.
             }
+
+            // Ensure fields can be consistently reflection set & get.
+            if (type.HasInstantiation && !type.IsTypeDefinition && !IsReflectionBlocked(type))
+            {
+                foreach (FieldDesc field in type.GetFields())
+                {
+                    // Tiny optimization: no get/set for literal fields
+                    if (field.IsLiteral)
+                        continue;
+
+                    if (IsReflectionBlocked(field))
+                        continue;
+
+                    dependencies ??= new CombinedDependencyList();
+                    dependencies.Add(new DependencyNodeCore<NodeFactory>.CombinedDependencyListEntry(
+                        factory.ReflectableField(field),
+                        factory.ReflectableField(field.GetTypicalFieldDefinition()),
+                        "GetType called on the interface"));
+                }
+            }
         }
 
         public override void GetDependenciesDueToLdToken(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
         {
-            // In order for the RuntimeFieldHandle data structure to be usable at runtime, ensure the field
-            // is generating metadata.
-            if ((GetMetadataCategory(field) & MetadataCategory.Description) == MetadataCategory.Description)
+            if (!IsReflectionBlocked(field))
             {
                 dependencies = dependencies ?? new DependencyList();
-                dependencies.Add(factory.FieldMetadata(field.GetTypicalFieldDefinition()), "LDTOKEN field");
+                dependencies.Add(factory.ReflectableField(field), "LDTOKEN field");
             }
         }
 
@@ -571,26 +564,7 @@ namespace ILCompiler
 
         protected override IEnumerable<FieldDesc> GetFieldsWithRuntimeMapping()
         {
-            if (_hasPreciseFieldUsageInformation)
-            {
-                // TODO
-            }
-            else
-            {
-                // This applies a policy that fields inherit runtime mapping from their owning type,
-                // unless they are blocked.
-                foreach (var type in GetTypesWithRuntimeMapping())
-                {
-                    if (type.IsGenericDefinition)
-                        continue;
-
-                    foreach (var field in type.GetFields())
-                    {
-                        if ((GetMetadataCategory(field) & MetadataCategory.RuntimeMapping) != 0)
-                            yield return field;
-                    }
-                }
-            }
+            return _fieldsWithRuntimeMapping;
         }
 
         public override IEnumerable<ModuleDesc> GetCompilationModulesWithMetadata()
@@ -624,6 +598,28 @@ namespace ILCompiler
             {
                 dependencies = dependencies ?? new DependencyList();
                 dependencies.Add(factory.DataflowAnalyzedMethod(methodIL.GetMethodILDefinition()), "Access to interesting field");
+            }
+
+            if ((_generationOptions & UsageBasedMetadataGenerationOptions.ReflectedMembersOnly) == 0
+                && !IsReflectionBlocked(writtenField))
+            {
+                FieldDesc fieldToReport = writtenField;
+
+                // The field could be on something odd like Foo<__Canon, object>. Normalize to Foo<__Canon, __Canon>.
+                TypeDesc fieldOwningType = writtenField.OwningType;
+                if (fieldOwningType.IsCanonicalSubtype(CanonicalFormKind.Specific))
+                {
+                    TypeDesc fieldOwningTypeNormalized = fieldOwningType.NormalizeInstantiation();
+                    if (fieldOwningType != fieldOwningTypeNormalized)
+                    {
+                        fieldToReport = factory.TypeSystemContext.GetFieldForInstantiatedType(
+                            writtenField.GetTypicalFieldDefinition(),
+                            (InstantiatedType)fieldOwningTypeNormalized);
+                    }
+                }
+
+                dependencies = dependencies ?? new DependencyList();
+                dependencies.Add(factory.ReflectableField(fieldToReport), "Use of a field");
             }
         }
 
@@ -795,41 +791,16 @@ namespace ILCompiler
                 reflectableFields[fieldWithMetadata] = MetadataCategory.Description;
             }
 
-            if (_hasPreciseFieldUsageInformation)
+            foreach (var fieldWithRuntimeMapping in _fieldsWithRuntimeMapping)
             {
-                // TODO
-            }
-            else
-            {
-                // If we don't have precise field usage information we apply a policy that
-                // says the fields inherit the setting from the type, potentially restricted by blocking.
-                // (I.e. if a type has RuntimeMapping metadata, the field has RuntimeMapping too, unless blocked.)
-                foreach (var reflectableType in reflectableTypes.ToEnumerable())
+                reflectableFields[fieldWithRuntimeMapping] |= MetadataCategory.RuntimeMapping;
+
+                // Also set the description bit if the definition is getting metadata.
+                FieldDesc typicalField = fieldWithRuntimeMapping.GetTypicalFieldDefinition();
+                if (fieldWithRuntimeMapping != typicalField &&
+                    (reflectableFields[typicalField] & MetadataCategory.Description) != 0)
                 {
-                    if (reflectableType.Entity.IsGenericDefinition)
-                        continue;
-
-                    if (reflectableType.Entity.IsCanonicalSubtype(CanonicalFormKind.Specific))
-                        continue;
-
-                    if ((reflectableType.Category & MetadataCategory.RuntimeMapping) == 0)
-                        continue;
-
-                    foreach (var field in reflectableType.Entity.GetFields())
-                    {
-                        if (!IsReflectionBlocked(field))
-                        {
-                            reflectableFields[field] |= MetadataCategory.RuntimeMapping;
-
-                            // Also set the description bit if the definition is getting metadata.
-                            FieldDesc typicalField = field.GetTypicalFieldDefinition();
-                            if (field != typicalField &&
-                                (reflectableFields[typicalField] & MetadataCategory.Description) != 0)
-                            {
-                                reflectableFields[field] |= MetadataCategory.Description;
-                            }
-                        }
-                    }
+                    reflectableFields[fieldWithRuntimeMapping] |= MetadataCategory.Description;
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -416,7 +416,7 @@ namespace ILCompiler
             {
                 foreach (FieldDesc field in type.GetFields())
                 {
-                    // Tiny optimization: no get/set for literal fields
+                    // Tiny optimization: no get/set for literal fields since they only exist in metadata
                     if (field.IsLiteral)
                         continue;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -975,8 +975,9 @@ namespace Internal.IL
         private void ImportFieldAccess(int token, bool isStatic, string reason)
         {
             var field = (FieldDesc)_methodIL.GetObject(token);
+            var canonField = (FieldDesc)_canonMethodIL.GetObject(token);
 
-            _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _compilation.NodeFactory, _canonMethodIL, field);
+            _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _compilation.NodeFactory, _canonMethodIL, canonField);
 
             // Covers both ldsfld/ldsflda and ldfld/ldflda with a static field
             if (isStatic || field.IsStatic)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -351,6 +351,7 @@
     <Compile Include="Compiler\DependencyAnalysis\MethodExceptionHandlingInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ModuleInitializerListNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ObjectGetTypeFlowDependenciesNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReflectableFieldNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectionInvokeSupportDependencyAlgorithm.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectionMethodBodyScanner.cs" />
     <Compile Include="Compiler\DependencyAnalysis\StructMarshallingDataNode.cs" />

--- a/src/tests/nativeaot/SmokeTests/Dataflow/Dataflow.cs
+++ b/src/tests/nativeaot/SmokeTests/Dataflow/Dataflow.cs
@@ -108,8 +108,8 @@ class Program
             Assert.NotNull(typeof(TestType1).GetMethod(nameof(TestType1.TestMethod)));
             Assert.Equal(1, typeof(TestType1).CountMethods());
 
-            //Assert.NotNull(typeof(TestType1).GetField(nameof(TestType1.TestField)));
-            //Assert.Equal(1, typeof(TestType1).CountFields());
+            Assert.NotNull(typeof(TestType1).GetField(nameof(TestType1.TestField)));
+            Assert.Equal(1, typeof(TestType1).CountFields());
 
             Assert.NotNull(typeof(TestType2).GetProperty(nameof(TestType2.TestProperty)));
             Assert.NotNull(typeof(TestType2).GetProperty(nameof(TestType2.TestProperty)).GetGetMethod());

--- a/src/tests/nativeaot/SmokeTests/DeadCodeElimination/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/DeadCodeElimination/DeadCodeElimination.cs
@@ -47,9 +47,7 @@ class Program
             public Type DoSomething() => typeof(UnreferencedType);
         }
 
-#if DEBUG
-        static NeverAllocatedType s_instance = null;
-#else
+#if !DEBUG
         static object s_instance = new object[10];
 #endif
 
@@ -58,8 +56,9 @@ class Program
             Console.WriteLine("Testing instance methods on unallocated types");
 
 #if DEBUG
-            if (s_instance != null)
-                s_instance.DoSomething();
+            NeverAllocatedType instance = null;
+            if (instance != null)
+                instance.DoSomething();
 #else
             // In release builds additionally test that the "is" check didn't introduce the constructed type
             if (s_instance is NeverAllocatedType never)


### PR DESCRIPTION
The AOT compiler used simple logic to decide what fields should be kept/generated: if a type is considered constructed, generate all fields. This works, but it's not very efficient.

With this change I'm introducing precise tracking of each field that should be accessible from reflection at runtime. The fields are represented by new nodes within the dependency graph.

We track fields on individual generic instantiations and ensure we end up in a consistent state where if e.g. we decided `Class<int>.Foo` should be reflection accessible and `Class<double>` is used elsewhere in the program, `Class<double>.Foo` is also reflection accessible. This matches how IL Linker thinks about reflectability where genericness doesn't matter. We could be more optimal here, but various suppressions in framework rely on this logic. Additional reflectable fields only cost tens of bytes.

I had to update various places within the compiler that didn't bother specifying field dependencies because they didn't matter in the past.

Added a couple new tests that test the various invariants.

This saves 2% in size on a `dotnet new webapi` template project with IlcTrimMetadata on. It is a small regression with `IlcTrimMetadata` off because we actually now track more things for the reflectable field: previously we would not make sure the field is reflection-accessible at runtime. We need a `TypeHandle` for the field type for it to be usable. As a potential future optimization, we could look into allowing reflection to see "unconstructed" `TypeHandles` (and use that one). Reflection is currently not allowed to see unconstructed `TypeHandles` to prevent people falling into a `RuntimeHelpers.AllocateUninitializedObject(someField.FieldType.TypeHandle)` trap that has a bad failure mode right now. Once we fix the failure mode, we could potentially allow it.

Cc @dotnet/ilc-contrib 