### PR TITLE
Implement digest one shots for browser implementation

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
@@ -39,9 +39,16 @@ namespace System.Security.Cryptography
 
             public static int HashData(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination)
             {
-                HashProvider provider = CreateHashProvider(hashAlgorithmId);
-                provider.AppendHashData(source);
-                return provider.FinalizeHashAndReset(destination);
+                if (CanUseSubtleCryptoImpl)
+                {
+                    return SHANativeHashProvider.HashOneShot(hashAlgorithmId, source, destination);
+                }
+                else
+                {
+                    HashProvider provider = CreateHashProvider(hashAlgorithmId);
+                    provider.AppendHashData(source);
+                    return provider.FinalizeHashAndReset(destination);
+                }
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Native.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Native.cs
@@ -19,28 +19,7 @@ namespace Internal.Cryptography
         public SHANativeHashProvider(string hashAlgorithmId)
         {
             Debug.Assert(HashProviderDispenser.CanUseSubtleCryptoImpl);
-
-            switch (hashAlgorithmId)
-            {
-                case HashAlgorithmNames.SHA1:
-                    _impl = SimpleDigest.Sha1;
-                    _hashSizeInBytes = 20;
-                    break;
-                case HashAlgorithmNames.SHA256:
-                    _impl = SimpleDigest.Sha256;
-                    _hashSizeInBytes = 32;
-                    break;
-                case HashAlgorithmNames.SHA384:
-                    _impl = SimpleDigest.Sha384;
-                    _hashSizeInBytes = 48;
-                    break;
-                case HashAlgorithmNames.SHA512:
-                    _impl = SimpleDigest.Sha512;
-                    _hashSizeInBytes = 64;
-                    break;
-                default:
-                    throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
-            }
+            (_impl, _hashSizeInBytes) = HashAlgorithmToPal(hashAlgorithmId);
         }
 
         public override void AppendHashData(ReadOnlySpan<byte> data)
@@ -82,6 +61,21 @@ namespace Internal.Cryptography
             return _hashSizeInBytes;
         }
 
+        public static unsafe int HashOneShot(string hashAlgorithmId, ReadOnlySpan<byte> data, Span<byte> destination)
+        {
+            (SimpleDigest impl, int hashSizeInBytes) = HashAlgorithmToPal(hashAlgorithmId);
+            Debug.Assert(destination.Length >= hashSizeInBytes);
+
+            fixed (byte* src = data)
+            fixed (byte* dest = destination)
+            {
+                int res = Interop.BrowserCrypto.SimpleDigestHash(impl, src, data.Length, dest, destination.Length);
+                Debug.Assert(res != 0);
+            }
+
+            return hashSizeInBytes;
+        }
+
         public override int HashSizeInBytes => _hashSizeInBytes;
 
         public override void Dispose(bool disposing)
@@ -91,6 +85,18 @@ namespace Internal.Cryptography
         public override void Reset()
         {
             _buffer = null;
+        }
+
+        private static (SimpleDigest, int) HashAlgorithmToPal(string hashAlgorithmId)
+        {
+            return hashAlgorithmId switch
+            {
+                HashAlgorithmNames.SHA256 => (SimpleDigest.Sha256, SHA256.HashSizeInBytes),
+                HashAlgorithmNames.SHA1 => (SimpleDigest.Sha1, SHA1.HashSizeInBytes),
+                HashAlgorithmNames.SHA384 => (SimpleDigest.Sha384, SHA384.HashSizeInBytes),
+                HashAlgorithmNames.SHA512 => (SimpleDigest.Sha512, SHA512.HashSizeInBytes),
+                _ => throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId)),
+            };
         }
     }
 }


### PR DESCRIPTION
This implements the browser hash one shots as "real" one shots. Instead of buffering data in to a memory stream and such, we can just go right to SubtleCrypto with the data.