### PR TITLE
Propagate c++ unhandled exception to previous handler

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1335,11 +1335,6 @@ part2:
                 // No longer process exceptions
                 g_fNoExceptions = true;
 
-                //
-                // Remove our global exception filter. If it was NULL before, we want it to be null now.
-                //
-                UninstallUnhandledExceptionFilter();
-
                 // <TODO>@TODO: This does things which shouldn't occur in part 2.  Namely,
                 // calling managed dll main callbacks (AppDomain::SignalProcessDetach), and
                 // RemoveAppDomainFromIPC.

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4967,20 +4967,10 @@ LONG InternalUnhandledExceptionFilter(
         return retval;
     }
 
-    // Chaining back to previous UEF handler could be a potential security risk. See
-    // http://uninformed.org/index.cgi?v=4&a=5&p=1 for details.
-    // Thus we are allowing only C++ exceptions to be chained to the previous handler.
     if (g_pOriginalUnhandledExceptionFilter != FILTER_NOT_INSTALLED
         && g_pOriginalUnhandledExceptionFilter != NULL)
     {
-        if (pExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_MSVC)
-        {
-            return g_pOriginalUnhandledExceptionFilter(pExceptionInfo);
-        }
-        else
-        {
-            STRESS_LOG1(LF_EH, LL_INFO100, "InternalUnhandledExceptionFilter: Not chaining back to previous UEF at address %p on CoreCLR!\n", g_pOriginalUnhandledExceptionFilter);
-        }
+        return g_pOriginalUnhandledExceptionFilter(pExceptionInfo);
     }
 
     return retval;

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4466,10 +4466,7 @@ BOOL InstallUnhandledExceptionFilter() {
     STATIC_CONTRACT_FORBID_FAULT;
 
 #ifndef TARGET_UNIX
-    #pragma prefast(push)
-    #pragma prefast(suppress:28725, "Calling to SetUnhandledExceptionFilter is intentional in this case.")
     g_pOriginalUnhandledExceptionFilter = SetUnhandledExceptionFilter(COMUnhandledExceptionFilter);
-    #pragma prefast(pop)
 
     LOG((LF_EH, LL_INFO10, "InstallUnhandledExceptionFilter registered UEF with OS for CoreCLR!\n"));
 #endif // !TARGET_UNIX

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -146,7 +146,6 @@ BOOL IsCOMPlusExceptionHandlerInstalled();
 #endif
 
 BOOL InstallUnhandledExceptionFilter();
-void UninstallUnhandledExceptionFilter();
 
 #if !defined(TARGET_UNIX)
 // Section naming is a strategy by itself. Ideally, we could have named the UEF section


### PR DESCRIPTION
Currently runtime doesn't propagate c++ unhandled exceptions to a handler
registered by the `std::set_terminate`. That is problematic for custom
hosts that want e.g. to log such exceptions.

This change adds chaining unhandled C++ exception to the previously
registered handler.

Close #70136