### PR TITLE
Fix AttributePresence in composite mode

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -663,7 +663,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (inputModule == TypeSystemContext.SystemModule)
                 {
                     AttributePresenceFilterNode attributePresenceTable = new AttributePresenceFilterNode(inputModule);
-                    Header.Add(Internal.Runtime.ReadyToRunSectionType.AttributePresence, attributePresenceTable, attributePresenceTable);
+                    tableHeader.Add(Internal.Runtime.ReadyToRunSectionType.AttributePresence, attributePresenceTable, attributePresenceTable);
                 }
             }
 


### PR DESCRIPTION
According to my comparative perf measurements composite framework
spends about 5M more instructions in the method

coreclr.dll!CMiniMdTemplate&lt;CMiniMd>::SearchTableForMultipleRows(CMiniColDef sColumn)

I tracked this down to the R2R table AttributePresence which is
used to speed up attribute queries against the ECMA metadata model.
In composite mode we were putting the table in the image header,
not component header, and so the runtime was unable to locate it.
This change fixes generation of the table in Crossgen2; I have
verified that with this change I no longer see the 5M outlier.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 