### PR TITLE
Predicate for valid Tracker Reference is inverted

### DIFF
--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -1166,12 +1166,11 @@ namespace InteropLibImports
         }
         CONTRACTL_END;
 
-        bool isValid = false;
         ::OBJECTHANDLE objectHandle = static_cast<::OBJECTHANDLE>(handle);
 
-        isValid = ObjectHandleIsNull(objectHandle) != FALSE;
-
-        return isValid;
+        // A valid target is one that is not null.
+        bool isNotNull = ObjectHandleIsNull(objectHandle) == FALSE;
+        return isNotNull;
     }
 
     bool GetGlobalPeggingState() noexcept

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -540,8 +540,8 @@ namespace ComWrappersTests
             Assert.Equal(0, refCount);
 
             // Inlining this method could unintentionally extend the lifetime of
-            // the Test instance. This extension makes clean-up of the CCW impossible
-            // because the GC seems the object as reachable.
+            // the Test instance. This lifetime extension makes clean-up of the CCW
+            // impossible when desired because the GC sees the object as reachable.
             [MethodImpl(MethodImplOptions.NoInlining)]
             static IntPtr CreateWrapper(TestComWrappers cw)
             {

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -539,6 +539,10 @@ namespace ComWrappersTests
             refCount = MockReferenceTrackerRuntime.TrackerTarget_ReleaseFromReferenceTracker(refTrackerTarget);
             Assert.Equal(0, refCount);
 
+            // Inlining this method could unintentionally extend the lifetime of
+            // the Test instance. This extension makes clean-up of the CCW impossible
+            // because the GC seems the object as reachable.
+            [MethodImpl(MethodImplOptions.NoInlining)]
             static IntPtr CreateWrapper(TestComWrappers cw)
             {
                 return cw.GetOrCreateComInterfaceForObject(new Test(), CreateComInterfaceFlags.TrackerSupport);


### PR DESCRIPTION
The logic was accidentally inverted in https://github.com/dotnet/runtime/pull/62066. This was reported through the C#/WinRT channel on .NET 7 previews.

Full validation from C#/WinRT is outstanding.

/cc @manodasanW @dotnet/interop-contrib 