### PR TITLE
Revert "? true : false" removal in ArraySortHelper.cs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
@@ -576,7 +576,7 @@ namespace System.Collections.Generic
             if (typeof(T) == typeof(float)) return (float)(object)left < (float)(object)right;
             if (typeof(T) == typeof(double)) return (double)(object)left < (double)(object)right;
             if (typeof(T) == typeof(Half)) return (Half)(object)left < (Half)(object)right;
-            return left.CompareTo(right) < 0;
+            return left.CompareTo(right) < 0 ? true : false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // compiles to a single comparison or method call
@@ -595,7 +595,7 @@ namespace System.Collections.Generic
             if (typeof(T) == typeof(float)) return (float)(object)left > (float)(object)right;
             if (typeof(T) == typeof(double)) return (double)(object)left > (double)(object)right;
             if (typeof(T) == typeof(Half)) return (Half)(object)left > (Half)(object)right;
-            return left.CompareTo(right) > 0;
+            return left.CompareTo(right) > 0 ? true : false;
         }
     }
 


### PR DESCRIPTION
Reverts a change from https://github.com/dotnet/runtime/pull/63095

Fixes https://github.com/dotnet/runtime/issues/70373 perf regression 
![image](https://user-images.githubusercontent.com/523221/173247578-f9222b06-a2fe-4a92-98f2-52c9508a3260.png)

Unfortunately, the proper fix in the JIT is quite difficult at this point 

Verified locally, cc @stephentoub 