### PR TITLE
Use IndexOf in WebUtility.HtmlDecode

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
@@ -185,7 +185,7 @@ namespace System.Net
 
             ReadOnlySpan<char> valueSpan = value.AsSpan();
 
-            int index = IndexOfHtmlDecodingChars(valueSpan);
+            int index = valueSpan.IndexOf('&');
             if (index < 0)
             {
                 return value;
@@ -215,7 +215,7 @@ namespace System.Net
 
             ReadOnlySpan<char> valueSpan = value.AsSpan();
 
-            int index = IndexOfHtmlDecodingChars(valueSpan);
+            int index = valueSpan.IndexOf('&');
             if (index == -1)
             {
                 output.Write(value);
@@ -699,21 +699,6 @@ namespace System.Net
             }
 
             return true;
-        }
-
-        private static int IndexOfHtmlDecodingChars(ReadOnlySpan<char> input)
-        {
-            // this string requires html decoding if it contains '&' or a surrogate character
-            for (int i = 0; i < input.Length; i++)
-            {
-                char c = input[i];
-                if (c == '&' || char.IsSurrogate(c))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
         }
 
         #endregion


### PR DESCRIPTION
The IndexOfHtmlDecodingChars method was iterating character by character looking for either a `&` or a surrogate, but then the slow path if one of those is found doesn't special-case surrogates.  So, we can just collapse this to a vectorized `IndexOf('&')`, which makes the fast path of detecting whether there's anything to decode much faster if there's any meaningful amount of input prior to a `&`. (I experimented with also using `IndexOf('&')` in the main routine, but it made cases with lots of entities slower, and so I'm not including that here.)