### PR TITLE
[wasm] Enable some previously failing WBT/AOT tests on windows

### DIFF
--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/MainWithArgsTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/MainWithArgsTests.cs
@@ -25,7 +25,6 @@ namespace Wasm.Build.Tests
             ).WithRunHosts(host).UnwrapItemsAsArrays();
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61725", TestPlatforms.Windows)]
         [MemberData(nameof(MainWithArgsTestData), parameters: new object[] { /*aot*/ false, RunHost.All })]
         [MemberData(nameof(MainWithArgsTestData), parameters: new object[] { /*aot*/ true, RunHost.All })]
         public void AsyncMainWithArgs(BuildArgs buildArgs, string[] args, RunHost host, string id)
@@ -40,7 +39,6 @@ namespace Wasm.Build.Tests
                 buildArgs, args, host, id);
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61725", TestPlatforms.Windows)]
         [MemberData(nameof(MainWithArgsTestData), parameters: new object[] { /*aot*/ false, RunHost.All })]
         [MemberData(nameof(MainWithArgsTestData), parameters: new object[] { /*aot*/ true, RunHost.All })]
         public void TopLevelWithArgs(BuildArgs buildArgs, string[] args, RunHost host, string id)

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeRebuildTests/ReferenceNewAssemblyRebuildTest.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeRebuildTests/ReferenceNewAssemblyRebuildTest.cs
@@ -20,7 +20,6 @@ namespace Wasm.Build.NativeRebuild.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61725", TestPlatforms.Windows)]
         [MemberData(nameof(NativeBuildData))]
         public void ReferenceNewAssembly(BuildArgs buildArgs, bool nativeRelink, bool invariant, RunHost host, string id)
         {

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/SatelliteAssembliesTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/SatelliteAssembliesTests.cs
@@ -22,21 +22,19 @@ namespace Wasm.Build.Tests
         public static IEnumerable<object?[]> SatelliteAssemblyTestData(bool aot, bool relinking, RunHost host)
             => ConfigWithAOTData(aot)
                     .Multiply(
-                        new object?[] { relinking, "es-ES", "got: hola" },
-                        new object?[] { relinking, null,    "got: hello" },
-                        new object?[] { relinking, "ja-JP", "got: \u3053\u3093\u306B\u3061\u306F" })
+                        new object?[] { relinking, "es-ES" },
+                        new object?[] { relinking, null },
+                        new object?[] { relinking, "ja-JP" })
                     .WithRunHosts(host)
                     .UnwrapItemsAsArrays();
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61725", TestPlatforms.Windows)]
         [MemberData(nameof(SatelliteAssemblyTestData), parameters: new object[] { /*aot*/ false, /*relinking*/ false, RunHost.All })]
         [MemberData(nameof(SatelliteAssemblyTestData), parameters: new object[] { /*aot*/ false, /*relinking*/ true,  RunHost.All })]
         [MemberData(nameof(SatelliteAssemblyTestData), parameters: new object[] { /*aot*/ true,  /*relinking*/ false, RunHost.All })]
         public void ResourcesFromMainAssembly(BuildArgs buildArgs,
                                               bool nativeRelink,
                                               string? argCulture,
-                                              string expectedOutput,
                                               RunHost host,
                                               string id)
         {
@@ -62,25 +60,21 @@ namespace Wasm.Build.Tests
                                 },
                                 DotnetWasmFromRuntimePack: dotnetWasmFromRuntimePack));
 
-            string output = RunAndTestWasmApp(
-                                buildArgs, expectedExitCode: 42,
-                                args: argCulture,
-                                host: host, id: id,
-                                // check that downloading assets doesn't have timing race conditions
-                                extraXHarnessMonoArgs: "--fetch-random-delay=200");
-
-            Assert.Contains(expectedOutput, output);
+            RunAndTestWasmApp(
+                            buildArgs, expectedExitCode: 42,
+                            args: argCulture,
+                            host: host, id: id,
+                            // check that downloading assets doesn't have timing race conditions
+                            extraXHarnessMonoArgs: "--fetch-random-delay=200");
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61725", TestPlatforms.Windows)]
         [MemberData(nameof(SatelliteAssemblyTestData), parameters: new object[] { /*aot*/ false, /*relinking*/ false, RunHost.All })]
         [MemberData(nameof(SatelliteAssemblyTestData), parameters: new object[] { /*aot*/ false, /*relinking*/ true,  RunHost.All })]
         [MemberData(nameof(SatelliteAssemblyTestData), parameters: new object[] { /*aot*/ true,  /*relinking*/ false, RunHost.All })]
         public void ResourcesFromProjectReference(BuildArgs buildArgs,
                                                   bool nativeRelink,
                                                   string? argCulture,
-                                                  string expectedOutput,
                                                   RunHost host,
                                                   string id)
         {
@@ -107,12 +101,10 @@ namespace Wasm.Build.Tests
                                     CreateProgramForCultureTest(_projectDir, "LibraryWithResources.resx.words", "LibraryWithResources.Class1");
                                 }));
 
-            string output = RunAndTestWasmApp(buildArgs,
-                                              expectedExitCode: 42,
-                                              args: argCulture,
-                                              host: host, id: id);
-
-            Assert.Contains(expectedOutput, output);
+            RunAndTestWasmApp(buildArgs,
+                              expectedExitCode: 42,
+                              args: argCulture,
+                              host: host, id: id);
         }
 
 #pragma warning disable xUnit1026
@@ -180,12 +172,23 @@ namespace ResourcesTest
     {
         public static int Main(string[] args)
         {
+            string expected;
             if (args.Length == 1)
             {
                 string cultureToTest = args[0];
                 var newCulture = new CultureInfo(cultureToTest);
                 Thread.CurrentThread.CurrentCulture = newCulture;
                 Thread.CurrentThread.CurrentUICulture = newCulture;
+
+                if (cultureToTest == ""es-ES"")
+                    expected = ""hola"";
+                else if (cultureToTest == ""ja-JP"")
+                    expected = ""\u3053\u3093\u306B\u3061\u306F"";
+                else
+                    throw new Exception(""Cannot determine the expected output for {cultureToTest}"");
+
+            } else {
+                expected = ""hello"";
             }
 
             var currentCultureName = Thread.CurrentThread.CurrentCulture.Name;
@@ -193,7 +196,7 @@ namespace ResourcesTest
             var rm = new ResourceManager(""##RESOURCE_NAME##"", typeof(##TYPE_NAME##).Assembly);
             Console.WriteLine($""For '{currentCultureName}' got: {rm.GetString(""hello"")}"");
 
-            return 42;
+            return rm.GetString(""hello"") == expected ? 42 : -1;
         }
     }
 }";

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmBuildAppTest.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmBuildAppTest.cs
@@ -16,7 +16,6 @@ namespace Wasm.Build.Tests
         {}
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61725", TestPlatforms.Windows)]
         [MemberData(nameof(MainMethodTestData), parameters: new object[] { /*aot*/ true, RunHost.All })]
         [MemberData(nameof(MainMethodTestData), parameters: new object[] { /*aot*/ false, RunHost.All })]
         public void TopLevelMain(BuildArgs buildArgs, RunHost host, string id)
@@ -25,7 +24,6 @@ namespace Wasm.Build.Tests
                     buildArgs, host, id);
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61725", TestPlatforms.Windows)]
         [MemberData(nameof(MainMethodTestData), parameters: new object[] { /*aot*/ true, RunHost.All })]
         [MemberData(nameof(MainMethodTestData), parameters: new object[] { /*aot*/ false, RunHost.All })]
         public void AsyncMain(BuildArgs buildArgs, RunHost host, string id)


### PR DESCRIPTION
- Enable AOT tests - Fixes #61725 
- SatelliteAssemblyTests - enable, and fix for windows. Fixes https://github.com/dotnet/runtime/issues/58709 .