### PR TITLE
[mono] Fix SpanHelpers.Reverse regression

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -2408,12 +2408,7 @@ namespace System
             }
 
             // Store any remaining values one-by-one
-            for (nuint i = 0; i < (length / 2); i++)
-            {
-                ref byte first = ref Unsafe.Add(ref buf, i);
-                ref byte last = ref Unsafe.Add(ref buf, length - 1 - i);
-                (last, first) = (first, last);
-            }
+            ReverseInner(ref buf, length);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -2096,12 +2096,7 @@ namespace System
 
             // Store any remaining values one-by-one
             buf = ref Unsafe.As<byte, char>(ref bufByte);
-            for (nuint i = 0; i < (length / 2); i++)
-            {
-                ref char first = ref Unsafe.Add(ref buf, i);
-                ref char last = ref Unsafe.Add(ref buf, length - 1 - i);
-                (last, first) = (first, last);
-            }
+            ReverseInner(ref buf, length);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -576,6 +576,7 @@ namespace System
             ReverseInner(ref elements, length);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void ReverseInner<T>(ref T elements, nuint length)
         {
             Debug.Assert(length > 0);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -579,7 +579,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void ReverseInner<T>(ref T elements, nuint length)
         {
-            Debug.Assert(length > 0);
+            if (length <= 1)
+                return;
             ref T first = ref elements;
             ref T last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, (int)length), 1);
             do

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -473,13 +473,7 @@ namespace System
                 length -= numIters * numElements * 2;
             }
 
-            // Store any remaining values one-by-one
-            for (nuint i = 0; i < (length / 2); i++)
-            {
-                ref int firstInt = ref Unsafe.Add(ref buf, i);
-                ref int lastInt = ref Unsafe.Add(ref buf, length - 1 - i);
-                (lastInt, firstInt) = (firstInt, lastInt);
-            }
+            ReverseInner(ref buf, length);
         }
 
         public static void Reverse(ref long buf, nuint length)
@@ -549,12 +543,7 @@ namespace System
             }
 
             // Store any remaining values one-by-one
-            for (nuint i = 0; i < (length / 2); i++)
-            {
-                ref long firstLong = ref Unsafe.Add(ref buf, i);
-                ref long lastLong = ref Unsafe.Add(ref buf, length - 1 - i);
-                (lastLong, firstLong) = (firstLong, lastLong);
-            }
+            ReverseInner(ref buf, length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
SpanHelpers.Reverse was optimized recently using vectorized operations. However, the unvectorized path (which is used by wasm for example) became slower. This change uses the old code pattern to reverse the array in non-vectorized case (or the rest of the array in the vectorized case). This is 2-3 times faster on wasm for example.

https://github.com/dotnet/runtime/pull/64412
https://github.com/dotnet/perf-autofiling-issues/issues/5014