### PR TITLE
fix 42219

### DIFF
--- a/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Http
         // IMPORTANT: This is used in a resource string. Update the resource if this changes.
         internal static readonly TimeSpan MinimumHandlerLifetime = TimeSpan.FromSeconds(1);
 
-        private TimeSpan _handlerLifetime = TimeSpan.FromMinutes(2);
+        private TimeSpan _handlerLifetime = TimeSpan.FromMinutes(10);
 
         /// <summary>
         /// Gets a list of operations used to configure an <see cref="HttpMessageHandlerBuilder"/>.

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpClientFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpClientFactoryTest.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Extensions.Http
             // Assert - 1
             var activeEntry1 = Assert.Single(factory._activeHandlers).Value.Value;
             Assert.Equal("github", activeEntry1.Name);
-            Assert.Equal(TimeSpan.FromMinutes(2), activeEntry1.Lifetime);
+            Assert.Equal(TimeSpan.FromMinutes(10), activeEntry1.Lifetime);
             Assert.NotNull(activeEntry1.Handler);
 
             // Act - 2 - Now simulate the timer triggering to complete the expiry.
@@ -289,7 +289,7 @@ namespace Microsoft.Extensions.Http
             // Assert - 3
             var activeEntry2 = Assert.Single(factory._activeHandlers).Value.Value;
             Assert.Equal("github", activeEntry1.Name);
-            Assert.Equal(TimeSpan.FromMinutes(2), activeEntry1.Lifetime);
+            Assert.Equal(TimeSpan.FromMinutes(10), activeEntry1.Lifetime);
             Assert.NotNull(activeEntry1.Handler);
             Assert.NotSame(activeEntry1, activeEntry2);
             Assert.NotSame(activeEntry1.Handler, activeEntry2.Handler);
@@ -311,7 +311,7 @@ namespace Microsoft.Extensions.Http
             // Assert - 1
             var activeEntry1 = Assert.Single(factory._activeHandlers).Value.Value;
             Assert.Equal("github", activeEntry1.Name);
-            Assert.Equal(TimeSpan.FromMinutes(2), activeEntry1.Lifetime);
+            Assert.Equal(TimeSpan.FromMinutes(10), activeEntry1.Lifetime);
             Assert.NotNull(activeEntry1.Handler);
 
             // Act - 2 - Now create another client, it shouldn't replace the entry.
@@ -338,7 +338,7 @@ namespace Microsoft.Extensions.Http
             // Assert - 4
             var activeEntry2 = Assert.Single(factory._activeHandlers).Value.Value;
             Assert.Equal("github", activeEntry1.Name);
-            Assert.Equal(TimeSpan.FromMinutes(2), activeEntry1.Lifetime);
+            Assert.Equal(TimeSpan.FromMinutes(10), activeEntry1.Lifetime);
             Assert.NotNull(activeEntry1.Handler);
             Assert.NotSame(activeEntry1, activeEntry2);
             Assert.NotSame(activeEntry1.Handler, activeEntry2.Handler);


### PR DESCRIPTION
fix [42219](https://github.com/dotnet/runtime/issues/42219)
According to the following,

1- Most packages do not change this time
```csharp
services.AddHttpClient("extendedhandlerlifetime") .SetHandlerLifetime(TimeSpan.FromMinutes(10));
```

2. Extensive use of microservices and the use of service discovery tools that minimize the need for DNS change.
In the real world, how likely is it that the DNS will change in a short time? If there is a special scenario, the user can reduce this time.

3- Avoid high repetition of expensive TCP handshake