### PR TITLE
Fix SOS tests on 7.0

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -647,9 +647,10 @@ ClrDataAccess::GetRegisterName(int regNum, unsigned int count, _Inout_updates_z_
         return E_UNEXPECTED;
 
     const WCHAR callerPrefix[] = W("caller.");
-    unsigned int prefixLen = (unsigned int)ARRAY_SIZE(callerPrefix) - 1;
-    unsigned int regLen = (unsigned int)wcslen(regs[regNum]);
-    unsigned int needed = (callerFrame?prefixLen:0) + regLen + 1;
+    // Include null terminator in prefixLen/regLen because wcscpy_s will fail otherwise
+    unsigned int prefixLen = (unsigned int)ARRAY_SIZE(callerPrefix);
+    unsigned int regLen = (unsigned int)wcslen(regs[regNum]) + 1;
+    unsigned int needed = (callerFrame ? prefixLen - 1 : 0) + regLen;
     if (pNeeded)
         *pNeeded = needed;
 
@@ -662,6 +663,8 @@ ClrDataAccess::GetRegisterName(int regNum, unsigned int count, _Inout_updates_z_
         {
             unsigned int toCopy = prefixLen < destSize ? prefixLen : destSize;
             wcscpy_s(curr, toCopy, callerPrefix);
+            // Point to null terminator
+            toCopy--;
             curr += toCopy;
             destSize -= toCopy;
         }
@@ -670,6 +673,8 @@ ClrDataAccess::GetRegisterName(int regNum, unsigned int count, _Inout_updates_z_
         {
             unsigned int toCopy = regLen < destSize ? regLen : destSize;
             wcscpy_s(curr, toCopy, regs[regNum]);
+            // Point to null terminator
+            toCopy--;
             curr += toCopy;
             destSize -= toCopy;
         }


### PR DESCRIPTION
The wcscpy_s in ClrDataAccess::GetRegisterName was failing with an invalid parameter exception because
the prefixLen and regLen didn't include the terminating null wchar.