### PR TITLE
Disable CertificateValidationRemoteServer.ConnectWithRevocation_WithCallback on Android

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -92,6 +92,7 @@ namespace System.Net.Security.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/68206", TestPlatforms.Android)]
         public Task ConnectWithRevocation_WithCallback(bool checkRevocation)
         {
             X509RevocationMode mode = checkRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck;


### PR DESCRIPTION
Closes #70469

New test, we missed that it will fail on Android, disabled the test with general Android issue (#68206).