### PR TITLE
[Mono] Fix C4018 warnings round II

### DIFF
--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -940,7 +940,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 	}
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "================================");
 
-	guint32 rows = mono_image_get_table_rows (image_base, MONO_TABLE_TYPEREF);
+	guint32 rows = table_info_get_rows (&image_base->tables [MONO_TABLE_TYPEREF]);
 	for (guint32 i = 1; i <= rows; ++i) {
 		guint32 cols [MONO_TYPEREF_SIZE];
 		mono_metadata_decode_row (&image_base->tables [MONO_TABLE_TYPEREF], i - 1, cols, MONO_TYPEREF_SIZE);
@@ -958,7 +958,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 	if (!image_dmeta->minimal_delta) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "--------------------------------");
 
-		rows = mono_image_get_table_rows (image_dmeta, MONO_TABLE_TYPEREF);
+		rows = table_info_get_rows (&image_dmeta->tables [MONO_TABLE_TYPEREF]);
 		for (guint32 i = 1; i <= rows; ++i) {
 			guint32 cols [MONO_TYPEREF_SIZE];
 			mono_metadata_decode_row (&image_dmeta->tables [MONO_TABLE_TYPEREF], i - 1, cols, MONO_TYPEREF_SIZE);
@@ -970,7 +970,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 	}
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "================================");
 
-	rows = mono_image_get_table_rows (image_dmeta, MONO_TABLE_TYPEDEF);
+	rows = table_info_get_rows (&image_dmeta->tables [MONO_TABLE_TYPEDEF]);
 	for (guint32 i = 1; i <= rows; ++i) {
 		guint32 cols [MONO_TYPEDEF_SIZE];
 		mono_metadata_decode_row (&image_dmeta->tables [MONO_TABLE_TYPEDEF], i - 1, cols, MONO_TYPEDEF_SIZE);
@@ -981,7 +981,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "================================");
 
-	rows = mono_image_get_table_rows (image_base, MONO_TABLE_METHOD);
+	rows = table_info_get_rows (&image_base->tables [MONO_TABLE_METHOD]);
 	for (guint32 i = 1; i <= rows ; ++i) {
 		guint32 cols [MONO_METHOD_SIZE];
 		mono_metadata_decode_row_raw (&image_base->tables [MONO_TABLE_METHOD], i - 1, cols, MONO_METHOD_SIZE);
@@ -991,7 +991,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 	}
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "--------------------------------");
 
-	rows = mono_image_get_table_rows (image_dmeta, MONO_TABLE_METHOD);
+	rows = table_info_get_rows (&image_dmeta->tables [MONO_TABLE_METHOD]);
 	for (guint32 i = 1; i <= rows ; ++i) {
 		guint32 cols [MONO_METHOD_SIZE];
 		mono_metadata_decode_row_raw (&image_dmeta->tables [MONO_TABLE_METHOD], i - 1, cols, MONO_METHOD_SIZE);
@@ -1001,7 +1001,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 	}
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "================================");
 
-	rows = mono_image_get_table_rows (image_base, MONO_TABLE_STANDALONESIG);
+	rows = table_info_get_rows (&image_base->tables [MONO_TABLE_STANDALONESIG]);
 	for (guint32 i = 1; i <= rows; ++i) {
 		guint32 cols [MONO_STAND_ALONE_SIGNATURE_SIZE];
 		mono_metadata_decode_row (&image_base->tables [MONO_TABLE_STANDALONESIG], i - 1, cols, MONO_STAND_ALONE_SIGNATURE_SIZE);
@@ -1011,7 +1011,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 	if (!image_dmeta->minimal_delta) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "--------------------------------");
 
-		rows = mono_image_get_table_rows (image_dmeta, MONO_TABLE_STANDALONESIG);
+		rows = table_info_get_rows (&image_dmeta->tables [MONO_TABLE_STANDALONESIG]);
 		for (guint32 i = 1; i <= rows; ++i) {
 			guint32 cols [MONO_STAND_ALONE_SIGNATURE_SIZE];
 			mono_metadata_decode_row_raw (&image_dmeta->tables [MONO_TABLE_STANDALONESIG], i - 1, cols, MONO_STAND_ALONE_SIGNATURE_SIZE);

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -933,8 +933,6 @@ scope_to_string (uint32_t tok)
 static void
 dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 {
-	int rows;
-
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "dmeta tables:");
 	for (int idx = 0; idx < MONO_TABLE_NUM; ++idx) {
 		if (image_dmeta->tables [idx].base)
@@ -942,8 +940,8 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 	}
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "================================");
 
-	rows = mono_image_get_table_rows (image_base, MONO_TABLE_TYPEREF);
-	for (int i = 1; i <= rows; ++i) {
+	guint32 rows = mono_image_get_table_rows (image_base, MONO_TABLE_TYPEREF);
+	for (guint32 i = 1; i <= rows; ++i) {
 		guint32 cols [MONO_TYPEREF_SIZE];
 		mono_metadata_decode_row (&image_base->tables [MONO_TABLE_TYPEREF], i - 1, cols, MONO_TYPEREF_SIZE);
 		const char *scope = scope_to_string (cols [MONO_TYPEREF_SCOPE]);
@@ -961,7 +959,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "--------------------------------");
 
 		rows = mono_image_get_table_rows (image_dmeta, MONO_TABLE_TYPEREF);
-		for (int i = 1; i <= rows; ++i) {
+		for (guint32 i = 1; i <= rows; ++i) {
 			guint32 cols [MONO_TYPEREF_SIZE];
 			mono_metadata_decode_row (&image_dmeta->tables [MONO_TABLE_TYPEREF], i - 1, cols, MONO_TYPEREF_SIZE);
 			const char *scope = scope_to_string (cols [MONO_TYPEREF_SCOPE]);
@@ -973,7 +971,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "================================");
 
 	rows = mono_image_get_table_rows (image_dmeta, MONO_TABLE_TYPEDEF);
-	for (int i = 1; i <= rows; ++i) {
+	for (guint32 i = 1; i <= rows; ++i) {
 		guint32 cols [MONO_TYPEDEF_SIZE];
 		mono_metadata_decode_row (&image_dmeta->tables [MONO_TABLE_TYPEDEF], i - 1, cols, MONO_TYPEDEF_SIZE);
 		const char *name = mono_metadata_string_heap (image_base, cols [MONO_TYPEDEF_NAME]);
@@ -984,7 +982,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "================================");
 
 	rows = mono_image_get_table_rows (image_base, MONO_TABLE_METHOD);
-	for (int i = 1; i <= rows ; ++i) {
+	for (guint32 i = 1; i <= rows ; ++i) {
 		guint32 cols [MONO_METHOD_SIZE];
 		mono_metadata_decode_row_raw (&image_base->tables [MONO_TABLE_METHOD], i - 1, cols, MONO_METHOD_SIZE);
 		const char *name = mono_metadata_string_heap (image_base, cols [MONO_METHOD_NAME]);
@@ -994,7 +992,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "--------------------------------");
 
 	rows = mono_image_get_table_rows (image_dmeta, MONO_TABLE_METHOD);
-	for (int i = 1; i <= rows ; ++i) {
+	for (guint32 i = 1; i <= rows ; ++i) {
 		guint32 cols [MONO_METHOD_SIZE];
 		mono_metadata_decode_row_raw (&image_dmeta->tables [MONO_TABLE_METHOD], i - 1, cols, MONO_METHOD_SIZE);
 		const char *name = mono_metadata_string_heap (image_base, cols [MONO_METHOD_NAME]);
@@ -1004,7 +1002,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "================================");
 
 	rows = mono_image_get_table_rows (image_base, MONO_TABLE_STANDALONESIG);
-	for (int i = 1; i <= rows; ++i) {
+	for (guint32 i = 1; i <= rows; ++i) {
 		guint32 cols [MONO_STAND_ALONE_SIGNATURE_SIZE];
 		mono_metadata_decode_row (&image_base->tables [MONO_TABLE_STANDALONESIG], i - 1, cols, MONO_STAND_ALONE_SIGNATURE_SIZE);
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "base  standalonesig i=%d (token=0x%08x) -> 0x%08x", i, MONO_TOKEN_SIGNATURE | i, cols [MONO_STAND_ALONE_SIGNATURE]);
@@ -1014,7 +1012,7 @@ dump_update_summary (MonoImage *image_base, MonoImage *image_dmeta)
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "--------------------------------");
 
 		rows = mono_image_get_table_rows (image_dmeta, MONO_TABLE_STANDALONESIG);
-		for (int i = 1; i <= rows; ++i) {
+		for (guint32 i = 1; i <= rows; ++i) {
 			guint32 cols [MONO_STAND_ALONE_SIGNATURE_SIZE];
 			mono_metadata_decode_row_raw (&image_dmeta->tables [MONO_TABLE_STANDALONESIG], i - 1, cols, MONO_STAND_ALONE_SIGNATURE_SIZE);
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "dmeta standalonesig i=%d (token=0x%08x) -> 0x%08x", i, MONO_TOKEN_SIGNATURE | i, cols [MONO_STAND_ALONE_SIGNATURE]);

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -2804,8 +2804,8 @@ hot_reload_field_parent (MonoImage *base_image, uint32_t field_token)
 
 /* HACK - keep in sync with locator_t in metadata/metadata.c */
 typedef struct {
-	int idx;			/* The index that we are trying to locate */
-	int col_idx;		/* The index in the row where idx may be stored */
+	guint32 idx;			/* The index that we are trying to locate */
+	guint32 col_idx;		/* The index in the row where idx may be stored */
 	MonoTableInfo *t;	/* pointer to the table */
 	guint32 result;
 } upd_locator_t;

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -1445,6 +1445,9 @@ __CAST_STYPE_TO_UTYPE(gssize, guint, UINT_MAX)
 __CAST_STYPE_TO_UTYPE(gssize, gsize, SIZE_MAX)
 __CAST_UTYPE_TO_STYPE(gsize, gssize, PTRDIFF_MIN, PTRDIFF_MAX)
 
+__CAST_STYPE_TO_UTYPE(glong, gulong, ULONG_MAX)
+__CAST_UTYPE_TO_STYPE(gulong, glong, LONG_MIN, LONG_MAX)
+
 __CAST_STYPE_TO_STYPE(gdouble, gint64, INT64_MIN, INT64_MAX)
 __CAST_STYPE_TO_UTYPE(gdouble, guint64, UINT64_MAX)
 __CAST_STYPE_TO_STYPE(gdouble, gint32, INT32_MIN, INT32_MAX)
@@ -1627,6 +1630,9 @@ __CAST_UTYPE_TO_STYPE(gunichar, gchar, CHAR_MIN, CHAR_MAX)
 
 #define GSSIZE_TO_SIZE(v)        G_CAST_TYPE_TO_TYPE(gssize, gsize, v)
 #define GSIZE_TO_SSIZE(v)        G_CAST_TYPE_TO_TYPE(gsize, gssize, v)
+
+#define GLONG_TO_ULONG(v)        G_CAST_TYPE_TO_TYPE(glong, gulong, v)
+#define GULONG_TO_LONG(v)        G_CAST_TYPE_TO_TYPE(gulong, glong, v)
 
 #define GDOUBLE_TO_INT64(v)      G_CAST_TYPE_TO_TYPE(gdouble, gint64, v)
 #define GDOUBLE_TO_UINT64(v)     G_CAST_TYPE_TO_TYPE(gdouble, guint64, v)

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -1406,6 +1406,8 @@ __CAST_PTRTYPE_TO_UTYPE(gintptr, gulong, ULONG_MAX)
 __CAST_PTRTYPE_TO_STYPE(gintptr, gint, INT_MIN, INT_MAX)
 __CAST_PTRTYPE_TO_UTYPE(gintptr, guint, UINT_MAX)
 
+__CAST_PTRTYPE_TO_UTYPE(gintptr, gsize, SIZE_MAX)
+
 __CAST_PTRTYPE_TO_STYPE(guintptr, gint32, INT32_MIN, INT32_MAX)
 __CAST_PTRTYPE_TO_UTYPE(guintptr, guint32, UINT32_MAX)
 __CAST_PTRTYPE_TO_STYPE(guintptr, gint16, INT16_MIN, INT16_MAX)
@@ -1587,6 +1589,8 @@ __CAST_UTYPE_TO_STYPE(gunichar, gchar, CHAR_MIN, CHAR_MAX)
 #define GINTPTR_TO_LONG(v)       G_CAST_PTRTYPE_TO_STYPE(gintptr, glong, v)
 #define GINTPTR_TO_INT(v)        G_CAST_PTRTYPE_TO_STYPE(gintptr, gint, v)
 #define GINTPTR_TO_UINT(v)       G_CAST_PTRTYPE_TO_UTYPE(gintptr, guint, v)
+
+#define GINTPTR_TO_SIZE(v)       G_CAST_PTRTYPE_TO_UTYPE(gintptr, gsize, v)
 
 #define GUINTPTR_TO_INT32(v)     G_CAST_PTRTYPE_TO_STYPE(guintptr, gint32, v)
 #define GUINTPTR_TO_UINT32(v)    G_CAST_PTRTYPE_TO_UTYPE(guintptr, guint32, v)

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -300,7 +300,7 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetLoadedAssemblies 
 
 	MonoArrayHandle res = mono_array_new_handle (mono_class_get_assembly_class (), assemblies->len, error);
 	goto_if_nok (error, leave);
-	for (int i = 0; i < assemblies->len; ++i) {
+	for (guint i = 0; i < assemblies->len; ++i) {
 		if (!add_assembly_to_array (res, i, (MonoAssembly *)g_ptr_array_index (assemblies, i), error))
 			goto leave;
 	}

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -2915,9 +2915,8 @@ mono_assembly_release_gc_roots (MonoAssembly *assembly)
 		return;
 
 	if (assembly_is_dynamic (assembly)) {
-		int i;
 		MonoDynamicImage *dynimg = (MonoDynamicImage *)assembly->image;
-		for (i = 0; i < dynimg->image.module_count; ++i)
+		for (guint32 i = 0; i < dynimg->image.module_count; ++i)
 			mono_dynamic_image_release_gc_roots ((MonoDynamicImage *)dynimg->image.modules [i]);
 		mono_dynamic_image_release_gc_roots (dynimg);
 	}

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -3233,7 +3233,6 @@ search_modules (MonoImage *image, const char *name_space, const char *name, gboo
 	MonoTableInfo *file_table = &image->tables [MONO_TABLE_FILE];
 	MonoImage *file_image;
 	MonoClass *klass;
-	int i;
 
 	error_init (error);
 
@@ -3243,8 +3242,8 @@ search_modules (MonoImage *image, const char *name_space, const char *name, gboo
 	 * Note: image->modules contains the contents of the MODULEREF table, while
 	 * the real module list is in the FILE table.
 	 */
-	int rows = table_info_get_rows (file_table);
-	for (i = 0; i < rows; i++) {
+	guint32 rows = table_info_get_rows (file_table);
+	for (guint32 i = 0; i < rows; i++) {
 		guint32 cols [MONO_FILE_SIZE];
 		mono_metadata_decode_row (file_table, i, cols, MONO_FILE_SIZE);
 		if (cols [MONO_FILE_FLAGS] == FILE_CONTAINS_NO_METADATA)

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -169,10 +169,9 @@ find_field_index (MonoClass *klass, MonoClassField *field) {
 static guint32
 find_property_index (MonoClass *klass, MonoProperty *property)
 {
-	int i;
 	MonoClassPropertyInfo *info = mono_class_get_property_info (klass);
 
-	for (i = 0; i < info->count; ++i) {
+	for (guint32 i = 0; i < info->count; ++i) {
 		if (property == &info->properties [i])
 			return info->first + 1 + i;
 	}
@@ -185,10 +184,9 @@ find_property_index (MonoClass *klass, MonoProperty *property)
 static guint32
 find_event_index (MonoClass *klass, MonoEvent *event)
 {
-	int i;
 	MonoClassEventInfo *info = mono_class_get_event_info (klass);
 
-	for (i = 0; i < info->count; ++i) {
+	for (guint32 i = 0; i < info->count; ++i) {
 		if (event == &info->events [i])
 			return info->first + 1 + i;
 	}
@@ -1631,7 +1629,6 @@ ves_icall_System_Reflection_RuntimeCustomAttributeData_ResolveArgumentsInternal 
 	MonoReflectionAssembly *assembly = MONO_HANDLE_RAW (assembly_h);
 	MonoMethodSignature *sig;
 	MonoObjectHandle obj_h, namedarg_h, minfo_h;
-	int i;
 
 	if (len == 0)
 		return;
@@ -1658,7 +1655,7 @@ ves_icall_System_Reflection_RuntimeCustomAttributeData_ResolveArgumentsInternal 
 		goto leave;
 
 	sig = mono_method_signature_internal (method);
-	for (i = 0; i < sig->param_count; ++i) {
+	for (guint16 i = 0; i < sig->param_count; ++i) {
 		MonoObject *obj;
 		MonoObject *typedarg;
 		MonoType *t;
@@ -1674,7 +1671,7 @@ ves_icall_System_Reflection_RuntimeCustomAttributeData_ResolveArgumentsInternal 
 		mono_array_setref_internal (typed_args, i, typedarg);
 	}
 
-	for (i = 0; i < mono_array_length_internal (named_args); ++i) {
+	for (guint32 i = 0; i < mono_array_length_internal (named_args); ++i) {
 		MonoObject *obj;
 		MonoObject *namedarg, *minfo;
 
@@ -2761,7 +2758,7 @@ metadata_foreach_custom_attr_from_index (MonoImage *image, guint32 idx, MonoAsse
 		return;
 	i --;
 	gboolean stop_iterating = FALSE;
-	int rows = table_info_get_rows (ca);
+	guint32 rows = table_info_get_rows (ca);
 	while (!stop_iterating && i < rows) {
 		if (mono_metadata_decode_row_col (ca, i, MONO_CUSTOM_ATTR_PARENT) != idx)
 			break;
@@ -2878,8 +2875,8 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 
 		tdef = &image->tables [MONO_TABLE_CUSTOMATTRIBUTE];
 		guint32 parent, field_idx, col, mtoken, idx;
-		int rows = table_info_get_rows (tdef);
-		for (int i = 0; i < rows; ++i) {
+		guint32 rows = table_info_get_rows (tdef);
+		for (guint32 i = 0; i < rows; ++i) {
 			parent = mono_metadata_decode_row_col (tdef, i, MONO_CUSTOM_ATTR_PARENT);
 			if ((parent & MONO_CUSTOM_ATTR_MASK) != MONO_CUSTOM_ATTR_FIELDDEF)
 				continue;
@@ -2903,8 +2900,8 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 		/* Check whenever the assembly references the WeakAttribute type */
 		gboolean found = FALSE;
 		tdef = &image->tables [MONO_TABLE_TYPEREF];
-		int rows = table_info_get_rows (tdef);
-		for (int i = 0; i < rows; ++i) {
+		guint32 rows = table_info_get_rows (tdef);
+		for (guint32 i = 0; i < rows; ++i) {
 			guint32 string_offset = mono_metadata_decode_row_col (tdef, i, MONO_TYPEREF_NAME);
 			const char *name = mono_metadata_string_heap (image, string_offset);
 			if (!strcmp (name, "WeakAttribute")) {

--- a/src/mono/mono/metadata/debug-helpers.c
+++ b/src/mono/mono/metadata/debug-helpers.c
@@ -131,8 +131,6 @@ mono_custom_modifiers_get_desc (GString *res, const MonoType *type, gboolean inc
 void
 mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 {
-	int i;
-
 	switch (type->type) {
 	case MONO_TYPE_VOID:
 		g_string_append (res, "void"); break;
@@ -177,7 +175,7 @@ mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 	case MONO_TYPE_ARRAY:
 		mono_type_get_desc (res, &type->data.array->eklass->_byval_arg, include_namespace);
 		g_string_append_c (res, '[');
-		for (i = 1; i < type->data.array->rank; ++i)
+		for (guint8 i = 1; i < type->data.array->rank; ++i)
 			g_string_append_c (res, ',');
 		g_string_append_c (res, ']');
 		break;
@@ -196,7 +194,7 @@ mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 		g_string_append (res, "<");
 		context = &type->data.generic_class->context;
 		if (context->class_inst) {
-			for (i = 0; i < context->class_inst->type_argc; ++i) {
+			for (guint i = 0; i < context->class_inst->type_argc; ++i) {
 				if (i > 0)
 					g_string_append (res, ", ");
 				mono_type_get_desc (res, context->class_inst->type_argv [i], include_namespace);
@@ -205,7 +203,7 @@ mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 		if (context->method_inst) {
 			if (context->class_inst)
 					g_string_append (res, "; ");
-			for (i = 0; i < context->method_inst->type_argc; ++i) {
+			for (guint i = 0; i < context->method_inst->type_argc; ++i) {
 				if (i > 0)
 					g_string_append (res, ", ");
 				mono_type_get_desc (res, context->method_inst->type_argv [i], include_namespace);
@@ -305,9 +303,7 @@ mono_signature_full_name (MonoMethodSignature *sig)
 void
 mono_ginst_get_desc (GString *str, MonoGenericInst *ginst)
 {
-	int i;
-
-	for (i = 0; i < ginst->type_argc; ++i) {
+	for (guint i = 0; i < ginst->type_argc; ++i) {
 		if (i > 0)
 			g_string_append (str, ", ");
 		mono_type_get_desc (str, ginst->type_argv [i], TRUE);
@@ -599,7 +595,6 @@ mono_method_desc_search_in_image (MonoMethodDesc *desc, MonoImage *image)
 	MonoClass *klass;
 	const MonoTableInfo *methods;
 	MonoMethod *method;
-	int i;
 
 	/* Handle short names for system classes */
 	if (!desc->name_space && image == mono_defaults.corlib) {
@@ -618,7 +613,7 @@ mono_method_desc_search_in_image (MonoMethodDesc *desc, MonoImage *image)
 	/* FIXME: Is this call necessary?  We don't use its result. */
 	mono_image_get_table_info (image, MONO_TABLE_TYPEDEF);
 	methods = mono_image_get_table_info (image, MONO_TABLE_METHOD);
-	for (i = 0; i < mono_table_info_get_rows (methods); ++i) {
+	for (guint32 i = 0; i < mono_table_info_get_rows (methods); ++i) {
 		ERROR_DECL (error);
 		guint32 token = mono_metadata_decode_row_col (methods, i, MONO_METHOD_NAME);
 		const char *n = mono_metadata_string_heap (image, token);

--- a/src/mono/mono/metadata/debug-helpers.c
+++ b/src/mono/mono/metadata/debug-helpers.c
@@ -613,7 +613,7 @@ mono_method_desc_search_in_image (MonoMethodDesc *desc, MonoImage *image)
 	/* FIXME: Is this call necessary?  We don't use its result. */
 	mono_image_get_table_info (image, MONO_TABLE_TYPEDEF);
 	methods = mono_image_get_table_info (image, MONO_TABLE_METHOD);
-	for (guint32 i = 0; i < mono_table_info_get_rows (methods); ++i) {
+	for (guint32 i = 0; i < table_info_get_rows (methods); ++i) {
 		ERROR_DECL (error);
 		guint32 token = mono_metadata_decode_row_col (methods, i, MONO_METHOD_NAME);
 		const char *n = mono_metadata_string_heap (image, token);

--- a/src/mono/mono/metadata/debug-mono-ppdb.c
+++ b/src/mono/mono/metadata/debug-mono-ppdb.c
@@ -66,7 +66,6 @@ get_pe_debug_info (MonoImage *image, guint8 *out_guid, gint32 *out_age, gint32 *
 {
 	MonoPEDirEntry *debug_dir_entry;
 	ImageDebugDirectory debug_dir;
-	int idx;
 	gboolean guid_found = FALSE;
 	guint8 *data;
 
@@ -77,7 +76,7 @@ get_pe_debug_info (MonoImage *image, guint8 *out_guid, gint32 *out_age, gint32 *
 		return FALSE;
 
 	int offset = mono_cli_rva_image_map (image, debug_dir_entry->rva);
-	for (idx = 0; idx < debug_dir_entry->size / sizeof (ImageDebugDirectory); ++idx) {
+	for (guint32 idx = 0; idx < debug_dir_entry->size / sizeof (ImageDebugDirectory); ++idx) {
 		data = (guint8 *) ((ImageDebugDirectory *) (image->raw_data + offset) + idx);
 		debug_dir.characteristics = read32(data);
 		debug_dir.time_date_stamp = read32(data + 4);
@@ -494,7 +493,7 @@ mono_ppdb_get_seq_points_internal (MonoImage *image, MonoPPDBFile *ppdb, MonoMet
 		return -1;
 
 	MonoTableInfo *methodbody_table = &tables [MONO_TABLE_METHODBODY];
-	if (G_UNLIKELY (method_idx - 1 >= table_info_get_rows (methodbody_table))) {
+	if (G_UNLIKELY (GINT_TO_UINT32(method_idx) - 1 >= table_info_get_rows (methodbody_table))) {
 		char *method_name = mono_method_full_name (method, FALSE);
 		g_error ("Method idx %d is greater than number of rows (%d) in PPDB MethodDebugInformation table, for method %s in '%s'. Likely a malformed PDB file.",
 		 method_idx - 1, table_info_get_rows (methodbody_table), method_name, image->name);
@@ -626,7 +625,7 @@ mono_ppdb_lookup_locals_internal (MonoImage *image, int method_idx)
 	guint32 cols [MONO_LOCALSCOPE_SIZE];
 	guint32 locals_cols [MONO_LOCALVARIABLE_SIZE];
 
-	int i, lindex, sindex, locals_idx, locals_end_idx, nscopes, start_scope_idx, scope_idx;
+	guint32 lindex, locals_idx, locals_end_idx, nscopes, start_scope_idx, scope_idx;
 
 	start_scope_idx = mono_metadata_localscope_from_methoddef (image, method_idx);
 
@@ -652,7 +651,7 @@ mono_ppdb_lookup_locals_internal (MonoImage *image, int method_idx)
 	// this endpoint becomes locals_end_idx below
 
 	// March to the last scope that is in this method
-	int rows = table_info_get_rows (&tables [MONO_TABLE_LOCALSCOPE]);
+	guint32 rows = table_info_get_rows (&tables [MONO_TABLE_LOCALSCOPE]);
 	while (scope_idx <= rows) {
 		mono_metadata_decode_row (&tables [MONO_TABLE_LOCALSCOPE], scope_idx-1, cols, MONO_LOCALSCOPE_SIZE);
 		if (cols [MONO_LOCALSCOPE_METHOD] != method_idx)
@@ -681,7 +680,7 @@ mono_ppdb_lookup_locals_internal (MonoImage *image, int method_idx)
 	res->locals = g_new0 (MonoDebugLocalVar, res->num_locals);
 
 	lindex = 0;
-	for (sindex = 0; sindex < nscopes; ++sindex) {
+	for (guint32 sindex = 0; sindex < nscopes; ++sindex) {
 		scope_idx = start_scope_idx + sindex;
 		mono_metadata_decode_row (&tables [MONO_TABLE_LOCALSCOPE], scope_idx-1, cols, MONO_LOCALSCOPE_SIZE);
 
@@ -697,7 +696,7 @@ mono_ppdb_lookup_locals_internal (MonoImage *image, int method_idx)
 
 		//printf ("Scope: %s %d %d %d-%d\n", mono_method_full_name (method, 1), cols [MONO_LOCALSCOPE_STARTOFFSET], cols [MONO_LOCALSCOPE_LENGTH], locals_idx, locals_end_idx);
 
-		for (i = locals_idx; i < locals_end_idx; ++i) {
+		for (guint32 i = locals_idx; i < locals_end_idx; ++i) {
 			mono_metadata_decode_row (&tables [MONO_TABLE_LOCALVARIABLE], i - 1, locals_cols, MONO_LOCALVARIABLE_SIZE);
 
 			res->locals [lindex].name = g_strdup (mono_metadata_string_heap (image, locals_cols [MONO_LOCALVARIABLE_NAME]));

--- a/src/mono/mono/metadata/debug-mono-ppdb.c
+++ b/src/mono/mono/metadata/debug-mono-ppdb.c
@@ -362,7 +362,8 @@ mono_ppdb_lookup_location_internal (MonoImage *image, int idx, uint32_t offset, 
 	const char *ptr;
 	const char *end;
 	char *docname = NULL;
-	int size, docidx, iloffset, delta_il, delta_lines, delta_cols, start_line, start_col, adv_line, adv_col;
+	int size, docidx, delta_lines, delta_cols, start_line, start_col, adv_line, adv_col;
+	guint32 iloffset;
 	gboolean first = TRUE, first_non_hidden = TRUE;
 	MonoDebugSourceLocation *location;
 
@@ -386,7 +387,7 @@ mono_ppdb_lookup_location_internal (MonoImage *image, int idx, uint32_t offset, 
 	start_line = 0;
 	start_col = 0;
 	while (ptr < end) {
-		delta_il = mono_metadata_decode_value (ptr, &ptr);
+		guint32 delta_il = mono_metadata_decode_value (ptr, &ptr);
 		if (!first && delta_il == 0) {
 			/* document-record */
 			docidx = mono_metadata_decode_value (ptr, &ptr);
@@ -743,8 +744,8 @@ mono_ppdb_lookup_locals (MonoDebugMethodInfo *minfo)
 * We use this to pass context information to the row locator
 */
 typedef struct {
-	int idx;			/* The index that we are trying to locate */
-	int col_idx;		/* The index in the row where idx may be stored */
+	guint32 idx;			/* The index that we are trying to locate */
+	guint32 col_idx;		/* The index in the row where idx may be stored */
 	MonoTableInfo *t;	/* pointer to the table */
 	guint32 result;
 } locator_t;

--- a/src/mono/mono/metadata/dynamic-image.c
+++ b/src/mono/mono/metadata/dynamic-image.c
@@ -104,13 +104,12 @@ MonoImage *
 mono_find_dynamic_image_owner (void *ptr)
 {
 	MonoImage *owner = NULL;
-	int i;
 
 	dynamic_images_lock ();
 
 	if (dynamic_images)
 	{
-		for (i = 0; !owner && i < dynamic_images->len; ++i) {
+		for (guint i = 0; !owner && i < dynamic_images->len; ++i) {
 			MonoImage *image = (MonoImage *)g_ptr_array_index (dynamic_images, i);
 			if (mono_mempool_contains_addr (image->mempool, ptr))
 				owner = image;

--- a/src/mono/mono/metadata/dynamic-stream.c
+++ b/src/mono/mono/metadata/dynamic-stream.c
@@ -28,7 +28,7 @@ mono_dynstream_init (MonoDynamicStream *sh)
 }
 
 static void
-make_room_in_stream (MonoDynamicStream *stream, int size)
+make_room_in_stream (MonoDynamicStream *stream, guint32 size)
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
 
@@ -60,7 +60,7 @@ mono_dynstream_insert_string (MonoDynamicStream *sh, const char *str)
 	len = strlen (str) + 1;
 	idx = sh->index;
 
-	make_room_in_stream (sh, (int)(idx + len));
+	make_room_in_stream (sh, idx + GSIZE_TO_UINT32(len));
 
 	/*
 	 * We strdup the string even if we already copy them in sh->data

--- a/src/mono/mono/metadata/exception.c
+++ b/src/mono/mono/metadata/exception.c
@@ -1328,7 +1328,6 @@ mono_error_set_field_missing (MonoError *error, MonoClass *klass, const char *fi
 void
 mono_error_set_method_missing (MonoError *error, MonoClass *klass, const char *method_name, MonoMethodSignature *sig, const char *reason, ...)
 {
-	int i;
 	char *result;
 	GString *res;
 
@@ -1361,7 +1360,7 @@ mono_error_set_method_missing (MonoError *error, MonoClass *klass, const char *m
 	if (sig) {
 		if (sig->generic_param_count) {
 			g_string_append_c (res, '<');
-			for (i = 0; i < sig->generic_param_count; ++i) {
+			for (guint i = 0; i < sig->generic_param_count; ++i) {
 				if (i > 0)
 					g_string_append (res, ",");
 				g_string_append_printf (res, "!%d", i);
@@ -1370,7 +1369,7 @@ mono_error_set_method_missing (MonoError *error, MonoClass *klass, const char *m
 		}
 
 		g_string_append_c (res, '(');
-		for (i = 0; i < sig->param_count; ++i) {
+		for (guint16 i = 0; i < sig->param_count; ++i) {
 			if (i > 0)
 				g_string_append_c (res, ',');
 			mono_type_get_desc (res, sig->params [i], TRUE);

--- a/src/mono/mono/metadata/image-internals.h
+++ b/src/mono/mono/metadata/image-internals.h
@@ -24,10 +24,10 @@ MonoImage*
 mono_image_loaded_internal (MonoAssemblyLoadContext *alc, const char *name);
 
 MonoImage*
-mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError *error);
+mono_image_load_file_for_image_checked (MonoImage *image, uint32_t fileidx, MonoError *error);
 
 MonoImage*
-mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error);
+mono_image_load_module_checked (MonoImage *image, uint32_t idx, MonoError *error);
 
 MonoImage *
 mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, const MonoImageOpenOptions *options);

--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -2772,7 +2772,7 @@ mono_image_get_table_info (MonoImage *image, int table_id)
 /**
  * mono_image_get_table_rows:
  */
-int
+guint32
 mono_image_get_table_rows (MonoImage *image, int table_id)
 {
 	if (table_id < 0 || table_id >= MONO_TABLE_NUM)
@@ -2783,7 +2783,7 @@ mono_image_get_table_rows (MonoImage *image, int table_id)
 /**
  * mono_table_info_get_rows:
  */
-int
+guint32
 mono_table_info_get_rows (const MonoTableInfo *table)
 {
 	return table_info_get_rows (table);

--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -700,7 +700,7 @@ mono_image_check_for_module_cctor (MonoImage *image)
  * it cannot be loaded. NULL without MonoError being set will be interpreted as "not found".
  */
 MonoImage*
-mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error)
+mono_image_load_module_checked (MonoImage *image, uint32_t idx, MonoError *error)
 {
 	error_init (error);
 
@@ -717,7 +717,7 @@ mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error)
  * mono_image_load_module:
  */
 MonoImage*
-mono_image_load_module (MonoImage *image, int idx)
+mono_image_load_module (MonoImage *image, uint32_t idx)
 {
 	ERROR_DECL (error);
 	MonoImage *result = mono_image_load_module_checked (image, idx, error);
@@ -928,7 +928,6 @@ mono_has_pdb_checksum (char *raw_data, uint32_t raw_data_len)
 {
 	MonoDotNetHeader cli_header;
 	MonoMSDOSHeader msdos;
-	int idx;
 	guint8 *data;
 
 	int offset = 0;
@@ -950,7 +949,7 @@ mono_has_pdb_checksum (char *raw_data, uint32_t raw_data_len)
 			return FALSE;
 		else {
 			const int top = cli_header.coff.coff_sections;
-			int addr = debug_dir_entry->rva;
+			guint32 addr = debug_dir_entry->rva;
 			int i = 0;
 			for (i = 0; i < top; i++){
 				MonoSectionTable t;
@@ -974,7 +973,7 @@ mono_has_pdb_checksum (char *raw_data, uint32_t raw_data_len)
 					break;
 				}
 			}
-			for (idx = 0; idx < debug_dir_entry->size / sizeof (ImageDebugDirectory); ++idx) {
+			for (guint32 idx = 0; idx < debug_dir_entry->size / sizeof (ImageDebugDirectory); ++idx) {
 				data = (guint8 *) ((ImageDebugDirectory *) (raw_data + addr) + idx);
 				debug_dir.characteristics = read32(data);
 				debug_dir.time_date_stamp = read32(data + 4);
@@ -1164,7 +1163,7 @@ dump_encmap (MonoImage *image)
 
 	if (mono_trace_is_traced (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE)) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "ENCMAP for %s", image->filename);
-		for (int i = 0; i < table_info_get_rows (encmap); ++i) {
+		for (guint32 i = 0; i < table_info_get_rows (encmap); ++i) {
 			guint32 cols [MONO_ENCMAP_SIZE];
 			mono_metadata_decode_row (encmap, i, cols, MONO_ENCMAP_SIZE);
 			int token = cols [MONO_ENCMAP_TOKEN];
@@ -2556,7 +2555,7 @@ mono_image_get_resource (MonoImage *image, guint32 offset, guint32 *size)
 
 // Returning NULL with no error set will be interpeted as "not found"
 MonoImage*
-mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError *error)
+mono_image_load_file_for_image_checked (MonoImage *image, uint32_t fileidx, MonoError *error)
 {
 	char *base_dir, *name;
 	MonoImage *res;
@@ -2591,7 +2590,6 @@ mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError
 		mono_image_unlock (image);
 		mono_image_close (old);
 	} else {
-		int i;
 		/* g_print ("loaded file %s from %s (%p)\n", name, image->name, image->assembly); */
 		if (!assign_assembly_parent_for_netmodule (res, image, error)) {
 			mono_image_unlock (image);
@@ -2599,13 +2597,13 @@ mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError
 			return NULL;
 		}
 
-		for (i = 0; i < res->module_count; ++i) {
+		for (guint32 i = 0; i < res->module_count; ++i) {
 			if (res->modules [i] && !res->modules [i]->assembly)
 				res->modules [i]->assembly = image->assembly;
 		}
 
 		if (!image->files) {
-			int n = table_info_get_rows (t);
+			guint32 n = table_info_get_rows (t);
 			image->files = g_new0 (MonoImage*, n);
 			image->file_count = n;
 		}
@@ -2628,7 +2626,7 @@ done:
  * mono_image_load_file_for_image:
  */
 MonoImage*
-mono_image_load_file_for_image (MonoImage *image, int fileidx)
+mono_image_load_file_for_image (MonoImage *image, uint32_t fileidx)
 {
 	ERROR_DECL (error);
 	MonoImage *result = mono_image_load_file_for_image_checked (image, fileidx, error);

--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -717,7 +717,7 @@ mono_image_load_module_checked (MonoImage *image, uint32_t idx, MonoError *error
  * mono_image_load_module:
  */
 MonoImage*
-mono_image_load_module (MonoImage *image, uint32_t idx)
+mono_image_load_module (MonoImage *image, int idx)
 {
 	ERROR_DECL (error);
 	MonoImage *result = mono_image_load_module_checked (image, idx, error);
@@ -2626,7 +2626,7 @@ done:
  * mono_image_load_file_for_image:
  */
 MonoImage*
-mono_image_load_file_for_image (MonoImage *image, uint32_t fileidx)
+mono_image_load_file_for_image (MonoImage *image, int fileidx)
 {
 	ERROR_DECL (error);
 	MonoImage *result = mono_image_load_file_for_image_checked (image, fileidx, error);
@@ -2770,7 +2770,7 @@ mono_image_get_table_info (MonoImage *image, int table_id)
 /**
  * mono_image_get_table_rows:
  */
-guint32
+int
 mono_image_get_table_rows (MonoImage *image, int table_id)
 {
 	if (table_id < 0 || table_id >= MONO_TABLE_NUM)
@@ -2781,7 +2781,7 @@ mono_image_get_table_rows (MonoImage *image, int table_id)
 /**
  * mono_table_info_get_rows:
  */
-guint32
+int
 mono_table_info_get_rows (const MonoTableInfo *table)
 {
 	return table_info_get_rows (table);

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -611,7 +611,6 @@ inflate_generic_signature_checked (MonoImage *image, MonoMethodSignature *sig, M
 {
 	MonoMethodSignature *res;
 	gboolean is_open;
-	int i;
 
 	error_init (error);
 	if (!context)
@@ -624,7 +623,7 @@ inflate_generic_signature_checked (MonoImage *image, MonoMethodSignature *sig, M
 	if (!is_ok (error))
 		goto fail;
 	is_open = mono_class_is_open_constructed_type (res->ret);
-	for (i = 0; i < sig->param_count; ++i) {
+	for (guint16 i = 0; i < sig->param_count; ++i) {
 		res->params [i] = mono_class_inflate_generic_type_checked (sig->params [i], context, error);
 		if (!is_ok (error))
 			goto fail;
@@ -645,7 +644,7 @@ inflate_generic_signature_checked (MonoImage *image, MonoMethodSignature *sig, M
 fail:
 	if (res->ret)
 		mono_metadata_free_type (res->ret);
-	for (i = 0; i < sig->param_count; ++i) {
+	for (guint16 i = 0; i < sig->param_count; ++i) {
 		if (res->params [i])
 			mono_metadata_free_type (res->params [i]);
 	}
@@ -693,12 +692,12 @@ inflate_generic_header (MonoMethodHeader *header, MonoGenericContext *context, M
 
 	error_init (error);
 
-	for (int i = 0; i < header->num_locals; ++i) {
+	for (guint16 i = 0; i < header->num_locals; ++i) {
 		res->locals [i] = mono_class_inflate_generic_type_checked (header->locals [i], context, error);
 		goto_if_nok (error, fail);
 	}
 	if (res->num_clauses) {
-		for (int i = 0; i < header->num_clauses; ++i) {
+		for (guint i = 0; i < header->num_clauses; ++i) {
 			MonoExceptionClause *clause = &res->clauses [i];
 			if (clause->flags != MONO_EXCEPTION_CLAUSE_NONE)
 				continue;

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -600,7 +600,7 @@ mono_string_from_byvalwstr_impl (const gunichar2 *data, int max_len, MonoError *
 	// FIXME Check max_len while scanning data? mono_string_from_byvalstr does.
 	const size_t len = g_utf16_len (data);
 
-	return mono_string_new_utf16_handle (data, (gint32)MIN (len, max_len), error);
+	return mono_string_new_utf16_handle (data, (gint32)MIN (len, GINT_TO_UINT(max_len)), error);
 }
 
 gpointer
@@ -765,7 +765,7 @@ mono_string_builder_new (int starting_string_length, MonoError *error)
 	mono_error_assert_ok (error);
 
 	MonoArrayHandle chunkChars = MONO_HANDLE_NEW_GET (MonoArray, sb, chunkChars);
-	g_assert (MONO_HANDLE_GETVAL (chunkChars, max_length) >= initial_len);
+	g_assert (MONO_HANDLE_GETVAL (chunkChars, max_length) >= GINT_TO_UINT(initial_len));
 
 	return sb;
 }
@@ -784,9 +784,9 @@ mono_string_utf16_to_builder_copy (MonoStringBuilderHandle sb, const gunichar2 *
 
 	do {
 		MONO_HANDLE_GET (chunkChars, chunk, chunkChars);
-		const int maxLength = MONO_HANDLE_GETVAL (chunkChars, max_length);
+		const guint32 maxLength = MONO_HANDLE_GETVAL (chunkChars, max_length);
 		g_assert (maxLength >= 0);
-		const int chunkOffset = MONO_HANDLE_GETVAL (chunk, chunkOffset);
+		const guint32 chunkOffset = MONO_HANDLE_GETVAL (chunk, chunkOffset);
 		g_assert (chunkOffset >= 0);
 		if (maxLength > 0 && chunkOffset < string_len) {
 			// Check that we will not overrun our boundaries.
@@ -828,9 +828,9 @@ mono_string_utf8len_to_builder (MonoStringBuilderHandle sb, const char *text, gs
 	GError *gerror = NULL;
 	glong copied;
 	gunichar2* ut = g_utf8_to_utf16 (text, (glong)len, NULL, &copied, &gerror);
-	int capacity = mono_string_builder_capacity (sb);
+	guint capacity = mono_string_builder_capacity (sb);
 
-	if (copied > capacity)
+	if (GLONG_TO_ULONG(copied) > capacity)
 		copied = capacity;
 
 	if (!gerror) {
@@ -917,7 +917,7 @@ mono_string_builder_to_utf8_impl (MonoStringBuilderHandle sb, MonoError *error)
 	}
 
 	len = mono_string_builder_capacity (sb) + 1;
-	res = (char *)mono_marshal_alloc (MAX (byte_count + 1, len), error);
+	res = (char *)mono_marshal_alloc (MAX (GLONG_TO_ULONG(byte_count) + 1, len), error);
 	if (!is_ok (error)) {
 		res = NULL;
 		goto exit;
@@ -978,7 +978,7 @@ mono_string_builder_to_utf16_impl (MonoStringBuilderHandle sb, MonoError *error)
 			const int chunkOffset = MONO_HANDLE_GETVAL (chunk, chunkOffset);
 			g_assert (chunkOffset >= 0);
 			g_assertf ((chunkOffset + chunkLength) >= chunkLength, "integer overflow");
-			g_assertf ((chunkOffset + chunkLength) <= capacity, "A chunk in the StringBuilder had a length longer than expected from the offset.");
+			g_assertf (GINT_TO_UINT(chunkOffset + chunkLength) <= capacity, "A chunk in the StringBuilder had a length longer than expected from the offset.");
 			memcpy (str + chunkOffset, MONO_HANDLE_RAW (chunkChars)->vector, chunkLength * sizeof (gunichar2));
 		}
 		MONO_HANDLE_GET (chunk, chunk, chunkPrevious);
@@ -1111,8 +1111,8 @@ mono_string_to_byvalstr_impl (char *dst, MonoStringHandle src, int size, MonoErr
 
 	char *s = mono_string_handle_to_utf8 (src, error);
 	return_if_nok (error);
-	size_t len = MIN (size, strlen (s));
-	len -= (len >= size);
+	size_t len = MIN (GINT_TO_UINT(size), strlen (s));
+	len -= (len >= GINT_TO_UINT(size));
 	memcpy (dst, s, len);
 	dst [len] = 0;
 	g_free (s);
@@ -3246,9 +3246,8 @@ mono_marshal_set_callconv_from_unmanaged_callconv_attribute (MonoMethod *method,
 		return;
 	}
 
-	mono_array_size_t i;
 	MonoCustomAttrEntry *attr = NULL;
-	for (i = 0; i < cinfo->num_attrs; ++i) {
+	for (int i = 0; i < cinfo->num_attrs; ++i) {
 		MonoClass *ctor_class = cinfo->attrs [i].ctor->klass;
 		if (ctor_class == attr_class) {
 			attr = &cinfo->attrs [i];
@@ -3262,7 +3261,7 @@ mono_marshal_set_callconv_from_unmanaged_callconv_attribute (MonoMethod *method,
 		MonoArray *named_args = mono_marshal_get_callconvs_array_from_attribute(attr, &arginfo);
 		if (named_args)
 		{
-			for (i = 0; i < mono_array_length_internal(named_args); ++i) {
+			for (mono_array_size_t i = 0; i < mono_array_length_internal(named_args); ++i) {
 				CattrNamedArg *info = &arginfo[i];
 				g_assert(info->field);
 				if (strcmp(info->field->name, "CallConvs") != 0)
@@ -3326,9 +3325,8 @@ mono_marshal_set_callconv_from_unmanaged_callers_only_attribute (MonoMethod *met
 		return;
 	}
 
-	mono_array_size_t i;
 	MonoCustomAttrEntry *attr = NULL;
-	for (i = 0; i < cinfo->num_attrs; ++i) {
+	for (int i = 0; i < cinfo->num_attrs; ++i) {
 		MonoClass *ctor_class = cinfo->attrs [i].ctor->klass;
 		if (ctor_class == attr_class) {
 			attr = &cinfo->attrs [i];
@@ -3339,7 +3337,7 @@ mono_marshal_set_callconv_from_unmanaged_callers_only_attribute (MonoMethod *met
 	if (attr != NULL) {
 		MonoDecodeCustomAttr *decoded_args = mono_reflection_create_custom_attr_data_args_noalloc (mono_defaults.corlib, attr->ctor, attr->data, attr->data_size, error);
 		mono_error_assert_ok (error);
-		for (i = 0; i < decoded_args->named_args_num; ++i) {
+		for (int i = 0; i < decoded_args->named_args_num; ++i) {
 			if (decoded_args->named_args_info [i].field && !strcmp (decoded_args->named_args_info [i].field->name, "CallConvs")) {
 				g_assertf(decoded_args->named_args_info [i].field->type->type == MONO_TYPE_SZARRAY, "UnmanagedCallersOnlyAttribute parameter %s must be an array, specified for method %s", decoded_args->named_args_info [i].field->name, method->name);
 				MonoCustomAttrValueArray *calling_conventions = decoded_args->named_args[i]->value.array;
@@ -5332,7 +5330,6 @@ void
 mono_struct_delete_old (MonoClass *klass, char *ptr)
 {
 	MonoMarshalType *info;
-	int i;
 
 	info = mono_marshal_load_type_info (klass);
 
@@ -5342,7 +5339,7 @@ mono_struct_delete_old (MonoClass *klass, char *ptr)
 	if (m_class_is_blittable (klass))
 		return;
 
-	for (i = 0; i < info->num_fields; i++) {
+	for (guint32 i = 0; i < info->num_fields; i++) {
 		MonoMarshalConv conv;
 		MonoType *ftype = info->fields [i].field->type;
 		char *cpos;

--- a/src/mono/mono/metadata/mono-basic-block.c
+++ b/src/mono/mono/metadata/mono-basic-block.c
@@ -252,7 +252,7 @@ bb_split (MonoSimpleBasicBlock *first, MonoSimpleBasicBlock *hint, MonoSimpleBas
 		do {
 			if (bb_idx_is_contained (first, target))
 				break;
-			if (first->start > target)
+			if (GINT_TO_UINT(first->start )> target)
 				first = first->left;
 			else
 				first = first->right;
@@ -353,7 +353,7 @@ bb_formation_il_pass (const unsigned char *start, const unsigned char *end, Mono
 			return;
 		}
 
-		while (current && cli_addr >= current->end)
+		while (current && cli_addr >= GINT_TO_UINT(current->end))
 			current = current->next;
 		g_assert (current);
 
@@ -469,13 +469,12 @@ bb_formation_il_pass (const unsigned char *start, const unsigned char *end, Mono
 static void
 bb_formation_eh_pass (MonoMethodHeader *header, MonoSimpleBasicBlock *bb, MonoSimpleBasicBlock **root, MonoMethod *method, MonoError *error)
 {
-	int i;
-	int end = header->code_size;
+	guint32 end = header->code_size;
 
 	error_init (error);
 
 	/*We must split at all points to verify for targets in the middle of an instruction*/
-	for (i = 0; i < header->num_clauses; ++i) {
+	for (guint i = 0; i < header->num_clauses; ++i) {
 		MonoExceptionClause *clause = header->clauses + i;
 		MonoSimpleBasicBlock *try_block, *handler;
 

--- a/src/mono/mono/metadata/mono-hash.c
+++ b/src/mono/mono/metadata/mono-hash.c
@@ -110,7 +110,7 @@ static void mono_g_hash_table_value_store (MonoGHashTable *hash, int slot, MonoO
 }
 
 /* Returns position of key or of an empty slot for it */
-static int mono_g_hash_table_find_slot (MonoGHashTable *hash, const MonoObject *key)
+static guint mono_g_hash_table_find_slot (MonoGHashTable *hash, const MonoObject *key)
 {
 	guint start = ((*hash->hash_func) (key)) % hash->table_size;
 	guint i = start;
@@ -132,9 +132,9 @@ static int mono_g_hash_table_find_slot (MonoGHashTable *hash, const MonoObject *
 	}
 
 	gint32 max_length = UnlockedRead (&mono_g_hash_table_max_chain_length);
-	if (i > start && (i - start) > max_length)
+	if (i > start && (i - start) > GINT32_TO_UINT32(max_length))
 		UnlockedWrite (&mono_g_hash_table_max_chain_length, i - start);
-	else if (i < start && (hash->table_size - (start - i)) > max_length)
+	else if (i < start && (hash->table_size - (start - i)) > GINT32_TO_UINT32(max_length))
 		UnlockedWrite (&mono_g_hash_table_max_chain_length, hash->table_size - (start - i));
 
 	return i;
@@ -199,7 +199,7 @@ do_rehash (void *_data)
 
 	for (i = 0; i < current_size; i++) {
 		if (old_keys [i]) {
-			int slot = mono_g_hash_table_find_slot (hash, old_keys [i]);
+			guint slot = mono_g_hash_table_find_slot (hash, old_keys [i]);
 			mono_g_hash_table_key_store (hash, slot, old_keys [i]);
 			mono_g_hash_table_value_store (hash, slot, old_values [i]);
 		}
@@ -277,11 +277,9 @@ mono_g_hash_table_lookup (MonoGHashTable *hash, gconstpointer key)
 gboolean
 mono_g_hash_table_lookup_extended (MonoGHashTable *hash, gconstpointer key, gpointer *orig_key, gpointer *value)
 {
-	int slot;
-
 	g_return_val_if_fail (hash != NULL, FALSE);
 
-	slot = mono_g_hash_table_find_slot (hash, (MonoObject*)key);
+	guint slot = mono_g_hash_table_find_slot (hash, (MonoObject*)key);
 
 	if (hash->keys [slot]) {
 		if (orig_key)
@@ -332,7 +330,7 @@ mono_g_hash_table_find (MonoGHashTable *hash, GHRFunc predicate, gpointer user_d
 gboolean
 mono_g_hash_table_remove (MonoGHashTable *hash, gconstpointer key)
 {
-	int slot, last_clear_slot;
+	guint slot, last_clear_slot;
 
 	g_return_val_if_fail (hash != NULL, FALSE);
 	slot = mono_g_hash_table_find_slot (hash, (MonoObject*)key);
@@ -438,13 +436,12 @@ static void
 mono_g_hash_table_insert_replace (MonoGHashTable *hash, gpointer key, gpointer value, gboolean replace)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
-	int slot;
 	g_return_if_fail (hash != NULL);
 
 	if (hash->in_use > (hash->table_size * HASH_TABLE_MAX_LOAD_FACTOR))
 		rehash (hash);
 
-	slot = mono_g_hash_table_find_slot (hash, (MonoObject*)key);
+	guint slot = mono_g_hash_table_find_slot (hash, (MonoObject*)key);
 
 	if (hash->keys [slot]) {
 		if (replace) {

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -330,7 +330,7 @@ struct _MonoStringBuilder {
 	int maxCapacity;
 };
 
-static inline int
+static inline guint
 mono_string_builder_capacity (MonoStringBuilderHandle sbh)
 {
 	MonoStringBuilder *sb = MONO_HANDLE_RAW (sbh);

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -879,16 +879,16 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 			case MONO_TYPE_ARRAY:
 				g_assert ((m_field_get_offset (field) % wordsize) == 0);
 
-				g_assert (pos < size || pos <= max_size);
+				g_assert (pos < GINT_TO_UINT32(size) || pos <= GINT_TO_UINT32(max_size));
 				bitmap [pos / BITMAP_EL_SIZE] |= ((gsize)1) << (pos % BITMAP_EL_SIZE);
-				*max_set = MAX (*max_set, pos);
+				*max_set = MAX (GINT_TO_UINT32(*max_set), pos);
 				break;
 			case MONO_TYPE_GENERICINST:
 				if (!mono_type_generic_inst_is_valuetype (type)) {
 					g_assert ((m_field_get_offset (field) % wordsize) == 0);
 
 					bitmap [pos / BITMAP_EL_SIZE] |= ((gsize)1) << (pos % BITMAP_EL_SIZE);
-					*max_set = MAX (*max_set, pos);
+					*max_set = MAX (GINT_TO_UINT32(*max_set), pos);
 					break;
 				} else {
 					/* fall through */
@@ -1462,10 +1462,9 @@ initialize_imt_slot (MonoVTable *vtable, MonoImtBuilderEntry *imt_builder_entry,
 			/* Collision, build the trampoline */
 			GPtrArray *imt_ir = imt_sort_slot_entries (imt_builder_entry);
 			gpointer result;
-			int i;
 			result = imt_trampoline_builder (vtable,
 				(MonoIMTCheckItem**)imt_ir->pdata, imt_ir->len, fail_tramp);
-			for (i = 0; i < imt_ir->len; ++i)
+			for (guint i = 0; i < imt_ir->len; ++i)
 				g_free (g_ptr_array_index (imt_ir, i));
 			g_ptr_array_free (imt_ir, TRUE);
 			return result;
@@ -1821,7 +1820,7 @@ mono_method_add_generic_virtual_invocation (MonoVTable *vtable,
 				entries = next;
 			}
 
-			for (int i = 0; i < sorted->len; ++i)
+			for (guint i = 0; i < sorted->len; ++i)
 				g_free (g_ptr_array_index (sorted, i));
 			g_ptr_array_free (sorted, TRUE);
 
@@ -5748,7 +5747,7 @@ mono_array_new_jagged_helper (MonoClass *klass, int n, uintptr_t *lengths, int i
 		// are also arrays and we allocate each one of them.
 		MonoClass *element_class = m_class_get_element_class (klass);
 		g_assert (m_class_get_rank (element_class) == 1);
-		for (int i = 0; i < lengths [index]; i++) {
+		for (uintptr_t i = 0; i < lengths [index]; i++) {
 			MonoArray *o = mono_array_new_jagged_helper (element_class, n, lengths, index + 1, error);
 			goto_if_nok (error, exit);
 			mono_array_setref_fast (ret, i, o);
@@ -6991,7 +6990,7 @@ mono_ldstr_utf8 (MonoImage *image, guint32 idx, MonoError *error)
 		return NULL;
 	}
 	/* g_utf16_to_utf8 may not be able to complete the conversion (e.g. NULL values were found, #335488) */
-	if (len2 > written) {
+	if (len2 > GLONG_TO_ULONG(written)) {
 		/* allocate the total length and copy the part of the string that has been converted */
 		char *as2 = (char *)g_malloc0 (len2);
 		memcpy (as2, as, written);
@@ -7054,7 +7053,7 @@ mono_utf16_to_utf8len (const gunichar2 *s, gsize slength, gsize *utf8_length, Mo
 		return NULL;
 	}
 	/* g_utf16_to_utf8 may not be able to complete the conversion (e.g. NULL values were found, #335488) */
-	if (slength > written) {
+	if (slength > GLONG_TO_ULONG(written)) {
 		/* allocate the total length and copy the part of the string that has been converted */
 		char *as2 = (char *)g_malloc0 (slength);
 		memcpy (as2, as, written);

--- a/src/mono/mono/metadata/sre-encode.c
+++ b/src/mono/mono/metadata/sre-encode.c
@@ -133,7 +133,6 @@ encode_generic_class (MonoDynamicImage *assembly, MonoGenericClass *gclass, SigB
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
 
-	int i;
 	MonoGenericInst *class_inst;
 	MonoClass *klass;
 
@@ -147,7 +146,7 @@ encode_generic_class (MonoDynamicImage *assembly, MonoGenericClass *gclass, SigB
 	sigbuffer_add_value (buf, mono_dynimage_encode_typedef_or_ref_full (assembly, m_class_get_byval_arg (klass), FALSE));
 
 	sigbuffer_add_value (buf, class_inst->type_argc);
-	for (i = 0; i < class_inst->type_argc; ++i)
+	for (guint i = 0; i < class_inst->type_argc; ++i)
 		encode_type (assembly, class_inst->type_argv [i], buf);
 
 }

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -2733,7 +2733,7 @@ wait_for_tids (struct wait_data *wait, guint32 timeout, gboolean check_state_cha
 	for( i = 0; i < wait->num; i++)
 		mono_threads_close_thread_handle (wait->handles [i]);
 
-	if (ret >= MONO_THREAD_INFO_WAIT_RET_SUCCESS_0 && ret < (MONO_THREAD_INFO_WAIT_RET_SUCCESS_0 + wait->num)) {
+	if (ret >= MONO_THREAD_INFO_WAIT_RET_SUCCESS_0 && GINT_TO_UINT32(ret) < MONO_THREAD_INFO_WAIT_RET_SUCCESS_0 + wait->num) {
 		MonoInternalThread *internal;
 
 		internal = wait->threads [ret - MONO_THREAD_INFO_WAIT_RET_SUCCESS_0];
@@ -3221,12 +3221,12 @@ mono_thread_get_undeniable_exception (void)
 
 #if MONO_SMALL_CONFIG
 #define NUM_STATIC_DATA_IDX 4
-static const int static_data_size [NUM_STATIC_DATA_IDX] = {
+static const guint32 static_data_size [NUM_STATIC_DATA_IDX] = {
 	64, 256, 1024, 4096
 };
 #else
 #define NUM_STATIC_DATA_IDX 8
-static const int static_data_size [NUM_STATIC_DATA_IDX] = {
+static const guint32 static_data_size [NUM_STATIC_DATA_IDX] = {
 	1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216
 };
 #endif
@@ -3268,7 +3268,6 @@ static void
 mono_alloc_static_data (gpointer **static_data_ptr, guint32 offset, void *alloc_key)
 {
 	guint idx = ACCESS_SPECIAL_STATIC_OFFSET (offset, index);
-	int i;
 
 	gpointer* static_data = *static_data_ptr;
 	if (!static_data) {
@@ -3287,7 +3286,7 @@ mono_alloc_static_data (gpointer **static_data_ptr, guint32 offset, void *alloc_
 		static_data [0] = static_data;
 	}
 
-	for (i = 1; i <= idx; ++i) {
+	for (guint i = 1; i <= idx; ++i) {
 		if (static_data [i])
 			continue;
 
@@ -3304,8 +3303,7 @@ mono_alloc_static_data (gpointer **static_data_ptr, guint32 offset, void *alloc_
 static void
 mono_free_static_data (gpointer* static_data)
 {
-	int i;
-	for (i = 1; i < NUM_STATIC_DATA_IDX; ++i) {
+	for (guint i = 1; i < NUM_STATIC_DATA_IDX; ++i) {
 		gpointer p = static_data [i];
 		if (!p)
 			continue;
@@ -3428,7 +3426,7 @@ clear_reference_bitmap (MonoBitSet **sets, guint32 offset, guint32 size)
 	offset = ACCESS_SPECIAL_STATIC_OFFSET (offset, offset);
 	offset /= sizeof (uintptr_t);
 	/* offset is now the bitmap offset */
-	for (int i = 0; i < size / sizeof (uintptr_t); i++)
+	for (guint i = 0; i < size / sizeof (uintptr_t); i++)
 		mono_bitset_clear_fast (rb, offset + i);
 }
 
@@ -4792,10 +4790,8 @@ mono_thread_internal_describe (MonoInternalThread *internal, GString *text)
 	}
 
 	if (internal->owned_mutexes) {
-		int i;
-
 		g_string_append (text, ", owns : [");
-		for (i = 0; i < internal->owned_mutexes->len; i++)
+		for (guint i = 0; i < internal->owned_mutexes->len; i++)
 			g_string_append_printf (text, i == 0 ? "%p" : ", %p", g_ptr_array_index (internal->owned_mutexes, i));
 		g_string_append (text, "]");
 	}

--- a/src/mono/mono/mini/abcremoval.c
+++ b/src/mono/mono/mini/abcremoval.c
@@ -1307,7 +1307,6 @@ mono_perform_abc_removal (MonoCompile *cfg)
 {
 	MonoVariableRelationsEvaluationArea area;
 	MonoBasicBlock *bb;
-	int i;
 
 	verbose_level = cfg->verbose_level;
 
@@ -1324,7 +1323,7 @@ mono_perform_abc_removal (MonoCompile *cfg)
 	area.variable_value_kind = (MonoIntegerValueKind *)
 		mono_mempool_alloc (cfg->mempool, sizeof (MonoIntegerValueKind) * (cfg->next_vreg));
 	area.defs = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * cfg->next_vreg);
-	for (i = 0; i < cfg->next_vreg; i++) {
+	for (guint32 i = 0; i < cfg->next_vreg; i++) {
 		area.variable_value_kind [i] = MONO_UNKNOWN_INTEGER_VALUE;
 		area.relations [i].relation = MONO_EQ_RELATION;
 		area.relations [i].relation_is_static_definition = TRUE;
@@ -1410,7 +1409,7 @@ mono_perform_abc_removal (MonoCompile *cfg)
 	}
 
 	/* Add symmetric relations */
-	for (i = 0; i < cfg->next_vreg; i++) {
+	for (guint32 i = 0; i < cfg->next_vreg; i++) {
 		if (area.relations [i].related_value.type == MONO_VARIABLE_SUMMARIZED_VALUE) {
 			int related_index = cfg->next_vreg + i;
 			int related_variable = area.relations [i].related_value.value.variable.variable;

--- a/src/mono/mono/mini/alias-analysis.c
+++ b/src/mono/mono/mini/alias-analysis.c
@@ -321,14 +321,11 @@ handle_instruction:
 static gboolean
 recompute_aliased_variables (MonoCompile *cfg, int *restored_vars)
 {
-	int i;
-	MonoBasicBlock *bb;
-	MonoInst *ins;
 	int kills = 0;
 	int adds = 0;
 	*restored_vars = 0;
 
-	for (i = 0; i < cfg->num_varinfo; i++) {
+	for (guint i = 0; i < cfg->num_varinfo; i++) {
 		MonoInst *var = cfg->varinfo [i];
 		if (var->flags & MONO_INST_INDIRECT) {
 			if (cfg->verbose_level > 2) {
@@ -342,8 +339,8 @@ recompute_aliased_variables (MonoCompile *cfg, int *restored_vars)
 	if (!kills)
 		return FALSE;
 
-	for (bb = cfg->bb_entry; bb; bb = bb->next_bb) {
-		for (ins = bb->code; ins; ins = ins->next) {
+	for (MonoBasicBlock *bb = cfg->bb_entry; bb; bb = bb->next_bb) {
+		for (MonoInst *ins = bb->code; ins; ins = ins->next) {
 			if (ins->opcode == OP_LDADDR) {
 				MonoInst *var;
 

--- a/src/mono/mono/mini/branch-opts.c
+++ b/src/mono/mono/mini/branch-opts.c
@@ -41,7 +41,6 @@ mono_branch_optimize_exception_target (MonoCompile *cfg, MonoBasicBlock *bb, con
 	MonoMethodHeader *header = cfg->header;
 	MonoExceptionClause *clause;
 	MonoClass *exclass;
-	int i;
 
 	if (!(cfg->opt & MONO_OPT_EXCEPTION))
 		return NULL;
@@ -51,7 +50,7 @@ mono_branch_optimize_exception_target (MonoCompile *cfg, MonoBasicBlock *bb, con
 
 	exclass = mono_class_load_from_name (mono_get_corlib (), "System", exname);
 	/* search for the handler */
-	for (i = 0; i < header->num_clauses; ++i) {
+	for (guint i = 0; i < header->num_clauses; ++i) {
 		clause = &header->clauses [i];
 		if (MONO_OFFSET_IN_CLAUSE (clause, bb->real_offset)) {
 			if (clause->flags == MONO_EXCEPTION_CLAUSE_NONE && clause->data.catch_class && mono_class_is_assignable_from_internal (clause->data.catch_class, exclass)) {

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -470,7 +470,6 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 	int result, expected, failed, cfailed, run, code_size;
 	double elapsed, comp_time, start_time;
 	char *n;
-	int i;
 
 	mono_set_defaults (verbose, opt_flags);
 	n = mono_opt_descr (opt_flags);
@@ -489,7 +488,7 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 	g_timer_start (timer);
 	if (mini_stats_fd)
 		fprintf (mini_stats_fd, "[");
-	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
 		ERROR_DECL (error);
 		MonoMethod *method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
 		if (!method) {
@@ -589,7 +588,6 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 static int
 mini_regression (MonoImage *image, int verbose, int *total_run)
 {
-	guint32 i, opt;
 	MonoMethod *method;
 	char *n;
 	GTimer *timer = g_timer_new ();
@@ -603,7 +601,7 @@ mini_regression (MonoImage *image, int verbose, int *total_run)
 		fprintf (mini_stats_fd, "$stattitle = \'Mono Benchmark Results (various optimizations)\';\n");
 
 		fprintf (mini_stats_fd, "$graph->set_legend(qw(");
-		for (opt = 0; opt < G_N_ELEMENTS (opt_sets); opt++) {
+		for (guint32 opt = 0; opt < G_N_ELEMENTS (opt_sets); opt++) {
 			guint32 opt_flags = opt_sets [opt];
 			n = mono_opt_descr (opt_flags);
 			if (!n [0])
@@ -621,7 +619,7 @@ mini_regression (MonoImage *image, int verbose, int *total_run)
 	}
 
 	/* load the metadata */
-	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
 		ERROR_DECL (error);
 		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
 		if (!method) {
@@ -664,7 +662,7 @@ mini_regression (MonoImage *image, int verbose, int *total_run)
 				return total;
 		}
 	} else {
-		for (opt = 0; opt < G_N_ELEMENTS (opt_sets); ++opt) {
+		for (guint32 opt = 0; opt < G_N_ELEMENTS (opt_sets); ++opt) {
 			/* aot-tests.cs need OPT_INTRINS enabled */
 			if (!strcmp ("aot-tests", image->assembly_name))
 				if (!(opt_sets [opt] & MONO_OPT_INTRINS))
@@ -723,7 +721,6 @@ interp_regression_step (MonoImage *image, int verbose, int *total_run, int *tota
 {
 	int result, expected, failed, cfailed, run;
 	double elapsed, transform_time;
-	int i;
 	MonoObject *result_obj;
 	int local_skip_index = 0;
 
@@ -742,7 +739,7 @@ interp_regression_step (MonoImage *image, int verbose, int *total_run, int *tota
 	mini_get_interp_callbacks ()->invalidate_transformed ();
 
 	g_timer_start (timer);
-	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
 		ERROR_DECL (error);
 		MonoMethod *method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
 		if (!method) {
@@ -803,11 +800,10 @@ interp_regression (MonoImage *image, int verbose, int *total_run)
 {
 	MonoMethod *method;
 	GTimer *timer = g_timer_new ();
-	guint32 i;
 	int total;
 
 	/* load the metadata */
-	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
 		ERROR_DECL (error);
 		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
 		if (!method) {
@@ -1206,9 +1202,9 @@ compile_all_methods_thread_main_inner (CompileAllThreadArgs *args)
 	MonoImage *image = mono_assembly_get_image_internal (ass);
 	MonoMethod *method;
 	MonoCompile *cfg;
-	int i, count = 0, fail_count = 0;
+	int count = 0, fail_count = 0;
 
-	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
 		ERROR_DECL (error);
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
 		MonoMethodSignature *sig;
@@ -3023,7 +3019,6 @@ merge_parsed_options (GPtrArray *parsed_options, int *ref_argc, char **ref_argv 
 		int new_argc = parsed_options->len + argc;
 		char **new_argv = g_new (char *, new_argc + 1);
 		guint i;
-		guint j;
 
 		new_argv [0] = argv [0];
 
@@ -3034,10 +3029,10 @@ merge_parsed_options (GPtrArray *parsed_options, int *ref_argc, char **ref_argv 
 				new_argv [i+1] = (char *)g_ptr_array_index (parsed_options, i);
 			i++;
 		}
-		for (j = 1; j < argc; j++)
+		for (int j = 1; j < argc; j++)
 			new_argv [i++] = argv [j];
 		if (!prepend){
-			for (j = 0; j < parsed_options->len; j++)
+			for (guint j = 0; j < parsed_options->len; j++)
 				new_argv [i++] = (char *)g_ptr_array_index (parsed_options, j);
 		}
 		new_argv [i] = NULL;

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -488,7 +488,7 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 	g_timer_start (timer);
 	if (mini_stats_fd)
 		fprintf (mini_stats_fd, "[");
-	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < table_info_get_rows (&image->tables [MONO_TABLE_METHOD]); ++i) {
 		ERROR_DECL (error);
 		MonoMethod *method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
 		if (!method) {
@@ -619,7 +619,7 @@ mini_regression (MonoImage *image, int verbose, int *total_run)
 	}
 
 	/* load the metadata */
-	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < table_info_get_rows (&image->tables [MONO_TABLE_METHOD]); ++i) {
 		ERROR_DECL (error);
 		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
 		if (!method) {
@@ -739,7 +739,7 @@ interp_regression_step (MonoImage *image, int verbose, int *total_run, int *tota
 	mini_get_interp_callbacks ()->invalidate_transformed ();
 
 	g_timer_start (timer);
-	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < table_info_get_rows (&image->tables [MONO_TABLE_METHOD]); ++i) {
 		ERROR_DECL (error);
 		MonoMethod *method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
 		if (!method) {
@@ -803,7 +803,7 @@ interp_regression (MonoImage *image, int verbose, int *total_run)
 	int total;
 
 	/* load the metadata */
-	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < table_info_get_rows (&image->tables [MONO_TABLE_METHOD]); ++i) {
 		ERROR_DECL (error);
 		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
 		if (!method) {
@@ -1204,7 +1204,7 @@ compile_all_methods_thread_main_inner (CompileAllThreadArgs *args)
 	MonoCompile *cfg;
 	int count = 0, fail_count = 0;
 
-	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < table_info_get_rows (&image->tables [MONO_TABLE_METHOD]); ++i) {
 		ERROR_DECL (error);
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
 		MonoMethodSignature *sig;

--- a/src/mono/mono/mini/exceptions-amd64.c
+++ b/src/mono/mono/mini/exceptions-amd64.c
@@ -1584,7 +1584,7 @@ mono_arch_unwindinfo_find_rt_func_in_table (const gpointer code, gsize code_size
 		g_assert_checked (found_entry->end_range >= begin_range && found_entry->end_range >= end_range);
 		g_assert_checked (found_entry->rt_funcs != NULL);
 
-		for (int i = 0; i < found_entry->rt_funcs_current_count; ++i) {
+		for (DWORD i = 0; i < found_entry->rt_funcs_current_count; ++i) {
 			PRUNTIME_FUNCTION current_rt_func = (PRUNTIME_FUNCTION)(&found_entry->rt_funcs [i]);
 
 			// Is this our RT function entry?
@@ -1621,7 +1621,7 @@ validate_rt_funcs_in_table_no_lock (DynamicFunctionTableEntry *entry)
 
 	PRUNTIME_FUNCTION current_rt_func = NULL;
 	PRUNTIME_FUNCTION previous_rt_func = NULL;
-	for (int i = 0; i < entry->rt_funcs_current_count; ++i) {
+	for (DWORD i = 0; i < entry->rt_funcs_current_count; ++i) {
 		current_rt_func = &(entry->rt_funcs [i]);
 
 		g_assert_checked (current_rt_func->BeginAddress < current_rt_func->EndAddress);

--- a/src/mono/mono/mini/graph.c
+++ b/src/mono/mono/mini/graph.c
@@ -46,7 +46,7 @@ static void
 dtree_emit_one_loop_level (MonoCompile *cfg, FILE *fp, MonoBasicBlock *h)
 {
 	MonoBasicBlock *bb;
-	int i, level = 0;
+	gint8 level = 0;
 
 	if (h) {
 		level = h->nesting;
@@ -54,7 +54,7 @@ dtree_emit_one_loop_level (MonoCompile *cfg, FILE *fp, MonoBasicBlock *h)
 		fprintf (fp, "label=\"loop_%d\"\n", h->block_num);
 	}
 
-	for (i = 1; i < cfg->num_bblocks; ++i) {
+	for (guint i = 1; i < cfg->num_bblocks; ++i) {
 		bb = cfg->bblocks [i];
 
 		if (!h || (g_list_find (h->loop_blocks, bb) && bb != h)) {

--- a/src/mono/mono/mini/helpers.c
+++ b/src/mono/mono/mini/helpers.c
@@ -91,7 +91,7 @@ void
 mono_blockset_print (MonoCompile *cfg, MonoBitSet *set, const char *name, guint idom)
 {
 #ifndef DISABLE_LOGGING
-	int i;
+	guint i;
 
 	if (name)
 		g_print ("%s:", name);

--- a/src/mono/mono/mini/ir-emit.h
+++ b/src/mono/mono/mini/ir-emit.h
@@ -969,7 +969,7 @@ mini_emit_bounds_check_offset (MonoCompile *cfg, int array_reg, int array_length
 		if (!(cfg->opt & MONO_OPT_ABCREM)) {
 			MONO_EMIT_NULL_CHECK (cfg, array_reg, FALSE);
 			if (COMPILE_LLVM (cfg))
-				MONO_EMIT_DEFAULT_BOUNDS_CHECK ((cfg), (array_reg), (array_length_offset), (index_reg), TRUE, ex_name);
+				MONO_EMIT_DEFAULT_BOUNDS_CHECK ((cfg), (array_reg), GINT_TO_UINT(array_length_offset), (index_reg), TRUE, ex_name);
 			else
 				MONO_ARCH_EMIT_BOUNDS_CHECK ((cfg), (array_reg), (array_length_offset), (index_reg), ex_name);
 		} else {

--- a/src/mono/mono/mini/linear-scan.c
+++ b/src/mono/mono/mini/linear-scan.c
@@ -206,7 +206,7 @@ mono_linear_scan (MonoCompile *cfg, GList *vars, GList *regs, regmask_t *used_ma
 		vmv = (MonoMethodVar *)l->data;
 
 		if (vmv->reg >= 0)  {
-			if ((gains [vmv->reg] > mono_arch_regalloc_cost (cfg, vmv)) && (cfg->varinfo [vmv->idx]->opcode != OP_REGVAR)) {
+			if ((GINT_TO_UINT32(gains [vmv->reg]) > mono_arch_regalloc_cost (cfg, vmv)) && (cfg->varinfo [vmv->idx]->opcode != OP_REGVAR)) {
 				if (cfg->verbose_level > 2) {
 					printf ("ALLOCATED R%d(%d) TO HREG %d COST %d\n", cfg->varinfo [vmv->idx]->dreg, vmv->idx, vmv->reg, vmv->spill_costs);
 				}
@@ -482,7 +482,7 @@ mono_linear_scan2 (MonoCompile *cfg, GList *vars, GList *regs, regmask_t *used_m
 			/* During allocation, vmv->reg is an index into the regs list */
 			vmv->reg = GPOINTER_TO_INT (g_list_nth_data (regs, vmv->reg));
 
-			if ((gains [reg_index] > regalloc_cost (cfg, vmv)) && (cfg->varinfo [vmv->idx]->opcode != OP_REGVAR)) {
+			if ((GINT_TO_UINT32(gains [reg_index]) > regalloc_cost (cfg, vmv)) && (cfg->varinfo [vmv->idx]->opcode != OP_REGVAR)) {
 				if (cfg->verbose_level > 2)
 					printf ("REGVAR R%d G%d C%d %s\n", cfg->varinfo [vmv->idx]->dreg, gains [reg_index], regalloc_cost (cfg, vmv), mono_arch_regname (vmv->reg));
 				cfg->varinfo [vmv->idx]->opcode = OP_REGVAR;

--- a/src/mono/mono/mini/lldb.c
+++ b/src/mono/mono/mini/lldb.c
@@ -416,7 +416,7 @@ mono_lldb_save_method_info (MonoCompile *cfg)
 	Buffer tmpbuf;
 	Buffer *buf = &tmpbuf;
 	MonoDebugMethodInfo *minfo;
-	int i, j, n_il_offsets;
+	int n_il_offsets;
 	int *source_files;
 	GPtrArray *source_file_list;
 	MonoSymSeqPoint *sym_seq_points;
@@ -466,17 +466,17 @@ mono_lldb_save_method_info (MonoCompile *cfg)
 	if (minfo && seq_points) {
 		mono_debug_get_seq_points (minfo, NULL, &source_file_list, &source_files, &sym_seq_points, &n_il_offsets);
 		buffer_add_int (buf, source_file_list->len);
-		for (i = 0; i < source_file_list->len; ++i) {
+		for (guint i = 0; i < source_file_list->len; ++i) {
 			MonoDebugSourceInfo *sinfo = (MonoDebugSourceInfo *)g_ptr_array_index (source_file_list, i);
 			buffer_add_string (buf, sinfo->source_file);
-			for (j = 0; j < 16; ++j)
+			for (guint j = 0; j < 16; ++j)
 				buffer_add_byte (buf, sinfo->hash [j]);
 		}
 
 		// The sym seq points are ordered by il offset, need to order them by address
 		int skipped = 0;
 		locs = g_new0 (FullSeqPoint, n_il_offsets);
-		for (i = 0; i < n_il_offsets; ++i) {
+		for (int i = 0; i < n_il_offsets; ++i) {
 			locs [i].sp = sym_seq_points [i];
 
 			// FIXME: O(n^2)
@@ -492,7 +492,7 @@ mono_lldb_save_method_info (MonoCompile *cfg)
 
 		n_il_offsets -= skipped;
 		buffer_add_int (buf, n_il_offsets);
-		for (i = 0; i < n_il_offsets; ++i) {
+		for (int i = 0; i < n_il_offsets; ++i) {
 			MonoSymSeqPoint *sp = &locs [i].sp;
 
 			//printf ("%s %x %d %d\n", cfg->method->name, locs [i].native_offset, sp->il_offset, sp->line);

--- a/src/mono/mono/mini/mini-amd64-gsharedvt.c
+++ b/src/mono/mono/mini/mini-amd64-gsharedvt.c
@@ -264,7 +264,6 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 	GSharedVtCallInfo *info;
 	CallInfo *caller_cinfo, *callee_cinfo;
 	MonoMethodSignature *caller_sig, *callee_sig;
-	int aindex, i;
 	gboolean var_ret = FALSE;
 	CallInfo *cinfo, *gcinfo;
 	MonoMethodSignature *sig;
@@ -318,7 +317,7 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 	 */
 	map = g_ptr_array_new ();
 
-	for (aindex = 0; aindex < cinfo->nargs; ++aindex) {
+	for (int aindex = 0; aindex < cinfo->nargs; ++aindex) {
 		ArgInfo *src_info = &caller_cinfo->args [aindex];
 		ArgInfo *dst_info = &callee_cinfo->args [aindex];
 		int *src = NULL, *dst = NULL;
@@ -398,7 +397,7 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 		nslots = MIN (nsrc, ndst);
 		DEBUG_AMD64_GSHAREDVT_PRINT ("nsrc %d ndst %d\n", nsrc, ndst);
 
-		for (i = 0; i < nslots; ++i)
+		for (int i = 0; i < nslots; ++i)
 			add_to_map (map, src [i], dst [i]);
 
 		g_free (src);
@@ -431,7 +430,7 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 
 #ifdef DEBUG_AMD64_GSHAREDVT
 	printf ("final map:\n");
-	for (i = 0; i < map->len; i += 2) {
+	for (guint i = 0; i < map->len; i += 2) {
 		printf ("\t[%d] src %x dst %x\n ",
 			i / 2,
 			GPOINTER_TO_UINT (g_ptr_array_index (map, i)),
@@ -441,7 +440,7 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 
 	info->vcall_offset = vcall_offset;
 	info->map_count = map->len / 2;
-	for (i = 0; i < map->len; ++i)
+	for (guint i = 0; i < map->len; ++i)
 		info->map [i] = GPOINTER_TO_UINT (g_ptr_array_index (map, i));
 	g_ptr_array_free (map, TRUE);
 

--- a/src/mono/mono/mini/mini-profiler.c
+++ b/src/mono/mono/mini/mini-profiler.c
@@ -41,7 +41,7 @@ emit_fill_call_ctx (MonoCompile *cfg, MonoInst *method, MonoInst *ret)
 	MONO_ADD_INS (cfg->cbb, args_alloc);
 	MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, alloc->dreg, MONO_STRUCT_OFFSET (MonoProfilerCallContext, args), args_alloc->dreg);
 
-	for (int i = 0; i < sig->hasthis + sig->param_count; ++i) {
+	for (guint i = 0; i < sig->hasthis + sig->param_count; ++i) {
 		NEW_VARLOADA (cfg, ins, cfg->args [i], cfg->args [i]->inst_vtype);
 		MONO_ADD_INS (cfg->cbb, ins);
 

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -1867,13 +1867,12 @@ void
 mini_init_gsctx (MonoMemPool *mp, MonoGenericContext *context, MonoGenericSharingContext *gsctx)
 {
 	MonoGenericInst *inst;
-	int i;
 
 	memset (gsctx, 0, sizeof (MonoGenericSharingContext));
 
 	if (context && context->class_inst) {
 		inst = context->class_inst;
-		for (i = 0; i < inst->type_argc; ++i) {
+		for (guint i = 0; i < inst->type_argc; ++i) {
 			MonoType *type = inst->type_argv [i];
 
 			if (mini_is_gsharedvt_gparam (type))
@@ -1883,7 +1882,7 @@ mini_init_gsctx (MonoMemPool *mp, MonoGenericContext *context, MonoGenericSharin
 	if (context && context->method_inst) {
 		inst = context->method_inst;
 
-		for (i = 0; i < inst->type_argc; ++i) {
+		for (guint i = 0; i < inst->type_argc; ++i) {
 			MonoType *type = inst->type_argv [i];
 
 			if (mini_is_gsharedvt_gparam (type))
@@ -2253,8 +2252,7 @@ unlock_compilation_data (void)
 static JitCompilationEntry*
 find_method (MonoMethod *method)
 {
-	int i;
-	for (i = 0; i < compilation_data.in_flight_methods->len; ++i){
+	for (guint i = 0; i < compilation_data.in_flight_methods->len; ++i){
 		JitCompilationEntry *e = (JitCompilationEntry*)compilation_data.in_flight_methods->pdata [i];
 		if (e->method == method)
 			return e;

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -5165,7 +5165,7 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 	if (mini_verbose > 0)
 		printf ("PRECOMPILE: %s.\n", mono_image_get_filename (image));
 
-	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < table_info_get_rows (&image->tables [MONO_TABLE_METHOD]); ++i) {
 		ERROR_DECL (error);
 
 		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
@@ -5197,7 +5197,7 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 	}
 
 	/* Load and precompile referenced assemblies as well */
-	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_ASSEMBLYREF); ++i) {
+	for (guint32 i = 0; i < table_info_get_rows (&image->tables [MONO_TABLE_ASSEMBLYREF]); ++i) {
 		mono_assembly_load_reference (image, i);
 		if (image->references [i])
 			mono_precompile_assembly (image->references [i], assemblies);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -5157,7 +5157,7 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 	GHashTable *assemblies = (GHashTable*)user_data;
 	MonoImage *image = mono_assembly_get_image_internal (ass);
 	MonoMethod *method, *invoke;
-	int i, count = 0;
+	int count = 0;
 
 	if (g_hash_table_lookup (assemblies, ass))
 		return;
@@ -5167,7 +5167,7 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 	if (mini_verbose > 0)
 		printf ("PRECOMPILE: %s.\n", mono_image_get_filename (image));
 
-	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
+	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
 		ERROR_DECL (error);
 
 		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
@@ -5199,7 +5199,7 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 	}
 
 	/* Load and precompile referenced assemblies as well */
-	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_ASSEMBLYREF); ++i) {
+	for (guint32 i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_ASSEMBLYREF); ++i) {
 		mono_assembly_load_reference (image, i);
 		if (image->references [i])
 			mono_precompile_assembly (image->references [i], assemblies);

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -4405,7 +4405,7 @@ mini_class_is_system_array (MonoClass *klass)
  *
  *   query pagesize used to determine if an implicit NRE can be used
  */
-int
+guint
 mono_target_pagesize (void)
 {
 	/* We could query the system's pagesize via mono_pagesize (), however there

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2208,7 +2208,7 @@ MonoInst* mono_emit_jit_icall_id (MonoCompile *cfg, MonoJitICallId jit_icall_id,
 MonoInst* mono_emit_jit_icall_by_info (MonoCompile *cfg, int il_offset, MonoJitICallInfo *info, MonoInst **args);
 MonoInst* mono_emit_method_call (MonoCompile *cfg, MonoMethod *method, MonoInst **args, MonoInst *this_ins);
 gboolean  mini_should_insert_breakpoint (MonoMethod *method);
-int mono_target_pagesize (void);
+guint     mono_target_pagesize (void);
 
 gboolean  mini_class_is_system_array (MonoClass *klass);
 

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1287,8 +1287,8 @@ typedef enum {
 
 #define vreg_is_volatile(cfg, vreg) (G_UNLIKELY (get_vreg_to_inst ((cfg), (vreg)) && (get_vreg_to_inst ((cfg), (vreg))->flags & (MONO_INST_VOLATILE|MONO_INST_INDIRECT))))
 
-#define vreg_is_ref(cfg, vreg) ((vreg) < (cfg)->vreg_is_ref_len ? (cfg)->vreg_is_ref [(vreg)] : 0)
-#define vreg_is_mp(cfg, vreg) ((vreg) < (cfg)->vreg_is_mp_len ? (cfg)->vreg_is_mp [(vreg)] : 0)
+#define vreg_is_ref(cfg, vreg) (GINT_TO_UINT32(vreg) < (cfg)->vreg_is_ref_len ? (cfg)->vreg_is_ref [(vreg)] : 0)
+#define vreg_is_mp(cfg, vreg) (GINT_TO_UINT32(vreg) < (cfg)->vreg_is_mp_len ? (cfg)->vreg_is_mp [(vreg)] : 0)
 
 /*
  * Control Flow Graph and compilation unit information

--- a/src/mono/mono/mini/monovm.c
+++ b/src/mono/mono/mini/monovm.c
@@ -113,7 +113,7 @@ mono_core_preload_hook (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, c
 	size_t basename_len;
 	basename_len = strlen (basename);
 
-	for (int i = 0; i < a->assembly_count; ++i) {
+	for (guint32 i = 0; i < a->assembly_count; ++i) {
 		if (basename_len == a->basename_lens [i] && !g_strncasecmp (basename, a->basenames [i], a->basename_lens [i])) {
 			MonoAssemblyOpenRequest req;
 			mono_assembly_request_prepare_open (&req, default_alc);

--- a/src/mono/mono/mini/seq-points.c
+++ b/src/mono/mono/mini/seq-points.c
@@ -104,7 +104,7 @@ mono_save_seq_point_info (MonoCompile *cfg, MonoJitInfo *jinfo)
 	MonoBasicBlock *bb;
 	GSList *bb_seq_points, *l;
 	MonoInst *last;
-	int i, seq_info_size;
+	int seq_info_size;
 	GSList **next = NULL;
 	SeqPoint* seq_points;
 	GByteArray* array;
@@ -115,7 +115,7 @@ mono_save_seq_point_info (MonoCompile *cfg, MonoJitInfo *jinfo)
 
 	seq_points = g_new0 (SeqPoint, cfg->seq_points->len);
 
-	for (i = 0; i < cfg->seq_points->len; ++i) {
+	for (guint i = 0; i < cfg->seq_points->len; ++i) {
 		SeqPoint *sp = &seq_points [i];
 		MonoInst *ins = (MonoInst *)g_ptr_array_index (cfg->seq_points, i);
 		sp->il_offset = GTMREG_TO_INT (ins->inst_imm);
@@ -185,7 +185,7 @@ mono_save_seq_point_info (MonoCompile *cfg, MonoJitInfo *jinfo)
 		if (cfg->verbose_level > 2) {
 			printf ("\nSEQ POINT MAP: \n");
 
-			for (i = 0; i < cfg->seq_points->len; ++i) {
+			for (guint i = 0; i < cfg->seq_points->len; ++i) {
 				SeqPoint *sp = &seq_points [i];
 
 				if (!next [i])
@@ -207,7 +207,7 @@ mono_save_seq_point_info (MonoCompile *cfg, MonoJitInfo *jinfo)
 		SeqPoint zero_seq_point = {0};
 		SeqPoint* last_seq_point = &zero_seq_point;
 
-		for (i = 0; i < cfg->seq_points->len; ++i) {
+		for (guint i = 0; i < cfg->seq_points->len; ++i) {
 			SeqPoint *sp = &seq_points [i];
 			GSList* next_list = NULL;
 

--- a/src/mono/mono/mini/unwind.c
+++ b/src/mono/mono/mini/unwind.c
@@ -393,7 +393,7 @@ guint8*
 mono_unwind_ops_encode_full (GSList *unwind_ops, guint32 *out_len, gboolean enable_extensions)
 {
 	MonoUnwindOp *op;
-	int loc = 0;
+	guint32 loc = 0;
 	guint8 buf [4096];
 	guint8 *p, *res;
 

--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -115,7 +115,7 @@ match_option (const char *arg, const char *opt_name, const char **rval)
 		if (!end)
 			return !strcmp (arg, opt_name);
 
-		if (strncmp (arg, opt_name, strlen (opt_name)) || (end - arg) > strlen (opt_name) + 1)
+		if (strncmp (arg, opt_name, strlen (opt_name)) || (end - arg) > GSIZE_TO_SSIZE(strlen (opt_name)) + 1)
 			return FALSE;
 		*rval = end + 1;
 		return TRUE;
@@ -526,12 +526,12 @@ add_type (MonoProfiler *prof, MonoType *type)
 static int
 add_ginst (MonoProfiler *prof, MonoGenericInst *inst)
 {
-	int i, id;
+	int id;
 	int *ids;
 
 	// FIXME: Cache
 	ids = g_malloc0 (inst->type_argc * sizeof (int));
-	for (i = 0; i < inst->type_argc; ++i) {
+	for (guint i = 0; i < inst->type_argc; ++i) {
 		MonoType *t = inst->type_argv [i];
 		ids [i] = add_type (prof, t);
 		if (ids [i] == -1) {
@@ -542,7 +542,7 @@ add_ginst (MonoProfiler *prof, MonoGenericInst *inst)
 	id = prof->id ++;
 	emit_record (prof, AOTPROF_RECORD_GINST, id);
 	emit_int32 (prof, inst->type_argc);
-	for (i = 0; i < inst->type_argc; ++i)
+	for (guint i = 0; i < inst->type_argc; ++i)
 		emit_int32 (prof, ids [i]);
 	g_free (ids);
 
@@ -631,7 +631,6 @@ prof_save (MonoProfiler *prof, FILE* file)
 	if (already_shutdown)
 		return;
 
-	int mindex;
 	char magic [32];
 
 	prof->buf_len = 4096;
@@ -645,7 +644,7 @@ prof_save (MonoProfiler *prof, FILE* file)
 
 	GHashTable *all_methods = g_hash_table_new (NULL, NULL);
 	mono_os_mutex_lock (&prof->mutex);
-	for (mindex = 0; mindex < prof->methods->len; ++mindex) {
+	for (guint mindex = 0; mindex < prof->methods->len; ++mindex) {
 	    MonoMethod *m = (MonoMethod*)g_ptr_array_index (prof->methods, mindex);
 
 		if (!mono_method_get_token (m))

--- a/src/mono/mono/utils/lock-free-alloc.c
+++ b/src/mono/mono/utils/lock-free-alloc.c
@@ -526,11 +526,11 @@ mono_lock_free_free (gpointer ptr, size_t block_size)
 static void
 descriptor_check_consistency (Descriptor *desc, gboolean print)
 {
-	int count = desc->anchor.data.count;
-	int max_count = LOCK_FREE_ALLOC_SB_USABLE_SIZE (desc->block_size) / desc->slot_size;
+	guint32 count = desc->anchor.data.count;
+	guint32 max_count = LOCK_FREE_ALLOC_SB_USABLE_SIZE (desc->block_size) / desc->slot_size;
 	gboolean* linked = g_newa (gboolean, max_count);
-	int i, last;
-	unsigned int index;
+	int last;
+	guint32 index;
 
 #ifndef DESC_AVAIL_DUMMY
 	Descriptor *avail;
@@ -564,12 +564,12 @@ descriptor_check_consistency (Descriptor *desc, gboolean print)
 		g_assert_OR_PRINT (FALSE, "invalid state\n");
 	}
 
-	for (i = 0; i < max_count; ++i)
+	for (guint32 i = 0; i < max_count; ++i)
 		linked [i] = FALSE;
 
 	index = desc->anchor.data.avail;
 	last = -1;
-	for (i = 0; i < count; ++i) {
+	for (guint32 i = 0; i < count; ++i) {
 		gpointer addr = (char*)desc->sb + index * desc->slot_size;
 		g_assert_OR_PRINT (index >= 0 && index < max_count,
 				"index %d for %dth available slot, linked from %d, not in range [0 .. %d)\n",

--- a/src/mono/mono/utils/mono-flight-recorder.c
+++ b/src/mono/mono/utils/mono-flight-recorder.c
@@ -35,7 +35,7 @@ mono_flight_recorder_iter_init (MonoFlightRecorder *recorder, MonoFlightRecorder
 	if (recorder->cursor == MONO_FLIGHT_RECORDER_SENTINEL) {
 		iter->lowest_index = MONO_FLIGHT_RECORDER_SENTINEL;
 		iter->highest_index = MONO_FLIGHT_RECORDER_SENTINEL;
-	} else if (recorder->cursor >= recorder->max_count) {
+	} else if (GINTPTR_TO_SIZE(recorder->cursor) >= recorder->max_count) {
 		// Ring buffer has wrapped around
 		// So the item *after* the highest index is the lowest index
 		iter->highest_index = (recorder->cursor + 1) % recorder->max_count;
@@ -62,14 +62,14 @@ mono_flight_recorder_iter_next (MonoFlightRecorderIter *iter, MonoFlightRecorder
 		return FALSE;
 
 	g_assert (iter->lowest_index >= 0);
-	g_assert (iter->lowest_index < iter->recorder->max_count);
+	g_assert (GINTPTR_TO_SIZE(iter->lowest_index) < iter->recorder->max_count);
 
 	// Reference to the variably-sized logging payload
 	memcpy (payload, (gpointer *) &iter->recorder->items [iter->lowest_index]->payload, iter->recorder->payload_size);
 	memcpy (header, (gpointer *) &iter->recorder->items [iter->lowest_index]->header, sizeof (MonoFlightRecorderHeader));
 	iter->lowest_index++;
 
-	if (iter->lowest_index >= iter->recorder->max_count)
+	if (GINTPTR_TO_SIZE(iter->lowest_index) >= iter->recorder->max_count)
 		iter->lowest_index = iter->lowest_index % iter->recorder->max_count;
 
 	return TRUE;

--- a/src/mono/mono/utils/mono-poll.c
+++ b/src/mono/mono/utils/mono-poll.c
@@ -62,7 +62,7 @@ int
 mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout)
 {
 	struct timeval tv, *tvptr;
-	int i, fd, events, affected, count;
+	int fd, events, affected, count;
 	fd_set rfds, wfds, efds;
 	int nexc = 0;
 	int maxfd = 0;
@@ -79,7 +79,7 @@ mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout)
 	FD_ZERO (&wfds);
 	FD_ZERO (&efds);
 
-	for (i = 0; i < nfds; i++) {
+	for (unsigned int i = 0; i < nfds; i++) {
 		ufds [i].revents = 0;
 		fd = ufds [i].fd;
 		if (fd < 0)
@@ -133,7 +133,7 @@ mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout)
 	}
 
 	count = 0;
-	for (i = 0; i < nfds && affected > 0; i++) {
+	for (unsigned int i = 0; i < nfds && affected > 0; i++) {
 		fd = ufds [i].fd;
 		if (fd < 0)
 			continue;

--- a/src/mono/mono/utils/monobitset.h
+++ b/src/mono/mono/utils/monobitset.h
@@ -34,9 +34,9 @@ enum {
 	do \
 	{ \
 		MonoBitSet *__set = (set); \
-		for (int __i = 0; __i < __set->size / MONO_BITSET_BITS_PER_CHUNK; __i++) { \
+		for (gsize __i = 0; __i < __set->size / MONO_BITSET_BITS_PER_CHUNK; __i++) { \
 			if (__set->data [__i]) { \
-				for (int __j = 0; __j < MONO_BITSET_BITS_PER_CHUNK; __j++) { \
+				for (gsize __j = 0; __j < MONO_BITSET_BITS_PER_CHUNK; __j++) { \
 					if (__set->data [__i] & ((gsize) 1 << __j)) { \
 						guint idx = __j + __i * MONO_BITSET_BITS_PER_CHUNK; \
 						__VA_ARGS__; \

--- a/src/mono/mono/utils/monobitset.h
+++ b/src/mono/mono/utils/monobitset.h
@@ -38,7 +38,7 @@ enum {
 			if (__set->data [__i]) { \
 				for (gsize __j = 0; __j < MONO_BITSET_BITS_PER_CHUNK; __j++) { \
 					if (__set->data [__i] & ((gsize) 1 << __j)) { \
-						guint idx = __j + __i * MONO_BITSET_BITS_PER_CHUNK; \
+						gsize idx = __j + __i * MONO_BITSET_BITS_PER_CHUNK; \
 						__VA_ARGS__; \
 					} \
 				} \

--- a/src/native/public/mono/metadata/details/image-functions.h
+++ b/src/native/public/mono/metadata/details/image-functions.h
@@ -30,9 +30,9 @@ MONO_API_FUNCTION(int, mono_image_ensure_section_idx, (MonoImage *image, int sec
 
 MONO_API_FUNCTION(uint32_t, mono_image_get_entry_point, (MonoImage *image))
 MONO_API_FUNCTION(const char *, mono_image_get_resource, (MonoImage *image, uint32_t offset, uint32_t *size))
-MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY MonoImage*, mono_image_load_file_for_image, (MonoImage *image, int fileidx))
+MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY MonoImage*, mono_image_load_file_for_image, (MonoImage *image, uint32_t fileidx))
 
-MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY MonoImage*, mono_image_load_module, (MonoImage *image, int idx))
+MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY MonoImage*, mono_image_load_module, (MonoImage *image, uint32_t idx))
 
 MONO_API_FUNCTION(const char*, mono_image_get_name, (MonoImage *image))
 MONO_API_FUNCTION(const char*, mono_image_get_filename, (MonoImage *image))

--- a/src/native/public/mono/metadata/details/image-functions.h
+++ b/src/native/public/mono/metadata/details/image-functions.h
@@ -30,9 +30,9 @@ MONO_API_FUNCTION(int, mono_image_ensure_section_idx, (MonoImage *image, int sec
 
 MONO_API_FUNCTION(uint32_t, mono_image_get_entry_point, (MonoImage *image))
 MONO_API_FUNCTION(const char *, mono_image_get_resource, (MonoImage *image, uint32_t offset, uint32_t *size))
-MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY MonoImage*, mono_image_load_file_for_image, (MonoImage *image, uint32_t fileidx))
+MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY MonoImage*, mono_image_load_file_for_image, (MonoImage *image, int fileidx))
 
-MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY MonoImage*, mono_image_load_module, (MonoImage *image, uint32_t idx))
+MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY MonoImage*, mono_image_load_module, (MonoImage *image, int idx))
 
 MONO_API_FUNCTION(const char*, mono_image_get_name, (MonoImage *image))
 MONO_API_FUNCTION(const char*, mono_image_get_filename, (MonoImage *image))
@@ -42,8 +42,8 @@ MONO_API_FUNCTION(mono_bool, mono_image_is_dynamic, (MonoImage *image))
 MONO_API_FUNCTION(char*, mono_image_rva_map, (MonoImage *image, uint32_t rva))
 
 MONO_API_FUNCTION(const MonoTableInfo *, mono_image_get_table_info, (MonoImage *image, int table_id))
-MONO_API_FUNCTION(uint32_t, mono_image_get_table_rows, (MonoImage *image, int table_id))
-MONO_API_FUNCTION(uint32_t, mono_table_info_get_rows, (const MonoTableInfo *table))
+MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY int, mono_image_get_table_rows, (MonoImage *image, int table_id))
+MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY int, mono_table_info_get_rows, (const MonoTableInfo *table))
 
 /* This actually returns a MonoPEResourceDataEntry *, but declaring it
  * causes an include file loop.

--- a/src/native/public/mono/metadata/details/image-functions.h
+++ b/src/native/public/mono/metadata/details/image-functions.h
@@ -42,8 +42,8 @@ MONO_API_FUNCTION(mono_bool, mono_image_is_dynamic, (MonoImage *image))
 MONO_API_FUNCTION(char*, mono_image_rva_map, (MonoImage *image, uint32_t rva))
 
 MONO_API_FUNCTION(const MonoTableInfo *, mono_image_get_table_info, (MonoImage *image, int table_id))
-MONO_API_FUNCTION(int, mono_image_get_table_rows, (MonoImage *image, int table_id))
-MONO_API_FUNCTION(int, mono_table_info_get_rows, (const MonoTableInfo *table))
+MONO_API_FUNCTION(uint32_t, mono_image_get_table_rows, (MonoImage *image, int table_id))
+MONO_API_FUNCTION(uint32_t, mono_table_info_get_rows, (const MonoTableInfo *table))
 
 /* This actually returns a MonoPEResourceDataEntry *, but declaring it
  * causes an include file loop.


### PR DESCRIPTION
Second portion of fixing C4018 warnings on Mono runtime x86/x64 Windows build, aligning with SDL requirements (https://github.com/dotnet/runtime/issues/66154).