### PR TITLE
[6.0] Switch the ClientPre Helix queues to Client

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -134,7 +134,7 @@ jobs:
           - ${{ if ne(parameters.jobParameters.isFullMatrix, true) }}:
             - Windows.81.Amd64.Open
             - Windows.10.Amd64.Server2022.ES.Open
-            - Windows.11.Amd64.ClientPre.Open
+            - Windows.11.Amd64.Client.Open
             - ${{ if eq(parameters.jobParameters.testScope, 'outerloop') }}:
               - (Windows.Server.Core.1909.Amd64.Open)windows.10.amd64.server20H2.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-2004-helix-amd64-20200904200251-272704c
             - ${{ if ne(parameters.jobParameters.runtimeFlavor, 'mono') }}:


### PR DESCRIPTION
Backporting Helix infra change: https://github.com/dotnet/runtime/pull/69871

ClientPre is leaving as of 2022-06-16, move to newer non-preview Windows 11