### PR TITLE
Add limited support for LocalCertificateSelectionCallback for QUIC

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
@@ -44,29 +44,22 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                         null,
                         Array.Empty<string>());
 
-                    try
+                    if (cert is X509Certificate2 cert2 && cert2.Handle != IntPtr.Zero && cert2.HasPrivateKey)
                     {
-                        if (((X509Certificate2)cert).HasPrivateKey)
-                        {
-                            certificate = cert;
-                        }
+                        certificate = cert;
                     }
-                    catch { }
                 }
                 else if (clientAuthenticationOptions.ClientCertificates != null)
                 {
-                    foreach (var cert in clientAuthenticationOptions.ClientCertificates)
+                    foreach (X509Certificate cert in clientAuthenticationOptions.ClientCertificates)
                     {
-                        try
+
+                        if (cert is X509Certificate2 cert2 && cert2.Handle != IntPtr.Zero && cert2.HasPrivateKey)
                         {
-                            if (((X509Certificate2)cert).HasPrivateKey)
-                            {
-                                // Pick first certificate with private key.
-                                certificate = cert;
-                                break;
-                            }
+                            // Pick first certificate with private key.
+                            certificate = cert;
+                            break;
                         }
-                        catch { }
                     }
                 }
             }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
@@ -26,16 +26,36 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
             if (options.ClientAuthenticationOptions != null)
             {
+                SslClientAuthenticationOptions clientAuthenticationOptions = options.ClientAuthenticationOptions;
+
 #pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
-                if (options.ClientAuthenticationOptions.EncryptionPolicy == EncryptionPolicy.NoEncryption)
+                if (clientAuthenticationOptions.EncryptionPolicy == EncryptionPolicy.NoEncryption)
                 {
-                    throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(options.ClientAuthenticationOptions.EncryptionPolicy)));
+                    throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(clientAuthenticationOptions.EncryptionPolicy)));
                 }
 #pragma warning restore SYSLIB0040
 
-                if (options.ClientAuthenticationOptions.ClientCertificates != null)
+                if (clientAuthenticationOptions.LocalCertificateSelectionCallback != null)
                 {
-                    foreach (var cert in options.ClientAuthenticationOptions.ClientCertificates)
+                    X509Certificate? cert = clientAuthenticationOptions.LocalCertificateSelectionCallback(
+                        options,
+                        clientAuthenticationOptions.TargetHost ?? string.Empty,
+                        clientAuthenticationOptions.ClientCertificates ?? new X509CertificateCollection(),
+                        null,
+                        Array.Empty<string>());
+
+                    try
+                    {
+                        if (((X509Certificate2)cert).HasPrivateKey)
+                        {
+                            certificate = cert;
+                        }
+                    }
+                    catch { }
+                }
+                else if (clientAuthenticationOptions.ClientCertificates != null)
+                {
+                    foreach (var cert in clientAuthenticationOptions.ClientCertificates)
                     {
                         try
                         {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -292,52 +292,6 @@ namespace System.Net.Quic.Implementations.MsQuic
         {
             ThrowIfDisposed();
 
-            using CancellationTokenRegistration registration = SetupWriteStartState(isEmpty, cancellationToken);
-
-            await WriteAsyncCore<TBuffer>(stateSetup, buffer, isEmpty, endStream).ConfigureAwait(false);
-
-            CleanupWriteCompletedState();
-        }
-
-        private unsafe ValueTask WriteAsyncCore<TBuffer>(Action<State, TBuffer> stateSetup, TBuffer buffer, bool isEmpty, bool endStream)
-        {
-            if (isEmpty)
-            {
-                if (endStream)
-                {
-                    // Start graceful shutdown sequence if passed in the fin flag and there is an empty buffer.
-                    StartShutdown(QUIC_STREAM_SHUTDOWN_FLAGS.GRACEFUL, errorCode: 0);
-                }
-                return default;
-            }
-
-            stateSetup(_state, buffer);
-
-            Debug.Assert(!Monitor.IsEntered(_state), "!Monitor.IsEntered(_state)");
-            int status = MsQuicApi.Api.ApiTable->StreamSend(
-                _state.Handle.QuicHandle,
-                _state.SendBuffers.Buffers,
-                (uint)_state.SendBuffers.Count,
-                endStream ? QUIC_SEND_FLAGS.FIN : QUIC_SEND_FLAGS.NONE,
-                (void*)IntPtr.Zero);
-
-            if (StatusFailed(status))
-            {
-                CleanupWriteFailedState();
-                CleanupSendState(_state);
-
-                if (status == QUIC_STATUS_ABORTED)
-                {
-                    throw ThrowHelper.GetConnectionAbortedException(_state.ConnectionState.AbortErrorCode);
-                }
-                ThrowIfFailure(status, "Could not send data to peer.");
-            }
-
-            return _state.SendResettableCompletionSource.GetTypelessValueTask();
-        }
-
-        private CancellationTokenRegistration SetupWriteStartState(bool emptyBuffer, CancellationToken cancellationToken)
-        {
             if (cancellationToken.IsCancellationRequested)
             {
                 lock (_state)
@@ -369,7 +323,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             }
 
             // if token was already cancelled, this would execute synchronously
-            CancellationTokenRegistration registration = cancellationToken.UnsafeRegister(static (s, token) =>
+            using CancellationTokenRegistration registration = cancellationToken.UnsafeRegister(static (s, token) =>
             {
                 var state = (State)s!;
                 bool shouldComplete = false;
@@ -417,14 +371,11 @@ namespace System.Net.Quic.Implementations.MsQuic
 
                 // Change the state in the same lock where we check for final states to prevent coming back from Aborted/ConnectionClosed.
                 Debug.Assert(_state.SendState != SendState.Pending);
-                _state.SendState = emptyBuffer ? SendState.Finished : SendState.Pending;
+                _state.SendState = isEmpty ? SendState.Finished : SendState.Pending;
             }
 
-            return registration;
-        }
+            await WriteAsyncCore<TBuffer>(stateSetup, buffer, isEmpty, endStream).ConfigureAwait(false);
 
-        private void CleanupWriteCompletedState()
-        {
             lock (_state)
             {
                 if (_state.SendState == SendState.Finished)
@@ -434,15 +385,48 @@ namespace System.Net.Quic.Implementations.MsQuic
             }
         }
 
-        private void CleanupWriteFailedState()
+        private unsafe ValueTask WriteAsyncCore<TBuffer>(Action<State, TBuffer> stateSetup, TBuffer buffer, bool isEmpty, bool endStream)
         {
-            lock (_state)
+            if (isEmpty)
             {
-                if (_state.SendState == SendState.Pending)
+                if (endStream)
                 {
-                    _state.SendState = SendState.Finished;
+                    // Start graceful shutdown sequence if passed in the fin flag and there is an empty buffer.
+                    StartShutdown(QUIC_STREAM_SHUTDOWN_FLAGS.GRACEFUL, errorCode: 0);
                 }
+                return default;
             }
+
+            stateSetup(_state, buffer);
+
+            Debug.Assert(!Monitor.IsEntered(_state), "!Monitor.IsEntered(_state)");
+            int status = MsQuicApi.Api.ApiTable->StreamSend(
+                _state.Handle.QuicHandle,
+                _state.SendBuffers.Buffers,
+                (uint)_state.SendBuffers.Count,
+                endStream ? QUIC_SEND_FLAGS.FIN : QUIC_SEND_FLAGS.NONE,
+                (void*)IntPtr.Zero);
+
+            if (StatusFailed(status))
+            {
+                lock (_state)
+                {
+                    if (_state.SendState == SendState.Pending)
+                    {
+                        _state.SendState = SendState.Finished;
+                    }
+                }
+
+                CleanupSendState(_state);
+
+                if (status == QUIC_STATUS_ABORTED)
+                {
+                    throw ThrowHelper.GetConnectionAbortedException(_state.ConnectionState.AbortErrorCode);
+                }
+                ThrowIfFailure(status, "Could not send data to peer.");
+            }
+
+            return _state.SendResettableCompletionSource.GetTypelessValueTask();
         }
 
         internal override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Closes #70651.

This PR adds limited suport for client's `LocalCertificateSelectionCallback`. The callback is called once before the connection is even attempted (as is done for SslStream).

Calling it second time once we get trusted issuers list and server certificate is out of scope for 7.0 and is left for future. (see the original issue).