### PR TITLE
[NativeAOT] Better fix for nativeaot lock/typesystem reentrancy

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
@@ -22,10 +22,8 @@ namespace System.Threading
         public ThreadInt64PersistentCounter()
         {
             _first = new ThreadLocalNode(this);
-            // terminator dummy, to simplify inserting/removing
-            ThreadLocalNode last = new ThreadLocalNode(this);
-            _first._next = last;
-            last._prev = _first;
+            _first._next = _first;
+            _first._prev = _first;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -73,11 +71,12 @@ namespace System.Threading
                 long count = _overflowCount;
                 try
                 {
-                    ThreadLocalNode node = _first._next!;
-                    while (node._next != null)
+                    ThreadLocalNode first = _first;
+                    ThreadLocalNode node = first._next!;
+                    while (node != first)
                     {
                         count += node.Count;
-                        node = node._next;
+                        node = node._next!;
                     }
                 }
                 finally

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
@@ -9,16 +9,24 @@ namespace System.Threading
 {
     internal sealed class ThreadInt64PersistentCounter
     {
-        private static readonly LowLevelLock s_lock = new LowLevelLock();
+        private readonly LowLevelLock _lock = new LowLevelLock();
 
         [ThreadStatic]
         private static List<ThreadLocalNodeFinalizationHelper>? t_nodeFinalizationHelpers;
 
         private long _overflowCount;
 
-        // we pass comparer explicitly so that in NativeAOT case we would not end up
-        // calling into the type system when lock contention increments its counter
-        private HashSet<ThreadLocalNode> _nodes = new HashSet<ThreadLocalNode>(ObjectEqualityComparer<object>.Default);
+        // dummy node serving as a start of the list
+        private ThreadLocalNode _first;
+
+        public ThreadInt64PersistentCounter()
+        {
+            _first = new ThreadLocalNode(this);
+            // terminator dummy, to simplify inserting/removing
+            ThreadLocalNode last = new ThreadLocalNode(this);
+            _first._next = last;
+            last._prev = _first;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Increment(object threadLocalCountObject)
@@ -41,14 +49,17 @@ namespace System.Threading
             List<ThreadLocalNodeFinalizationHelper>? nodeFinalizationHelpers = t_nodeFinalizationHelpers ??= new List<ThreadLocalNodeFinalizationHelper>(1);
             nodeFinalizationHelpers.Add(new ThreadLocalNodeFinalizationHelper(node));
 
-            s_lock.Acquire();
+            _lock.Acquire();
             try
             {
-                _nodes.Add(node);
+                node._next = _first._next;
+                node._prev = _first;
+                _first._next!._prev = node;
+                _first._next = node;
             }
             finally
             {
-                s_lock.Release();
+                _lock.Release();
             }
 
             return node;
@@ -58,22 +69,20 @@ namespace System.Threading
         {
             get
             {
-                s_lock.Acquire();
+                _lock.Acquire();
                 long count = _overflowCount;
                 try
                 {
-                    foreach (ThreadLocalNode node in _nodes)
+                    ThreadLocalNode node = _first._next!;
+                    while (node._next != null)
                     {
                         count += node.Count;
+                        node = node._next;
                     }
-                }
-                catch (OutOfMemoryException)
-                {
-                    // Some allocation occurs above and it may be a bit awkward to get an OOM from this property getter
                 }
                 finally
                 {
-                    s_lock.Release();
+                    _lock.Release();
                 }
 
                 return count;
@@ -85,6 +94,9 @@ namespace System.Threading
             private uint _count;
             private readonly ThreadInt64PersistentCounter _counter;
 
+            internal ThreadLocalNode? _prev;
+            internal ThreadLocalNode? _next;
+
             public ThreadLocalNode(ThreadInt64PersistentCounter counter)
             {
                 Debug.Assert(counter != null);
@@ -94,15 +106,17 @@ namespace System.Threading
             public void Dispose()
             {
                 ThreadInt64PersistentCounter counter = _counter;
-                s_lock.Acquire();
+                counter._lock.Acquire();
                 try
                 {
                     counter._overflowCount += _count;
-                    counter._nodes.Remove(this);
+
+                    _prev!._next = _next;
+                    _next!._prev = _prev;
                 }
                 finally
                 {
-                    s_lock.Release();
+                    counter._lock.Release();
                 }
             }
 
@@ -145,7 +159,7 @@ namespace System.Threading
                 // The lock, in coordination with other places that read these values, ensures that both changes below become
                 // visible together
                 ThreadInt64PersistentCounter counter = _counter;
-                s_lock.Acquire();
+                counter._lock.Acquire();
                 try
                 {
                     counter._overflowCount += (long)_count + count;
@@ -153,7 +167,7 @@ namespace System.Threading
                 }
                 finally
                 {
-                    s_lock.Release();
+                    counter._lock.Release();
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
@@ -16,7 +16,7 @@ namespace System.Threading
 
         private long _overflowCount;
 
-        // dummy node serving as a start of the list
+        // dummy node serving as a start and end of the ring list
         private ThreadLocalNode _first;
 
         public ThreadInt64PersistentCounter()


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/70453

Let's not involve `HashSet` and `EqualityComparer`