### PR TITLE
Remove Android crypto internals from System.Security.Cryptography.X509Certificates tests

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
@@ -98,10 +98,6 @@ internal static partial class Interop
             IntPtr[] customTrustStore,
             int customTrustStoreLen);
 
-        [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainSupportsRevocationOptions")]
-        [return:MarshalAs(UnmanagedType.U1)]
-        internal static partial bool X509ChainSupportsRevocationOptions();
-
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainValidate")]
         internal static partial int X509ChainValidate(
             SafeX509ChainContextHandle ctx,

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.Android.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.Android.cs
@@ -11,6 +11,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 {
     public static partial class DynamicRevocationTests
     {
-        public static bool SupportsDynamicRevocation { get; } = Interop.AndroidCrypto.X509ChainSupportsRevocationOptions();
+        public static bool SupportsDynamicRevocation { get; } = OperatingSystem.IsAndroidVersionAtLeast(24);
     }
 }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -124,16 +124,6 @@
   <ItemGroup Condition="'$(UseAndroidCrypto)' == 'true'">
     <Compile Include="X509StoreMutableTests.Android.cs" />
     <Compile Include="RevocationTests\DynamicRevocationTests.Android.cs" />
-    <Compile Include="$(CommonPath)Interop\Android\System.Security.Cryptography.Native.Android\Interop.X509.cs"
-             Link="Common\Interop\Android\System.Security.Cryptography.Native.Android\Interop.X509.cs" />
-    <Compile Include="$(CommonPath)Interop\Android\System.Security.Cryptography.Native.Android\Interop.X509Chain.cs"
-             Link="Common\Interop\Android\System.Security.Cryptography.Native.Android\Interop.X509Chain.cs" />
-    <Compile Include="$(CommonPath)Interop\Android\Interop.JObjectLifetime.cs"
-             Link="Common\Interop\Android\Interop.JObjectLifetime.cs" />
-    <Compile Include="$(CommonPath)Interop\Android\Interop.Libraries.cs"
-             Link="Common\Interop\Android\Interop.Libraries.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs"
-             Link="Common\Interop\Unix\Interop.Libraries.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseAppleCrypto)' == 'true' and '$(TargetPlatformIdentifier)' == 'OSX'">
     <Compile Include="X509StoreMutableTests.OSX.cs" />

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509chain.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509chain.c
@@ -428,7 +428,7 @@ int32_t AndroidCryptoNative_X509ChainSetCustomTrustStore(X509ChainContext* ctx,
     return CheckJNIExceptions(env) ? FAIL : SUCCESS;
 }
 
-bool AndroidCryptoNative_X509ChainSupportsRevocationOptions(void)
+static bool X509ChainSupportsRevocationOptions(void)
 {
     return g_CertPathValidatorGetRevocationChecker != NULL && g_PKIXRevocationCheckerClass != NULL;
 }
@@ -507,7 +507,7 @@ static int32_t ValidateWithRevocation(JNIEnv* env,
         else
         {
             certPathToUse = ctx->certPath;
-            if (AndroidCryptoNative_X509ChainSupportsRevocationOptions())
+            if (X509ChainSupportsRevocationOptions())
             {
                 // Only add the ONLY_END_ENTITY if we are not just checking the trust anchor. If ONLY_END_ENTITY is
                 // specified, revocation checking will skip the trust anchor even if it is the only certificate.
@@ -536,7 +536,7 @@ static int32_t ValidateWithRevocation(JNIEnv* env,
     }
 
     jobject params = ctx->params;
-    if (AndroidCryptoNative_X509ChainSupportsRevocationOptions())
+    if (X509ChainSupportsRevocationOptions())
     {
         // PKIXRevocationChecker checker = validator.getRevocationChecker();
         loc[checker] = (*env)->CallObjectMethod(env, validator, g_CertPathValidatorGetRevocationChecker);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509chain.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509chain.h
@@ -62,11 +62,6 @@ PALEXPORT int32_t AndroidCryptoNative_X509ChainSetCustomTrustStore(X509ChainCont
                                                                    jobject* /*X509Certificate[]*/ customTrustStore,
                                                                    int32_t customTrustStoreLen);
 
-/*
-Returns true if revocation checking is supported. Returns false otherwise.
-*/
-PALEXPORT bool AndroidCryptoNative_X509ChainSupportsRevocationOptions(void);
-
 // Matches managed X509RevocationMode enum
 enum
 {


### PR DESCRIPTION
The `Interop.AndroidCrypto.X509ChainSupportsRevocationOptions` internally just checks that a certain Java class exists, we can assume it is always there on Android API 24+.
This allows us to remove a bunch of internal crypto interop code from the tests.