### PR TITLE
Add markdown readme for System.Reflection.MetadataLoadContext

### DIFF
--- a/src/libraries/System.Reflection.MetadataLoadContext/src/README.md
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/README.md
@@ -12,7 +12,7 @@ For more information, see the documentation:
 
 The following example shows how print the list of types defined in an assembly.
 
-```
+```cs
 using System;
 using System.Reflection;
 

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/README.md
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/README.md
@@ -1,0 +1,40 @@
+## About
+
+Provides read-only reflection on assemblies in an isolated context with support for assemblies that target different processor architectures and runtimes. Using MetadataLoadContext enables you to inspect assemblies without loading them into the main execution context. Assemblies in MetadataLoadContext are treated only as metadata, that is, you can read information about their members, but cannot execute any code contained in them.
+
+For more information, see the documentation:
+
+- [How to: Inspect assembly contents using MetadataLoadContext](https://docs.microsoft.com/dotnet/standard/assembly/inspect-contents-using-metadataloadcontext)
+- [System.Reflection.MetadataLoadContext](https://docs.microsoft.com/dotnet/api/system.reflection.metadataloadcontext)
+- [System.Reflection.MetadataAssemblyResolver](https://docs.microsoft.com/dotnet/api/system.reflection.metadataassemblyresolver)
+
+## Example
+
+The following example shows how print the list of types defined in an assembly.
+
+```
+using System;
+using System.Reflection;
+
+class Program
+{
+    static void Main()
+    {
+        string inspectedAssembly = "Example.dll";
+        var resolver = new PathAssemblyResolver(new string[] {inspectedAssembly, typeof(object).Assembly.Location});
+        using var mlc = new MetadataLoadContext(resolver, typeof(object).Assembly.GetName().ToString());
+
+        // Load assembly into MetadataLoadContext
+        Assembly assembly = mlc.LoadFromAssemblyPath(inspectedAssembly);
+        AssemblyName name = assembly.GetName();
+
+        // Print types defined in assembly
+        Console.WriteLine($"{name.Name} has following types: ");
+
+        foreach (Type t in assembly.GetTypes())
+        {
+            Console.WriteLine(t.FullName);
+        }
+    }
+}
+```

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
@@ -4,11 +4,8 @@
     <RootNamespace>System.Reflection</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
-    <PackageDescription>Provides read-only reflection on assemblies in an isolated context with support for assemblies that have different architectures and runtimes.
-
-Commonly Used Types:
-System.Reflection.MetadataLoadContext
-System.Reflection.MetadataAssemblyResolver</PackageDescription>
+    <PackageDescription>Provides read-only reflection on assemblies in an isolated context with support for assemblies that target different processor architectures and runtimes. Using MetadataLoadContext enables you to inspect assemblies without loading them into the main execution context. Assemblies in MetadataLoadContext are treated only as metadata, that is, you can read information about their members, but cannot execute any code contained in them.</PackageDescription>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -145,6 +142,7 @@ System.Reflection.MetadataAssemblyResolver</PackageDescription>
     <Compile Include="System\Reflection\TypeLoading\Types\RoType.TypeClassification.cs" />
     <Compile Include="System\Reflection\TypeLoading\Types\RoWrappedType.cs" />
     <Compile Include="$(CommonPath)System\Obsoletions.cs" Link="Common\System\Obsoletions.cs" />
+    <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/59630

Previous related PR: https://github.com/dotnet/runtime/pull/69015

I've decided to include example here, unlike in previous PR, because MLC does not have a lot of conceptual docs with examples on Microsoft Docs site, and also its API surface is not evolving very fast, so it won't be much hard to maintain the additional example. I can remove it if consistency is more important.