### PR TITLE
Allow `TYP_STRUCT` `LCL_FLD` on the RHS of block copies

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -10283,7 +10283,7 @@ void CodeGen::genCodeForAddEx(GenTreeOp* tree)
 void CodeGen::genCodeForCond(GenTreeOp* tree)
 {
     assert(tree->OperIs(GT_CSNEG_MI));
-    assert(!(tree->gtFlags & GTF_SET_FLAGS) && (tree->gtFlags & GTF_USE_FLAGS));
+    assert(!(tree->gtFlags & GTF_SET_FLAGS));
     genConsumeOperands(tree);
 
     instruction ins;

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4764,7 +4764,8 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
     unsigned varNum = tree->GetLclNum();
     assert(varNum < compiler->lvaCount);
 
-    GetEmitter()->emitIns_R_S(ins_Load(targetType), size, targetReg, varNum, offs);
+    instruction loadIns = tree->DontExtend() ? INS_mov : ins_Load(targetType);
+    GetEmitter()->emitIns_R_S(loadIns, size, targetReg, varNum, offs);
 
     genProduceReg(tree);
 }
@@ -5115,16 +5116,7 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
     else
     {
         genConsumeAddress(addr);
-        instruction loadIns = ins_Load(targetType);
-        if (tree->DontExtend())
-        {
-            assert(varTypeIsSmall(tree));
-            // The user of this IND does not need
-            // the upper bits to be set, so we don't need to use longer
-            // INS_movzx/INS_movsx and can use INS_mov instead.
-            // It usually happens when the real type is a small struct.
-            loadIns = INS_mov;
-        }
+        instruction loadIns = tree->DontExtend() ? INS_mov : ins_Load(targetType);
         emit->emitInsLoadInd(loadIns, emitTypeSize(tree), tree->GetRegNum(), tree);
     }
 

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -931,7 +931,6 @@ GenTree* DecomposeLongs::DecomposeNeg(LIR::Use& use)
     Range().InsertAfter(loResult, zero, hiAdjust, hiResult);
 
     loResult->gtFlags |= GTF_SET_FLAGS;
-    hiAdjust->gtFlags |= GTF_USE_FLAGS;
 
 #elif defined(TARGET_ARM)
 
@@ -942,7 +941,6 @@ GenTree* DecomposeLongs::DecomposeNeg(LIR::Use& use)
     Range().InsertAfter(loResult, hiResult);
 
     loResult->gtFlags |= GTF_SET_FLAGS;
-    hiResult->gtFlags |= GTF_USE_FLAGS;
 
 #endif
 
@@ -997,7 +995,6 @@ GenTree* DecomposeLongs::DecomposeArith(LIR::Use& use)
     if ((oper == GT_ADD) || (oper == GT_SUB))
     {
         loResult->gtFlags |= GTF_SET_FLAGS;
-        hiResult->gtFlags |= GTF_USE_FLAGS;
 
         if ((loResult->gtFlags & GTF_OVERFLOW) != 0)
         {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4642,6 +4642,11 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                     costEx += 1;
                     costSz += 1;
                 }
+                else if (tree->TypeIs(TYP_STRUCT))
+                {
+                    costEx += IND_COST_EX;
+                    costSz += 2;
+                }
                 break;
 
             case GT_LCL_FLD_ADDR:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -408,7 +408,7 @@ enum GenTreeFlags : unsigned int
     GTF_NOREG_AT_USE = 0x00000100, // tree node is in memory at the point of use
 
     GTF_SET_FLAGS   = 0x00000200, // Requires that codegen for this node set the flags. Use gtSetFlags() to check this flag.
-    GTF_USE_FLAGS   = 0x00000400, // Indicates that this node uses the flags bits.
+//  GTF_UNUSED      = 0x00000400,
 
     GTF_MAKE_CSE    = 0x00000800, // Hoisted expression: try hard to make this into CSE (see optPerformHoistExpr)
     GTF_DONT_CSE    = 0x00001000, // Don't bother CSE'ing this expr

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -408,7 +408,12 @@ enum GenTreeFlags : unsigned int
     GTF_NOREG_AT_USE = 0x00000100, // tree node is in memory at the point of use
 
     GTF_SET_FLAGS   = 0x00000200, // Requires that codegen for this node set the flags. Use gtSetFlags() to check this flag.
-//  GTF_UNUSED      = 0x00000400,
+
+#ifdef TARGET_XARCH
+    GTF_DONT_EXTEND = 0x00000400, // This small-typed tree produces a value with undefined upper bits. Used on x86/x64 as a
+                                  // lowering optimization and tells the codegen to use instructions like "mov al, [addr]"
+                                  // instead of "movzx/movsx", when the user node doesn't need the upper bits.
+#endif // TARGET_XARCH
 
     GTF_MAKE_CSE    = 0x00000800, // Hoisted expression: try hard to make this into CSE (see optPerformHoistExpr)
     GTF_DONT_CSE    = 0x00001000, // Don't bother CSE'ing this expr
@@ -526,16 +531,9 @@ enum GenTreeFlags : unsigned int
                                               //             alignment of 1 byte)
     GTF_IND_INVARIANT           = 0x01000000, // GT_IND   -- the target is invariant (a prejit indirection)
     GTF_IND_NONNULL             = 0x00400000, // GT_IND   -- the indirection never returns null (zero)
-#if defined(TARGET_XARCH)
-    GTF_IND_DONT_EXTEND         = 0x00200000, // GT_IND   -- the indirection does not need to extend for small types
-#endif // TARGET_XARCH
 
     GTF_IND_FLAGS = GTF_IND_VOLATILE | GTF_IND_NONFAULTING | GTF_IND_TLS_REF | GTF_IND_UNALIGNED | GTF_IND_INVARIANT |
-                    GTF_IND_NONNULL | GTF_IND_TGT_NOT_HEAP | GTF_IND_TGT_HEAP
-#if defined(TARGET_XARCH)
-                     | GTF_IND_DONT_EXTEND
-#endif // TARGET_XARCH
-                    ,
+                    GTF_IND_NONNULL | GTF_IND_TGT_NOT_HEAP | GTF_IND_TGT_HEAP,
 
     GTF_ADDRMODE_NO_CSE         = 0x80000000, // GT_ADD/GT_MUL/GT_LSH -- Do not CSE this node only, forms complex
                                               //                         addressing mode
@@ -2009,6 +2007,25 @@ public:
     {
         gtFlags &= ~GTF_REVERSE_OPS;
     }
+
+#if defined(TARGET_XARCH)
+    void SetDontExtend()
+    {
+        assert(varTypeIsSmall(TypeGet()) && OperIs(GT_IND, GT_LCL_FLD));
+        gtFlags |= GTF_DONT_EXTEND;
+    }
+
+    void ClearDontExtend()
+    {
+        gtFlags &= ~GTF_DONT_EXTEND;
+    }
+
+    bool DontExtend() const
+    {
+        assert(varTypeIsSmall(TypeGet()) || ((gtFlags & GTF_DONT_EXTEND) == 0));
+        return (gtFlags & GTF_DONT_EXTEND) != 0;
+    }
+#endif // TARGET_XARCH
 
     bool IsUnsigned() const
     {
@@ -6764,23 +6781,6 @@ struct GenTreeIndir : public GenTreeOp
     {
         return (gtFlags & GTF_IND_UNALIGNED) != 0;
     }
-
-#if defined(TARGET_XARCH)
-    void SetDontExtend()
-    {
-        gtFlags |= GTF_IND_DONT_EXTEND;
-    }
-
-    void ClearDontExtend()
-    {
-        gtFlags &= ~GTF_IND_DONT_EXTEND;
-    }
-
-    bool DontExtend() const
-    {
-        return (gtFlags & GTF_IND_DONT_EXTEND) != 0;
-    }
-#endif // TARGET_XARCH
 
 #if DEBUGGABLE_GENTREE
     // Used only for GenTree::GetVtableForOper()

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1099,21 +1099,21 @@ private:
 
         // Current matrix of matches/users/types:
         //
-        // |------------|------|---------|---------|
-        // | STRUCT     | CALL | ASG     | RETURN  |
-        // |------------|------|---------|---------|
-        // | Exact      | None | LCL_VAR | LCL_VAR |
-        // | Compatible | None | LCL_VAR | LCL_VAR |
-        // | Partial    | None | OBJ     | LCL_FLD |
-        // |------------|------|---------|---------|
+        // |------------|------|-------------|---------|
+        // | STRUCT     | CALL | ASG         | RETURN  |
+        // |------------|------|-------------|---------|
+        // | Exact      | None | LCL_VAR     | LCL_VAR |
+        // | Compatible | None | LCL_VAR     | LCL_VAR |
+        // | Partial    | None | OBJ/LCL_FLD | LCL_FLD |
+        // |------------|------|-------------|---------|
         //
-        // |------------|------|---------|---------|----------|
-        // | SIMD       | CALL | ASG     | RETURN  | HWI/SIMD |
-        // |------------|------|---------|---------|----------|
-        // | Exact      | None | None    | None    | None     |
-        // | Compatible | None | None    | None    | None     |
-        // | Partial    | None | None    | None    | None     |
-        // |------------|------|---------|---------|----------|
+        // |------------|------|------|--------|----------|
+        // | SIMD       | CALL | ASG  | RETURN | HWI/SIMD |
+        // |------------|------|------|--------|----------|
+        // | Exact      | None | None | None   | None     |
+        // | Compatible | None | None | None   | None     |
+        // | Partial    | None | None | None   | None     |
+        // |------------|------|------|--------|----------|
         //
         // TODO-ADDR: delete all the "None" entries and always
         // transform local nodes into LCL_VAR or LCL_FLD.
@@ -1127,7 +1127,7 @@ private:
             return IndirTransform::LclVar;
         }
 
-        if (user->OperIs(GT_ASG))
+        if (user->OperIs(GT_ASG) && (indir == user->AsOp()->gtGetOp1()))
         {
             return IndirTransform::ObjAddrLclFld;
         }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1023,7 +1023,6 @@ bool Lowering::TryLowerSwitchToBitTest(
     GenTree*  bitTest      = comp->gtNewOperNode(GT_BT, TYP_VOID, bitTableIcon, switchValue);
     bitTest->gtFlags |= GTF_SET_FLAGS;
     GenTreeCC* jcc = new (comp, GT_JCC) GenTreeCC(GT_JCC, bbSwitchCondition);
-    jcc->gtFlags |= GTF_USE_FLAGS;
 
     LIR::AsRange(bbSwitch).InsertAfter(switchValue, bitTableIcon, bitTest, jcc);
 
@@ -2727,7 +2726,6 @@ GenTree* Lowering::DecomposeLongCompare(GenTree* cmp)
         GenTree* jcc       = cmpUse.User();
         jcc->AsOp()->gtOp1 = nullptr;
         jcc->ChangeOper(GT_JCC);
-        jcc->gtFlags |= GTF_USE_FLAGS;
         jcc->AsCC()->gtCondition = GenCondition::FromIntegralRelop(condition, cmp->IsUnsigned());
     }
     else
@@ -2735,7 +2733,6 @@ GenTree* Lowering::DecomposeLongCompare(GenTree* cmp)
         cmp->AsOp()->gtOp1 = nullptr;
         cmp->AsOp()->gtOp2 = nullptr;
         cmp->ChangeOper(GT_SETCC);
-        cmp->gtFlags |= GTF_USE_FLAGS;
         cmp->AsCC()->gtCondition = GenCondition::FromIntegralRelop(condition, cmp->IsUnsigned());
     }
 
@@ -2983,8 +2980,6 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
                 cmpUse.ReplaceWith(cc);
             }
 
-            cc->gtFlags |= GTF_USE_FLAGS;
-
             return cmp->gtNext;
         }
 #endif // TARGET_XARCH
@@ -3052,7 +3047,6 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
             GenCondition condition = GenCondition::FromIntegralRelop(cmp);
             cc->ChangeOper(ccOp);
             cc->AsCC()->gtCondition = condition;
-            cc->gtFlags |= GTF_USE_FLAGS;
 
             return next;
         }
@@ -3270,7 +3264,6 @@ GenTreeCC* Lowering::LowerNodeCC(GenTree* node, GenCondition condition)
     if (cc != nullptr)
     {
         node->gtFlags |= GTF_SET_FLAGS;
-        cc->gtFlags |= GTF_USE_FLAGS;
     }
 
     // Remove the chain of EQ/NE(x, 0) relop nodes, if any. Note that if a SETCC was

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3532,13 +3532,13 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
                     // Do it now.
                     GenTreeIndir* indir = src->AsIndir();
                     LowerIndir(indir);
-#if defined(TARGET_XARCH)
-                    if (varTypeIsSmall(lclRegType))
-                    {
-                        indir->SetDontExtend();
-                    }
-#endif // TARGET_XARCH
                 }
+#if defined(TARGET_XARCH)
+                if (varTypeIsSmall(lclRegType))
+                {
+                    src->SetDontExtend();
+                }
+#endif // TARGET_XARCH
             }
             convertToStoreObj = false;
 #else  // TARGET_ARM64
@@ -7368,9 +7368,9 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
     }
 
 #if defined(TARGET_XARCH)
-    if (varTypeIsSmall(regType) && src->OperIs(GT_IND))
+    if (varTypeIsSmall(regType) && src->OperIs(GT_IND, GT_LCL_FLD))
     {
-        src->AsIndir()->SetDontExtend();
+        src->SetDontExtend();
     }
 #endif // TARGET_XARCH
 

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -722,7 +722,6 @@ void Lowering::LowerModPow2(GenTree* node)
     mod->ChangeOper(GT_CSNEG_MI);
     mod->gtOp1 = trueExpr;
     mod->gtOp2 = falseExpr;
-    mod->gtFlags |= GTF_USE_FLAGS;
 
     JITDUMP("Lower: optimize X MOD POW2");
     DISPNODE(mod);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9621,6 +9621,11 @@ GenTree* Compiler::fgMorphBlockOperand(GenTree* tree, var_types asgType, ClassLa
         {
             lclNode = effectiveVal->AsLclVarCommon();
         }
+        else if (effectiveVal->OperIs(GT_LCL_FLD))
+        {
+            needsIndirection = false;
+            assert(ClassLayout::AreCompatible(effectiveVal->AsLclFld()->GetLayout(), blockLayout));
+        }
         else if (effectiveVal->IsCall())
         {
             needsIndirection = false;

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -3582,7 +3582,6 @@ bool Compiler::optIsCSEcandidate(GenTree* tree)
 
         case GT_ARR_ELEM:
         case GT_ARR_LENGTH:
-        case GT_LCL_FLD:
             return true;
 
         case GT_LCL_VAR:
@@ -3685,7 +3684,9 @@ bool Compiler::optIsCSEcandidate(GenTree* tree)
             return true; // allow Intrinsics to be CSE-ed
 
         case GT_OBJ:
-            return varTypeIsEnregisterable(type); // Allow enregisterable GT_OBJ's to be CSE-ed. (i.e. SIMD types)
+        case GT_LCL_FLD:
+            // TODO-1stClassStructs: support CSE for enregisterable TYP_STRUCTs.
+            return varTypeIsEnregisterable(type);
 
         case GT_COMMA:
             return true; // Allow GT_COMMA nodes to be CSE-ed.


### PR DESCRIPTION
It turns out the backend already has the necessary support.

We are expecting a minimal set of diffs:
1) From costing and `ASG` reversal - `LCL_FLD` is cheaper than `OBJ(ADDR(LCL))`.
2) From forward substitution: `FIELD` nodes turned `OBJ`s would retain some conservative `GLOB_REF` flags.