### PR TITLE
Fix race condition between GCInfo and Rundown

### DIFF
--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -1010,13 +1010,6 @@ void LCGMethodResolver::Destroy()
         }
     }
 
-    // Note that we need to do this before m_jitTempData is deleted
-    RecycleIndCells();
-
-    m_jitMetaHeap.Delete();
-    m_jitTempData.Delete();
-
-
     if (m_recordCodePointer)
     {
 #if defined(TARGET_AMD64)
@@ -1049,6 +1042,12 @@ void LCGMethodResolver::Destroy()
         delete m_pJumpStubCache;
         m_pJumpStubCache = NULL;
     }
+
+    // Note that we need to do this before m_jitTempData is deleted
+    RecycleIndCells();
+
+    m_jitMetaHeap.Delete();
+    m_jitTempData.Delete();
 
     if (m_managedResolver)
     {


### PR DESCRIPTION
Fixes #69375

* Adds a check to see if the GCInfo is published yet before trying to emit a rundown event
* Published GCInfo under the code heap crst so we can only see an uninitialized GCInfo or a complete one
* Moved the freeing of the temporary code heaps in LCG methods to after we call FreeCodeMemory so we don't race on deletion