### PR TITLE
Use crypto.subtle for HMAC on Browser WASM

### DIFF
--- a/src/libraries/Common/src/Interop/Browser/System.Security.Cryptography.Native.Browser/Interop.Sign.cs
+++ b/src/libraries/Common/src/Interop/Browser/System.Security.Cryptography.Native.Browser/Interop.Sign.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class BrowserCrypto
+    {
+        [LibraryImport(Libraries.CryptoNative, EntryPoint = "SystemCryptoNativeBrowser_Sign")]
+        internal static unsafe partial int Sign(
+            SimpleDigest hashAlgorithm,
+            byte* key_buffer,
+            int key_len,
+            byte* input_buffer,
+            int input_len,
+            byte* output_buffer,
+            int output_len);
+    }
+}

--- a/src/libraries/Common/src/Interop/Browser/System.Security.Cryptography.Native.Browser/Interop.SimpleDigestHash.cs
+++ b/src/libraries/Common/src/Interop/Browser/System.Security.Cryptography.Native.Browser/Interop.SimpleDigestHash.cs
@@ -18,8 +18,8 @@ internal static partial class Interop
             Sha512,
         };
 
-        [LibraryImport(Libraries.CryptoNative, EntryPoint = "SystemCryptoNativeBrowser_CanUseSimpleDigestHash")]
-        internal static partial int CanUseSimpleDigestHash();
+        [LibraryImport(Libraries.CryptoNative, EntryPoint = "SystemCryptoNativeBrowser_CanUseSubtleCryptoImpl")]
+        internal static partial int CanUseSubtleCryptoImpl();
 
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "SystemCryptoNativeBrowser_SimpleDigestHash")]
         internal static unsafe partial int SimpleDigestHash(

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -543,6 +543,8 @@
              Link="Common\System\Sha1ForNonSecretPurposes.cs" />
     <Compile Include="$(CommonPath)Interop\Browser\System.Security.Cryptography.Native.Browser\Interop.SimpleDigestHash.cs"
              Link="Common\Interop\Browser\System.Security.Cryptography.Native.Browser\Interop.SimpleDigestHash.cs" /> 
+    <Compile Include="$(CommonPath)Interop\Browser\System.Security.Cryptography.Native.Browser\Interop.Sign.cs"
+             Link="Common\Interop\Browser\System.Security.Cryptography.Native.Browser\Interop.Sign.cs" /> 
     <Compile Include="System\Security\Cryptography\AesCcm.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\AesGcm.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\AesImplementation.NotSupported.cs" />
@@ -559,6 +561,7 @@
     <Compile Include="System\Security\Cryptography\ECDsa.Create.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\HashProviderDispenser.Browser.cs" />
     <Compile Include="System\Security\Cryptography\HMACHashProvider.Browser.Managed.cs" />
+    <Compile Include="System\Security\Cryptography\HMACHashProvider.Browser.Native.cs" />
     <Compile Include="System\Security\Cryptography\LiteHash.Browser.cs" />
     <Compile Include="System\Security\Cryptography\OidLookup.NoFallback.cs" />
     <Compile Include="System\Security\Cryptography\OpenSsl.NotSupported.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
@@ -1,13 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Internal.Cryptography;
-
 namespace System.Security.Cryptography
 {
     internal static partial class HashProviderDispenser
     {
-        internal static readonly bool CanUseSubtleCryptoImpl = Interop.BrowserCrypto.CanUseSimpleDigestHash() == 1;
+        internal static readonly bool CanUseSubtleCryptoImpl = Interop.BrowserCrypto.CanUseSubtleCryptoImpl() == 1;
 
         public static HashProvider CreateHashProvider(string hashAlgorithmId)
         {
@@ -32,9 +30,16 @@ namespace System.Security.Cryptography
                 ReadOnlySpan<byte> source,
                 Span<byte> destination)
             {
-                HashProvider provider = CreateMacProvider(hashAlgorithmId, key);
-                provider.AppendHashData(source);
-                return provider.FinalizeHashAndReset(destination);
+                if (CanUseSubtleCryptoImpl)
+                {
+                    return HMACNativeHashProvider.MacDataOneShot(hashAlgorithmId, key, source, destination);
+                }
+                else
+                {
+                    HashProvider provider = CreateMacProvider(hashAlgorithmId, key);
+                    provider.AppendHashData(source);
+                    return provider.FinalizeHashAndReset(destination);
+                }
             }
 
             public static int HashData(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination)
@@ -60,7 +65,9 @@ namespace System.Security.Cryptography
                 case HashAlgorithmNames.SHA256:
                 case HashAlgorithmNames.SHA384:
                 case HashAlgorithmNames.SHA512:
-                    return new HMACManagedHashProvider(hashAlgorithmId, key);
+                    return CanUseSubtleCryptoImpl
+                        ? new HMACNativeHashProvider(hashAlgorithmId, key)
+                        : new HMACManagedHashProvider(hashAlgorithmId, key);
             }
             throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
@@ -36,7 +36,7 @@ namespace System.Security.Cryptography
                 }
                 else
                 {
-                    HashProvider provider = CreateMacProvider(hashAlgorithmId, key);
+                    using HashProvider provider = CreateMacProvider(hashAlgorithmId, key);
                     provider.AppendHashData(source);
                     return provider.FinalizeHashAndReset(destination);
                 }

--- a/src/libraries/System.Security.Cryptography/tests/HmacMD5Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacMD5Tests.cs
@@ -138,6 +138,16 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public void HMacMD5_EmptyKey()
+        {
+            VerifyRepeating(
+                input: "Crypto is fun!",
+                1,
+                hexKey: "",
+                output: "7554A8C4641CBA36BE2AC20CACEA1136");
+        }
+
+        [Fact]
         public void HmacMD5_Stream_MultipleOf4096()
         {
             // Verfied with:

--- a/src/libraries/System.Security.Cryptography/tests/HmacSha1Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacSha1Tests.cs
@@ -113,6 +113,16 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public void HmacSha1_EmptyKey()
+        {
+            VerifyRepeating(
+                input: "Crypto is fun!",
+                1,
+                hexKey: "",
+                output: "C979AD8DE8CC546CF82D948226FDD8024599F6CE");
+        }
+
+        [Fact]
         public void HmacSha1_Rfc2202_1()
         {
             VerifyHmac(1, s_testMacs2202[1]);

--- a/src/libraries/System.Security.Cryptography/tests/HmacSha256Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacSha256Tests.cs
@@ -125,6 +125,16 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public void HmacSha256_EmptyKey()
+        {
+            VerifyRepeating(
+                input: "Crypto is fun!",
+                1,
+                hexKey: "",
+                output: "DE26DD5A23A91021F61EACF8A8DD324AB5637977486A10D701C4DFA4AE33CB4F");
+        }
+
+        [Fact]
         public void HmacSha256_Stream_MultipleOf4096()
         {
             // Verfied with:

--- a/src/libraries/System.Security.Cryptography/tests/HmacSha384Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacSha384Tests.cs
@@ -138,6 +138,16 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public void HmacSha384_EmptyKey()
+        {
+            VerifyRepeating(
+                input: "Crypto is fun!",
+                1,
+                hexKey: "",
+                output: "CFEB81812C8DB4EDB385FCC7CB81E4D715685741AAB1E470FB0B395A414F89867E510E4A2BA2F1F11D7005849FA0DF11");
+        }
+
+        [Fact]
         public void HmacSha384_Stream_MultipleOf4096()
         {
             // Verfied with:

--- a/src/libraries/System.Security.Cryptography/tests/HmacSha512Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacSha512Tests.cs
@@ -138,6 +138,16 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public void HmacSha512_EmptyKey()
+        {
+            VerifyRepeating(
+                input: "Crypto is fun!",
+                1,
+                hexKey: "",
+                output: "0C75CCE182743282AAB081BA12AA6C9DEA44852E567063B4EEBD7B33F940B6C8BC16958F9A23401E6FAA00483962A2A8FC7DE9D8B7A14EDD55B49419A211BC37");
+        }
+
+        [Fact]
         public void HmacSha512_Stream_MultipleOf4096()
         {
             // Verfied with:

--- a/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
+++ b/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
@@ -70,8 +70,9 @@ const linked_functions = [
     "mono_wasm_get_icudt_name",
 
     // pal_crypto_webworker.c
+    "dotnet_browser_can_use_subtle_crypto_impl",
     "dotnet_browser_simple_digest_hash",
-    "dotnet_browser_can_use_simple_digest_hash",
+    "dotnet_browser_sign",
 ];
 
 // -- this javascript file is evaluated by emcc during compilation! --

--- a/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
+++ b/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
@@ -107,8 +107,9 @@ const linked_functions = [
     "mono_wasm_get_icudt_name",
 
     // pal_crypto_webworker.c
+    "dotnet_browser_can_use_subtle_crypto_impl",
     "dotnet_browser_simple_digest_hash",
-    "dotnet_browser_can_use_simple_digest_hash",
+    "dotnet_browser_sign",
 ];
 
 // -- this javascript file is evaluated by emcc during compilation! --

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -69,7 +69,11 @@ import { fetch_like, readAsync_like } from "./polyfills";
 import { EmscriptenModule } from "./types/emscripten";
 import { mono_run_main, mono_run_main_and_exit } from "./run";
 import { diagnostics } from "./diagnostics";
-import { dotnet_browser_can_use_simple_digest_hash, dotnet_browser_simple_digest_hash } from "./crypto-worker";
+import {
+    dotnet_browser_can_use_subtle_crypto_impl,
+    dotnet_browser_simple_digest_hash,
+    dotnet_browser_sign
+} from "./crypto-worker";
 
 const MONO = {
     // current "public" MONO API
@@ -370,8 +374,9 @@ export const __linker_exports: any = {
     mono_wasm_get_icudt_name,
 
     // pal_crypto_webworker.c
+    dotnet_browser_can_use_subtle_crypto_impl,
     dotnet_browser_simple_digest_hash,
-    dotnet_browser_can_use_simple_digest_hash,
+    dotnet_browser_sign
 };
 
 const INTERNAL: any = {

--- a/src/mono/wasm/runtime/workers/dotnet-crypto-worker.js
+++ b/src/mono/wasm/runtime/workers/dotnet-crypto-worker.js
@@ -163,20 +163,38 @@ var ChannelWorker = {
 };
 
 async function call_digest(type, data) {
-    var digest_type = "";
-    switch(type) {
-        case 0: digest_type = "SHA-1"; break;
-        case 1: digest_type = "SHA-256"; break;
-        case 2: digest_type = "SHA-384"; break;
-        case 3: digest_type = "SHA-512"; break;
-        default:
-            throw "CRYPTO: Unknown digest: " + type;
-    }
+    const digest_type = get_hash_name(type);
 
     // The 'crypto' API is not available in non-browser
     // environments (for example, v8 server).
-    var digest = await crypto.subtle.digest(digest_type, data);
+    const digest = await crypto.subtle.digest(digest_type, data);
     return Array.from(new Uint8Array(digest));
+}
+
+async function sign(type, key, data) {
+    const hash_name = get_hash_name(type);
+
+    if (key.length === 0) {
+        // crypto.subtle.importKey will raise an error for an empty key.
+        // To prevent an error, reset it to a key with just a `0x00` byte. This is equivalent
+        // since HMAC keys get zero-extended up to the block size of the algorithm.
+        key = new Uint8Array([0]);
+    }
+
+    const cryptoKey = await crypto.subtle.importKey("raw", key, {name: "HMAC", hash: hash_name}, false, ["sign"]);
+    const signResult = await crypto.subtle.sign("HMAC", cryptoKey, data);
+    return Array.from(new Uint8Array(signResult));
+}
+
+function get_hash_name(type) {
+    switch(type) {
+        case 0: return "SHA-1";
+        case 1: return "SHA-256";
+        case 2: return "SHA-384";
+        case 3: return "SHA-512";
+        default:
+            throw "CRYPTO: Unknown digest: " + type;
+    }
 }
 
 // Operation to perform.
@@ -184,8 +202,12 @@ async function async_call(msg) {
     const req = JSON.parse(msg);
 
     if (req.func === "digest") {
-        var digestArr = await call_digest(req.type, new Uint8Array(req.data));
+        const digestArr = await call_digest(req.type, new Uint8Array(req.data));
         return JSON.stringify(digestArr);
+    } 
+    else if (req.func === "sign") {
+        const signResult = await sign(req.type, new Uint8Array(req.key), new Uint8Array(req.data));
+        return JSON.stringify(signResult);
     } else {
         throw "CRYPTO: Unknown request: " + req.func;
     }

--- a/src/mono/wasm/runtime/workers/dotnet-crypto-worker.js
+++ b/src/mono/wasm/runtime/workers/dotnet-crypto-worker.js
@@ -181,7 +181,7 @@ async function sign(type, key, data) {
         key = new Uint8Array([0]);
     }
 
-    const cryptoKey = await crypto.subtle.importKey("raw", key, {name: "HMAC", hash: hash_name}, false, ["sign"]);
+    const cryptoKey = await crypto.subtle.importKey("raw", key, {name: "HMAC", hash: hash_name}, false /* extractable */, ["sign"]);
     const signResult = await crypto.subtle.sign("HMAC", cryptoKey, data);
     return Array.from(new Uint8Array(signResult));
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Browser/pal_crypto_webworker.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Browser/pal_crypto_webworker.c
@@ -12,7 +12,16 @@ extern int32_t dotnet_browser_simple_digest_hash(
     uint8_t* output_buffer,
     int32_t output_len);
 
-extern int32_t dotnet_browser_can_use_simple_digest_hash(void);
+extern int32_t dotnet_browser_sign(
+    enum simple_digest hashAlgorithm,
+    uint8_t* key_buffer,
+    int32_t key_len,
+    uint8_t* input_buffer,
+    int32_t input_len,
+    uint8_t* output_buffer,
+    int32_t output_len);
+
+extern int32_t dotnet_browser_can_use_subtle_crypto_impl(void);
 
 int32_t SystemCryptoNativeBrowser_SimpleDigestHash(
     enum simple_digest ver,
@@ -24,7 +33,19 @@ int32_t SystemCryptoNativeBrowser_SimpleDigestHash(
     return dotnet_browser_simple_digest_hash(ver, input_buffer, input_len, output_buffer, output_len);
 }
 
-int32_t SystemCryptoNativeBrowser_CanUseSimpleDigestHash(void)
+int32_t SystemCryptoNativeBrowser_Sign(
+    enum simple_digest hashAlgorithm,
+    uint8_t* key_buffer,
+    int32_t key_len,
+    uint8_t* input_buffer,
+    int32_t input_len,
+    uint8_t* output_buffer,
+    int32_t output_len)
 {
-    return dotnet_browser_can_use_simple_digest_hash();
+    return dotnet_browser_sign(hashAlgorithm, key_buffer, key_len, input_buffer, input_len, output_buffer, output_len);
+}
+
+int32_t SystemCryptoNativeBrowser_CanUseSubtleCryptoImpl(void)
+{
+    return dotnet_browser_can_use_subtle_crypto_impl();
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Browser/pal_crypto_webworker.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Browser/pal_crypto_webworker.h
@@ -22,4 +22,13 @@ PALEXPORT int32_t SystemCryptoNativeBrowser_SimpleDigestHash(
     uint8_t* output_buffer,
     int32_t output_len);
 
-PALEXPORT int32_t SystemCryptoNativeBrowser_CanUseSimpleDigestHash(void);
+PALEXPORT int32_t SystemCryptoNativeBrowser_Sign(
+    enum simple_digest ver,
+    uint8_t* key_buffer,
+    int32_t key_len,
+    uint8_t* input_buffer,
+    int32_t input_len,
+    uint8_t* output_buffer,
+    int32_t output_len);
+
+PALEXPORT int32_t SystemCryptoNativeBrowser_CanUseSubtleCryptoImpl(void);


### PR DESCRIPTION
Implement the browser "native" portion for HMAC on Browser WASM.

I also made a few refactoring / simplifications where necessary.

Contributes to #40074

~This should probably wait for https://github.com/dotnet/runtime/pull/70461 to be merged, to ensure both paths (managed and crypto.subtle) are being tested in CI.~ This is now merged - so both SubtleCrypto and managed fallback implementations are being tested in CI.