### PR TITLE
[wasm] Re-enable previously failing tests - System.IO.FileSystem

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -247,7 +247,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40536", TestPlatforms.Browser)]
         public void RecursiveDeleteWithTrailingSlash()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Move.cs
@@ -173,7 +173,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40536", TestPlatforms.Browser)]
         public void TrailingDirectorySeparators()
         {
             string testDirSource = Path.Combine(TestDirectory, GetTestFileName());

--- a/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/MoveTo.cs
+++ b/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/MoveTo.cs
@@ -24,7 +24,6 @@ namespace System.IO.Tests
         #region UniversalTests
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40536", TestPlatforms.Browser)]
         public void DirectoryPathUpdatesOnMove()
         {
             //NOTE: MoveTo adds a trailing separator character to the FullName of a DirectoryInfo


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/40536