### PR TITLE
Fix compilation without HAVE_GSS_KRB5_CRED_NO_CI_FLAGS_X

### DIFF
--- a/src/native/libs/System.Net.Security.Native/pal_gssapi.c
+++ b/src/native/libs/System.Net.Security.Native/pal_gssapi.c
@@ -159,10 +159,12 @@ static int32_t ensure_gss_shim_initialized()
 FOR_ALL_REQUIRED_GSS_FUNCTIONS
 #undef PER_FUNCTION_BLOCK
     // for optional functions skip the error check
+#if HAVE_GSS_KRB5_CRED_NO_CI_FLAGS_X
 #define PER_FUNCTION_BLOCK(fn) \
     fn##_ptr = (TYPEOF(fn)*)dlsym(s_gssLib, #fn);
 FOR_ALL_OPTIONAL_GSS_FUNCTIONS
 #undef PER_FUNCTION_BLOCK
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Mostly theoretical fix since the only supported system that doesn't have `GSS_KRB5_CRED_NO_CI_FLAGS_X` is RHEL 7. It could still happen with stale CMake cache though.

Ref: https://github.com/dotnet/runtime/pull/70447#issuecomment-1155088323