### PR TITLE
Remove the backing field from unused `AppDomain` events.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -64,7 +64,12 @@ namespace System
 
         public bool IsHomogenous => true;
 
-        public event EventHandler? DomainUnload;
+        // This event is no longer raised by the runtime.
+        public event EventHandler? DomainUnload
+        {
+            add { }
+            remove { }
+        }
 
         public event EventHandler<FirstChanceExceptionEventArgs>? FirstChanceException
         {
@@ -242,7 +247,12 @@ namespace System
             remove { AssemblyLoadContext.AssemblyResolve -= value; }
         }
 
-        public event ResolveEventHandler? ReflectionOnlyAssemblyResolve;
+        // This event is no longer raised by the runtime.
+        public event ResolveEventHandler? ReflectionOnlyAssemblyResolve
+        {
+            add { }
+            remove { }
+        }
 
         public event ResolveEventHandler? TypeResolve
         {


### PR DESCRIPTION
`AppDomain.DomainUnload` and `ReflectionOnlyAssemblyResolve` are no longer raised by the runtime. This PR makes their event accessors explicit and empty, removing the compiler-generated backing field and its updating logic.