### PR TITLE
[WIP][wasm] Fixes for OuterLoop mono pipeline

### DIFF
--- a/eng/pipelines/libraries/outerloop-mono.yml
+++ b/eng/pipelines/libraries/outerloop-mono.yml
@@ -20,6 +20,7 @@ jobs:
       helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
       buildConfig: Release
       runtimeFlavor: mono
+      shouldContinueOnError: true
       platforms:
       - windows_x86
       - Browser_wasm
@@ -43,7 +44,7 @@ jobs:
           testScope: outerloop
           creator: dotnet-bot
           testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-    
+
   - ${{ if eq(variables['isRollingBuild'], false) }}:
     - template: /eng/pipelines/common/platform-matrix.yml
       parameters:
@@ -51,6 +52,7 @@ jobs:
         helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
         buildConfig: Debug
         runtimeFlavor: mono
+        shouldContinueOnError: true
         platforms:
         - windows_x64
         - Linux_x64

--- a/eng/testing/ProvisioningVersions.props
+++ b/eng/testing/ProvisioningVersions.props
@@ -15,6 +15,7 @@
     <ChromiumDirName>chrome-linux</ChromiumDirName>
     <ChromeDriverDirName>chromedriver_linux64</ChromeDriverDirName>
     <ChromiumBinaryName>chrome</ChromiumBinaryName>
+    <ChromeDriverBinaryName>chromedriver</ChromeDriverBinaryName>
     <FirefoxRevision>97.0.1</FirefoxRevision>
     <FirefoxUrl>https://ftp.mozilla.org/pub/firefox/releases/$(FirefoxRevision)/linux-x86_64/en-US/firefox-$(FirefoxRevision).tar.bz2</FirefoxUrl>
     <FirefoxBinaryName>firefox</FirefoxBinaryName>

--- a/eng/testing/provisioning.targets
+++ b/eng/testing/provisioning.targets
@@ -3,6 +3,10 @@
     <ChromeDir>$(ArtifactsBinDir)chrome\</ChromeDir>
     <BrowserStampDir>$(ArtifactsBinDir)\</BrowserStampDir>
     <ChromeStampFile>$(BrowserStampDir).install-chrome-$(ChromiumRevision).stamp</ChromeStampFile>
+
+    <ChromeDriverDir>$(ArtifactsBinDir)chromedriver\</ChromeDriverDir>
+    <ChromeDriverStampFile>$(BrowserStampDir).install-chromedriver-$(ChromiumRevision).stamp</ChromeDriverStampFile>
+
     <FirefoxDir>$(ArtifactsBinDir)firefox\</FirefoxDir>
     <FirefoxStampFile>$(BrowserStampDir).install-firefox-$(FirefoxRevision).stamp</FirefoxStampFile>
   </PropertyGroup>
@@ -36,6 +40,35 @@
 
     <Touch Files="$(ChromeStampFile)" AlwaysCreate="true" />
   </Target>
+
+  <Target Name="DownloadAndInstallChromeDriver"
+          AfterTargets="Build"
+          Condition="!Exists($(ChromeDriverStampFile)) and '$(InstallChromeDriverForTests)' == 'true'">
+
+    <ItemGroup>
+      <_StampFile Include="$(BrowserStampDir).install-chrome*.stamp" />
+    </ItemGroup>
+
+    <Delete Files="@(_StampFile)" />
+    <RemoveDir Directories="$(ChromeDriverDir)" />
+
+    <DownloadFile SourceUrl="$(ChromeDriverUrl)" DestinationFolder="$(ChromeDriverDir)" SkipUnchangedFiles="true">
+      <Output TaskParameter="DownloadedFile" PropertyName="_DownloadedFile" />
+    </DownloadFile>
+    <Unzip SourceFiles="$(_DownloadedFile)" DestinationFolder="$(ChromeDriverDir)" />
+
+    <PropertyGroup>
+      <_ChromeDriverBinaryPath>$([MSBuild]::NormalizePath($(ChromeDriverDir), $(ChromeDriverDirName), $(ChromeDriverBinaryName)))</_ChromeDriverBinaryPath>
+    </PropertyGroup>
+
+    <Error Text="Cannot find chrome at $(_ChromeDriverBinaryPath) in the downloaded copy"
+           Condition="!Exists($(_ChromeDriverBinaryPath))" />
+
+    <Exec Command="chmod +x $(_ChromeDriverBinaryPath)" Condition="!$([MSBuild]::IsOSPlatform('windows'))" />
+
+    <Touch Files="$(ChromeDriverStampFile)" AlwaysCreate="true" />
+  </Target>
+
 
   <Target Name="DownloadAndInstallFirefox"
           AfterTargets="Build"

--- a/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
+++ b/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
@@ -1728,7 +1728,7 @@ namespace System.IO.Tests
             select new object[] { mode, writeSize, startWithFlush };
 
         [OuterLoop]
-        [Theory]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(ReadWrite_Success_Large_MemberData))]
         public virtual async Task ReadWrite_Success_Large(ReadWriteMode mode, int writeSize, bool startWithFlush) =>
             await ReadWrite_Success(mode, writeSize, startWithFlush);
@@ -2427,7 +2427,7 @@ namespace System.IO.Tests
             select new object[] { byteCount, useAsync };
 
         [OuterLoop]
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public virtual async Task CopyToAsync_AllDataCopied_Large(bool useAsync) =>

--- a/src/libraries/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/libraries/System.Console/tests/WindowAndCursorProps.cs
@@ -287,6 +287,7 @@ public class WindowAndCursorProps
     [Fact]
     [OuterLoop] // makes noise, not very inner-loop friendly
     [PlatformSpecific(TestPlatforms.Windows)]
+    [SkipOnPlatform(TestPlatforms.Browser, "Console.Beep is not supported on browser")]
     public static void BeepWithFrequency_Invoke_Success()
     {
         // Nothing to verify; just run the code.

--- a/src/libraries/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
@@ -178,7 +178,7 @@ namespace System.Linq.Parallel.Tests
 
         // Zip with ordering on showed issues, but it was due to the ordering component.
         // This is included as a regression test for that particular repro.
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [OuterLoop]
         [MemberData(nameof(ZipThreadedData), new[] { 1, 2, 16, 128, 1024 }, new[] { 1, 2, 4, 7, 8, 31, 32 })]
         public static void Zip_AsOrdered_ThreadedDeadlock(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int degree)

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/Wasm.Build.Tests.csproj
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/Wasm.Build.Tests.csproj
@@ -14,6 +14,7 @@
     <TestUsingWorkloads Condition="'$(TestUsingWorkloads)' == ''">true</TestUsingWorkloads>
     <InstallWorkloadForTesting>true</InstallWorkloadForTesting>
     <InstallChromeForTests Condition="'$(InstallChromeForTests)' == '' and '$(ContinuousIntegrationBuild)' != 'true' and Exists('/.dockerenv')">true</InstallChromeForTests>
+    <InstallChromeDriverForTests Condition="'$(InstallChromeDriverForTests)' == '' and '$(ContinuousIntegrationBuild)' != 'true' and Exists('/.dockerenv')">true</InstallChromeDriverForTests>
 
     <!-- don't run any wasm build steps -->
     <IsWasmProject>false</IsWasmProject>


### PR DESCRIPTION
- [ ] Most of the wasm tests are failing because they are not getting correctly skipped - https://github.com/dotnet/xharness/issues/908
- [ ] Add proper Skips on other tests
- [ ] Use `shouldContinueOnError: true` for all the jobs, since they have tests failing
- [ ] And enable scheduled runs of outerloop mono pipeline