### PR TITLE
[mono] Remove dead code.

### DIFF
--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2272,11 +2272,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 			mini_set_abort_threshold (&catch_frame);
 			mono_unhandled_exception_internal (obj);
 		} else {
-			gboolean unhandled = FALSE;
-
-			if (unhandled)
-				mono_component_debugger ()->handle_exception ((MonoException *)obj, ctx, NULL, NULL);
-			else if (!ji || (jinfo_get_method (ji)->wrapper_type == MONO_WRAPPER_RUNTIME_INVOKE)) {
+			if (!ji || (jinfo_get_method (ji)->wrapper_type == MONO_WRAPPER_RUNTIME_INVOKE)) {
 				if (last_mono_wrapper_runtime_invoke && !mono_thread_internal_current ()->threadpool_thread) {
 					mono_component_debugger ()->handle_exception ((MonoException *)obj, ctx, NULL, NULL);
 					if (mini_get_debug_options ()->top_runtime_invoke_unhandled) {


### PR DESCRIPTION
A variable initialized to false and never modified means we can remove the
variable and any code that depends on that variable not being false.

This is a consequence of 15ab9f985ed45feaa619df70d288fbd0acd5c45f, where code
that assigned the variable was removed.