### PR TITLE
Enable `TYP_STRUCT` `LCL_VAR/LCL_FLD` call args on Windows x64

### DIFF
--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -665,6 +665,15 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
 
     // Quirks:
     //
+    // Don't substitute nodes "AddFinalArgsAndDetermineABIInfo" doesn't handle into struct args.
+    //
+    if (fsv.IsCallArg() && fsv.GetNode()->TypeIs(TYP_STRUCT) &&
+        !fwdSubNode->OperIs(GT_OBJ, GT_LCL_VAR, GT_LCL_FLD, GT_MKREFANY))
+    {
+        JITDUMP(" use is a struct arg; fwd sub node is not OBJ/LCL_VAR/LCL_FLD/MKREFANY\n");
+        return false;
+    }
+
     // We may sometimes lose or change a type handle. Avoid substituting if so.
     //
     if (gtGetStructHandleIfPresent(fwdSubNode) != gtGetStructHandleIfPresent(fsv.GetNode()))

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -597,6 +597,9 @@ ClassLayout* GenTree::GetLayout(Compiler* compiler) const
         case GT_BLK:
             return AsBlk()->GetLayout();
 
+        case GT_MKREFANY:
+            return compiler->typGetObjLayout(compiler->impGetRefAnyClass());
+
         default:
             unreached();
     }

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1049,10 +1049,9 @@ private:
             return IndirTransform::None;
         }
 
-        if ((user == nullptr) || !user->OperIs(GT_ASG, GT_RETURN))
+        if ((user == nullptr) || !user->OperIs(GT_ASG, GT_CALL, GT_RETURN))
         {
-            // TODO-ADDR: call args require extra work because currently they must
-            // be wrapped in OBJ nodes so we can't replace those with local nodes.
+            // TODO-ADDR: remove unused indirections.
             return IndirTransform::None;
         }
 
@@ -1075,7 +1074,6 @@ private:
         //
         enum class StructMatch
         {
-            Exact,
             Compatible,
             Partial
         };
@@ -1084,32 +1082,25 @@ private:
         assert(varDsc->GetLayout() != nullptr);
 
         StructMatch match = StructMatch::Partial;
-        if (val.Offset() == 0)
+        if ((val.Offset() == 0) && ClassLayout::AreCompatible(indirLayout, varDsc->GetLayout()))
         {
-            if (indirLayout->GetClassHandle() == varDsc->GetStructHnd())
-            {
-                match = StructMatch::Exact;
-            }
-            else if (ClassLayout::AreCompatible(indirLayout, varDsc->GetLayout()))
-            {
-                match = StructMatch::Compatible;
-            }
+            match = StructMatch::Compatible;
         }
 
         // Current matrix of matches/users/types:
         //
-        // |------------|------|-------------|---------|
-        // | STRUCT     | CALL | ASG         | RETURN  |
-        // |------------|------|-------------|---------|
-        // | Exact      | None | LCL_VAR     | LCL_VAR |
-        // | Compatible | None | LCL_VAR     | LCL_VAR |
-        // | Partial    | None | OBJ/LCL_FLD | LCL_FLD |
-        // |------------|------|-------------|---------|
+        // |------------|---------|-------------|---------|
+        // | STRUCT     | CALL(*) | ASG         | RETURN  |
+        // |------------|---------|-------------|---------|
+        // | Compatible | LCL_VAR | LCL_VAR     | LCL_VAR |
+        // | Partial    | LCL_FLD | OBJ/LCL_FLD | LCL_FLD |
+        // |------------|---------|-------------|---------|
+        //
+        // * - On Windows x64 only.
         //
         // |------------|------|------|--------|----------|
         // | SIMD       | CALL | ASG  | RETURN | HWI/SIMD |
         // |------------|------|------|--------|----------|
-        // | Exact      | None | None | None   | None     |
         // | Compatible | None | None | None   | None     |
         // | Partial    | None | None | None   | None     |
         // |------------|------|------|--------|----------|
@@ -1117,11 +1108,18 @@ private:
         // TODO-ADDR: delete all the "None" entries and always
         // transform local nodes into LCL_VAR or LCL_FLD.
 
-        assert(indir->TypeIs(TYP_STRUCT) && user->OperIs(GT_ASG, GT_RETURN));
+        assert(indir->TypeIs(TYP_STRUCT) && user->OperIs(GT_ASG, GT_CALL, GT_RETURN));
 
         *pStructLayout = indirLayout;
 
-        if ((match == StructMatch::Exact) || (match == StructMatch::Compatible))
+        if (user->IsCall())
+        {
+#ifndef WINDOWS_AMD64_ABI
+            return IndirTransform::None;
+#endif // !WINDOWS_AMD64_ABI
+        }
+
+        if (match == StructMatch::Compatible)
         {
             return IndirTransform::LclVar;
         }


### PR DESCRIPTION
The start of enabling `TYP_STRUCT` local nodes in call arguments.

[Overall nice diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1826734&view=ms.vss-build-web.run-extensions-tab), with some regressions due to second-order effects from reducing the number of temps (CSE, copy propagation, RA, etc).