### PR TITLE
Reduce allocations when using DataContractSerializer with SurrogateTypes

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1210,11 +1210,11 @@ namespace System.Runtime.Serialization
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         internal static bool IsTypeSerializable(Type type)
         {
-            return IsTypeSerializable(type, new HashSet<Type>());
+            return IsTypeSerializable(type, null);
         }
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        private static bool IsTypeSerializable(Type type, HashSet<Type> previousCollectionTypes)
+        private static bool IsTypeSerializable(Type type, HashSet<Type>? previousCollectionTypes)
         {
             Type? itemType;
 
@@ -1231,6 +1231,7 @@ namespace System.Runtime.Serialization
             }
             if (CollectionDataContract.IsCollection(type, out itemType))
             {
+                previousCollectionTypes ??= new HashSet<Type>();
                 ValidatePreviousCollectionTypes(type, itemType, previousCollectionTypes);
                 if (IsTypeSerializable(itemType, previousCollectionTypes))
                 {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1208,13 +1208,7 @@ namespace System.Runtime.Serialization
         }
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        internal static bool IsTypeSerializable(Type type)
-        {
-            return IsTypeSerializable(type, null);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        private static bool IsTypeSerializable(Type type, HashSet<Type>? previousCollectionTypes)
+        internal static bool IsTypeSerializable(Type type, HashSet<Type>? previousCollectionTypes = null)
         {
             Type? itemType;
 


### PR DESCRIPTION
I was making profiling/stress testing my rewrite of OpenRiaServices from WCF to aspnet core I came across suprisingly large allocations from the datacontract serializer.

I came upon unexpected high allocation counts from the framework when serializing a [fairly simple type](https://github.com/OpenRIAServices/Benchmarks/blob/9b39102949b8dcfd79054779cc431443608a72ae/OpenRiaServices.Client.Benchmarks/Server/Cities/CityTypes.cs#L48) with a datacontract surrogate which looks the same.

The majority of allocations seems to come IsTypeSerializable which seems to be called for every instance (surrogate created),
the following is from a short run:
![image](https://user-images.githubusercontent.com/3167509/173205557-cee87a61-7c18-4232-9b34-6cd3fe9535e2.png)
![image](https://user-images.githubusercontent.com/3167509/173205569-de65b8cb-2da6-453a-b011-b6eaf3951d17.png)

By not creating the HashSet unless we know it will be used, we can remove all allocations for this scenario. 