### PR TITLE
Fix perf regression in Type.op_Equality

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -587,7 +587,7 @@ namespace System
             // Runtime types are never equal to non-runtime types
             // If `left` is a non-runtime type with a weird Equals implementation
             // this is where operator `==` would differ from `Equals` call.
-            if (left is null || right is null || left is RuntimeType || right is RuntimeType)
+            if (left is null || right is null || left.GetType() == typeof(RuntimeType) || right.GetType() == typeof(RuntimeType))
                 return false;
 
             return left.Equals(right);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/59704 regression.
There were two problems in there:
1) `typeof(RuntimeType)` wasn't CSE'd - it's handled with https://github.com/dotnet/runtime/pull/70580
2) `isinst` produces complicated branch layout we're not there to fix in JIT yet (e.g. https://github.com/dotnet/runtime/issues/70480 and a few more existing issues).

Unfortunately 1) CSE won't work without this PR's change (because of blocks' weights impacting CSE decisions)

codegen diff: https://www.diffchecker.com/rVgqsQnY