### PR TITLE
Updating HWIntrinsicInfo::lookupId to not accelerate Vector256 APIs when AVX2 is unsupported

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -517,22 +517,28 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
 
             if (vecCon->IsAllBitsSet())
             {
+                if ((attr != EA_32BYTE) || compiler->compOpportunisticallyDependsOn(InstructionSet_AVX2))
+                {
 #if defined(FEATURE_SIMD)
-                emit->emitIns_SIMD_R_R_R(INS_pcmpeqd, attr, targetReg, targetReg, targetReg);
+                    emit->emitIns_SIMD_R_R_R(INS_pcmpeqd, attr, targetReg, targetReg, targetReg);
 #else
-                emit->emitIns_R_R(INS_pcmpeqd, attr, targetReg, targetReg);
+                    emit->emitIns_R_R(INS_pcmpeqd, attr, targetReg, targetReg);
 #endif // FEATURE_SIMD
-                break;
+                    break;
+                }
             }
 
             if (vecCon->IsZero())
             {
+                if ((attr != EA_32BYTE) || compiler->compOpportunisticallyDependsOn(InstructionSet_AVX))
+                {
 #if defined(FEATURE_SIMD)
-                emit->emitIns_SIMD_R_R_R(INS_xorps, attr, targetReg, targetReg, targetReg);
+                    emit->emitIns_SIMD_R_R_R(INS_xorps, attr, targetReg, targetReg, targetReg);
 #else
-                emit->emitIns_R_R(INS_xorps, attr, targetReg, targetReg);
+                    emit->emitIns_R_R(INS_xorps, attr, targetReg, targetReg);
 #endif // FEATURE_SIMD
-                break;
+                    break;
+                }
             }
 
             switch (tree->TypeGet())

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -329,7 +329,7 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
 #if defined(TARGET_XARCH)
     else if (isa == InstructionSet_Vector256)
     {
-        if (comp->compOpportunisticallyDependsOn(InstructionSet_AVX2))
+        if (!comp->compOpportunisticallyDependsOn(InstructionSet_AVX2))
         {
             return NI_Illegal;
         }

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -314,20 +314,35 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
         return NI_Throw_PlatformNotSupportedException;
     }
 
-#if defined(TARGET_XARCH)
-    if ((isa == InstructionSet_Vector128) || (isa == InstructionSet_Vector256))
-#elif defined(TARGET_ARM64)
-    if ((isa == InstructionSet_Vector64) || (isa == InstructionSet_Vector128))
-#endif
+    // Special case: For Vector64/128/256 we currently don't accelerate any of the methods when
+    // IsHardwareAccelerated reports false. For Vector64 and Vector128 this is when the baseline
+    // ISA is unsupported. For Vector256 this is when AVX2 is unsupported since integer types
+    // can't get properly accelerated.
+
+    if (isa == InstructionSet_Vector128)
     {
         if (!comp->IsBaselineSimdIsaSupported())
         {
-            // Special case: For Vector64/128/256 we currently don't accelerate any of the methods when SSE/SSE2
-            // aren't supported since IsHardwareAccelerated reports false. To simplify the importation logic we'll
-            // just return illegal here and let it fallback to the software path instead.
             return NI_Illegal;
         }
     }
+#if defined(TARGET_XARCH)
+    else if (isa == InstructionSet_Vector256)
+    {
+        if (comp->compOpportunisticallyDependsOn(InstructionSet_AVX2))
+        {
+            return NI_Illegal;
+        }
+    }
+#elif defined(TARGET_ARM64)
+    else if (isa == InstructionSet_Vector64)
+    {
+        if (!comp->IsBaselineSimdIsaSupported())
+        {
+            return NI_Illegal;
+        }
+    }
+#endif
 
     for (int i = 0; i < (NI_HW_INTRINSIC_END - NI_HW_INTRINSIC_START - 1); i++)
     {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9869,7 +9869,7 @@ GenTree* Compiler::fgMorphFieldToSimdGetElement(GenTree* tree)
         var_types simdBaseType = JitType2PreciseVarType(simdBaseJitType);
         GenTree*  op2          = gtNewIconNode(index, TYP_INT);
 
-        assert(simdSize <= 16);
+        assert(simdSize <= 32);
         assert(simdSize >= ((index + 1) * genTypeSize(simdBaseType)));
 
 #if defined(TARGET_XARCH)
@@ -9944,7 +9944,7 @@ GenTree* Compiler::fgMorphFieldAssignToSimdSetElement(GenTree* tree)
         var_types simdType     = simdStructNode->gtType;
         var_types simdBaseType = JitType2PreciseVarType(simdBaseJitType);
 
-        assert(simdSize <= 16);
+        assert(simdSize <= 32);
         assert(simdSize >= ((index + 1) * genTypeSize(simdBaseType)));
 
         GenTree*       op2         = gtNewIconNode(index, TYP_INT);


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/70663.