### PR TITLE
[wasm] Fix Debug configuration builds

### DIFF
--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -289,6 +289,12 @@ if(ENABLE_INTERP_LIB)
 add_library(mono-ee-interp STATIC "${interp_sources}")
 target_link_libraries(mono-ee-interp monoapi)
 install(TARGETS mono-ee-interp LIBRARY)
+if(HOST_WASM AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+# Always optimize the interpreter, even in Debug builds.  Unoptimized interp_exec_method and
+# generate_code are so big that some browsers overflow the stack with even a few recursive
+# invocations (e.g. during .cctor initialization)
+target_compile_options(mono-ee-interp PRIVATE -O1)
+endif()
 endif()
 
 if(ENABLE_LLVM)

--- a/src/mono/wasm/runtime/CMakeLists.txt
+++ b/src/mono/wasm/runtime/CMakeLists.txt
@@ -34,6 +34,8 @@ set_target_properties(dotnet PROPERTIES
     LINK_FLAGS "@${NATIVE_BIN_DIR}/src/emcc-default.rsp @${NATIVE_BIN_DIR}/src/emcc-link.rsp ${CONFIGURATION_LINK_FLAGS} --extern-pre-js ${NATIVE_BIN_DIR}/src/cjs/runtime.cjs.iffe.js --pre-js ${NATIVE_BIN_DIR}/src/cjs/dotnet.cjs.pre.js --js-library ${NATIVE_BIN_DIR}/src/cjs/dotnet.cjs.lib.js --js-library ${NATIVE_BIN_DIR}/src/pal_random.lib.js --post-js ${NATIVE_BIN_DIR}/src/cjs/dotnet.cjs.post.js --extern-post-js ${NATIVE_BIN_DIR}/src/cjs/dotnet.cjs.extpost.js "
     RUNTIME_OUTPUT_DIRECTORY "${NATIVE_BIN_DIR}")
 
+set(ignoreMeWasmOptFlags "${CONFIGURATION_WASM_OPT_FLAGS}")  
+
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_custom_command(TARGET dotnet
                         POST_BUILD COMMAND ${EMSDK_PATH}/upstream/bin/wasm-opt --enable-exception-handling ${CONFIGURATION_WASM_OPT_FLAGS} --strip-dwarf ${NATIVE_BIN_DIR}/dotnet.wasm -o ${NATIVE_BIN_DIR}/dotnet.wasm


### PR DESCRIPTION
1.  Fix cmake error
   ```
   Manually-specified variables were not used by the project:
   CONFIGURATION_WASM_OPT_FLAGS
   ```
2. Always build the interpreter with `-O1`.  Otherwise `generate_code` and `interp_exec_method` are so big that they overflow the stack on some browsers during .cctor initialization