### PR TITLE
Fix nullability annotation of `ILGenerator.BeginCatchBlock`.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -341,7 +341,7 @@ namespace System.Reflection.Emit
             current.MarkFilterAddr(ILOffset);
         }
 
-        public override void BeginCatchBlock(Type exceptionType)
+        public override void BeginCatchBlock(Type? exceptionType)
         {
             if (CurrExcStackCount == 0)
                 throw new NotSupportedException(SR.Argument_NotInExceptionBlock);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
@@ -992,7 +992,7 @@ namespace System.Reflection.Emit
             current.MarkFilterAddr(m_length);
         }
 
-        public virtual void BeginCatchBlock(Type exceptionType)
+        public virtual void BeginCatchBlock(Type? exceptionType)
         {
             // Begins a catch block.  Emits a branch instruction to the end of the current exception block.
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public virtual void BeginCatchBlock(Type exceptionType)
+        public virtual void BeginCatchBlock(Type? exceptionType)
         {
         }
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -946,7 +946,7 @@ namespace System.Linq.Expressions.Compiler
             // begin the catch, clear the exception, we've
             // already saved it
             _ilg.MarkLabel(endFilter);
-            _ilg.BeginCatchBlock(exceptionType: null!);
+            _ilg.BeginCatchBlock(exceptionType: null);
             _ilg.Emit(OpCodes.Pop);
         }
 

--- a/src/libraries/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
@@ -17,7 +17,7 @@ namespace System.Reflection.Emit
     {
         internal ILGenerator() { }
         public virtual int ILOffset { get { throw null; } }
-        public virtual void BeginCatchBlock(System.Type exceptionType) { }
+        public virtual void BeginCatchBlock(System.Type? exceptionType) { }
         public virtual void BeginExceptFilterBlock() { }
         public virtual System.Reflection.Emit.Label BeginExceptionBlock() { throw null; }
         public virtual void BeginFaultBlock() { }

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.Mono.cs
@@ -343,7 +343,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public virtual void BeginCatchBlock(Type exceptionType)
+        public virtual void BeginCatchBlock(Type? exceptionType)
         {
             if (!InExceptionBlock)
                 throw new NotSupportedException("Not in an exception block");


### PR DESCRIPTION
The `exceptionType` parameter was marked as not null, but it must be null if we have declared a filter clause.