### PR TITLE
[wasm] Re-enable previously failing test - `System.Globalization.Tests.RegionInfoPropertyTests.DisplayName`

### DIFF
--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -100,7 +100,6 @@ namespace System.Globalization.Tests
         [Theory]
         [InlineData("en-US", "United States")]
         [OuterLoop("May fail on machines with multiple language packs installed")] // see https://github.com/dotnet/runtime/issues/30132
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45951", TestPlatforms.Browser)]
         public void DisplayName(string name, string expected)
         {
             using (new ThreadCultureChange(null, new CultureInfo(name)))


### PR DESCRIPTION
No failures described in https://github.com/dotnet/runtime/issues/45951 happen anymore. Runfo does not have any failures of `System.Globalization.Tests.RegionInfoPropertyTests.DisplayName` and running libs tests locally on Windows machine with 3 language packs no failures are recorded. Most probably got fixed by https://github.com/dotnet/runtime/issues/30132. This is to remove the comment linking to the issue and making sure you agree with the decision.

Fixes https://github.com/dotnet/runtime/issues/45951 .