### PR TITLE
optRelopImpliesRelop experiments

### DIFF
--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -212,6 +212,7 @@ void Compiler::optRelopImpliesRelop(RelopImplicationInfo* rii)
                     {
                         rii->canInfer   = true;
                         rii->vnRelation = rule.relationKind;
+                        rii->canInferFromFalse = false;
                         return;
                     }
                 }

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -211,17 +211,7 @@ void Compiler::optRelopImpliesRelop(RelopImplicationInfo* rii)
                     rii->vnRelation        = rule.relationKind;
                     rii->canInferFromTrue  = rule.canInferFromTrue;
                     rii->canInferFromFalse = rule.canInferFromFalse;
-                    if (swapped)
-                    {
-                        if (rule.relationKind == ValueNumStore::VN_RELATION_KIND::VRK_Reverse)
-                        {
-                            rii->vnRelation = ValueNumStore::VN_RELATION_KIND::VRK_SwapReverse;
-                        }
-                        if (rule.relationKind == ValueNumStore::VN_RELATION_KIND::VRK_Same)
-                        {
-                            rii->vnRelation = ValueNumStore::VN_RELATION_KIND::VRK_Swap;
-                        }
-                    }
+                    rii->reverseSense      = false;
                     return;
                 }
             }
@@ -381,7 +371,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                 // We can use liberal VNs here, as bounds checks are not yet
                 // manifest explicitly as relops.
                 //
-                RelopImplicationInfo rii;
+                RelopImplicationInfo rii = {};
                 rii.treeNormVN = treeNormVN;
                 vnStore->VNUnpackExc(domCmpTree->GetVN(VNK_Liberal), &rii.domCmpNormVN, &domCmpExcVN);
 

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -170,15 +170,14 @@ void Compiler::optRelopImpliesRelop(RelopImplicationInfo* rii)
             assert(vnStore->IsVNRelop(rii->domCmpNormVN));
             assert((domCmpFuncApp.m_arity == 2) && (treeFuncApp.m_arity == 2));
 
-            ValueNum domOp1 = domCmpFuncApp.m_args[0];
-            ValueNum domOp2 = domCmpFuncApp.m_args[1];
+            ValueNum domOp1  = domCmpFuncApp.m_args[0];
+            ValueNum domOp2  = domCmpFuncApp.m_args[1];
             ValueNum treeOp1 = treeFuncApp.m_args[0];
             ValueNum treeOp2 = treeFuncApp.m_args[1];
 
             // Check that operands of domCmp and treeCmp are the same (and have VNs)
             if (((domOp1 != ValueNumStore::NoVN) && (domOp2 != ValueNumStore::NoVN)) &&
-                (((domOp1 == treeOp1) && (domOp2 == treeOp2)) ||
-                    ((domOp1 == treeOp2) && (domOp2 == treeOp1))))
+                (((domOp1 == treeOp1) && (domOp2 == treeOp2)) || ((domOp1 == treeOp2) && (domOp2 == treeOp1))))
             {
                 if (domOp1 == treeOp2)
                 {
@@ -190,20 +189,20 @@ void Compiler::optRelopImpliesRelop(RelopImplicationInfo* rii)
 
                 struct ImpliedRelops
                 {
-                    genTreeOps domOper;
-                    genTreeOps treeOper;
+                    genTreeOps                      domOper;
+                    genTreeOps                      treeOper;
                     ValueNumStore::VN_RELATION_KIND relationKind;
                 };
 
                 ImpliedRelops rules[] = {
                     // To explain it, the first rule means:
-                    // if domOp is "X GE Y" and treeOp is "X LE Y" than treeOp is implied by domOp
-                    { GT_GE, GT_LE, ValueNumStore::VN_RELATION_KIND::VRK_Same},
-                    { GT_GE, GT_EQ, ValueNumStore::VN_RELATION_KIND::VRK_Same},
-                    { GT_LE, GT_LE, ValueNumStore::VN_RELATION_KIND::VRK_Same},
-                    { GT_LE, GT_EQ, ValueNumStore::VN_RELATION_KIND::VRK_Same},
-                    { GT_EQ, GT_LE, ValueNumStore::VN_RELATION_KIND::VRK_Same},
-                    { GT_EQ, GT_GE, ValueNumStore::VN_RELATION_KIND::VRK_Same},
+                    // if domOp is "X GE Y" and treeOp is "X LE Y" then treeOp is implied by domOp
+                    {GT_GE, GT_LE, ValueNumStore::VN_RELATION_KIND::VRK_Same},
+                    {GT_GE, GT_EQ, ValueNumStore::VN_RELATION_KIND::VRK_Same},
+                    {GT_LE, GT_LE, ValueNumStore::VN_RELATION_KIND::VRK_Same},
+                    {GT_LE, GT_EQ, ValueNumStore::VN_RELATION_KIND::VRK_Same},
+                    {GT_EQ, GT_LE, ValueNumStore::VN_RELATION_KIND::VRK_Same},
+                    {GT_EQ, GT_GE, ValueNumStore::VN_RELATION_KIND::VRK_Same},
                     // TODO: more rules
                 };
 
@@ -211,7 +210,7 @@ void Compiler::optRelopImpliesRelop(RelopImplicationInfo* rii)
                 {
                     if ((rule.domOper == domOper) && (rule.treeOper == treeOper))
                     {
-                        rii->canInfer = true;
+                        rii->canInfer   = true;
                         rii->vnRelation = rule.relationKind;
                         return;
                     }

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -199,6 +199,7 @@ void Compiler::optRelopImpliesRelop(RelopImplicationInfo* rii)
 
             ImpliedRelops rules[] = {
                 {GT_GE, GT_LE, false, true, ValueNumStore::VN_RELATION_KIND::VRK_Reverse},
+                {GT_LE, GT_GE, false, true, ValueNumStore::VN_RELATION_KIND::VRK_Reverse},
                 // TODO: more rules
             };
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4531,6 +4531,28 @@ ValueNumPair ValueNumStore::VNPairForLoadStoreBitCast(ValueNumPair value, var_ty
     return ValueNumPair(liberalVN, conservVN);
 }
 
+genTreeOps ValueNumStore::VNFuncToRelopOp(VNFunc vnf, bool& isUnsigned)
+{
+    assert(VNFuncIsComparison(vnf));
+
+    isUnsigned = true;
+    switch (vnf)
+    {
+        case VNF_LT_UN:
+            return GT_LT;
+        case VNF_LE_UN:
+            return GT_LE;
+        case VNF_GT_UN:
+            return GT_GT;
+        case VNF_GE_UN:
+            return GT_GE;
+        default:
+            isUnsigned = false;
+            break;
+    }
+    return (genTreeOps)vnf;
+}
+
 //------------------------------------------------------------------------
 // IsVNNotAField: Is the value number a "NotAField" field sequence?
 //

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -719,6 +719,8 @@ public:
 
     ValueNumPair VNPairForLoadStoreBitCast(ValueNumPair value, var_types indType, unsigned indSize);
 
+    genTreeOps VNFuncToRelopOp(VNFunc vnf, bool& isUnsigned);
+
     // Compute the ValueNumber for a cast
     ValueNum VNForCast(ValueNum  srcVN,
                        var_types castToType,


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/70373
Might also close https://github.com/dotnet/runtime/issues/65327 if it works 

Minimal repro (the reason why https://github.com/dotnet/runtime/issues/70373 regressed):
```csharp
bool Test(int a, int b) => a.CompareTo(b) > 0;
```
codegen diff:  https://www.diffchecker.com/5vriKD2u