### PR TITLE
Enable `TYP_STRUCT` `LCL_VAR/LCL_FLD` call args on x86

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1096,7 +1096,7 @@ private:
         // | Partial    | LCL_FLD | OBJ/LCL_FLD | LCL_FLD |
         // |------------|---------|-------------|---------|
         //
-        // * - On Windows x64 only.
+        // * - On x86/Windows x64 only.
         //
         // |------------|------|------|--------|----------|
         // | SIMD       | CALL | ASG  | RETURN | HWI/SIMD |
@@ -1114,9 +1114,9 @@ private:
 
         if (user->IsCall())
         {
-#ifndef WINDOWS_AMD64_ABI
+#if !defined(WINDOWS_AMD64_ABI) && !defined(TARGET_X86)
             return IndirTransform::None;
-#endif // !WINDOWS_AMD64_ABI
+#endif // !defined(WINDOWS_AMD64_ABI) && !defined(TARGET_X86)
         }
 
         if (match == StructMatch::Compatible)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1419,7 +1419,6 @@ GenTree* CallArgs::MakeTmpArgNode(Compiler* comp, CallArg* arg)
 
     if (varTypeIsStruct(type))
     {
-
 #if defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_ARM) || defined(TARGET_LOONGARCH64)
 
         // Can this type be passed as a primitive type?
@@ -1491,21 +1490,8 @@ GenTree* CallArgs::MakeTmpArgNode(Compiler* comp, CallArg* arg)
 #endif // !(TARGET_ARM64 || TARGET_LOONGARCH64)
 #endif // FEATURE_MULTIREG_ARGS
         }
-
-#else // not (TARGET_AMD64 or TARGET_ARM64 or TARGET_ARM or TARGET_LOONGARCH64)
-
-        // other targets, we pass the struct by value
-        assert(varTypeIsStruct(type));
-
-        addrNode = comp->gtNewOperNode(GT_ADDR, TYP_BYREF, argNode);
-
-        // Get a new Obj node temp to use it as a call argument.
-        // gtNewObjNode will set the GTF_EXCEPT flag if this is not a local stack object.
-        argNode               = comp->gtNewObjNode(comp->lvaGetStruct(tmpVarNum), addrNode);
-
-#endif // not (TARGET_AMD64 or TARGET_ARM64 or TARGET_ARM or TARGET_LOONGARCH64)
-
-    } // (varTypeIsStruct(type))
+#endif // (TARGET_AMD64 or TARGET_ARM64 or TARGET_ARM or TARGET_LOONGARCH64)
+    }  // (varTypeIsStruct(type))
 
     if (addrNode != nullptr)
     {
@@ -4168,7 +4154,7 @@ void Compiler::fgMakeOutgoingStructArgCopy(GenTreeCall* call, CallArg* arg)
             {
                 tmp   = (unsigned)lclNum;
                 found = true;
-                JITDUMP("reusing outgoing struct arg");
+                JITDUMP("reusing outgoing struct arg\n");
                 break;
             }
         }
@@ -4215,7 +4201,7 @@ void Compiler::fgMakeOutgoingStructArgCopy(GenTreeCall* call, CallArg* arg)
     // When on Unix create LCL_FLD for structs passed in more than one registers. See fgMakeTmpArgNode
     GenTree* argNode = copyBlk;
 
-#else // FEATURE_FIXED_OUT_ARGS
+#else // !FEATURE_FIXED_OUT_ARGS
 
     // Structs are always on the stack, and thus never need temps
     // so we have to put the copy and temp all into one expression.
@@ -4224,7 +4210,7 @@ void Compiler::fgMakeOutgoingStructArgCopy(GenTreeCall* call, CallArg* arg)
     // Change the expression to "(tmp=val),tmp"
     argNode                              = gtNewOperNode(GT_COMMA, argNode->TypeGet(), copyBlk, argNode);
 
-#endif // FEATURE_FIXED_OUT_ARGS
+#endif // !FEATURE_FIXED_OUT_ARGS
 
     arg->SetEarlyNode(argNode);
 }


### PR DESCRIPTION
[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1833398&view=ms.vss-build-web.run-extensions-tab) are for pretty much the same reasons as in https://github.com/dotnet/runtime/pull/70777#issuecomment-1157504877, the one difference being that there are a lot of regressions in libraries tests.

I have analyzed them, and the large number is due to the fact they're coming from the numerous `MoveNext` methods on async state machines. All have a singular cause: we don't set DNER on a small struct argument (which by itself is good) and this causes the RA to not enregister another local.