### PR TITLE
Add two new stages to prepare for our new custom type marshalling design.

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Interop
                     LiteralExpression(SyntaxKind.TrueLiteralExpression))));
             }
 
-            tryStatements.AddRange(statements.KeepAlive);
+            tryStatements.AddRange(statements.NotifyForSuccessfulInvoke);
             tryStatements.AddRange(statements.Unmarshal);
 
             List<StatementSyntax> allStatements = setupStatements;

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
@@ -146,18 +146,20 @@ namespace Microsoft.Interop
             var tryStatements = new List<StatementSyntax>();
             tryStatements.AddRange(statements.Marshal);
 
-            var invokeStatement = statements.InvokeStatement;
+            BlockSyntax fixedBlock = Block(statements.PinnedMarshal);
             if (_setLastError)
             {
                 StatementSyntax clearLastError = MarshallerHelpers.CreateClearLastSystemErrorStatement(SuccessErrorCode);
 
                 StatementSyntax getLastError = MarshallerHelpers.CreateGetLastSystemErrorStatement(LastErrorIdentifier);
 
-                invokeStatement = Block(clearLastError, invokeStatement, getLastError);
+                fixedBlock = fixedBlock.AddStatements(clearLastError, statements.InvokeStatement, getLastError);
             }
-            invokeStatement = statements.Pin.NestFixedStatements(invokeStatement);
-
-            tryStatements.Add(invokeStatement);
+            else
+            {
+                fixedBlock = fixedBlock.AddStatements(statements.InvokeStatement);
+            }
+            tryStatements.Add(statements.Pin.NestFixedStatements(fixedBlock));
             // <invokeSucceeded> = true;
             if (!statements.GuaranteedUnmarshal.IsEmpty)
             {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Interop
         public ImmutableArray<StatementSyntax> PinnedMarshal { get; init; }
         public StatementSyntax InvokeStatement { get; init; }
         public ImmutableArray<StatementSyntax> Unmarshal { get; init; }
-        public ImmutableArray<StatementSyntax> KeepAlive { get; init; }
+        public ImmutableArray<StatementSyntax> NotifyForSuccessfulInvoke { get; init; }
         public ImmutableArray<StatementSyntax> GuaranteedUnmarshal { get; init; }
         public ImmutableArray<StatementSyntax> Cleanup { get; init; }
 
@@ -36,7 +36,7 @@ namespace Microsoft.Interop
                 InvokeStatement = GenerateStatementForNativeInvoke(marshallers, context with { CurrentStage = StubCodeContext.Stage.Invoke }, expressionToInvoke),
                 Unmarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.UnmarshalCapture })
                             .AddRange(GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.Unmarshal })),
-                KeepAlive = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.NotifyForSuccessfulInvoke }),
+                NotifyForSuccessfulInvoke = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.NotifyForSuccessfulInvoke }),
                 GuaranteedUnmarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.GuaranteedUnmarshal }),
                 Cleanup = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.Cleanup }),
             };

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Interop
         public ImmutableArray<StatementSyntax> Setup { get; init; }
         public ImmutableArray<StatementSyntax> Marshal { get; init; }
         public ImmutableArray<FixedStatementSyntax> Pin { get; init; }
+        public ImmutableArray<StatementSyntax> PinnedMarshal { get; init; }
         public StatementSyntax InvokeStatement { get; init; }
         public ImmutableArray<StatementSyntax> Unmarshal { get; init; }
         public ImmutableArray<StatementSyntax> KeepAlive { get; init; }
@@ -31,9 +32,11 @@ namespace Microsoft.Interop
                 Setup = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.Setup }),
                 Marshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.Marshal }),
                 Pin = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.Pin }).Cast<FixedStatementSyntax>().ToImmutableArray(),
+                PinnedMarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.PinnedMarshal }),
                 InvokeStatement = GenerateStatementForNativeInvoke(marshallers, context with { CurrentStage = StubCodeContext.Stage.Invoke }, expressionToInvoke),
-                Unmarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.Unmarshal }),
-                KeepAlive = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.KeepAlive }),
+                Unmarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.UnmarshalCapture })
+                            .AddRange(GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.Unmarshal })),
+                KeepAlive = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.NotifyForSuccessfulInvoke }),
                 GuaranteedUnmarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.GuaranteedUnmarshal }),
                 Cleanup = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubCodeContext.Stage.Cleanup }),
             };
@@ -113,10 +116,12 @@ namespace Microsoft.Interop
                 StubCodeContext.Stage.Setup => "Perform required setup.",
                 StubCodeContext.Stage.Marshal => "Convert managed data to native data.",
                 StubCodeContext.Stage.Pin => "Pin data in preparation for calling the P/Invoke.",
+                StubCodeContext.Stage.PinnedMarshal => "Convert managed data to native data that requires the managed data to be pinned.",
                 StubCodeContext.Stage.Invoke => "Call the P/Invoke.",
+                StubCodeContext.Stage.UnmarshalCapture => "Capture the native data into marshaller instances in case conversion to managed data throws an exception.",
                 StubCodeContext.Stage.Unmarshal => "Convert native data to managed data.",
                 StubCodeContext.Stage.Cleanup => "Perform required cleanup.",
-                StubCodeContext.Stage.KeepAlive => "Keep alive any managed objects that need to stay alive across the call.",
+                StubCodeContext.Stage.NotifyForSuccessfulInvoke => "Keep alive any managed objects that need to stay alive across the call.",
                 StubCodeContext.Stage.GuaranteedUnmarshal => "Convert native data to managed data even in the case of an exception during the non-cleanup phases.",
                 _ => throw new ArgumentOutOfRangeException(nameof(stage))
             };

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Interop
                 statementsToUpdate.AddRange(retStatements);
             }
 
-            if (context.CurrentStage is StubCodeContext.Stage.Unmarshal or StubCodeContext.Stage.GuaranteedUnmarshal)
+            if (context.CurrentStage is StubCodeContext.Stage.UnmarshalCapture or StubCodeContext.Stage.Unmarshal or StubCodeContext.Stage.GuaranteedUnmarshal)
             {
                 // For Unmarshal and GuaranteedUnmarshal stages, use the topologically sorted
                 // marshaller list to generate the marshalling statements

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
@@ -63,6 +63,18 @@ namespace Microsoft.Interop
                         return _nativeTypeMarshaller.GeneratePinStatements(info, context);
                     }
                     break;
+                case StubCodeContext.Stage.PinnedMarshal:
+                    if (!info.IsManagedReturnPosition && info.RefKind != RefKind.Out)
+                    {
+                        return _nativeTypeMarshaller.GeneratePinnedMarshalStatements(info, context);
+                    }
+                    break;
+                case StubCodeContext.Stage.UnmarshalCapture:
+                    if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In))
+                    {
+                        return _nativeTypeMarshaller.GenerateUnmarshalCaptureStatements(info, context);
+                    }
+                    break;
                 case StubCodeContext.Stage.Unmarshal:
                     if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In)
                         || (_enableByValueContentsMarshalling && !info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out)))

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Interop
                                     LiteralExpression(SyntaxKind.NullLiteralExpression))));
                     }
                     break;
-                case StubCodeContext.Stage.KeepAlive:
+                case StubCodeContext.Stage.NotifyForSuccessfulInvoke:
                     if (info.RefKind != RefKind.Out)
                     {
                         yield return ExpressionStatement(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
@@ -58,7 +58,8 @@ namespace Microsoft.Interop
             Unmarshal,
 
             /// <summary>
-            /// Notify a marshaller object that the Invoke stage was successful (no exception thrown).
+            /// Notify a marshaller object that the Invoke stage and all stages preceeding the Invoke stage
+            /// successfully completed without any exceptions.
             /// </summary>
             NotifyForSuccessfulInvoke,
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
@@ -34,6 +34,11 @@ namespace Microsoft.Interop
             Pin,
 
             /// <summary>
+            /// Convert managed data to native data, assuming that any values pinned in the <see cref="Pin"/> stage are pinned.
+            /// </summary>
+            PinnedMarshal,
+
+            /// <summary>
             /// Call the generated P/Invoke
             /// </summary>
             /// <remarks>
@@ -43,19 +48,24 @@ namespace Microsoft.Interop
             Invoke,
 
             /// <summary>
+            /// Capture native values to ensure that we do not leak if an exception is thrown during unmarshalling
+            /// </summary>
+            UnmarshalCapture,
+
+            /// <summary>
             /// Convert native data to managed data
             /// </summary>
             Unmarshal,
 
             /// <summary>
+            /// Notify a marshaller object that the Invoke stage was successful (no exception thrown).
+            /// </summary>
+            NotifyForSuccessfulInvoke,
+
+            /// <summary>
             /// Perform any cleanup required
             /// </summary>
             Cleanup,
-
-            /// <summary>
-            /// Keep alive any managed objects that need to stay alive across the call.
-            /// </summary>
-            KeepAlive,
 
             /// <summary>
             /// Convert native data to managed data even in the case of an exception during

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SyntaxExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SyntaxExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Interop
             if (!fixedStatements.IsEmpty)
             {
                 int i = fixedStatements.Length - 1;
-                nestedStatement = fixedStatements[i].AddStatementWithoutEmptyStatements(SyntaxFactory.Block(nestedStatement));
+                nestedStatement = fixedStatements[i].AddStatementWithoutEmptyStatements(WrapStatementInBlock(nestedStatement));
                 i--;
                 for (; i >= 0; i--)
                 {
@@ -60,6 +60,15 @@ namespace Microsoft.Interop
                 }
             }
             return nestedStatement;
+
+            static StatementSyntax WrapStatementInBlock(StatementSyntax statement)
+            {
+                if (statement.IsKind(SyntaxKind.Block))
+                {
+                    return statement;
+                }
+                return SyntaxFactory.Block(statement);
+            }
         }
 
         public static SyntaxTokenList StripTriviaFromTokens(this SyntaxTokenList tokenList)


### PR DESCRIPTION
Add a PinnedMarshal stage to make it easier to grok the ordering between the two-phase marshalling with GetPinnableReference.

Add an UnmarshalCapture stage so we can emit all of the "FromNativeValue" calls before the "ToManaged" calls.