### PR TITLE
Fix invalid suppression in System.Attribute

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Attribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Attribute.cs
@@ -10,12 +10,11 @@ namespace System
     [AttributeUsage(AttributeTargets.All, Inherited = true, AllowMultiple = false)]
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicFields)]
     public abstract partial class Attribute
     {
         protected Attribute() { }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
-            Justification = "Unused fields don't make a difference for equality")]
         public override bool Equals([NotNullWhen(true)] object? obj)
         {
             if (obj == null)
@@ -48,8 +47,6 @@ namespace System
             return true;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
-            Justification = "Unused fields don't make a difference for hashcode quality")]
         public override int GetHashCode()
         {
             Type type = GetType();

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -498,6 +498,7 @@ namespace System
     public delegate void AssemblyLoadEventHandler(object? sender, System.AssemblyLoadEventArgs args);
     public delegate void AsyncCallback(System.IAsyncResult ar);
     [System.AttributeUsageAttribute(System.AttributeTargets.All, Inherited=true, AllowMultiple=false)]
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]
     public abstract partial class Attribute
     {
         protected Attribute() { }


### PR DESCRIPTION
The suppression on `System.Attribute` is wrong. Ran into this in #70201 where `EditorBrowsableAttributeTests.EqualsTest` is failing because we didn't generate any reflection metadata for the field. This proves beyond any doubt that even I can't write a correct trim warning suppression.

There's a difference between "a field is kept" and "a field is accessible from reflection without issues". The issue is more pronounced in Native AOT (where the field can be completely erased from reflection). The implementation of `Attribute.Equals` didn't see any fields on the attribute type because the static analysis didn't deem any of them necessary.

Fields (or methods) that are provably not visible from reflection without warnings are free to be optimized in any way by trimming (e.g. how we strip method parameter names in illink).

This fixes the suppression and replaces it with a more correct DAM on type.

Cc @dotnet/ilc-contrib 