### PR TITLE
[wasm] Don't use a fixed listening port for the proxy

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/ProxyOptions.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/ProxyOptions.cs
@@ -11,9 +11,9 @@ public class ProxyOptions
 {
     public Uri DevToolsUrl { get; set; } = new Uri($"http://localhost:9222");
     public int? OwnerPid { get; set; }
-    public int FirefoxProxyPort { get; set; } = 6300;
+    public int FirefoxProxyPort { get; set; }
     public int FirefoxDebugPort { get; set; } = 6000;
-    public int DevToolsProxyPort { get; set; } = 9300;
+    public int DevToolsProxyPort { get; set; }
     public int DevToolsDebugPort
     {
         get => DevToolsUrl.Port;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/70670 .

Some follow up work - https://github.com/dotnet/runtime/issues/70680