### PR TITLE
Skip X.509 extension copies where possible

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Oids.Shared.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Oids.Shared.cs
@@ -28,6 +28,7 @@ namespace System.Security.Cryptography
         private static volatile Oid? _enhancedKeyUsageOid;
         private static volatile Oid? _keyUsageOid;
         private static volatile Oid? _subjectKeyIdentifierOid;
+        private static volatile Oid? _authorityInformationAccessOid;
 
         internal static Oid RsaOid => _rsaOid ??= InitializeOid(Rsa);
         internal static Oid EcPublicKeyOid => _ecPublicKeyOid ??= InitializeOid(EcPublicKey);
@@ -51,6 +52,7 @@ namespace System.Security.Cryptography
         internal static Oid EnhancedKeyUsageOid => _enhancedKeyUsageOid ??= InitializeOid(EnhancedKeyUsage);
         internal static Oid KeyUsageOid => _keyUsageOid ??= InitializeOid(KeyUsage);
         internal static Oid SubjectKeyIdentifierOid => _subjectKeyIdentifierOid ??= InitializeOid(SubjectKeyIdentifier);
+        internal static Oid AuthorityInformationAccessOid => _authorityInformationAccessOid ??= InitializeOid(AuthorityInformationAccess);
 
         private static Oid InitializeOid(string oidValue)
         {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AsnEncodedData.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AsnEncodedData.cs
@@ -39,14 +39,12 @@ namespace System.Security.Cryptography
             Reset(asnEncodedData._oid, asnEncodedData._rawData);
         }
 
-        public AsnEncodedData(Oid? oid, byte[] rawData)
+        public AsnEncodedData(Oid? oid, byte[] rawData) : this(oid, rawData, skipCopy: false)
         {
-            Reset(oid, rawData);
         }
 
-        public AsnEncodedData(string oid, byte[] rawData)
+        public AsnEncodedData(string oid, byte[] rawData) : this(new Oid(oid), rawData, skipCopy: false)
         {
-            Reset(new Oid(oid), rawData);
         }
 
         /// <summary>
@@ -77,6 +75,21 @@ namespace System.Security.Cryptography
         public AsnEncodedData(string oid, ReadOnlySpan<byte> rawData)
         {
             Reset(new Oid(oid), rawData);
+        }
+
+        internal AsnEncodedData(Oid? oid, byte[] rawData, bool skipCopy)
+        {
+            if (skipCopy)
+            {
+                ArgumentNullException.ThrowIfNull(rawData);
+                Oid = oid;
+                _rawData = rawData;
+            }
+            else
+            {
+                Reset(oid, rawData);
+            }
+
         }
 
         public Oid? Oid

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509AuthorityInformationAccessExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509AuthorityInformationAccessExtension.cs
@@ -20,7 +20,7 @@ namespace System.Security.Cryptography.X509Certificates
         ///   class.
         /// </summary>
         public X509AuthorityInformationAccessExtension()
-            : base(Oids.AuthorityInformationAccess)
+            : base(Oids.AuthorityInformationAccessOid)
         {
             _decoded = Array.Empty<AccessDescriptionAsn>();
         }
@@ -43,7 +43,7 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <paramref name="rawData" /> did not decode as an Authority Information Access extension.
         /// </exception>
         public X509AuthorityInformationAccessExtension(byte[] rawData, bool critical = false)
-            : base(Oids.AuthorityInformationAccess, rawData, critical)
+            : base(Oids.AuthorityInformationAccessOid, rawData, critical)
         {
             _decoded = Decode(RawData);
         }
@@ -63,7 +63,7 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <paramref name="rawData" /> did not decode as an Authority Information Access extension.
         /// </exception>
         public X509AuthorityInformationAccessExtension(ReadOnlySpan<byte> rawData, bool critical = false)
-            : base(Oids.AuthorityInformationAccess, rawData, critical)
+            : base(Oids.AuthorityInformationAccessOid, rawData, critical)
         {
             _decoded = Decode(RawData);
         }
@@ -95,7 +95,7 @@ namespace System.Security.Cryptography.X509Certificates
             IEnumerable<string>? ocspUris,
             IEnumerable<string>? caIssuersUris,
             bool critical = false)
-            : base(Oids.AuthorityInformationAccess, Encode(ocspUris, caIssuersUris), critical)
+            : base(Oids.AuthorityInformationAccessOid, Encode(ocspUris, caIssuersUris), critical, skipCopy: true)
         {
             _decoded = Decode(RawData);
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509BasicConstraintsExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509BasicConstraintsExtension.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509BasicConstraintsExtension(bool certificateAuthority, bool hasPathLengthConstraint, int pathLengthConstraint, bool critical)
-            : base(Oids.BasicConstraints2Oid, EncodeExtension(certificateAuthority, hasPathLengthConstraint, pathLengthConstraint), critical)
+            : base(Oids.BasicConstraints2Oid, EncodeExtension(certificateAuthority, hasPathLengthConstraint, pathLengthConstraint), critical, skipCopy: true)
         {
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509EnhancedKeyUsageExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509EnhancedKeyUsageExtension.cs
@@ -18,7 +18,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509EnhancedKeyUsageExtension(OidCollection enhancedKeyUsages, bool critical)
-            : base(Oids.EnhancedKeyUsageOid, EncodeExtension(enhancedKeyUsages), critical)
+            : base(Oids.EnhancedKeyUsageOid, EncodeExtension(enhancedKeyUsages), critical, skipCopy: true)
         {
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Extension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Extension.cs
@@ -68,6 +68,18 @@ namespace System.Security.Cryptography.X509Certificates
         {
         }
 
+        internal X509Extension(Oid oid, byte[] rawData, bool critical, bool skipCopy)
+            : base(oid, rawData, skipCopy)
+        {
+            if (base.Oid?.Value == null)
+                throw new ArgumentNullException(nameof(oid));
+
+            if (base.Oid.Value.Length == 0)
+                throw new ArgumentException(SR.Format(SR.Arg_EmptyOrNullString_Named, "oid.Value"), nameof(oid));
+
+            Critical = critical;
+        }
+
         public bool Critical { get; set; }
 
         public override void CopyFrom(AsnEncodedData asnEncodedData)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509KeyUsageExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509KeyUsageExtension.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509KeyUsageExtension(X509KeyUsageFlags keyUsages, bool critical)
-            : base(Oids.KeyUsageOid, X509Pal.Instance.EncodeX509KeyUsageExtension(keyUsages), critical)
+            : base(Oids.KeyUsageOid, X509Pal.Instance.EncodeX509KeyUsageExtension(keyUsages), critical, skipCopy: true)
         {
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509SubjectKeyIdentifierExtension(ReadOnlySpan<byte> subjectKeyIdentifier, bool critical)
-            : base(Oids.SubjectKeyIdentifierOid, EncodeExtension(subjectKeyIdentifier), critical)
+            : base(Oids.SubjectKeyIdentifierOid, EncodeExtension(subjectKeyIdentifier), critical, skipCopy: true)
         {
         }
 
@@ -35,12 +35,12 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509SubjectKeyIdentifierExtension(PublicKey key, X509SubjectKeyIdentifierHashAlgorithm algorithm, bool critical)
-            : base(Oids.SubjectKeyIdentifierOid, EncodeExtension(key, algorithm), critical)
+            : base(Oids.SubjectKeyIdentifierOid, EncodeExtension(key, algorithm), critical, skipCopy: true)
         {
         }
 
         public X509SubjectKeyIdentifierExtension(string subjectKeyIdentifier, bool critical)
-            : base(Oids.SubjectKeyIdentifierOid, EncodeExtension(subjectKeyIdentifier), critical)
+            : base(Oids.SubjectKeyIdentifierOid, EncodeExtension(subjectKeyIdentifier), critical, skipCopy: true)
         {
         }
 


### PR DESCRIPTION
There are a few places where we take a strongly typed object for an `X509Extension`, serialize it to bytes, and then pass it to a base constructor, which copies it.

This PR introduces an internal constructor that skips the copy for the places where we know that the data going in to `AsnEncodedData` can have ownership of the data being passed.

This also adds a cached Oid instance for the AIA extension.