### PR TITLE
Restore ArchivingUtils.AttemptSetLastWriteTime

### DIFF
--- a/src/libraries/Common/src/System/IO/Archiving.Utils.cs
+++ b/src/libraries/Common/src/System/IO/Archiving.Utils.cs
@@ -83,7 +83,7 @@ namespace System.IO
             {
                 File.SetLastWriteTime(destinationFileName, lastWriteTime.DateTime);
             }
-            catch (UnauthorizedAccessException)
+            catch
             {
                 // Some OSes like Android (#35374) might not support setting the last write time, the extraction should not fail because of that
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/70575

When I merged the [initial Tar PR](https://github.com/dotnet/runtime/pull/67883), I moved a System.IO.Compression utils file to Common so I could share it with System.Formats.Tar, but I brought an old version of the code. This change bring back that fix.

Thank you @cremor for noticing.