### PR TITLE
[release/6.0] Correctly format chuncked response with Content-Length header

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -739,6 +739,10 @@ namespace System.Net.Http
                     _pool.InvalidateHttp11Connection(this);
                     _detachedFromPool = true;
                 }
+                else if (response.Headers.TransferEncodingChunked == true)
+                {
+                    responseStream = new ChunkedEncodingReadStream(this, response);
+                }
                 else if (response.Content.Headers.ContentLength != null)
                 {
                     long contentLength = response.Content.Headers.ContentLength.GetValueOrDefault();
@@ -751,10 +755,6 @@ namespace System.Net.Http
                     {
                         responseStream = new ContentLengthReadStream(this, (ulong)contentLength);
                     }
-                }
-                else if (response.Headers.TransferEncodingChunked == true)
-                {
-                    responseStream = new ChunkedEncodingReadStream(this, response);
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #68581
Backport of https://github.com/dotnet/runtime/pull/69016 to release/6.0

## Customer Impact

This is fixing an edge-case bug in HttpClient where we currently violate RFC.
**This is a regression in Core compared to Framework.**

As per ([RFC 2616 section 4.4 para 3](https://datatracker.ietf.org/doc/html/rfc2616#section-4.4)):

> If a message is received with both a Transfer-Encoding header field and a Content-Length header field, the latter MUST be ignored.

While the server ***should not*** respond with both headers, the spec is clear that the client ***must*** respect the latter one if it does happen.

Today's behavior (without this fix) means that the user of `HttpClient` will receive a response body including the chunk frames, which won't be removed. The only workaround is to detect this case and remove chunk framing manually (~600 LOC).

## Testing

Added a targeted test case for the new behavior.
We have existing test coverage to ensure nothing else regressed.

## Risk

A user could be relying on the current non-RFC-compliant 6.0 behavior. Such users will have to change their code.

The risk of unrelated regressions is low - the change is trivial (swapping the order of two `else if` branches).