### PR TITLE
JIT: Enable addressing modes for gc types

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -4485,11 +4485,13 @@ void CodeGen::genLeaInstruction(GenTreeAddrMode* lea)
         }
         else
         {
+#ifdef TARGET_ARM64
             if (index->isContained() && index->OperIs(GT_BFIZ))
             {
                 scale = (DWORD)index->gtGetOp2()->AsIntConCommon()->IconValue();
                 index = index->gtGetOp1()->gtGetOp1();
             }
+#endif
 
             // Then compute target reg from [base + index*scale]
             genScaledAdd(size, lea->GetRegNum(), memBase->GetRegNum(), index->GetRegNum(), scale);

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -4485,6 +4485,12 @@ void CodeGen::genLeaInstruction(GenTreeAddrMode* lea)
         }
         else
         {
+            if (index->isContained() && index->OperIs(GT_BFIZ))
+            {
+                scale = (DWORD)index->gtGetOp2()->AsIntConCommon()->IconValue();
+                index = index->gtGetOp1()->gtGetOp1();
+            }
+
             // Then compute target reg from [base + index*scale]
             genScaledAdd(size, lea->GetRegNum(), memBase->GetRegNum(), index->GetRegNum(), scale);
         }

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -4486,8 +4486,10 @@ void CodeGen::genLeaInstruction(GenTreeAddrMode* lea)
         else
         {
 #ifdef TARGET_ARM64
+            // Handle LEA with "contained" BFIZ
             if (index->isContained() && index->OperIs(GT_BFIZ))
             {
+                assert(scale == 0);
                 scale = (DWORD)index->gtGetOp2()->AsIntConCommon()->IconValue();
                 index = index->gtGetOp1()->gtGetOp1();
             }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5443,8 +5443,7 @@ bool Lowering::TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* par
 
     // Check if we can "contain" LEA(BFIZ) in order to extend 32bit index to 64bit as part of load/store.
     if ((index != nullptr) && index->OperIs(GT_BFIZ) && index->gtGetOp1()->OperIs(GT_CAST) &&
-        index->gtGetOp2()->IsCnsIntOrI() &&
-        (varTypeIsIntegral(targetType) || varTypeIsFloating(targetType) || varTypeIsGC(targetType)))
+        index->gtGetOp2()->IsCnsIntOrI() && !varTypeIsStruct(targetType))
     {
         // BFIZ node is a binary op where op1 is GT_CAST and op2 is GT_CNS_INT
         GenTreeCast* cast = index->gtGetOp1()->AsCast();

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5443,7 +5443,8 @@ bool Lowering::TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* par
 
     // Check if we can "contain" LEA(BFIZ) in order to extend 32bit index to 64bit as part of load/store.
     if ((index != nullptr) && index->OperIs(GT_BFIZ) && index->gtGetOp1()->OperIs(GT_CAST) &&
-        index->gtGetOp2()->IsCnsIntOrI() && (varTypeIsIntegral(targetType) || varTypeIsFloating(targetType)))
+        index->gtGetOp2()->IsCnsIntOrI() &&
+        (varTypeIsIntegral(targetType) || varTypeIsFloating(targetType) || varTypeIsGC(targetType)))
     {
         // BFIZ node is a binary op where op1 is GT_CAST and op2 is GT_CNS_INT
         GenTreeCast* cast = index->gtGetOp1()->AsCast();

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4735,8 +4735,8 @@ GenTree* Compiler::fgMorphIndexAddr(GenTreeIndexAddr* indexAddr)
     // we at least will be able to hoist/CSE "index + elemOffset" in some cases.
     // See https://github.com/dotnet/runtime/pull/61293#issuecomment-964146497
 
-    // Use 2) form only for primitive types for now - it significantly reduced number of size regressions
-    if (!varTypeIsIntegral(elemTyp) && !varTypeIsFloating(elemTyp) && !varTypeIsGC(elemTyp))
+    // Don't use 2) for structs to reduce number of size regressions
+    if (varTypeIsStruct(elemTyp))
     {
         groupArrayRefWithElemOffset = false;
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4736,7 +4736,7 @@ GenTree* Compiler::fgMorphIndexAddr(GenTreeIndexAddr* indexAddr)
     // See https://github.com/dotnet/runtime/pull/61293#issuecomment-964146497
 
     // Use 2) form only for primitive types for now - it significantly reduced number of size regressions
-    if (!varTypeIsIntegral(elemTyp) && !varTypeIsFloating(elemTyp))
+    if (!varTypeIsIntegral(elemTyp) && !varTypeIsFloating(elemTyp) && !varTypeIsGC(elemTyp))
     {
         groupArrayRefWithElemOffset = false;
     }


### PR DESCRIPTION
Example:
```csharp
object Test(object[] args, int i) => args[i];
```
Codegen diff:
```diff
; Method Program:Test(System.Object[],int):System.Object:this
G_M59644_IG01:
            stp     fp, lr, [sp,#-16]!
            mov     fp, sp
G_M59644_IG02:
            ldr     w0, [x1,#8]
            cmp     w2, w0
            bhs     G_M59644_IG04
-           ubfiz   x0, x2, #3, #32
-           add     x0, x0, #16
-           ldr     x0, [x1, x0]
+           add     x0, x1, #16
+           ldr     x0, [x0, w2, UXTW #3]
G_M59644_IG03:
            ldp     fp, lr, [sp],#16
            ret     lr
G_M59644_IG04:
            bl      CORINFO_HELP_RNGCHKFAIL
            brk_windows #0
```
Some nice [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1824552&view=ms.vss-build-web.run-extensions-tab)