### PR TITLE
Unpin locals, attempt 2

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -614,6 +614,8 @@ public:
     unsigned char lvSingleDefDisqualifyReason = 'H';
 #endif
 
+    unsigned char lvAllDefsAreNoGc : 1; // For pinned locals: true if all defs of this local are no-gc
+
 #if FEATURE_MULTIREG_ARGS
     regNumber lvRegNumForSlot(unsigned slotNum)
     {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1109,6 +1109,11 @@ public:
         return true;
     }
 
+    bool IsNotGcDef() const
+    {
+        return IsIntegralConst(0) || IsLocalAddrExpr();
+    }
+
     // LIR flags
     //   These helper methods, along with the flag values they manipulate, are defined in lir.h
     //

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4712,8 +4712,6 @@ void Compiler::lvaComputeRefCounts(bool isRecompute, bool setSlotNumbers)
             varDsc->setLvRefCnt(0);
             varDsc->setLvRefCntWtd(BB_ZERO_WEIGHT);
 
-            varDsc->lvAllDefsAreNoGc = true;
-
             // Special case for some varargs params ... these must
             // remain unreferenced.
             const bool isSpecialVarargsParam = varDsc->lvIsParam && raIsVarargsStackArg(lclNum);
@@ -4762,7 +4760,7 @@ void Compiler::lvaComputeRefCounts(bool isRecompute, bool setSlotNumbers)
             varDsc->lvSingleDef             = varDsc->lvIsParam;
             varDsc->lvSingleDefRegCandidate = varDsc->lvIsParam;
 
-            varDsc->lvAllDefsAreNoGc = true;
+            varDsc->lvAllDefsAreNoGc = (varDsc->lvImplicitlyReferenced == false);
         }
     }
 


### PR DESCRIPTION
Cherry pick of the #70264 with the fix for the GC hole introduced when a method is optimized with OSR. The [PinnedLocal](https://github.com/dotnet/runtime/blob/5c559f14ff23a34eb5585bc8112a73a579648b87/src/tests/JIT/opt/OSR/pinnedlocal.cs) test no longer AVs with this.

Alternatively we could also introduce a new flag to the `PatchpointInfo` but that most likely has small benefits.

cc @AndyAyersMS 