### PR TITLE
[wasm] Build WasmAppHost with UseAppHost=false

### DIFF
--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -120,8 +120,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(WasmGenerateAppBundle)' == 'true'">
+    <RunCommand Condition="'$(DOTNET_HOST_PATH)' != '' and Exists($(DOTNET_HOST_PATH))">$(DOTNET_HOST_PATH)</RunCommand>
+    <RunCommand Condition="'$(RunCommand)' == ''">dotnet</RunCommand>
     <RunCommand>$([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost'))</RunCommand>
-    <RunArguments Condition="'$(RunArguments)' == ''">--runtime-config $(_AppBundleDirForRunCommand)/$(AssemblyName).runtimeconfig.json $(WasmHostArguments)</RunArguments>
+    <RunArguments Condition="'$(RunArguments)' == ''">exec $([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost.dll')) --runtime-config $(_AppBundleDirForRunCommand)/$(AssemblyName).runtimeconfig.json $(WasmHostArguments)</RunArguments>
     <RunWorkingDirectory Condition="'$(RunWorkingDirectory)' == ''">$(_AppBundleDirForRunCommand)</RunWorkingDirectory>
   </PropertyGroup>
 

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -122,7 +122,6 @@
   <PropertyGroup Condition="'$(WasmGenerateAppBundle)' == 'true'">
     <RunCommand Condition="'$(DOTNET_HOST_PATH)' != '' and Exists($(DOTNET_HOST_PATH))">$(DOTNET_HOST_PATH)</RunCommand>
     <RunCommand Condition="'$(RunCommand)' == ''">dotnet</RunCommand>
-    <RunCommand>$([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost'))</RunCommand>
     <RunArguments Condition="'$(RunArguments)' == ''">exec $([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost.dll')) --runtime-config $(_AppBundleDirForRunCommand)/$(AssemblyName).runtimeconfig.json $(WasmHostArguments)</RunArguments>
     <RunWorkingDirectory Condition="'$(RunWorkingDirectory)' == ''">$(_AppBundleDirForRunCommand)</RunWorkingDirectory>
   </PropertyGroup>

--- a/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj
+++ b/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(AspNetCoreAppCurrent)</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoWarn>$(NoWarn),CA2007</NoWarn>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/host/WasmAppHost.csproj
+++ b/src/mono/wasm/host/WasmAppHost.csproj
@@ -5,6 +5,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoWarn>$(NoWarn),CA2007</NoWarn>
     <Nullable>enable</Nullable>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- WasmAppHost is included in the WebAssembly.Sdk pack, and doesn't have a
platform specific package.
- Since, this is being built for x64, the build defaults to using the
app host, which means that we get a single binary file that can be run
directly.
    - But this also means that the binary included in the
    WebAssembly.Sdk platform-agnostic package will target the platform
    where it was built.

- Instead, build with UseAppHost=false, and update the wasm host to use
the managed assembly instead.

And update the RunCommand to use `dotnet exec WasmAppHost.dll`.

Fixes https://github.com/dotnet/runtime/issues/70603 .