### PR TITLE
[wasm][debugger] Remove workaround to get pauseOnExceptions setting

### DIFF
--- a/src/libraries/sendtohelix-wasm.targets
+++ b/src/libraries/sendtohelix-wasm.targets
@@ -3,6 +3,7 @@
     <_workItemTimeout Condition="'$(Scenario)' == 'BuildWasmApps' and '$(_workItemTimeout)' == ''">01:30:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(NeedsToBuildWasmAppsOnHelix)' == 'true'">01:00:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(Scenario)' == 'WasmDebuggerTests'">01:00:00</_workItemTimeout>
+    <_workItemTimeout Condition="'$(Scenario)' == 'WasmDebuggerTests' and '$(BrowserHost)' == 'windows'">01:30:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(Scenario)' == 'WasmTestOnBrowser' and '$(BrowserHost)' == 'windows'">00:45:00</_workItemTimeout>
 
     <IsWasmDebuggerTests Condition="'$(Scenario)' == 'WasmDebuggerTests'">true</IsWasmDebuggerTests>

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -401,11 +401,12 @@ namespace Microsoft.WebAssembly.Diagnostics
 
     internal class ExecutionContext
     {
-        public ExecutionContext(MonoSDBHelper sdbAgent, int id, object auxData)
+        public ExecutionContext(MonoSDBHelper sdbAgent, int id, object auxData, PauseOnExceptionsKind pauseOnExceptions)
         {
             Id = id;
             AuxData = auxData;
             SdbAgent = sdbAgent;
+            PauseOnExceptions = pauseOnExceptions;
         }
 
         public string DebugId { get; set; }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxExecutionContext.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxExecutionContext.cs
@@ -14,7 +14,7 @@ internal sealed class FirefoxExecutionContext : ExecutionContext
     public string? GlobalName { get; set; }
     public Result LastDebuggerAgentBufferReceived { get; set; }
 
-    public FirefoxExecutionContext(MonoSDBHelper sdbAgent, int id, string actorName) : base(sdbAgent, id, actorName)
+    public FirefoxExecutionContext(MonoSDBHelper sdbAgent, int id, string actorName, PauseOnExceptionsKind pauseOnExceptions = PauseOnExceptionsKind.Unset) : base(sdbAgent, id, actorName, pauseOnExceptions)
     {
         ActorName = actorName;
     }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxExecutionContext.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxExecutionContext.cs
@@ -14,7 +14,7 @@ internal sealed class FirefoxExecutionContext : ExecutionContext
     public string? GlobalName { get; set; }
     public Result LastDebuggerAgentBufferReceived { get; set; }
 
-    public FirefoxExecutionContext(MonoSDBHelper sdbAgent, int id, string actorName, PauseOnExceptionsKind pauseOnExceptions = PauseOnExceptionsKind.Unset) : base(sdbAgent, id, actorName, pauseOnExceptions)
+    public FirefoxExecutionContext(MonoSDBHelper sdbAgent, int id, string actorName) : base(sdbAgent, id, actorName, PauseOnExceptionsKind.Unset)
     {
         ActorName = actorName;
     }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -27,7 +27,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         // index of the runtime in a same JS page/process
         public int RuntimeId { get; private init; }
         public bool JustMyCode { get; private set; }
-        private PauseOnExceptionsKind PauseOnExceptions { get; set; }
+        private PauseOnExceptionsKind _defaultPauseOnExceptions { get; set; }
 
         protected readonly ProxyOptions _options;
 
@@ -36,7 +36,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             this.urlSymbolServerList = urlSymbolServerList ?? new List<string>();
             RuntimeId = runtimeId;
             _options = options;
-            PauseOnExceptions = PauseOnExceptionsKind.Unset;
+            _defaultPauseOnExceptions = PauseOnExceptionsKind.Unset;
         }
 
         internal ExecutionContext GetContext(SessionId sessionId)
@@ -161,7 +161,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                             bool? is_default = aux_data["isDefault"]?.Value<bool>();
                             if (is_default == true)
                             {
-                                await OnDefaultContext(sessionId, new ExecutionContext(new MonoSDBHelper (this, logger, sessionId), id, aux_data, PauseOnExceptions), token);
+                                await OnDefaultContext(sessionId, new ExecutionContext(new MonoSDBHelper (this, logger, sessionId), id, aux_data, _defaultPauseOnExceptions), token);
                             }
                         }
                         return true;
@@ -279,7 +279,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     string state = args["state"].Value<string>();
                     var pauseOnException = GetPauseOnExceptionsStatusFromString(state);
                     if (pauseOnException != PauseOnExceptionsKind.Unset)
-                        PauseOnExceptions = pauseOnException;
+                        _defaultPauseOnExceptions = pauseOnException;
                 }
                 return false;
             }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -21,14 +21,14 @@ namespace Microsoft.WebAssembly.Diagnostics
         private IList<string> urlSymbolServerList;
         private HashSet<SessionId> sessions = new HashSet<SessionId>();
         protected Dictionary<SessionId, ExecutionContext> contexts = new Dictionary<SessionId, ExecutionContext>();
-        private const string sPauseOnUncaught = "pause_on_uncaught";
-        private const string sPauseOnCaught = "pause_on_caught";
 
         public static HttpClient HttpClient => new HttpClient();
 
         // index of the runtime in a same JS page/process
         public int RuntimeId { get; private init; }
         public bool JustMyCode { get; private set; }
+        public PauseOnExceptionsKind PauseOnExceptions { get; set; }
+
         protected readonly ProxyOptions _options;
 
         public MonoProxy(ILogger logger, IList<string> urlSymbolServerList, int runtimeId = 0, string loggerId = "", ProxyOptions options = null) : base(logger, loggerId)
@@ -160,54 +160,17 @@ namespace Microsoft.WebAssembly.Diagnostics
                             bool? is_default = aux_data["isDefault"]?.Value<bool>();
                             if (is_default == true)
                             {
-                                await OnDefaultContext(sessionId, new ExecutionContext(new MonoSDBHelper (this, logger, sessionId), id, aux_data), token);
+                                await OnDefaultContext(sessionId, new ExecutionContext(new MonoSDBHelper (this, logger, sessionId), id, aux_data, PauseOnExceptions), token);
                             }
                         }
                         return true;
                     }
 
-                case "Runtime.exceptionThrown":
-                    {
-                        // Don't process events from sessions we aren't tracking
-                        if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
-                            return false;
-
-                        if (!context.IsRuntimeReady)
-                        {
-                            string exceptionError = args?["exceptionDetails"]?["exception"]?["value"]?.Value<string>();
-                            if (exceptionError == sPauseOnUncaught || exceptionError == sPauseOnCaught)
-                                return true;
-                        }
-                        break;
-                    }
-
                 case "Debugger.paused":
                     {
                         // Don't process events from sessions we aren't tracking
-                        if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
+                        if (!contexts.TryGetValue(sessionId, out _))
                             return false;
-
-                        if (!context.IsRuntimeReady)
-                        {
-                            string reason = args?["reason"]?.Value<string>();
-                            if (reason == "exception")
-                            {
-                                string exceptionError = args?["data"]?["value"]?.Value<string>();
-                                if (exceptionError == sPauseOnUncaught)
-                                {
-                                    await SendResume(sessionId, token);
-                                    if (context.PauseOnExceptions == PauseOnExceptionsKind.Unset)
-                                        context.PauseOnExceptions = PauseOnExceptionsKind.Uncaught;
-                                    return true;
-                                }
-                                if (exceptionError == sPauseOnCaught)
-                                {
-                                    await SendResume(sessionId, token);
-                                    context.PauseOnExceptions = PauseOnExceptionsKind.All;
-                                    return true;
-                                }
-                            }
-                        }
 
                         //TODO figure out how to stich out more frames and, in particular what happens when real wasm is on the stack
                         string top_func = args?["callFrames"]?[0]?["functionName"]?.Value<string>();
@@ -291,7 +254,16 @@ namespace Microsoft.WebAssembly.Diagnostics
             Result res = await SendMonoCommand(sessionId, MonoCommands.IsRuntimeReady(RuntimeId), token);
             return res.Value?["result"]?["value"]?.Value<bool>() ?? false;
         }
-
+        private static PauseOnExceptionsKind GetPauseOnExceptionsStatusFromString(string state)
+        {
+            return state switch
+            {
+                "all" => PauseOnExceptionsKind.All,
+                "uncaught" => PauseOnExceptionsKind.Uncaught,
+                "none" => PauseOnExceptionsKind.None,
+                _ => PauseOnExceptionsKind.Unset
+            };
+        }
         protected override async Task<bool> AcceptCommand(MessageId id, JObject parms, CancellationToken token)
         {
             var method = parms["method"].Value<string>();
@@ -302,7 +274,14 @@ namespace Microsoft.WebAssembly.Diagnostics
                 await AttachToTarget(id, token);
 
             if (!contexts.TryGetValue(id, out ExecutionContext context))
+            {
+                if  (method ==  "Debugger.setPauseOnExceptions")
+                {
+                    string state = args["state"].Value<string>();
+                    PauseOnExceptions = GetPauseOnExceptionsStatusFromString(state);
+                }
                 return false;
+            }
 
             switch (method)
             {
@@ -513,13 +492,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 case "Debugger.setPauseOnExceptions":
                     {
                         string state = args["state"].Value<string>();
-                        context.PauseOnExceptions = state switch
-                        {
-                            "all"      => PauseOnExceptionsKind.All,
-                            "uncaught" => PauseOnExceptionsKind.Uncaught,
-                            "none"     => PauseOnExceptionsKind.None,
-                            _          => PauseOnExceptionsKind.Unset
-                        };
+                        context.PauseOnExceptions = GetPauseOnExceptionsStatusFromString(state);
 
                         if (context.IsRuntimeReady)
                             await context.SdbAgent.EnableExceptions(context.PauseOnExceptions, token);
@@ -1779,23 +1752,10 @@ namespace Microsoft.WebAssembly.Diagnostics
             // see https://github.com/mono/mono/issues/19549 for background
             if (sessions.Add(sessionId))
             {
-                string checkUncaughtExceptions = string.Empty;
-                string checkCaughtExceptions = string.Empty;
-
-                //we only need this check if it's a non-vs debugging
-                if (sessionId == SessionId.Null)
-                {
-                    if (!contexts.TryGetValue(sessionId, out ExecutionContext context) || context.PauseOnExceptions == PauseOnExceptionsKind.Unset)
-                    {
-                        checkUncaughtExceptions = $"throw \"{sPauseOnUncaught}\";";
-                        checkCaughtExceptions = $"try {{throw \"{sPauseOnCaught}\";}} catch {{}}";
-                    }
-                }
-
                 await SendMonoCommand(sessionId, new MonoCommands("globalThis.dotnetDebugger = true"), token);
                 Result res = await SendCommand(sessionId,
                     "Page.addScriptToEvaluateOnNewDocument",
-                    JObject.FromObject(new { source = $"globalThis.dotnetDebugger = true; delete navigator.constructor.prototype.webdriver; {checkCaughtExceptions} {checkUncaughtExceptions}" }),
+                    JObject.FromObject(new { source = $"globalThis.dotnetDebugger = true; delete navigator.constructor.prototype.webdriver;" }),
                     token);
 
                 if (sessionId != SessionId.Null && !res.IsOk)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -169,7 +169,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 case "Debugger.paused":
                     {
                         // Don't process events from sessions we aren't tracking
-                        if (!contexts.TryGetValue(sessionId, out _))
+                        if (!contexts.ContainsKey(sessionId))
                             return false;
 
                         //TODO figure out how to stich out more frames and, in particular what happens when real wasm is on the stack

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -264,6 +264,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 _ => PauseOnExceptionsKind.Unset
             };
         }
+
         protected override async Task<bool> AcceptCommand(MessageId id, JObject parms, CancellationToken token)
         {
             var method = parms["method"].Value<string>();

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -275,7 +275,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
             if (!contexts.TryGetValue(id, out ExecutionContext context))
             {
-                if  (method ==  "Debugger.setPauseOnExceptions")
+                if  (method == "Debugger.setPauseOnExceptions")
                 {
                     string state = args["state"].Value<string>();
                     PauseOnExceptions = GetPauseOnExceptionsStatusFromString(state);


### PR DESCRIPTION
Remove workaround to get pauseOnExceptions, now we receive it from Browser.
Fixes #62146 