### PR TITLE
Find&replace FastInterlock* with Interlocked*

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -903,7 +903,7 @@ OBJECTREF AppDomain::GetMissingObject()
         // Retrieve the value static field and store it.
         OBJECTHANDLE hndMissing = CreateHandle(pValueFD->GetStaticOBJECTREF());
 
-        if (FastInterlockCompareExchangePointer(&m_hndMissing, hndMissing, NULL) != NULL)
+        if (InterlockedCompareExchangeT(&m_hndMissing, hndMissing, NULL) != NULL)
         {
             // Exchanged failed. The m_hndMissing did not equal NULL and was returned.
             DestroyHandle(hndMissing);
@@ -2390,7 +2390,7 @@ void FileLoadLock::SetError(Exception *ex)
 void FileLoadLock::AddRef()
 {
     LIMITED_METHOD_CONTRACT;
-    FastInterlockIncrement((LONG *) &m_dwRefCount);
+    InterlockedIncrement((LONG *) &m_dwRefCount);
 }
 
 UINT32 FileLoadLock::Release()
@@ -2403,7 +2403,7 @@ UINT32 FileLoadLock::Release()
     }
     CONTRACTL_END;
 
-    LONG count = FastInterlockDecrement((LONG *) &m_dwRefCount);
+    LONG count = InterlockedDecrement((LONG *) &m_dwRefCount);
     if (count == 0)
         delete this;
 
@@ -4034,7 +4034,7 @@ RCWRefCache *AppDomain::GetRCWRefCache()
 
     if (!m_pRCWRefCache) {
         NewHolder<RCWRefCache> pRCWRefCache = new RCWRefCache(this);
-        if (FastInterlockCompareExchangePointer(&m_pRCWRefCache, (RCWRefCache *)pRCWRefCache, NULL) == NULL)
+        if (InterlockedCompareExchangeT(&m_pRCWRefCache, (RCWRefCache *)pRCWRefCache, NULL) == NULL)
         {
             pRCWRefCache.SuppressRelease();
         }

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -2001,14 +2001,14 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(m_dwIterHolders);
-        FastInterlockDecrement(&m_dwIterHolders);
+        InterlockedDecrement(&m_dwIterHolders);
     }
 
 
     void IteratorAcquire()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockIncrement(&m_dwIterHolders);
+        InterlockedIncrement(&m_dwIterHolders);
     }
 
 #endif
@@ -2152,7 +2152,7 @@ private:
         STRESS_LOG1(LF_APPDOMAIN, LL_INFO100,"Updating AD stage, stage=%d\n",stage);
         Stage lastStage=m_Stage;
         while (lastStage !=stage)
-            lastStage = (Stage)FastInterlockCompareExchange((LONG*)&m_Stage,stage,lastStage);
+            lastStage = (Stage)InterlockedCompareExchange((LONG*)&m_Stage,stage,lastStage);
     };
 
     // List of unloaded LoaderAllocators, protected by code:GetLoaderAllocatorReferencesLock (for now)

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -1064,7 +1064,7 @@ struct ThisPtrRetBufPrecode {
         CONTRACTL_END;
 
         ExecutableWriterHolder<ThisPtrRetBufPrecode> precodeWriterHolder(this, sizeof(ThisPtrRetBufPrecode));
-        return FastInterlockCompareExchange((LONG*)&precodeWriterHolder.GetRW()->m_pTarget, (LONG)target, (LONG)expected) == (LONG)expected;
+        return InterlockedCompareExchange((LONG*)&precodeWriterHolder.GetRW()->m_pTarget, (LONG)target, (LONG)expected) == (LONG)expected;
     }
 #endif // !DACCESS_COMPILE
 };

--- a/src/coreclr/vm/array.cpp
+++ b/src/coreclr/vm/array.cpp
@@ -1183,7 +1183,7 @@ public:
         if (s_pArrayStubCache == NULL)
         {
             ArrayStubCache * pArrayStubCache = new ArrayStubCache(SystemDomain::GetGlobalLoaderAllocator()->GetStubHeap());
-            if (FastInterlockCompareExchangePointer(&s_pArrayStubCache, pArrayStubCache, NULL) != NULL)
+            if (InterlockedCompareExchangeT(&s_pArrayStubCache, pArrayStubCache, NULL) != NULL)
                 delete pArrayStubCache;
         }
 

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -195,7 +195,7 @@ void Assembly::Init(AllocMemTracker *pamTracker, LoaderAllocator *pLoaderAllocat
     else
         m_pModule = Module::Create(this, mdFileNil, pPEAssembly, pamTracker);
 
-    FastInterlockIncrement((LONG*)&g_cAssemblies);
+    InterlockedIncrement((LONG*)&g_cAssemblies);
 
     PrepareModuleForAssembly(m_pModule, pamTracker);
 
@@ -312,7 +312,7 @@ void Assembly::Terminate( BOOL signalProfiler )
         m_pClassLoader = NULL;
     }
 
-    FastInterlockDecrement((LONG*)&g_cAssemblies);
+    InterlockedDecrement((LONG*)&g_cAssemblies);
 
 #ifdef PROFILING_SUPPORTED
     if (CORProfilerTrackAssemblyLoads())
@@ -1084,7 +1084,7 @@ void Assembly::PublishModuleIntoAssembly(Module *module)
     CONTRACTL_END
 
     GetModule()->EnsuredStoreFile(module->GetModuleRef(), module);
-    FastInterlockIncrement((LONG*)&m_pClassLoader->m_cUnhashedModules);
+    InterlockedIncrement((LONG*)&m_pClassLoader->m_cUnhashedModules);
 }
 
 

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -178,7 +178,7 @@ BOOL Module::SetTransientFlagInterlocked(DWORD dwFlag)
         DWORD dwTransientFlags = m_dwTransientFlags;
         if ((dwTransientFlags & dwFlag) != 0)
             return FALSE;
-        if ((DWORD)FastInterlockCompareExchange((LONG*)&m_dwTransientFlags, dwTransientFlags | dwFlag, dwTransientFlags) == dwTransientFlags)
+        if ((DWORD)InterlockedCompareExchange((LONG*)&m_dwTransientFlags, dwTransientFlags | dwFlag, dwTransientFlags) == dwTransientFlags)
             return TRUE;
     }
 }
@@ -434,7 +434,7 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
 #ifdef FEATURE_COLLECTIBLE_TYPES
     if (GetAssembly()->IsCollectible())
     {
-        FastInterlockOr(&m_dwPersistedFlags, COLLECTIBLE_MODULE);
+        InterlockedOr((LONG*)&m_dwPersistedFlags, COLLECTIBLE_MODULE);
     }
 #endif // FEATURE_COLLECTIBLE_TYPES
 
@@ -962,7 +962,7 @@ MethodTable *Module::GetGlobalMethodTable()
                                                    ClassLoader::FailIfUninstDefOrRef).AsMethodTable();
         }
 
-        FastInterlockOr(&m_dwPersistedFlags, COMPUTED_GLOBAL_CLASS);
+        InterlockedOr((LONG*)&m_dwPersistedFlags, COMPUTED_GLOBAL_CLASS);
         RETURN pMT;
     }
     else
@@ -1580,11 +1580,11 @@ BOOL Module::HasDefaultDllImportSearchPathsAttribute()
     attributeIsFound = GetDefaultDllImportSearchPathsAttributeValue(this, TokenFromRid(1, mdtAssembly),&m_DefaultDllImportSearchPathsAttributeValue);
     if(attributeIsFound)
     {
-        FastInterlockOr(&m_dwPersistedFlags, DEFAULT_DLL_IMPORT_SEARCH_PATHS_IS_CACHED | DEFAULT_DLL_IMPORT_SEARCH_PATHS_STATUS);
+        InterlockedOr((LONG*)&m_dwPersistedFlags, DEFAULT_DLL_IMPORT_SEARCH_PATHS_IS_CACHED | DEFAULT_DLL_IMPORT_SEARCH_PATHS_STATUS);
     }
     else
     {
-        FastInterlockOr(&m_dwPersistedFlags, DEFAULT_DLL_IMPORT_SEARCH_PATHS_IS_CACHED);
+        InterlockedOr((LONG*)&m_dwPersistedFlags, DEFAULT_DLL_IMPORT_SEARCH_PATHS_IS_CACHED);
     }
 
     return (m_dwPersistedFlags & DEFAULT_DLL_IMPORT_SEARCH_PATHS_STATUS) != 0 ;
@@ -1644,7 +1644,7 @@ BOOL Module::IsRuntimeWrapExceptions()
                 fRuntimeWrapExceptions = TRUE;
         }
 ErrExit:
-        FastInterlockOr(&m_dwPersistedFlags, COMPUTED_WRAP_EXCEPTIONS |
+        InterlockedOr((LONG*)&m_dwPersistedFlags, COMPUTED_WRAP_EXCEPTIONS |
             (fRuntimeWrapExceptions ? WRAP_EXCEPTIONS : 0));
     }
 
@@ -1681,7 +1681,7 @@ BOOL Module::IsRuntimeMarshallingEnabled()
                         (const void**)&pVal, &cbVal);
     }
 
-    FastInterlockOr(&m_dwPersistedFlags, RUNTIME_MARSHALLING_ENABLED_IS_CACHED |
+    InterlockedOr((LONG*)&m_dwPersistedFlags, RUNTIME_MARSHALLING_ENABLED_IS_CACHED |
         (hr == S_OK ? 0 : RUNTIME_MARSHALLING_ENABLED));
 
     return hr != S_OK;
@@ -1712,7 +1712,7 @@ BOOL Module::IsPreV4Assembly()
             }
         }
 
-        FastInterlockOr(&m_dwPersistedFlags, COMPUTED_IS_PRE_V4_ASSEMBLY |
+        InterlockedOr((LONG*)&m_dwPersistedFlags, COMPUTED_IS_PRE_V4_ASSEMBLY |
             (fIsPreV4Assembly ? IS_PRE_V4_ASSEMBLY : 0));
     }
 
@@ -1731,7 +1731,7 @@ DWORD Module::AllocateDynamicEntry(MethodTable *pMT)
     }
     CONTRACTL_END;
 
-    DWORD newId = FastInterlockExchangeAdd((LONG*)&m_cDynamicEntries, 1);
+    DWORD newId = InterlockedExchangeAdd((LONG*)&m_cDynamicEntries, 1);
 
     if (newId >= VolatileLoad(&m_maxDynamicEntries))
     {
@@ -2123,7 +2123,7 @@ void Module::FreeClassTables()
     if (m_dwTransientFlags & CLASSES_FREED)
         return;
 
-    FastInterlockOr(&m_dwTransientFlags, CLASSES_FREED);
+    InterlockedOr((LONG*)&m_dwTransientFlags, CLASSES_FREED);
 
 #if _DEBUG
     DebugLogRidMapOccupancy();
@@ -2698,7 +2698,7 @@ ILStubCache* Module::GetILStubCache()
     {
         ILStubCache *pILStubCache = new ILStubCache(GetLoaderAllocator()->GetHighFrequencyHeap());
 
-        if (FastInterlockCompareExchangePointer(&m_pILStubCache, pILStubCache, NULL) != NULL)
+        if (InterlockedCompareExchangeT(&m_pILStubCache, pILStubCache, NULL) != NULL)
         {
             // some thread swooped in and set the field
             delete pILStubCache;
@@ -4398,7 +4398,7 @@ LoaderHeap *Module::GetThunkHeap()
             ThunkHeapStubManager::g_pManager->GetRangeList(),
             UnlockedLoaderHeap::HeapKind::Executable);
 
-        if (FastInterlockCompareExchangePointer(&m_pThunkHeap, pNewHeap, 0) != 0)
+        if (InterlockedCompareExchangeT(&m_pThunkHeap, pNewHeap, 0) != 0)
         {
             delete pNewHeap;
         }
@@ -4732,7 +4732,7 @@ void SaveManagedCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv)
 void Module::SetIsIJWFixedUp()
 {
     LIMITED_METHOD_CONTRACT;
-    FastInterlockOr(&m_dwTransientFlags, IS_IJW_FIXED_UP);
+    InterlockedOr((LONG*)&m_dwTransientFlags, IS_IJW_FIXED_UP);
 }
 #endif // !DACCESS_COMPILE
 
@@ -4740,7 +4740,7 @@ void Module::SetIsIJWFixedUp()
 void Module::SetBeingUnloaded()
 {
     LIMITED_METHOD_CONTRACT;
-    FastInterlockOr((ULONG*)&m_dwTransientFlags, IS_BEING_UNLOADED);
+    InterlockedOr((LONG*)&m_dwTransientFlags, IS_BEING_UNLOADED);
 }
 
 // ===========================================================================

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -891,7 +891,7 @@ protected:
     VOID SetIsTenured()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockOr(&m_dwTransientFlags, MODULE_IS_TENURED);
+        InterlockedOr((LONG*)&m_dwTransientFlags, MODULE_IS_TENURED);
     }
 #endif // !DACCESS_COMPILE
 
@@ -909,7 +909,7 @@ protected:
     VOID SetIsReadyForTypeLoad()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockOr(&m_dwTransientFlags, MODULE_READY_FOR_TYPELOAD);
+        InterlockedOr((LONG*)&m_dwTransientFlags, MODULE_READY_FOR_TYPELOAD);
     }
 #endif
 

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1528,7 +1528,7 @@ void STDMETHODCALLTYPE EEShutDown(BOOL fIsDllUnloading)
 
     if (!fIsDllUnloading)
     {
-        if (FastInterlockIncrement(&OnlyOne) != 0)
+        if (InterlockedIncrement(&OnlyOne) != 0)
         {
             // I'm in a regular shutdown -- but another thread got here first.
             // It's a race if I return from here -- I'll call ExitProcess next, and

--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -2192,7 +2192,7 @@ void EEClass::GetBestFitMapping(MethodTable * pMT, BOOL *pfBestFitMapping, BOOL 
         if (*pfBestFitMapping) flags |= VMFLAG_BESTFITMAPPING;
         if (*pfThrowOnUnmappableChar) flags |= VMFLAG_THROWONUNMAPPABLECHAR;
 
-        FastInterlockOr(&pClass->m_VMFlags, flags);
+        InterlockedOr((LONG*)&pClass->m_VMFlags, flags);
     }
     else
     {

--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -1198,7 +1198,7 @@ public:
     inline void SetHasNoGuid()
     {
         WRAPPER_NO_CONTRACT;
-        FastInterlockOr(&m_VMFlags, VMFLAG_NO_GUID);
+        InterlockedOr((LONG*)&m_VMFlags, VMFLAG_NO_GUID);
     }
 
 public:

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -894,7 +894,7 @@ void ClassLoader::LazyPopulateCaseInsensitiveHashTables()
 
             amTracker.SuppressRelease();
             pModule->SetAvailableClassCaseInsHash(pNewClassCaseInsHash);
-            FastInterlockDecrement((LONG*)&m_cUnhashedModules);
+            InterlockedDecrement((LONG*)&m_cUnhashedModules);
 
             _ASSERT(m_cUnhashedModules >= 0);
         }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -654,7 +654,7 @@ ExecutionManager::ReaderLockHolder::ReaderLockHolder(HostCallPreference hostCall
 
     IncCantAllocCount();
 
-    FastInterlockIncrement(&m_dwReaderCount);
+    InterlockedIncrement(&m_dwReaderCount);
 
     EE_LOCK_TAKEN(GetPtrForLockContract());
 
@@ -687,7 +687,7 @@ ExecutionManager::ReaderLockHolder::~ReaderLockHolder()
     }
     CONTRACTL_END;
 
-    FastInterlockDecrement(&m_dwReaderCount);
+    InterlockedDecrement(&m_dwReaderCount);
     DecCantAllocCount();
 
     EE_LOCK_RELEASED(GetPtrForLockContract());
@@ -725,10 +725,10 @@ ExecutionManager::WriterLockHolder::WriterLockHolder()
         // or allow a profiler to walk its stack
         Thread::IncForbidSuspendThread();
 
-        FastInterlockIncrement(&m_dwWriterLock);
+        InterlockedIncrement(&m_dwWriterLock);
         if (m_dwReaderCount == 0)
             break;
-        FastInterlockDecrement(&m_dwWriterLock);
+        InterlockedDecrement(&m_dwWriterLock);
 
         // Before we loop and retry, it's safe to suspend or hijack and inspect
         // this thread
@@ -743,7 +743,7 @@ ExecutionManager::WriterLockHolder::~WriterLockHolder()
 {
     LIMITED_METHOD_CONTRACT;
 
-    FastInterlockDecrement(&m_dwWriterLock);
+    InterlockedDecrement(&m_dwWriterLock);
 
     // Writer lock released, so it's safe again for this thread to be
     // suspended or have its stack walked by a profiler

--- a/src/coreclr/vm/codepitchingmanager.cpp
+++ b/src/coreclr/vm/codepitchingmanager.cpp
@@ -78,7 +78,7 @@ static void CreateRWLock(SimpleRWLock** lock)
         void *pLockSpace = SystemDomain::GetGlobalLoaderAllocator()->GetLowFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(SimpleRWLock)));
         SimpleRWLock *pLock = new (pLockSpace) SimpleRWLock(COOPERATIVE_OR_PREEMPTIVE, LOCK_TYPE_DEFAULT);
 
-        if (FastInterlockCompareExchangePointer(lock, pLock, NULL) != NULL)
+        if (InterlockedCompareExchangeT(lock, pLock, NULL) != NULL)
             SystemDomain::GetGlobalLoaderAllocator()->GetLowFrequencyHeap()->BackoutMem(pLockSpace, sizeof(SimpleRWLock));
     }
 }

--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -110,7 +110,7 @@ NativeCodeVersionId NativeCodeVersionNode::GetVersionId() const
 BOOL NativeCodeVersionNode::SetNativeCodeInterlocked(PCODE pCode, PCODE pExpected)
 {
     LIMITED_METHOD_CONTRACT;
-    return FastInterlockCompareExchangePointer(&m_pNativeCode,
+    return InterlockedCompareExchangeT(&m_pNativeCode,
         (TADDR&)pCode, (TADDR&)pExpected) == (TADDR&)pExpected;
 }
 #endif

--- a/src/coreclr/vm/comcache.cpp
+++ b/src/coreclr/vm/comcache.cpp
@@ -1100,7 +1100,7 @@ HRESULT IUnkEntry::MarshalIUnknownToStream()
 
     // Try to set the stream in the IUnkEntry. If another thread already set it,
     // then we need to release the stream we just set up.
-    if (FastInterlockCompareExchangePointer(&m_pStream, pStream, NULL) != NULL)
+    if (InterlockedCompareExchangeT(&m_pStream, pStream, NULL) != NULL)
         SafeReleaseStream(pStream);
 
     return hr;
@@ -1248,7 +1248,7 @@ DWORD CtxEntry::AddRef()
     }
     CONTRACTL_END;
 
-    ULONG cbRef = FastInterlockIncrement((LONG*)&m_dwRefCount);
+    ULONG cbRef = InterlockedIncrement((LONG*)&m_dwRefCount);
     LOG((LF_INTEROP, LL_INFO100, "CtxEntry::Addref %8.8x with %d\n", this, cbRef));
     return cbRef;
 }
@@ -1269,7 +1269,7 @@ DWORD CtxEntry::Release()
 
     LPVOID pCtxCookie = m_pCtxCookie;
 
-    LONG cbRef = FastInterlockDecrement((LONG*)&m_dwRefCount);
+    LONG cbRef = InterlockedDecrement((LONG*)&m_dwRefCount);
     LOG((LF_INTEROP, LL_INFO100, "CtxEntry::Release %8.8x with %d\n", this, cbRef));
 
     // If the ref count falls to 0, try and delete the ctx entry.

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -991,7 +991,7 @@ BOOL SimpleComCallWrapper::CustomQIRespondsToIMarshal()
         {
             newFlags |= enum_CustomQIRespondsToIMarshal;
         }
-        FastInterlockOr((ULONG *)&m_flags, newFlags);
+        InterlockedOr((LONG*)&m_flags, newFlags);
     }
 
     return (m_flags & enum_CustomQIRespondsToIMarshal);
@@ -1034,7 +1034,7 @@ void SimpleComCallWrapper::InitDispatchExInfo()
     pDispExInfo->SynchWithManagedView();
 
     // Swap the lock into the class member in a thread safe manner.
-    if (NULL == FastInterlockCompareExchangePointer(&pAuxData->m_pDispatchExInfo, pDispExInfo.GetValue(), NULL))
+    if (NULL == InterlockedCompareExchangeT(&pAuxData->m_pDispatchExInfo, pDispExInfo.GetValue(), NULL))
         pDispExInfo.SuppressRelease();
 
     // Set the vtable entry to ensure that the next QI call will return immediately.
@@ -2083,7 +2083,7 @@ void ComCallWrapper::ClearHandle()
     WRAPPER_NO_CONTRACT;
 
     OBJECTHANDLE pThis = m_ppThis;
-    if (FastInterlockCompareExchangePointer(&m_ppThis, NULL, pThis) == pThis)
+    if (InterlockedCompareExchangeT(&m_ppThis, NULL, pThis) == pThis)
     {
         DestroyRefcountedHandle(pThis);
     }
@@ -3068,7 +3068,7 @@ LONG ComCallWrapperCache::AddRef()
     }
     CONTRACTL_END;
 
-    LONG i = FastInterlockIncrement(&m_cbRef);
+    LONG i = InterlockedIncrement(&m_cbRef);
     LOG((LF_INTEROP, LL_INFO100, "ComCallWrapperCache::Addref %8.8x with %d in loader allocator [%d] %8.8x\n",
         this, i, GetLoaderAllocator()?GetLoaderAllocator()->GetCreationNumber() : 0, GetLoaderAllocator()));
 
@@ -3089,7 +3089,7 @@ LONG ComCallWrapperCache::Release()
     }
     CONTRACTL_END;
 
-    LONG i = FastInterlockDecrement(&m_cbRef);
+    LONG i = InterlockedDecrement(&m_cbRef);
     _ASSERTE(i >= 0);
 
     LOG((LF_INTEROP, LL_INFO100, "ComCallWrapperCache::Release %8.8x with %d in loader allocator [%d] %8.8x\n",
@@ -3790,7 +3790,7 @@ void ComMethodTable::LayOutBasicMethodTable()
     //
     // Set the layout complete flag.
     //
-    FastInterlockOr((DWORD *)&m_Flags, enum_LayoutComplete);
+    InterlockedOr((LONG*)&m_Flags, enum_LayoutComplete);
 
     LOG((LF_INTEROP, LL_INFO1000, "LayOutClassMethodTable: %s, this: %p  [DONE]\n", m_pMT->GetDebugClassName(), this));
 }
@@ -3821,7 +3821,7 @@ DispatchInfo *ComMethodTable::GetDispatchInfo()
 
         ExecutableWriterHolder<ComMethodTable> comMTWriterHolder(this, sizeof(ComMethodTable));
         // Swap the lock into the class member in a thread safe manner.
-        if (NULL == FastInterlockCompareExchangePointer(&comMTWriterHolder.GetRW()->m_pDispatchInfo, pDispInfo.GetValue(), NULL))
+        if (NULL == InterlockedCompareExchangeT(&comMTWriterHolder.GetRW()->m_pDispatchInfo, pDispInfo.GetValue(), NULL))
             pDispInfo.SuppressRelease();
 
     }
@@ -4140,7 +4140,7 @@ BOOL ComCallWrapperTemplate::IsSafeTypeForMarshalling()
 
     if (isSafe)
     {
-        FastInterlockOr(&m_flags, enum_IsSafeTypeForMarshalling);
+        InterlockedOr((LONG*)&m_flags, enum_IsSafeTypeForMarshalling);
     }
 
     return isSafe;
@@ -4212,7 +4212,7 @@ DefaultInterfaceType ComCallWrapperTemplate::GetDefaultInterface(MethodTable **p
         _ASSERTE(th.IsNull() || !th.IsTypeDesc());
         m_pDefaultItf = th.AsMethodTable();
 
-        FastInterlockOr(&m_flags, enum_DefaultInterfaceTypeComputed | (DWORD)defItfType);
+        InterlockedOr((LONG*)&m_flags, enum_DefaultInterfaceTypeComputed | (DWORD)defItfType);
     }
 
     *ppDefaultItf = m_pDefaultItf;

--- a/src/coreclr/vm/comcallablewrapper.h
+++ b/src/coreclr/vm/comcallablewrapper.h
@@ -1249,14 +1249,14 @@ public:
     {
         WRAPPER_NO_CONTRACT;
 
-        FastInterlockOr((ULONG*)&m_flags, enum_IsAggregated);
+        InterlockedOr((LONG*)&m_flags, enum_IsAggregated);
     }
 
     void UnMarkAggregated()
     {
         WRAPPER_NO_CONTRACT;
 
-        FastInterlockAnd((ULONG*)&m_flags, ~enum_IsAggregated);
+        InterlockedAnd((LONG*)&m_flags, ~enum_IsAggregated);
     }
 
     BOOL IsHandleWeak()
@@ -1270,14 +1270,14 @@ public:
     {
         WRAPPER_NO_CONTRACT;
 
-        FastInterlockOr((ULONG*)&m_flags, enum_IsHandleWeak);
+        InterlockedOr((LONG*)&m_flags, enum_IsHandleWeak);
     }
 
     VOID ResetHandleStrength()
     {
         WRAPPER_NO_CONTRACT;
 
-        FastInterlockAnd((ULONG*)&m_flags, ~enum_IsHandleWeak);
+        InterlockedAnd((LONG*)&m_flags, ~enum_IsHandleWeak);
     }
 
     // is the object extends from (aggregates) a COM component
@@ -1297,7 +1297,7 @@ public:
     void MarkComActivated()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockOr((ULONG*)&m_flags, enum_IsComActivated);
+        InterlockedOr((LONG*)&m_flags, enum_IsComActivated);
     }
 
     // Determines if the type associated with the ComCallWrapper supports exceptions.

--- a/src/coreclr/vm/comconnectionpoints.cpp
+++ b/src/coreclr/vm/comconnectionpoints.cpp
@@ -822,7 +822,7 @@ ULONG __stdcall ConnectionPointEnum::AddRef()
 
     SetupForComCallHR();
 
-    LONG i = FastInterlockIncrement((LONG*)&m_cbRefCount );
+    LONG i = InterlockedIncrement((LONG*)&m_cbRefCount );
     return i;
 }
 
@@ -843,7 +843,7 @@ ULONG __stdcall ConnectionPointEnum::Release()
 
     BEGIN_EXTERNAL_ENTRYPOINT(&hr)
     {
-        cbRef = FastInterlockDecrement((LONG*)&m_cbRefCount );
+        cbRef = InterlockedDecrement((LONG*)&m_cbRefCount );
         _ASSERTE(cbRef >=0);
         if (cbRef == 0)
             delete this;
@@ -1063,7 +1063,7 @@ ULONG __stdcall ConnectionEnum::AddRef()
 
     SetupForComCallHR();
 
-    LONG i = FastInterlockIncrement((LONG*)&m_cbRefCount);
+    LONG i = InterlockedIncrement((LONG*)&m_cbRefCount);
     return i;
 }
 
@@ -1079,7 +1079,7 @@ ULONG __stdcall ConnectionEnum::Release()
 
     SetupForComCallHR();
 
-    LONG i = FastInterlockDecrement((LONG*)&m_cbRefCount);
+    LONG i = InterlockedDecrement((LONG*)&m_cbRefCount);
     _ASSERTE(i >=0);
     if (i == 0)
         delete this;

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -834,7 +834,7 @@ Stub* COMDelegate::SetupShuffleThunk(MethodTable * pDelMT, MethodDesc *pTargetMe
 
     if (!pTargetMeth->IsStatic() && pTargetMeth->HasRetBuffArg() && IsRetBuffPassedAsFirstArg())
     {
-        if (FastInterlockCompareExchangePointer(&pClass->m_pInstRetBuffCallStub, pShuffleThunk, NULL ) != NULL)
+        if (InterlockedCompareExchangeT(&pClass->m_pInstRetBuffCallStub, pShuffleThunk, NULL ) != NULL)
         {
             ExecutableWriterHolder<Stub> shuffleThunkWriterHolder(pShuffleThunk, sizeof(Stub));
             shuffleThunkWriterHolder.GetRW()->DecRef();
@@ -843,7 +843,7 @@ Stub* COMDelegate::SetupShuffleThunk(MethodTable * pDelMT, MethodDesc *pTargetMe
     }
     else
     {
-        if (FastInterlockCompareExchangePointer(&pClass->m_pStaticCallStub, pShuffleThunk, NULL ) != NULL)
+        if (InterlockedCompareExchangeT(&pClass->m_pStaticCallStub, pShuffleThunk, NULL ) != NULL)
         {
             ExecutableWriterHolder<Stub> shuffleThunkWriterHolder(pShuffleThunk, sizeof(Stub));
             shuffleThunkWriterHolder.GetRW()->DecRef();
@@ -1273,7 +1273,7 @@ LPVOID COMDelegate::ConvertToCallback(OBJECTREF pDelegateObj)
                 ExecutableWriterHolder<UMThunkMarshInfo> uMThunkMarshInfoWriterHolder(pUMThunkMarshInfo, sizeof(UMThunkMarshInfo));
                 uMThunkMarshInfoWriterHolder.GetRW()->LoadTimeInit(pInvokeMeth);
 
-                if (FastInterlockCompareExchangePointer(&(pClass->m_pUMThunkMarshInfo),
+                if (InterlockedCompareExchangeT(&(pClass->m_pUMThunkMarshInfo),
                                                         pUMThunkMarshInfo,
                                                         NULL ) != NULL)
                 {

--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -295,7 +295,7 @@ void ThreadNative::Start(Thread* pNewThread, int threadStackSize, int priority, 
     pNewThread->SetThreadPriority(MapToNTPriority(priority));
     pNewThread->ChooseThreadCPUGroupAffinity();
 
-    FastInterlockOr((ULONG *) &pNewThread->m_State, Thread::TS_LegalToJoin);
+    pNewThread->SetThreadState(Thread::TS_LegalToJoin);
 
     DWORD ret = pNewThread->StartThread();
 

--- a/src/coreclr/vm/comtoclrcall.cpp
+++ b/src/coreclr/vm/comtoclrcall.cpp
@@ -868,7 +868,7 @@ void ComCallMethodDesc::InitRuntimeNativeInfo(MethodDesc *pStubMD)
     comCallMDWriterHolder.GetRW()->m_dwSlotInfo = (wSourceSlotEDX | (wStubStackSlotCount << 16));
     if (pwStubStackSlotOffsets != NULL)
     {
-        if (FastInterlockCompareExchangePointer(&comCallMDWriterHolder.GetRW()->m_pwStubStackSlotOffsets, pwStubStackSlotOffsets.GetValue(), NULL) == NULL)
+        if (InterlockedCompareExchangeT(&comCallMDWriterHolder.GetRW()->m_pwStubStackSlotOffsets, pwStubStackSlotOffsets.GetValue(), NULL) == NULL)
         {
             pwStubStackSlotOffsets.SuppressRelease();
         }

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -987,7 +987,7 @@ FCIMPL1(INT64, GCInterface::GetTotalAllocatedBytes, CLR_BOOL precise)
 #else
         // As it could be noticed we read 64bit values that may be concurrently updated.
         // Such reads are not guaranteed to be atomic on 32bit so extra care should be taken.
-        uint64_t unused_bytes = FastInterlockCompareExchangeLong((LONG64*)& Thread::dead_threads_non_alloc_bytes, 0, 0);
+        uint64_t unused_bytes = InterlockedCompareExchange64((LONG64*)& Thread::dead_threads_non_alloc_bytes, 0, 0);
 #endif
 
         uint64_t allocated_bytes = GCHeapUtilities::GetGCHeap()->GetTotalAllocatedBytes() - unused_bytes;
@@ -998,7 +998,7 @@ FCIMPL1(INT64, GCInterface::GetTotalAllocatedBytes, CLR_BOOL precise)
         uint64_t current_high = high_watermark;
         while (allocated_bytes > current_high)
         {
-            uint64_t orig = FastInterlockCompareExchangeLong((LONG64*)& high_watermark, allocated_bytes, current_high);
+            uint64_t orig = InterlockedCompareExchange64((LONG64*)& high_watermark, allocated_bytes, current_high);
             if (orig == current_high)
                 return allocated_bytes;
 
@@ -1402,7 +1402,7 @@ FCIMPL2(INT32,COMInterlocked::Exchange, INT32 *location, INT32 value)
         FCThrow(kNullReferenceException);
     }
 
-    return FastInterlockExchange((LONG *) location, value);
+    return InterlockedExchange((LONG *) location, value);
 }
 FCIMPLEND
 
@@ -1414,7 +1414,7 @@ FCIMPL2_IV(INT64,COMInterlocked::Exchange64, INT64 *location, INT64 value)
         FCThrow(kNullReferenceException);
     }
 
-    return FastInterlockExchangeLong((INT64 *) location, value);
+    return InterlockedExchange64((INT64 *) location, value);
 }
 FCIMPLEND
 
@@ -1426,7 +1426,7 @@ FCIMPL3(INT32, COMInterlocked::CompareExchange, INT32* location, INT32 value, IN
         FCThrow(kNullReferenceException);
     }
 
-    return FastInterlockCompareExchange((LONG*)location, value, comparand);
+    return InterlockedCompareExchange((LONG*)location, value, comparand);
 }
 FCIMPLEND
 
@@ -1438,7 +1438,7 @@ FCIMPL3_IVV(INT64, COMInterlocked::CompareExchange64, INT64* location, INT64 val
         FCThrow(kNullReferenceException);
     }
 
-    return FastInterlockCompareExchangeLong((INT64*)location, value, comparand);
+    return InterlockedCompareExchange64((INT64*)location, value, comparand);
 }
 FCIMPLEND
 
@@ -1450,7 +1450,7 @@ FCIMPL2_IV(float,COMInterlocked::ExchangeFloat, float *location, float value)
         FCThrow(kNullReferenceException);
     }
 
-    LONG ret = FastInterlockExchange((LONG *) location, *(LONG*)&value);
+    LONG ret = InterlockedExchange((LONG *) location, *(LONG*)&value);
     return *(float*)&ret;
 }
 FCIMPLEND
@@ -1464,7 +1464,7 @@ FCIMPL2_IV(double,COMInterlocked::ExchangeDouble, double *location, double value
     }
 
 
-    INT64 ret = FastInterlockExchangeLong((INT64 *) location, *(INT64*)&value);
+    INT64 ret = InterlockedExchange64((INT64 *) location, *(INT64*)&value);
     return *(double*)&ret;
 }
 FCIMPLEND
@@ -1477,7 +1477,7 @@ FCIMPL3_IVV(float,COMInterlocked::CompareExchangeFloat, float *location, float v
         FCThrow(kNullReferenceException);
     }
 
-    LONG ret = (LONG)FastInterlockCompareExchange((LONG*) location, *(LONG*)&value, *(LONG*)&comparand);
+    LONG ret = (LONG)InterlockedCompareExchange((LONG*) location, *(LONG*)&value, *(LONG*)&comparand);
     return *(float*)&ret;
 }
 FCIMPLEND
@@ -1490,7 +1490,7 @@ FCIMPL3_IVV(double,COMInterlocked::CompareExchangeDouble, double *location, doub
         FCThrow(kNullReferenceException);
     }
 
-    INT64 ret = (INT64)FastInterlockCompareExchangeLong((INT64*) location, *(INT64*)&value, *(INT64*)&comparand);
+    INT64 ret = (INT64)InterlockedCompareExchange64((INT64*) location, *(INT64*)&value, *(INT64*)&comparand);
     return *(double*)&ret;
 }
 FCIMPLEND
@@ -1503,7 +1503,7 @@ FCIMPL2(LPVOID,COMInterlocked::ExchangeObject, LPVOID*location, LPVOID value)
         FCThrow(kNullReferenceException);
     }
 
-    LPVOID ret = FastInterlockExchangePointer(location, value);
+    LPVOID ret = InterlockedExchangeT(location, value);
 #ifdef _DEBUG
     Thread::ObjectRefAssign((OBJECTREF *)location);
 #endif
@@ -1521,7 +1521,7 @@ FCIMPL3(LPVOID,COMInterlocked::CompareExchangeObject, LPVOID *location, LPVOID v
     }
 
     // <TODO>@todo: only set ref if is updated</TODO>
-    LPVOID ret = FastInterlockCompareExchangePointer(location, value, comparand);
+    LPVOID ret = InterlockedCompareExchangeT(location, value, comparand);
     if (ret == comparand) {
 #ifdef _DEBUG
         Thread::ObjectRefAssign((OBJECTREF *)location);
@@ -1540,7 +1540,7 @@ FCIMPL2(INT32,COMInterlocked::ExchangeAdd32, INT32 *location, INT32 value)
         FCThrow(kNullReferenceException);
     }
 
-    return FastInterlockExchangeAdd((LONG *) location, value);
+    return InterlockedExchangeAdd((LONG *) location, value);
 }
 FCIMPLEND
 
@@ -1552,7 +1552,7 @@ FCIMPL2_IV(INT64,COMInterlocked::ExchangeAdd64, INT64 *location, INT64 value)
         FCThrow(kNullReferenceException);
     }
 
-    return FastInterlockExchangeAddLong((INT64 *) location, value);
+    return InterlockedExchangeAdd64((INT64 *) location, value);
 }
 FCIMPLEND
 

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -90,7 +90,7 @@ STDMETHODIMP CorHost2::Start()
         else
         {
             // Increment the global (and dynamic) refCount...
-            FastInterlockIncrement(&m_RefCount);
+            InterlockedIncrement(&m_RefCount);
 
             // And set our flag that this host has invoked the Start...
             m_fStarted = TRUE;
@@ -113,7 +113,7 @@ STDMETHODIMP CorHost2::Start()
             // So, if you want to do that, just make sure you are the first host to load the
             // specific version of CLR in memory AND start it.
             m_fFirstToLoadCLR = TRUE;
-            FastInterlockIncrement(&m_RefCount);
+            InterlockedIncrement(&m_RefCount);
         }
     }
 
@@ -159,7 +159,7 @@ HRESULT CorHost2::Stop()
                 break;
             }
             else
-            if (FastInterlockCompareExchange(&m_RefCount, refCount - 1, refCount) == refCount)
+            if (InterlockedCompareExchange(&m_RefCount, refCount - 1, refCount) == refCount)
             {
                 // Indicate that we have got a Stop for a corresponding Start call from the
                 // Host. Semantically, CoreCLR has stopped for them.

--- a/src/coreclr/vm/crst.cpp
+++ b/src/coreclr/vm/crst.cpp
@@ -308,7 +308,7 @@ void CrstBase::Enter(INDEBUG(NoLevelCheckFlag noLevelCheckFlag/* = CRST_LEVEL_CH
         if (m_dwFlags & CRST_TAKEN_DURING_SHUTDOWN)
         {
             // increment the usage count of locks that can be taken during shutdown
-            FastInterlockIncrement(&g_ShutdownCrstUsageCount);
+            InterlockedIncrement(&g_ShutdownCrstUsageCount);
         }
 
         // If this is a debugger lock, bump up the "Can't-Stop" count.
@@ -368,7 +368,7 @@ void CrstBase::Leave()
         {
             // decrement the usage count of locks that can be taken during shutdown
             _ASSERTE_MSG(g_ShutdownCrstUsageCount.Load() > 0, "Attempting to leave a lock that was never taken!");
-            FastInterlockDecrement(&g_ShutdownCrstUsageCount);
+            InterlockedDecrement(&g_ShutdownCrstUsageCount);
         }
     }
 

--- a/src/coreclr/vm/crst.h
+++ b/src/coreclr/vm/crst.h
@@ -240,11 +240,11 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         if (bSet)
-            FastInterlockIncrement(&m_cannotLeave);
+            InterlockedIncrement(&m_cannotLeave);
         else
         {
             _ASSERTE(m_cannotLeave);
-            FastInterlockDecrement(&m_cannotLeave);
+            InterlockedDecrement(&m_cannotLeave);
         }
     };
     //-----------------------------------------------------------------

--- a/src/coreclr/vm/disassembler.cpp
+++ b/src/coreclr/vm/disassembler.cpp
@@ -158,7 +158,7 @@ Disassembler::Disassembler()
 
     // Try to get an external disassembler that is already available for use before creating one
     ExternalDisassembler *externalDisassembler =
-        FastInterlockExchangePointer(&s_availableExternalDisassembler, static_cast<ExternalDisassembler *>(nullptr));
+        InterlockedExchangeT(&s_availableExternalDisassembler, static_cast<ExternalDisassembler *>(nullptr));
     if (externalDisassembler == nullptr)
     {
     #if USE_COREDISTOOLS_DISASSEMBLER
@@ -186,7 +186,7 @@ Disassembler::~Disassembler()
 
     // Save the external disassembler for future use. We only save one instance, so delete a previously saved one.
     ExternalDisassembler *externalDisassemblerToDelete =
-        FastInterlockExchangePointer(&s_availableExternalDisassembler, m_externalDisassembler);
+        InterlockedExchangeT(&s_availableExternalDisassembler, m_externalDisassembler);
     if (externalDisassemblerToDelete == nullptr)
     {
         return;

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -340,7 +340,7 @@ OBJECTREF DomainAssembly::GetExposedModuleObject()
         // Atomically create a handle
         LOADERHANDLE handle = pLoaderAllocator->AllocateHandle(NULL);
 
-        FastInterlockCompareExchangePointer(&m_hExposedModuleObject, handle, static_cast<LOADERHANDLE>(NULL));
+        InterlockedCompareExchangeT(&m_hExposedModuleObject, handle, static_cast<LOADERHANDLE>(NULL));
     }
 
     if (pLoaderAllocator->GetHandleValue(m_hExposedModuleObject) == NULL)
@@ -650,7 +650,7 @@ OBJECTREF DomainAssembly::GetExposedAssemblyObject()
 
         LOADERHANDLE handle = pLoaderAllocator->AllocateHandle(NULL);
 
-        FastInterlockCompareExchangePointer(&m_hExposedAssemblyObject, handle, static_cast<LOADERHANDLE>(NULL));
+        InterlockedCompareExchangeT(&m_hExposedAssemblyObject, handle, static_cast<LOADERHANDLE>(NULL));
     }
 
     if (pLoaderAllocator->GetHandleValue(m_hExposedAssemblyObject) == NULL)

--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -88,7 +88,7 @@ void DynamicMethodTable::CreateDynamicMethodTable(DynamicMethodTable **ppLocatio
 
     if (*ppLocation) RETURN;
 
-    if (FastInterlockCompareExchangePointer(ppLocation, pDynMT, NULL) != NULL)
+    if (InterlockedCompareExchangeT(ppLocation, pDynMT, NULL) != NULL)
     {
         LOG((LF_BCL, LL_INFO100, "Level2 - Another thread got here first - deleting DynamicMethodTable {0x%p}...\n", pDynMT));
         RETURN;

--- a/src/coreclr/vm/eehash.inl
+++ b/src/coreclr/vm/eehash.inl
@@ -749,7 +749,7 @@ BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::GrowHashTable()
     // we are doing this, as there can be concurrent readers!  Note that
     // it is OK if the concurrent reader misses out on a match, though -
     // they will have to acquire the lock on a miss & try again.
-    FastInterlockExchange( (LONG *) &m_bGrowing, 1);
+    InterlockedExchange( (LONG *) &m_bGrowing, 1);
     for (DWORD i = 0; i < m_pVolatileBucketTable->m_dwNumBuckets; i++)
     {
         EEHashEntry_t * pEntry = m_pVolatileBucketTable->m_pBuckets[i];
@@ -800,7 +800,7 @@ BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::GrowHashTable()
     //
     m_pVolatileBucketTable = pNewBucketTable;
 
-    FastInterlockExchange( (LONG *) &m_bGrowing, 0);
+    InterlockedExchange( (LONG *) &m_bGrowing, 0);
 
     return TRUE;
 }

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -41,7 +41,7 @@ void SafeExitProcess(UINT exitCode, ShutdownCompleteAction sca = SCA_ExitProcess
     // other DLLs call Release() on us in their detach [dangerous!], etc.
     GCX_PREEMP_NO_DTOR();
 
-    FastInterlockExchange((LONG*)&g_fForbidEnterEE, TRUE);
+    InterlockedExchange((LONG*)&g_fForbidEnterEE, TRUE);
 
     // Note that for free and retail builds StressLog must also be enabled
     if (g_pConfig && g_pConfig->StressLog())

--- a/src/coreclr/vm/encee.cpp
+++ b/src/coreclr/vm/encee.cpp
@@ -1358,7 +1358,7 @@ PTR_CBYTE EnCSyncBlockInfo::ResolveOrAllocateField(OBJECTREF thisPointer, EnCFie
 
         // put at front of list so the list is in order of most recently added
         pEntry->m_pNext = m_pList;
-        if (FastInterlockCompareExchangePointer(&m_pList, pEntry, pEntry->m_pNext) == pEntry->m_pNext)
+        if (InterlockedCompareExchangeT(&m_pList, pEntry, pEntry->m_pNext) == pEntry->m_pNext)
             break;
 
         // There was a race and another thread modified the list here, so we need to try again

--- a/src/coreclr/vm/eventreporter.cpp
+++ b/src/coreclr/vm/eventreporter.cpp
@@ -478,7 +478,7 @@ BOOL ShouldLogInEventLog()
     }
 
     static LONG fOnce = 0;
-    if (fOnce == 1 || FastInterlockExchange(&fOnce, 1) == 1)
+    if (fOnce == 1 || InterlockedExchange(&fOnce, 1) == 1)
     {
         return FALSE;
     }

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -3807,7 +3807,7 @@ LONG WatsonLastChance(                  // EXCEPTION_CONTINUE_SEARCH, _CONTINUE_
         else
         {
             BOOL fWatsonAlreadyLaunched = FALSE;
-            if (FastInterlockCompareExchange(&g_watsonAlreadyLaunched, 1, 0) != 0)
+            if (InterlockedCompareExchange(&g_watsonAlreadyLaunched, 1, 0) != 0)
             {
                 fWatsonAlreadyLaunched = TRUE;
             }

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -907,7 +907,7 @@ ProcessCLRException(IN     PEXCEPTION_RECORD   pExceptionRecord
             // We should be in cooperative mode if we are going to handle the SO.
             // We track SO state for the thread.
             EEPolicy::HandleStackOverflow();
-            FastInterlockAnd (&pThread->m_fPreemptiveGCDisabled, 0);
+            InterlockedAnd((LONG*)&pThread->m_fPreemptiveGCDisabled, 0);
             return ExceptionContinueSearch;
         }
     }
@@ -5487,7 +5487,7 @@ void TrackerAllocator::FreeTrackerMemory(ExceptionTracker* pTracker)
     // mark this entry as free
     EH_LOG((LL_INFO100, "TrackerAllocator: freeing tracker 0x%p, thread = 0x%p\n", pTracker, pTracker->m_pThread));
     CONSISTENCY_CHECK(pTracker->IsValid());
-    FastInterlockExchangePointer(&(pTracker->m_pThread), NULL);
+    InterlockedExchangeT(&(pTracker->m_pThread), NULL);
 }
 
 #ifndef TARGET_UNIX
@@ -5935,7 +5935,7 @@ UMThunkUnwindFrameChainHandler(IN     PEXCEPTION_RECORD   pExceptionRecord
         if (fIsSO)
         {
             // We don't have stack to do full-version EnablePreemptiveGC.
-            FastInterlockAnd (&pThread->m_fPreemptiveGCDisabled, 0);
+            InterlockedAnd((LONG*)&pThread->m_fPreemptiveGCDisabled, 0);
         }
         else
         {
@@ -6020,7 +6020,7 @@ CallDescrWorkerUnwindFrameChainHandler(IN     PEXCEPTION_RECORD   pExceptionReco
             CleanUpForSecondPass(pThread, true, (void*)MemoryStackFp, (void*)MemoryStackFp);
         }
 
-        FastInterlockAnd (&pThread->m_fPreemptiveGCDisabled, 0);
+        InterlockedAnd((LONG*)&pThread->m_fPreemptiveGCDisabled, 0);
         // We'll let the SO infrastructure handle this exception... at that point, we
         // know that we'll have enough stack to do it.
         return ExceptionContinueSearch;

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -473,7 +473,7 @@ void FinalizerThread::SignalFinalizationDone(BOOL fFinalizer)
 
     if (fFinalizer)
     {
-        FastInterlockAnd((DWORD*)&g_FinalizerWaiterStatus, ~FWS_WaitInterrupt);
+        InterlockedAnd((LONG*)&g_FinalizerWaiterStatus, ~FWS_WaitInterrupt);
     }
     hEventFinalizerDone->Set();
 }

--- a/src/coreclr/vm/gccover.cpp
+++ b/src/coreclr/vm/gccover.cpp
@@ -1494,7 +1494,7 @@ void DoGcStress (PCONTEXT regs, NativeCodeVersion nativeCodeVersion)
     bool bShouldUpdateProlog = true;
     if (gcCover->doingEpilogChecks) {
         if (offset == 0) {
-            if ((gcCover->callerThread == 0) && (FastInterlockCompareExchangePointer(&gcCover->callerThread, pThread, 0) == 0)) {
+            if ((gcCover->callerThread == 0) && (InterlockedCompareExchangeT(&gcCover->callerThread, pThread, 0) == 0)) {
                 gcCover->callerRegs = *regs;
                 gcCover->gcCount = GCHeapUtilities::GetGCHeap()->GetGcCount();
                 bShouldUpdateProlog = false;

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -86,7 +86,7 @@ public:
         } CONTRACTL_END;
 
         DWORD spinCount = 0;
-        while(FastInterlockExchange(&m_lock, 0) != -1)
+        while(InterlockedExchange(&m_lock, 0) != -1)
         {
             GCX_PREEMP();
             __SwitchToThread(0, spinCount++);

--- a/src/coreclr/vm/genericdict.cpp
+++ b/src/coreclr/vm/genericdict.cpp
@@ -530,7 +530,7 @@ Dictionary* Dictionary::GetMethodDictionaryWithSizeCheck(MethodDesc* pMD, ULONG 
             *pNewDictionary->GetBackPointerSlot(numGenericArgs) = pDictionary;
 
             // Publish the new dictionary slots to the type.
-            FastInterlockExchangePointer(&pIMD->m_pPerInstInfo, pNewDictionary);
+            InterlockedExchangeT(&pIMD->m_pPerInstInfo, pNewDictionary);
 
             pDictionary = pNewDictionary;
         }
@@ -590,7 +590,7 @@ Dictionary* Dictionary::GetTypeDictionaryWithSizeCheck(MethodTable* pMT, ULONG s
             // Publish the new dictionary slots to the type.
             ULONG dictionaryIndex = pMT->GetNumDicts() - 1;
             Dictionary** pPerInstInfo = pMT->GetPerInstInfo();
-            FastInterlockExchangePointer(pPerInstInfo + dictionaryIndex, pNewDictionary);
+            InterlockedExchangeT(pPerInstInfo + dictionaryIndex, pNewDictionary);
 
             pDictionary = pNewDictionary;
         }

--- a/src/coreclr/vm/hash.cpp
+++ b/src/coreclr/vm/hash.cpp
@@ -441,13 +441,13 @@ void HashMap::ProfileLookup(UPTR ntry, UPTR retValue)
 #ifndef DACCESS_COMPILE
     #ifdef HASHTABLE_PROFILE
         if (ntry < HASHTABLE_LOOKUP_PROBES_DATA - 2)
-            FastInterlockIncrement(&m_rgLookupProbes[ntry]);
+            InterlockedIncrement(&m_rgLookupProbes[ntry]);
         else
-            FastInterlockIncrement(&m_rgLookupProbes[HASHTABLE_LOOKUP_PROBES_DATA - 2]);
+            InterlockedIncrement(&m_rgLookupProbes[HASHTABLE_LOOKUP_PROBES_DATA - 2]);
 
         if (retValue == NULL)
         {   // failure probes
-            FastInterlockIncrement(&m_rgLookupProbes[HASHTABLE_LOOKUP_PROBES_DATA - 1]);
+            InterlockedIncrement(&m_rgLookupProbes[HASHTABLE_LOOKUP_PROBES_DATA - 1]);
             // the following code is usually executed
             // only for special case of lookup done before insert
             // check hash.h SyncHash::InsertValue

--- a/src/coreclr/vm/hosting.cpp
+++ b/src/coreclr/vm/hosting.cpp
@@ -207,7 +207,7 @@ BOOL ClrVirtualProtect(LPVOID lpAddress, SIZE_T dwSize, DWORD flNewProtect, PDWO
                 BYTE* pEndOfUEFSectionBoundary = pAddressOfFollowingSection - 1;
 
                 // Set the end of UEF section boundary
-                FastInterlockExchangePointer(s_pEndOfUEFSectionBoundary.GetPointer(), pEndOfUEFSectionBoundary);
+                InterlockedExchangeT(s_pEndOfUEFSectionBoundary.GetPointer(), pEndOfUEFSectionBoundary);
             }
             else
             {

--- a/src/coreclr/vm/i386/excepx86.cpp
+++ b/src/coreclr/vm/i386/excepx86.cpp
@@ -1658,7 +1658,7 @@ EXCEPTION_HANDLER_IMPL(COMPlusFrameHandler)
 
             // Switch to preemp mode since we are returning back to the OS.
             // We will do the quick switch since we are short of stack
-            FastInterlockAnd (&pThread->m_fPreemptiveGCDisabled, 0);
+            InterlockedAnd((LONG*)&pThread->m_fPreemptiveGCDisabled, 0);
 
             return ExceptionContinueSearch;
         }
@@ -1710,7 +1710,7 @@ EXCEPTION_HANDLER_IMPL(COMPlusFrameHandler)
 
             // Switch to preemp mode since we are returning back to the OS.
             // We will do the quick switch since we are short of stack
-            FastInterlockAnd(&pThread->m_fPreemptiveGCDisabled, 0);
+            InterlockedAnd((LONG*)&pThread->m_fPreemptiveGCDisabled, 0);
 
             return ExceptionContinueSearch;
         }

--- a/src/coreclr/vm/i386/stublinkerx86.cpp
+++ b/src/coreclr/vm/i386/stublinkerx86.cpp
@@ -5019,7 +5019,7 @@ BOOL ThisPtrRetBufPrecode::SetTargetInterlocked(TADDR target, TADDR expected)
 
     _ASSERTE(IS_ALIGNED(&m_rel32, sizeof(INT32)));
     ExecutableWriterHolder<INT32> rel32WriterHolder(&m_rel32, sizeof(INT32));
-    FastInterlockExchange((LONG*)rel32WriterHolder.GetRW(), (LONG)newRel32);
+    InterlockedExchange((LONG*)rel32WriterHolder.GetRW(), (LONG)newRel32);
 
     return TRUE;
 }

--- a/src/coreclr/vm/ilstubresolver.cpp
+++ b/src/coreclr/vm/ilstubresolver.cpp
@@ -311,7 +311,7 @@ ILStubResolver::AllocGeneratedIL(
 #ifdef _DEBUG
         LPVOID pPrevCompileTimeState =
 #endif // _DEBUG
-            FastInterlockExchangePointer(&m_pCompileTimeState, pNewCompileTimeState.GetValue());
+            InterlockedExchangeT(&m_pCompileTimeState, pNewCompileTimeState.GetValue());
         CONSISTENCY_CHECK(ILNotYetGenerated == (UINT_PTR)pPrevCompileTimeState);
 
         pNewLocalSig.SuppressRelease();
@@ -338,7 +338,7 @@ ILStubResolver::AllocGeneratedIL(
 #ifdef _DEBUG
         LPVOID pPrevCompileTimeState =
 #endif // _DEBUG
-            FastInterlockExchangePointer(&m_pCompileTimeState, (CompileTimeState*)pNewCompileTimeState);
+            InterlockedExchangeT(&m_pCompileTimeState, (CompileTimeState*)pNewCompileTimeState);
         CONSISTENCY_CHECK(ILNotYetGenerated == (UINT_PTR)pPrevCompileTimeState);
 
         pNewLocalSig.SuppressRelease();
@@ -458,7 +458,7 @@ ILStubResolver::ClearCompileTimeState(CompileTimeStatePtrSpecialValues newState)
 
     delete m_pCompileTimeState;
 
-    FastInterlockExchangePointer(&m_pCompileTimeState, dac_cast<PTR_CompileTimeState>((TADDR)newState));
+    InterlockedExchangeT(&m_pCompileTimeState, dac_cast<PTR_CompileTimeState>((TADDR)newState));
 } // ILStubResolver::ClearCompileTimeState
 
 //---------------------------------------------------------------------------------------

--- a/src/coreclr/vm/instmethhash.h
+++ b/src/coreclr/vm/instmethhash.h
@@ -81,8 +81,8 @@ private:
 public:
     void            InitUnseal() { LIMITED_METHOD_CONTRACT; m_dwSealCount = 0; }
     bool            IsUnsealed() { LIMITED_METHOD_CONTRACT; return (m_dwSealCount == 0); }
-    void            Seal()   { LIMITED_METHOD_CONTRACT; FastInterlockIncrement(&m_dwSealCount); }
-    void            Unseal() { LIMITED_METHOD_CONTRACT; FastInterlockDecrement(&m_dwSealCount); }
+    void            Seal()   { LIMITED_METHOD_CONTRACT; InterlockedIncrement(&m_dwSealCount); }
+    void            Unseal() { LIMITED_METHOD_CONTRACT; InterlockedDecrement(&m_dwSealCount); }
 #endif  // _DEBUG
 
 private:

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -236,7 +236,7 @@ namespace
                 ExtObjCxtCache* instMaybe = new ExtObjCxtCache();
 
                 // Attempt to set the global instance.
-                if (NULL != FastInterlockCompareExchangePointer(&g_Instance, instMaybe, NULL))
+                if (NULL != InterlockedCompareExchangeT(&g_Instance, instMaybe, NULL))
                     delete instMaybe;
             }
 

--- a/src/coreclr/vm/interoplibinterface_objc.cpp
+++ b/src/coreclr/vm/interoplibinterface_objc.cpp
@@ -42,7 +42,7 @@ extern "C" BOOL QCALLTYPE ObjCMarshal_TryInitializeReferenceTracker(
     // while they are being set.
     {
         GCX_COOP();
-        if (FastInterlockCompareExchange((LONG*)&g_ReferenceTrackerInitialized, TRUE, FALSE) == FALSE)
+        if (InterlockedCompareExchange((LONG*)&g_ReferenceTrackerInitialized, TRUE, FALSE) == FALSE)
         {
             g_BeginEndCallback = beginEndCallback;
             g_IsReferencedCallback = isReferencedCallback;
@@ -164,10 +164,10 @@ extern "C" BOOL QCALLTYPE ObjCMarshal_TrySetGlobalMessageSendCallback(
     BEGIN_QCALL;
 
     _ASSERTE(msgSendFunction >= 0 && msgSendFunction < ARRAY_SIZE(s_msgSendOverrides));
-    success = FastInterlockCompareExchangePointer(&s_msgSendOverrides[msgSendFunction], fptr, NULL) == NULL;
+    success = InterlockedCompareExchangeT(&s_msgSendOverrides[msgSendFunction], fptr, NULL) == NULL;
 
     // Set P/Invoke override callback if we haven't already
-    if (success && FALSE == FastInterlockCompareExchange((LONG*)&s_msgSendOverridden, TRUE, FALSE))
+    if (success && FALSE == InterlockedCompareExchange((LONG*)&s_msgSendOverridden, TRUE, FALSE))
         PInvokeOverride::SetPInvokeOverride(&MessageSendPInvokeOverride, PInvokeOverride::Source::ObjectiveCInterop);
 
     END_QCALL;

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -3146,7 +3146,7 @@ CORINFO_GENERIC_HANDLE JIT_GenericHandleWorker(MethodDesc * pMD, MethodTable * p
         if (pMTDictionary != pDeclaringMTDictionary)
         {
             TypeHandle** pPerInstInfo = (TypeHandle**)pMT->GetPerInstInfo();
-            FastInterlockExchangePointer(pPerInstInfo + dictionaryIndex, (TypeHandle*)pDeclaringMTDictionary);
+            InterlockedExchangeT(pPerInstInfo + dictionaryIndex, (TypeHandle*)pDeclaringMTDictionary);
         }
     }
 
@@ -4753,7 +4753,7 @@ HCIMPL0(VOID, JIT_StressGC)
         BYTE* retInstrs = ((BYTE*) *__ms->pRetAddr()) - 4;
         _ASSERTE(retInstrs[-1] == 0xE8);                // it is a call instruction
                 // Wack it to point to the JITStressGCNop instead
-        FastInterlockExchange((LONG*) retInstrs), (LONG) JIT_StressGC_NOP);
+        InterlockedExchange((LONG*) retInstrs), (LONG) JIT_StressGC_NOP);
 #endif // _X86
 
     HELPER_METHOD_FRAME_END();

--- a/src/coreclr/vm/listlock.h
+++ b/src/coreclr/vm/listlock.h
@@ -153,7 +153,7 @@ public:
         }
         CONTRACTL_END;
 
-        FastInterlockIncrement((LONG*)&m_dwRefCount);
+        InterlockedIncrement((LONG*)&m_dwRefCount);
     }
 
     void Release()
@@ -169,7 +169,7 @@ public:
 
         ListLockHolder lock(m_pList);
 
-        if (FastInterlockDecrement((LONG*)&m_dwRefCount) == 0)
+        if (InterlockedDecrement((LONG*)&m_dwRefCount) == 0)
         {
             // Remove from list
             m_pList->Unlink(this);

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -115,7 +115,7 @@ void LoaderAllocator::AddReference()
     CONTRACTL_END;
 
     _ASSERTE((m_cReferences > (UINT32)0) && (m_cReferences != (UINT32)-1));
-    FastInterlockIncrement((LONG *)&m_cReferences);
+    InterlockedIncrement((LONG *)&m_cReferences);
 }
 #endif //!DACCESS_COMPILE
 
@@ -146,7 +146,7 @@ BOOL LoaderAllocator::AddReferenceIfAlive()
             return FALSE;
         }
 
-        UINT32 cOriginalReferences = FastInterlockCompareExchange(
+        UINT32 cOriginalReferences = InterlockedCompareExchange(
             (LONG *)&m_cReferences,
             cReferencesLocalSnapshot + 1,
             cReferencesLocalSnapshot);
@@ -181,7 +181,7 @@ BOOL LoaderAllocator::Release()
 #ifndef DACCESS_COMPILE
 
     _ASSERTE((m_cReferences > (UINT32)0) && (m_cReferences != (UINT32)-1));
-    LONG cNewReferences = FastInterlockDecrement((LONG *)&m_cReferences);
+    LONG cNewReferences = InterlockedDecrement((LONG *)&m_cReferences);
     return (cNewReferences == 0);
 #else //DACCESS_COMPILE
 
@@ -1511,7 +1511,7 @@ DispatchToken LoaderAllocator::GetDispatchToken(
             SimpleWriteLockHolder lock(pFatTokenSetLock);
             NewHolder<FatTokenSet> pFatTokenSet = new FatTokenSet;
 
-            if (FastInterlockCompareExchangePointer(
+            if (InterlockedCompareExchangeT(
                     &m_pFatTokenSetLock, pFatTokenSetLock.GetValue(), NULL) != NULL)
             {   // Someone beat us to it
                 lock.Release();
@@ -2057,7 +2057,7 @@ UMEntryThunkCache *LoaderAllocator::GetUMEntryThunkCache()
     {
         UMEntryThunkCache *pUMEntryThunkCache = new UMEntryThunkCache(GetAppDomain());
 
-        if (FastInterlockCompareExchangePointer(&m_pUMEntryThunkCache, pUMEntryThunkCache, NULL) != NULL)
+        if (InterlockedCompareExchangeT(&m_pUMEntryThunkCache, pUMEntryThunkCache, NULL) != NULL)
         {
             // some thread swooped in and set the field
             delete pUMEntryThunkCache;
@@ -2169,7 +2169,7 @@ PTR_OnStackReplacementManager LoaderAllocator::GetOnStackReplacementManager()
     {
         OnStackReplacementManager * newManager = new OnStackReplacementManager(this);
 
-        if (FastInterlockCompareExchangePointer(&m_onStackReplacementManager, newManager, NULL) != NULL)
+        if (InterlockedCompareExchangeT(&m_onStackReplacementManager, newManager, NULL) != NULL)
         {
             // some thread swooped in and set the field
             delete newManager;

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -844,7 +844,7 @@ WORD MethodDesc::InterlockedUpdateFlags(WORD wMask, BOOL fSet)
     // is a word and we only have interlock operations over dwords. So we round down the flags field address to the nearest aligned
     // dword (along with the intended bitfield mask). Note that we make the assumption that the flags word is aligned itself, so we
     // only have two possibilites: the field already lies on a dword boundary or it's precisely one word out.
-    DWORD* pdwFlags = (DWORD*)((ULONG_PTR)&m_wFlags - (offsetof(MethodDesc, m_wFlags) & 0x3));
+    LONG* pdwFlags = (LONG*)((ULONG_PTR)&m_wFlags - (offsetof(MethodDesc, m_wFlags) & 0x3));
 
 #ifdef _PREFAST_
 #pragma warning(push)
@@ -864,9 +864,9 @@ WORD MethodDesc::InterlockedUpdateFlags(WORD wMask, BOOL fSet)
 #endif
 
     if (fSet)
-        FastInterlockOr(pdwFlags, dwMask);
+        InterlockedOr(pdwFlags, dwMask);
     else
-        FastInterlockAnd(pdwFlags, ~dwMask);
+        InterlockedAnd(pdwFlags, ~dwMask);
 
     return wOldState;
 }
@@ -882,7 +882,7 @@ WORD MethodDesc::InterlockedUpdateFlags3(WORD wMask, BOOL fSet)
     // is a word and we only have interlock operations over dwords. So we round down the flags field address to the nearest aligned
     // dword (along with the intended bitfield mask). Note that we make the assumption that the flags word is aligned itself, so we
     // only have two possibilites: the field already lies on a dword boundary or it's precisely one word out.
-    DWORD* pdwFlags = (DWORD*)((ULONG_PTR)&m_wFlags3AndTokenRemainder - (offsetof(MethodDesc, m_wFlags3AndTokenRemainder) & 0x3));
+    LONG* pdwFlags = (LONG*)((ULONG_PTR)&m_wFlags3AndTokenRemainder - (offsetof(MethodDesc, m_wFlags3AndTokenRemainder) & 0x3));
 
 #ifdef _PREFAST_
 #pragma warning(push)
@@ -902,9 +902,9 @@ WORD MethodDesc::InterlockedUpdateFlags3(WORD wMask, BOOL fSet)
 #endif
 
     if (fSet)
-        FastInterlockOr(pdwFlags, dwMask);
+        InterlockedOr(pdwFlags, dwMask);
     else
-        FastInterlockAnd(pdwFlags, ~dwMask);
+        InterlockedAnd(pdwFlags, ~dwMask);
 
     return wOldState;
 }
@@ -2957,19 +2957,19 @@ void MethodDesc::InterlockedUpdateFlags2(BYTE bMask, BOOL fSet)
 {
     WRAPPER_NO_CONTRACT;
 
-    ULONG* pLong = (ULONG*)(&m_bFlags2 - 3);
+    LONG* pLong = (LONG*)(&m_bFlags2 - 3);
     static_assert_no_msg(offsetof(MethodDesc, m_bFlags2) % sizeof(LONG) == 3);
 
 #if BIGENDIAN
     if (fSet)
-        FastInterlockOr(pLong, (ULONG)bMask);
+        InterlockedOr(pLong, (ULONG)bMask);
     else
-        FastInterlockAnd(pLong, ~(ULONG)bMask);
+        InterlockedAnd(pLong, ~(ULONG)bMask);
 #else // !BIGENDIAN
     if (fSet)
-        FastInterlockOr(pLong, (ULONG)bMask << (3 * 8));
+        InterlockedOr(pLong, (LONG)bMask << (3 * 8));
     else
-        FastInterlockAnd(pLong, ~((ULONG)bMask << (3 * 8)));
+        InterlockedAnd(pLong, ~((LONG)bMask << (3 * 8)));
 #endif // !BIGENDIAN
 }
 
@@ -3005,7 +3005,7 @@ Precode* MethodDesc::GetOrCreatePrecode()
         AllocMemTracker amt;
         Precode* pPrecode = Precode::Allocate(requiredType, this, GetLoaderAllocator(), &amt);
 
-        if (FastInterlockCompareExchangePointer(pSlot, pPrecode->GetEntryPoint(), tempEntry) == tempEntry)
+        if (InterlockedCompareExchangeT(pSlot, pPrecode->GetEntryPoint(), tempEntry) == tempEntry)
             amt.SuppressRelease();
     }
 
@@ -3296,7 +3296,7 @@ BOOL MethodDesc::SetNativeCodeInterlocked(PCODE addr, PCODE pExpected /*=NULL*/)
 
         expected = *pSlot;
 
-        return FastInterlockCompareExchangePointer(reinterpret_cast<TADDR*>(pSlot),
+        return InterlockedCompareExchangeT(reinterpret_cast<TADDR*>(pSlot),
             (TADDR&)addr, (TADDR&)expected) == (TADDR&)expected;
     }
 
@@ -3333,7 +3333,7 @@ BOOL MethodDesc::SetStableEntryPointInterlocked(PCODE addr)
     PCODE pExpected = GetTemporaryEntryPoint();
     PTR_PCODE pSlot = GetAddrOfSlot();
 
-    BOOL fResult = FastInterlockCompareExchangePointer(pSlot, addr, pExpected) == pExpected;
+    BOOL fResult = InterlockedCompareExchangeT(pSlot, addr, pExpected) == pExpected;
 
     InterlockedUpdateFlags2(enum_flag2_HasStableEntryPoint, TRUE);
 
@@ -3419,7 +3419,7 @@ void NDirectMethodDesc::InterlockedSetNDirectFlags(WORD wFlags)
     ((WORD*)&dwMask)[0] |= wFlags;
 
     // Now, slam all 32 bits atomically.
-    FastInterlockOr((DWORD*)pFlags, dwMask);
+    InterlockedOr((LONG*)pFlags, dwMask);
 }
 
 
@@ -4020,7 +4020,7 @@ void ComPlusCallMethodDesc::InitRetThunk()
 
     LPVOID pRetThunk = ComPlusCall::GetRetThunk(numStackBytes);
 
-    FastInterlockCompareExchangePointer<void *>(&m_pComPlusCallInfo->m_pRetThunk, pRetThunk, NULL);
+    InterlockedCompareExchangeT<void *>(&m_pComPlusCallInfo->m_pRetThunk, pRetThunk, NULL);
 #endif // TARGET_X86
 }
 #endif //!DACCESS_COMPILE

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -3239,7 +3239,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
 
-        FastInterlockOr(reinterpret_cast<DWORD *>(&m_pComPlusCallInfo->m_flags), newFlags);
+        InterlockedOr((LONG*)&m_pComPlusCallInfo->m_flags, newFlags);
     }
 
 #ifdef TARGET_X86

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -552,7 +552,7 @@ void MethodTable::SetIsRestored()
 
     PRECONDITION(!IsFullyLoaded());
 
-    FastInterlockAnd(&GetWriteableDataForWrite()->m_dwFlags, ~MethodTableWriteableData::enum_flag_Unrestored);
+    InterlockedAnd((LONG*)&GetWriteableDataForWrite()->m_dwFlags, ~MethodTableWriteableData::enum_flag_Unrestored);
 
 #ifndef DACCESS_COMPILE
     if (ETW_PROVIDER_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER))
@@ -3952,7 +3952,7 @@ void CallFinalizerOnThreadObject(Object *obj)
                 refThis->ClearInternal();
             }
 
-            FastInterlockOr ((ULONG *)&thread->m_State, Thread::TS_Finalized);
+            thread->SetThreadState(Thread::TS_Finalized);
             Thread::SetCleanupNeededForFinalizedThread();
         }
     }
@@ -4099,7 +4099,7 @@ OBJECTREF MethodTable::GetManagedClassObject()
         // Only the winner can set m_ExposedClassObject from NULL.
         LOADERHANDLE exposedClassObjectHandle = pLoaderAllocator->AllocateHandle(refClass);
 
-        if (FastInterlockCompareExchangePointer(&GetWriteableDataForWrite()->m_hExposedClassObject, exposedClassObjectHandle, static_cast<LOADERHANDLE>(NULL)))
+        if (InterlockedCompareExchangeT(&GetWriteableDataForWrite()->m_hExposedClassObject, exposedClassObjectHandle, static_cast<LOADERHANDLE>(NULL)))
         {
             pLoaderAllocator->FreeHandle(exposedClassObjectHandle);
         }

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -886,7 +886,7 @@ public:
         PRECONDITION(!HasApproxParent());
         PRECONDITION(IsRestored_NoLogging());
 
-        FastInterlockAnd(&GetWriteableDataForWrite()->m_dwFlags, ~MethodTableWriteableData::enum_flag_IsNotFullyLoaded);
+        InterlockedAnd((LONG*)&GetWriteableDataForWrite()->m_dwFlags, ~MethodTableWriteableData::enum_flag_IsNotFullyLoaded);
     }
 
     // Equivalent to GetLoadLevel() == CLASS_LOADED
@@ -911,7 +911,7 @@ public:
         if (canCompare)
         {
             // Set checked and canCompare flags in one interlocked operation.
-            FastInterlockOr(&GetWriteableDataForWrite_NoLogging()->m_dwFlags,
+            InterlockedOr((LONG*)&GetWriteableDataForWrite_NoLogging()->m_dwFlags,
                 MethodTableWriteableData::enum_flag_HasCheckedCanCompareBitsOrUseFastGetHashCode | MethodTableWriteableData::enum_flag_CanCompareBitsOrUseFastGetHashCode);
         }
         else
@@ -929,7 +929,7 @@ public:
     inline void SetHasCheckedCanCompareBitsOrUseFastGetHashCode()
     {
         WRAPPER_NO_CONTRACT;
-        FastInterlockOr(&GetWriteableDataForWrite_NoLogging()->m_dwFlags, MethodTableWriteableData::enum_flag_HasCheckedCanCompareBitsOrUseFastGetHashCode);
+        InterlockedOr((LONG*)&GetWriteableDataForWrite_NoLogging()->m_dwFlags, MethodTableWriteableData::enum_flag_HasCheckedCanCompareBitsOrUseFastGetHashCode);
     }
 
     inline void SetIsDependenciesLoaded()
@@ -945,7 +945,7 @@ public:
         PRECONDITION(!HasApproxParent());
         PRECONDITION(IsRestored_NoLogging());
 
-        FastInterlockOr(&GetWriteableDataForWrite()->m_dwFlags, MethodTableWriteableData::enum_flag_DependenciesLoaded);
+        InterlockedOr((LONG*)&GetWriteableDataForWrite()->m_dwFlags, MethodTableWriteableData::enum_flag_DependenciesLoaded);
     }
 
     inline ClassLoadLevel GetLoadLevel()
@@ -1747,7 +1747,7 @@ public:
     inline void SetHasExactParent()
     {
         WRAPPER_NO_CONTRACT;
-        FastInterlockAnd(&(GetWriteableDataForWrite()->m_dwFlags), ~MethodTableWriteableData::enum_flag_HasApproxParent);
+        InterlockedAnd((LONG*)&GetWriteableDataForWrite()->m_dwFlags, ~MethodTableWriteableData::enum_flag_HasApproxParent);
     }
 
 

--- a/src/coreclr/vm/mngstdinterfaces.h
+++ b/src/coreclr/vm/mngstdinterfaces.h
@@ -60,7 +60,7 @@ public:
 
         if (m_pMngStdItfMap == NULL) {
             MngStdInterfaceMap *tmp = new MngStdInterfaceMap;
-            if (FastInterlockCompareExchangePointer(&m_pMngStdItfMap, tmp, NULL) != NULL) {
+            if (InterlockedCompareExchangeT(&m_pMngStdItfMap, tmp, NULL) != NULL) {
                 tmp->m_TypeNameToNativeIIDMap.ClearHashTable();
                 delete tmp;
             }

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -307,7 +307,7 @@ void PEAssembly::OpenImporter()
                                                        (void **)&pIMDImport));
 
     // Atomically swap it into the field (release it if we lose the race)
-    if (FastInterlockCompareExchangePointer(&m_pImporter, pIMDImport, NULL) != NULL)
+    if (InterlockedCompareExchangeT(&m_pImporter, pIMDImport, NULL) != NULL)
         pIMDImport->Release();
 }
 
@@ -362,7 +362,7 @@ void PEAssembly::ConvertMDInternalToReadWrite()
     // Swap the pointers in a thread safe manner.  If the contents of *ppImport
     //  equals pOld then no other thread got here first, and the old contents are
     //  replaced with pNew.  The old contents are returned.
-    if (FastInterlockCompareExchangePointer(&m_pMDImport, pNew, pOld) == pOld)
+    if (InterlockedCompareExchangeT(&m_pMDImport, pNew, pOld) == pOld)
     {
         //if the debugger queries, it will now see that we have RW metadata
         m_MDImportIsRW_Debugger_Use_Only = TRUE;
@@ -428,7 +428,7 @@ void PEAssembly::OpenEmitter()
                                                        (void **)&pIMDEmit));
 
     // Atomically swap it into the field (release it if we lose the race)
-    if (FastInterlockCompareExchangePointer(&m_pEmitter, pIMDEmit, NULL) != NULL)
+    if (InterlockedCompareExchangeT(&m_pEmitter, pIMDEmit, NULL) != NULL)
         pIMDEmit->Release();
 }
 

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -56,7 +56,7 @@ inline ULONG PEAssembly::AddRef()
     }
     CONTRACTL_END;
 
-    return FastInterlockIncrement(&m_refCount);
+    return InterlockedIncrement(&m_refCount);
 }
 
 inline ULONG PEAssembly::Release()
@@ -70,7 +70,7 @@ inline ULONG PEAssembly::Release()
     }
     CONTRACT_END;
 
-    LONG result = FastInterlockDecrement(&m_refCount);
+    LONG result = InterlockedDecrement(&m_refCount);
     _ASSERTE(result >= 0);
     if (result == 0)
         delete this;

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -144,7 +144,7 @@ ULONG PEImage::Release()
         CrstHolder holder(&s_hashLock);
 
         // Decrement and check the refcount - if we hit 0, remove it from the hash and delete it.
-        result=FastInterlockDecrement(&m_refCount);
+        result=InterlockedDecrement(&m_refCount);
         if (result == 0 )
         {
             LOG((LF_LOADER, LL_INFO100, "PEImage: Closing Image %S\n", (LPCWSTR) m_path));
@@ -348,7 +348,7 @@ void PEImage::OpenNativeMDImport()
                                                  IID_IMDInternalImport,
                                                  (void **) &m_pNewImport));
 
-        if(FastInterlockCompareExchangePointer(&m_pNativeMDImport, m_pNewImport, NULL))
+        if(InterlockedCompareExchangeT(&m_pNativeMDImport, m_pNewImport, NULL))
             m_pNewImport->Release();
     }
     _ASSERTE(m_pNativeMDImport);
@@ -390,7 +390,7 @@ void PEImage::OpenMDImport()
                                                  IID_IMDInternalImport,
                                                  (void **) &m_pNewImport));
 
-        if(FastInterlockCompareExchangePointer(&m_pMDImport, m_pNewImport, NULL))
+        if(InterlockedCompareExchangeT(&m_pMDImport, m_pNewImport, NULL))
         {
             m_pNewImport->Release();
         }
@@ -507,7 +507,7 @@ LoaderHeap *PEImage::IJWFixupData::GetThunkHeap()
             ThunkHeapStubManager::g_pManager->GetRangeList(),
             UnlockedLoaderHeap::HeapKind::Executable);
 
-        if (FastInterlockCompareExchangePointer((PVOID*)&m_DllThunkHeap, (VOID*)pNewHeap, (VOID*)0) != 0)
+        if (InterlockedCompareExchangeT((PVOID*)&m_DllThunkHeap, (VOID*)pNewHeap, (VOID*)0) != 0)
         {
             delete pNewHeap;
         }

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -22,7 +22,7 @@ inline ULONG PEImage::AddRef()
     }
     CONTRACT_END;
 
-    RETURN (static_cast<ULONG>(FastInterlockIncrement(&m_refCount)));
+    RETURN (static_cast<ULONG>(InterlockedIncrement(&m_refCount)));
 }
 
 inline const SString &PEImage::GetPath()

--- a/src/coreclr/vm/peimagelayout.inl
+++ b/src/coreclr/vm/peimagelayout.inl
@@ -19,7 +19,7 @@ inline void PEImageLayout::AddRef()
     }
     CONTRACT_END;
 
-    FastInterlockIncrement(&m_refCount);
+    InterlockedIncrement(&m_refCount);
 
     RETURN;
 }
@@ -41,7 +41,7 @@ inline ULONG PEImageLayout::Release()
         return m_refCount;
 #endif
 
-    ULONG result=FastInterlockDecrement(&m_refCount);
+    ULONG result=InterlockedDecrement(&m_refCount);
     if (result == 0 )
     {
         delete this;

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -918,8 +918,8 @@ void __stdcall UpdateGenerationBounds()
         GC_NOTRIGGER;
         MODE_ANY; // can be called even on GC threads
 #ifdef PROFILING_SUPPORTED
-        PRECONDITION(FastInterlockIncrement(&s_generationTableWriterCount) == 1);
-        POSTCONDITION(FastInterlockDecrement(&s_generationTableWriterCount) == 0);
+        PRECONDITION(InterlockedIncrement(&s_generationTableWriterCount) == 1);
+        POSTCONDITION(InterlockedDecrement(&s_generationTableWriterCount) == 0);
 #endif // PROFILING_SUPPORTED
     } CONTRACT_END;
 

--- a/src/coreclr/vm/spinlock.cpp
+++ b/src/coreclr/vm/spinlock.cpp
@@ -56,7 +56,7 @@ void SpinLock::Init(LOCK_TYPE type, bool RequireCoopGC)
 
     while (TRUE)
     {
-        LONG curValue = FastInterlockCompareExchange((LONG*)&m_Initialized, BeingInitialized, UnInitialized);
+        LONG curValue = InterlockedCompareExchange((LONG*)&m_Initialized, BeingInitialized, UnInitialized);
         if (curValue == Initialized)
         {
             return;
@@ -163,7 +163,7 @@ BOOL SpinLock::GetLockNoWait()
     CONTRACTL_END;
 
     {
-        if (VolatileLoad(&m_lock) == 0 && FastInterlockExchange (&m_lock, 1) == 0)
+        if (VolatileLoad(&m_lock) == 0 && InterlockedExchange (&m_lock, 1) == 0)
         {
             EE_LOCK_TAKEN(this);
             return 1;

--- a/src/coreclr/vm/spinlock.h
+++ b/src/coreclr/vm/spinlock.h
@@ -84,13 +84,13 @@ private:
     FORCEINLINE void Acquire()
     {
         WRAPPER_NO_CONTRACT;
-        YIELD_WHILE(FastInterlockExchange(&m_value, 1) == 1);
+        YIELD_WHILE(InterlockedExchange(&m_value, 1) == 1);
     }
 
     FORCEINLINE BOOL TryAcquire()
     {
         WRAPPER_NO_CONTRACT;
-        return (FastInterlockExchange(&m_value, 1) == 0);
+        return (InterlockedExchange(&m_value, 1) == 0);
     }
 
     FORCEINLINE void Release()

--- a/src/coreclr/vm/stublink.cpp
+++ b/src/coreclr/vm/stublink.cpp
@@ -1918,7 +1918,7 @@ VOID Stub::IncRef()
     CONTRACTL_END;
 
     _ASSERTE(m_signature == kUsedStub);
-    FastInterlockIncrement((LONG*)&m_refcount);
+    InterlockedIncrement((LONG*)&m_refcount);
 }
 
 //-------------------------------------------------------------------
@@ -1934,7 +1934,7 @@ BOOL Stub::DecRef()
     CONTRACTL_END;
 
     _ASSERTE(m_signature == kUsedStub);
-    int count = FastInterlockDecrement((LONG*)&m_refcount);
+    int count = InterlockedDecrement((LONG*)&m_refcount);
     if (count <= 0) {
         DeleteStub();
         return TRUE;

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -879,7 +879,7 @@ void SyncBlockCache::Grow()
         // note: we do not care if another thread does not see the new size
         // however we really do not want it to see the new size without seeing the new array
         //@TODO do we still leak here if two threads come here at the same time ?
-        FastInterlockExchangePointer(&SyncTableEntry::GetSyncTableEntryByRef(), newSyncTable.GetValue());
+        InterlockedExchangeT(&SyncTableEntry::GetSyncTableEntryByRef(), newSyncTable.GetValue());
 
         m_FreeSyncTableIndex++;
 
@@ -1904,7 +1904,7 @@ DEBUG_NOINLINE void ObjHeader::EnterSpinLock()
         {
             // try to take the lock
             LONG newValue = curValue | BIT_SBLK_SPIN_LOCK;
-            LONG result = FastInterlockCompareExchange((LONG*)&m_SyncBlockValue, newValue, curValue);
+            LONG result = InterlockedCompareExchange((LONG*)&m_SyncBlockValue, newValue, curValue);
             if (result == curValue)
                 break;
         }
@@ -1952,7 +1952,7 @@ DEBUG_NOINLINE void ObjHeader::EnterSpinLock()
         {
             // try to take the lock
             LONG newValue = curValue | BIT_SBLK_SPIN_LOCK;
-            LONG result = FastInterlockCompareExchange((LONG*)&m_SyncBlockValue, newValue, curValue);
+            LONG result = InterlockedCompareExchange((LONG*)&m_SyncBlockValue, newValue, curValue);
             if (result == curValue)
                 break;
         }
@@ -1972,7 +1972,7 @@ DEBUG_NOINLINE void ObjHeader::ReleaseSpinLock()
     INCONTRACT(Thread* pThread = GetThreadNULLOk());
     INCONTRACT(if (pThread != NULL) pThread->EndNoTriggerGC());
 
-    FastInterlockAnd(&m_SyncBlockValue, ~BIT_SBLK_SPIN_LOCK);
+    InterlockedAnd((LONG*)&m_SyncBlockValue, ~BIT_SBLK_SPIN_LOCK);
 }
 
 #endif //!DACCESS_COMPILE
@@ -2918,7 +2918,7 @@ bool SyncBlock::SetInteropInfo(InteropSyncBlockInfo* pInteropInfo)
               m_dwAppDomainIndex == GetAppDomain()->GetIndex());
     m_dwAppDomainIndex = GetAppDomain()->GetIndex();
 */
-    return (FastInterlockCompareExchangePointer(&m_pInteropInfo,
+    return (InterlockedCompareExchangeT(&m_pInteropInfo,
                                                 pInteropInfo,
                                                 NULL) == NULL);
 }

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -567,7 +567,7 @@ public:
     void    IncrementTransientPrecious()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockIncrement(&m_TransientPrecious);
+        InterlockedIncrement(&m_TransientPrecious);
         _ASSERTE(m_TransientPrecious > 0);
     }
 
@@ -575,7 +575,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(m_TransientPrecious > 0);
-        FastInterlockDecrement(&m_TransientPrecious);
+        InterlockedDecrement(&m_TransientPrecious);
     }
 
     DWORD GetSyncBlockIndex();
@@ -738,7 +738,7 @@ public:
     bool SetUMEntryThunk(void* pUMEntryThunk)
     {
         WRAPPER_NO_CONTRACT;
-        return (FastInterlockCompareExchangePointer(&m_pUMEntryThunk,
+        return (InterlockedCompareExchangeT(&m_pUMEntryThunk,
                                                     pUMEntryThunk,
                                                     NULL) == NULL);
     }
@@ -801,7 +801,7 @@ public:
         if (m_managedObjectComWrapperMap == NULL)
         {
             NewHolder<ManagedObjectComWrapperByIdMap> map = new ManagedObjectComWrapperByIdMap();
-            if (FastInterlockCompareExchangePointer((ManagedObjectComWrapperByIdMap**)&m_managedObjectComWrapperMap, (ManagedObjectComWrapperByIdMap *)map, NULL) == NULL)
+            if (InterlockedCompareExchangeT((ManagedObjectComWrapperByIdMap**)&m_managedObjectComWrapperMap, (ManagedObjectComWrapperByIdMap *)map, NULL) == NULL)
             {
                 map.SuppressRelease();
             }
@@ -880,7 +880,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
 
-        return (FastInterlockCompareExchangePointer(
+        return (InterlockedCompareExchangeT(
                         &m_externalComObjectContext,
                         eoc,
                         curr) == curr);
@@ -1117,7 +1117,7 @@ class SyncBlock
     DWORD SetHashCode(DWORD hashCode)
     {
         WRAPPER_NO_CONTRACT;
-        DWORD result = FastInterlockCompareExchange((LONG*)&m_dwHashCode, hashCode, 0);
+        DWORD result = InterlockedCompareExchange((LONG*)&m_dwHashCode, hashCode, 0);
         if (result == 0)
         {
             // the sync block now holds a hash code, which we can't afford to lose.
@@ -1473,7 +1473,7 @@ class ObjHeader
             // note that indx could be carrying the BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX bit that we need to preserve
             newValue = (indx |
                 (oldValue & ~(BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX | BIT_SBLK_IS_HASHCODE | MASK_SYNCBLOCKINDEX)));
-            if (FastInterlockCompareExchange((LONG*)&m_SyncBlockValue,
+            if (InterlockedCompareExchange((LONG*)&m_SyncBlockValue,
                                              newValue,
                                              oldValue)
                 == oldValue)
@@ -1489,7 +1489,7 @@ class ObjHeader
         LIMITED_METHOD_CONTRACT;
 
         _ASSERTE(m_SyncBlockValue & BIT_SBLK_SPIN_LOCK);
-        FastInterlockAnd(&m_SyncBlockValue, ~(BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX | BIT_SBLK_IS_HASHCODE | MASK_SYNCBLOCKINDEX));
+        InterlockedAnd((LONG*)&m_SyncBlockValue, ~(BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX | BIT_SBLK_IS_HASHCODE | MASK_SYNCBLOCKINDEX));
     }
 
     // Used only GC
@@ -1509,14 +1509,14 @@ class ObjHeader
         LIMITED_METHOD_CONTRACT;
 
         _ASSERTE((bit & MASK_SYNCBLOCKINDEX) == 0);
-        FastInterlockOr(&m_SyncBlockValue, bit);
+        InterlockedOr((LONG*)&m_SyncBlockValue, bit);
     }
     void ClrBit(DWORD bit)
     {
         LIMITED_METHOD_CONTRACT;
 
         _ASSERTE((bit & MASK_SYNCBLOCKINDEX) == 0);
-        FastInterlockAnd(&m_SyncBlockValue, ~bit);
+        InterlockedAnd((LONG*)&m_SyncBlockValue, ~bit);
     }
     //GC accesses this bit when all threads are stopped.
     void SetGCBit()
@@ -1554,7 +1554,7 @@ class ObjHeader
         LIMITED_METHOD_CONTRACT;
 
         _ASSERTE((oldBits & BIT_SBLK_SPIN_LOCK) == 0);
-        DWORD result = FastInterlockCompareExchange((LONG*)&m_SyncBlockValue, newBits, oldBits);
+        DWORD result = InterlockedCompareExchange((LONG*)&m_SyncBlockValue, newBits, oldBits);
         return result;
     }
 

--- a/src/coreclr/vm/syncclean.cpp
+++ b/src/coreclr/vm/syncclean.cpp
@@ -38,7 +38,7 @@ void SyncClean::AddHashMap (Bucket *bucket)
         pTempBucket = (Bucket *)m_HashMap;
         NextObsolete (bucket) = pTempBucket;
     }
-    while (FastInterlockCompareExchangePointer(m_HashMap.GetPointer(), bucket, pTempBucket) != pTempBucket);
+    while (InterlockedCompareExchangeT(m_HashMap.GetPointer(), bucket, pTempBucket) != pTempBucket);
 }
 
 void SyncClean::AddEEHashTable (EEHashEntry** entry)
@@ -58,7 +58,7 @@ void SyncClean::AddEEHashTable (EEHashEntry** entry)
         pTempHashEntry = (EEHashEntry**)m_EEHashTable;
         entry[-1] = (EEHashEntry *)pTempHashEntry;
     }
-    while (FastInterlockCompareExchangePointer(m_EEHashTable.GetPointer(), entry, pTempHashEntry) != pTempHashEntry);
+    while (InterlockedCompareExchangeT(m_EEHashTable.GetPointer(), entry, pTempHashEntry) != pTempHashEntry);
 }
 
 void SyncClean::CleanUp ()
@@ -71,7 +71,7 @@ void SyncClean::CleanUp ()
               (GCHeapUtilities::IsGCInProgress()  && GetThreadNULLOk() == ThreadSuspend::GetSuspensionThread()));
     if (m_HashMap)
     {
-        Bucket * pTempBucket = FastInterlockExchangePointer(m_HashMap.GetPointer(), NULL);
+        Bucket * pTempBucket = InterlockedExchangeT(m_HashMap.GetPointer(), NULL);
 
         while (pTempBucket)
         {
@@ -83,7 +83,7 @@ void SyncClean::CleanUp ()
 
     if (m_EEHashTable)
     {
-        EEHashEntry ** pTempHashEntry = FastInterlockExchangePointer(m_EEHashTable.GetPointer(), NULL);
+        EEHashEntry ** pTempHashEntry = InterlockedExchangeT(m_EEHashTable.GetPointer(), NULL);
 
         while (pTempHashEntry) {
             EEHashEntry **pNextHashEntry = (EEHashEntry **)pTempHashEntry[-1];

--- a/src/coreclr/vm/synch.cpp
+++ b/src/coreclr/vm/synch.cpp
@@ -124,14 +124,14 @@ void CLREventBase::CreateMonitorEvent(SIZE_T Cookie)
     CONTRACTL_END;
 
     // thread-safe SetAutoEvent
-    FastInterlockOr(&m_dwFlags, CLREVENT_FLAGS_AUTO_EVENT);
+    InterlockedOr((LONG*)&m_dwFlags, CLREVENT_FLAGS_AUTO_EVENT);
 
     {
         HANDLE h = WszCreateEvent(NULL,FALSE,FALSE,NULL);
         if (h == NULL) {
             ThrowOutOfMemory();
         }
-        if (FastInterlockCompareExchangePointer(&m_handle,
+        if (InterlockedCompareExchangeT(&m_handle,
                                                 h,
                                                 INVALID_HANDLE_VALUE) != INVALID_HANDLE_VALUE)
         {
@@ -141,7 +141,7 @@ void CLREventBase::CreateMonitorEvent(SIZE_T Cookie)
     }
 
     // thread-safe SetInDeadlockDetection
-    FastInterlockOr(&m_dwFlags, CLREVENT_FLAGS_IN_DEADLOCK_DETECTION);
+    InterlockedOr((LONG*)&m_dwFlags, CLREVENT_FLAGS_IN_DEADLOCK_DETECTION);
 
     for (;;)
     {
@@ -154,7 +154,7 @@ void CLREventBase::CreateMonitorEvent(SIZE_T Cookie)
         }
 
         LONG newFlags = oldFlags | CLREVENT_FLAGS_MONITOREVENT_ALLOCATED;
-        if (FastInterlockCompareExchange((LONG*)&m_dwFlags, newFlags, oldFlags) != oldFlags)
+        if (InterlockedCompareExchange((LONG*)&m_dwFlags, newFlags, oldFlags) != oldFlags)
         {
             // We lost the race
             continue;
@@ -196,7 +196,7 @@ void CLREventBase::SetMonitorEvent()
         }
 
         LONG newFlags = oldFlags | CLREVENT_FLAGS_MONITOREVENT_SIGNALLED;
-        if (FastInterlockCompareExchange((LONG*)&m_dwFlags, newFlags, oldFlags) != oldFlags)
+        if (InterlockedCompareExchange((LONG*)&m_dwFlags, newFlags, oldFlags) != oldFlags)
         {
             // We lost the race
             continue;

--- a/src/coreclr/vm/threadpoolrequest.cpp
+++ b/src/coreclr/vm/threadpoolrequest.cpp
@@ -325,7 +325,7 @@ void UnManagedPerAppDomainTPCount::SetAppDomainRequestsActive()
     LONG count = VolatileLoad(&m_outstandingThreadRequestCount);
     while (count < (LONG)ThreadpoolMgr::NumberOfProcessors)
     {
-        LONG prevCount = FastInterlockCompareExchange(&m_outstandingThreadRequestCount, count+1, count);
+        LONG prevCount = InterlockedCompareExchange(&m_outstandingThreadRequestCount, count+1, count);
         if (prevCount == count)
         {
             ThreadpoolMgr::MaybeAddWorkingWorker();
@@ -346,7 +346,7 @@ bool FORCEINLINE UnManagedPerAppDomainTPCount::TakeActiveRequest()
 
     while (count > 0)
     {
-        LONG prevCount = FastInterlockCompareExchange(&m_outstandingThreadRequestCount, count-1, count);
+        LONG prevCount = InterlockedCompareExchange(&m_outstandingThreadRequestCount, count-1, count);
         if (prevCount == count)
             return true;
         count = prevCount;
@@ -568,7 +568,7 @@ void ManagedPerAppDomainTPCount::SetAppDomainRequestsActive()
         LONG count = VolatileLoad(&m_numRequestsPending);
         while (true)
         {
-            LONG prev = FastInterlockCompareExchange(&m_numRequestsPending, count+1, count);
+            LONG prev = InterlockedCompareExchange(&m_numRequestsPending, count+1, count);
             if (prev == count)
             {
                 ThreadpoolMgr::MaybeAddWorkingWorker();
@@ -593,7 +593,7 @@ void ManagedPerAppDomainTPCount::ClearAppDomainRequestsActive()
     LONG count = VolatileLoad(&m_numRequestsPending);
     while (count > 0)
     {
-        LONG prev = FastInterlockCompareExchange(&m_numRequestsPending, 0, count);
+        LONG prev = InterlockedCompareExchange(&m_numRequestsPending, 0, count);
         if (prev == count)
             break;
         count = prev;
@@ -608,7 +608,7 @@ bool ManagedPerAppDomainTPCount::TakeActiveRequest()
     LONG count = VolatileLoad(&m_numRequestsPending);
     while (count > 0)
     {
-        LONG prev = FastInterlockCompareExchange(&m_numRequestsPending, count-1, count);
+        LONG prev = InterlockedCompareExchange(&m_numRequestsPending, count-1, count);
         if (prev == count)
             return true;
         count = prev;

--- a/src/coreclr/vm/threadpoolrequest.h
+++ b/src/coreclr/vm/threadpoolrequest.h
@@ -136,7 +136,7 @@ private:
     TPIndex m_index;
     struct DECLSPEC_ALIGN(MAX_CACHE_LINE_SIZE) {
         BYTE m_padding1[MAX_CACHE_LINE_SIZE - sizeof(LONG)];
-        // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
+        // Only use with VolatileLoad+VolatileStore+InterlockedCompareExchange
         LONG m_numRequestsPending;
         BYTE m_padding2[MAX_CACHE_LINE_SIZE];
     };
@@ -214,7 +214,7 @@ private:
     ULONG m_NumRequests;
     struct DECLSPEC_ALIGN(MAX_CACHE_LINE_SIZE) {
         BYTE m_padding1[MAX_CACHE_LINE_SIZE - sizeof(LONG)];
-        // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
+        // Only use with VolatileLoad+VolatileStore+InterlockedCompareExchange
         LONG m_outstandingThreadRequestCount;
         BYTE m_padding2[MAX_CACHE_LINE_SIZE];
     };

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -612,7 +612,7 @@ static void DeleteThread(Thread* pThread)
         pThread->RevokeApartmentSpy();
 #endif // FEATURE_COMINTEROP
 
-        FastInterlockOr((ULONG *)&pThread->m_State, Thread::TS_Dead);
+        pThread->SetThreadState(Thread::TS_Dead);
 
         // ~Thread() calls SafeSetThrowables which has a conditional contract
         // which says that if you call it with a NULL throwable then it is
@@ -695,17 +695,17 @@ Thread* SetupThread()
         {
             if (IsThreadPoolWorkerSpecialThread())
             {
-                FastInterlockOr((ULONG *) &pThread->m_State, Thread::TS_TPWorkerThread);
+                pThread->SetThreadState(Thread::TS_TPWorkerThread);
                 pThread->SetBackground(TRUE);
             }
             else if (IsThreadPoolIOCompletionSpecialThread())
             {
-                FastInterlockOr ((ULONG *) &pThread->m_State, Thread::TS_CompletionPortThread);
+                pThread->SetThreadState(Thread::TS_CompletionPortThread);
                 pThread->SetBackground(TRUE);
             }
             else if (IsTimerSpecialThread() || IsWaitSpecialThread())
             {
-                FastInterlockOr((ULONG *) &pThread->m_State, Thread::TS_TPWorkerThread);
+                pThread->SetThreadState(Thread::TS_TPWorkerThread);
                 pThread->SetBackground(TRUE);
             }
 
@@ -727,8 +727,8 @@ Thread* SetupThread()
     pThread->PrepareApartmentAndContext();
 
     // reset any unstarted bits on the thread object
-    FastInterlockAnd((ULONG *) &pThread->m_State, ~Thread::TS_Unstarted);
-    FastInterlockOr((ULONG *) &pThread->m_State, Thread::TS_LegalToJoin);
+    pThread->ResetThreadState(Thread::TS_Unstarted);
+    pThread->SetThreadState(Thread::TS_LegalToJoin);
 
     ThreadStore::AddThread(pThread);
 
@@ -745,7 +745,7 @@ Thread* SetupThread()
 
     threadHolder.SuppressRelease();
 
-    FastInterlockOr((ULONG *) &pThread->m_State, Thread::TS_FullyInitialized);
+    pThread->SetThreadState(Thread::TS_FullyInitialized);
 
 #ifdef DEBUGGING_SUPPORTED
     //
@@ -788,15 +788,15 @@ Thread* SetupThread()
 
     if (IsThreadPoolWorkerSpecialThread())
     {
-        FastInterlockOr((ULONG *) &pThread->m_State, Thread::TS_TPWorkerThread);
+        pThread->SetThreadState(Thread::TS_TPWorkerThread);
     }
     else if (IsThreadPoolIOCompletionSpecialThread())
     {
-        FastInterlockOr ((ULONG *) &pThread->m_State, Thread::TS_CompletionPortThread);
+        pThread->SetThreadState(Thread::TS_CompletionPortThread);
     }
     else if (IsTimerSpecialThread() || IsWaitSpecialThread())
     {
-        FastInterlockOr((ULONG *) &pThread->m_State, Thread::TS_TPWorkerThread);
+        pThread->SetThreadState(Thread::TS_TPWorkerThread);
     }
 
 #ifdef FEATURE_EVENT_TRACE
@@ -878,8 +878,7 @@ Thread* SetupUnstartedThread(SetupUnstartedThreadFlags flags)
         pThread->SetThreadStateNC(Thread::TSNC_TSLTakenForStartup);
     }
 
-    FastInterlockOr((ULONG *) &pThread->m_State,
-                    (Thread::TS_Unstarted | Thread::TS_WeOwn));
+    pThread->SetThreadState((Thread::ThreadState)(Thread::TS_Unstarted | Thread::TS_WeOwn));
 
     ThreadStore::AddThread(pThread);
 
@@ -989,7 +988,7 @@ HRESULT Thread::DetachThread(BOOL fDLLThreadDetach)
 
     _ASSERTE (this == GetThread());
 
-    FastInterlockIncrement(&Thread::m_DetachCount);
+    InterlockedIncrement(&Thread::m_DetachCount);
 
     if (IsAbortRequested()) {
         // Reset trapping count.
@@ -998,7 +997,7 @@ HRESULT Thread::DetachThread(BOOL fDLLThreadDetach)
 
     if (!IsBackground())
     {
-        FastInterlockIncrement(&Thread::m_ActiveDetachCount);
+        InterlockedIncrement(&Thread::m_ActiveDetachCount);
         ThreadStore::CheckForEEShutdown();
     }
 
@@ -1021,7 +1020,7 @@ HRESULT Thread::DetachThread(BOOL fDLLThreadDetach)
     SetThread(NULL);
     SetAppDomain(NULL);
 
-    FastInterlockOr((ULONG*)&m_State, (int) (Thread::TS_Detached | Thread::TS_ReportDead));
+    SetThreadState((Thread::ThreadState)(Thread::TS_Detached | Thread::TS_ReportDead));
     // Do not touch Thread object any more.  It may be destroyed.
 
     // These detached threads will be cleaned up by finalizer thread.  But if the process uses
@@ -1898,7 +1897,7 @@ BOOL Thread::HasStarted()
     if (res == FALSE)
         goto FAILURE;
 
-    FastInterlockOr((ULONG *) &m_State, TS_FullyInitialized);
+    SetThreadState(TS_FullyInitialized);
 
 #ifdef DEBUGGING_SUPPORTED
     //
@@ -1969,7 +1968,7 @@ FAILURE:
         CleanupCOMState();
     }
 #endif
-    FastInterlockDecrement(&ThreadStore::s_pThreadStore->m_PendingThreadCount);
+    InterlockedDecrement(&ThreadStore::s_pThreadStore->m_PendingThreadCount);
     // One of the components of OtherThreadsComplete() has changed, so check whether
     // we should now exit the EE.
     ThreadStore::CheckForEEShutdown();
@@ -2376,7 +2375,7 @@ BOOL Thread::CreateNewOSThread(SIZE_T sizeToCommitOrReserve, LPTHREAD_START_ROUT
 
     m_OSThreadId = ourId;
 
-    FastInterlockIncrement(&ThreadStore::s_pThreadStore->m_PendingThreadCount);
+    InterlockedIncrement(&ThreadStore::s_pThreadStore->m_PendingThreadCount);
 
 #ifdef _DEBUG
     m_Creator.SetToCurrentThread();
@@ -2423,7 +2422,7 @@ int Thread::IncExternalCount()
     Thread *pCurThread = GetThreadNULLOk();
 
     _ASSERTE(m_ExternalRefCount > 0);
-    int retVal = FastInterlockIncrement((LONG*)&m_ExternalRefCount);
+    int retVal = InterlockedIncrement((LONG*)&m_ExternalRefCount);
     // If we have an exposed object and the refcount is greater than one
     // we must make sure to keep a strong handle to the exposed object
     // so that we keep it alive even if nobody has a reference to it.
@@ -2493,7 +2492,7 @@ int Thread::DecExternalCount(BOOL holdingLock)
              ThreadStore::s_pThreadStore->m_Crst.GetEnterCount() > 0 ||
              IsAtProcessExit());
 
-    retVal = FastInterlockDecrement((LONG*)&m_ExternalRefCount);
+    retVal = InterlockedDecrement((LONG*)&m_ExternalRefCount);
 
     if (retVal == 0)
     {
@@ -2785,7 +2784,7 @@ void Thread::CoUninitialize()
         if (IsCoInitialized())
         {
             BaseCoUninitialize();
-            FastInterlockAnd((ULONG *)&m_State, ~TS_CoInitialized);
+            ResetThreadState(TS_CoInitialized);
         }
 
 #ifdef FEATURE_COMINTEROP
@@ -2827,10 +2826,10 @@ void Thread::CleanupDetachedThreads()
             // Unmark that the thread is detached while we have the
             // thread store lock. This will ensure that no other
             // thread will race in here and try to delete it, too.
-            FastInterlockAnd((ULONG*)&(thread->m_State), ~TS_Detached);
-            FastInterlockDecrement(&m_DetachCount);
+            thread->ResetThreadState(TS_Detached);
+            InterlockedDecrement(&m_DetachCount);
             if (!thread->IsBackground())
-                FastInterlockDecrement(&m_ActiveDetachCount);
+                InterlockedDecrement(&m_ActiveDetachCount);
 
             // If the debugger is attached, then we need to unlock the
             // thread store before calling OnThreadTerminate. That
@@ -3016,7 +3015,7 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
             GCX_COOP();
             // GetTotalAllocatedBytes reads dead_threads_non_alloc_bytes, but will suspend EE, being in COOP mode we cannot race with that
             // however, there could be other threads terminating and doing the same Add.
-            FastInterlockExchangeAddLong((LONG64*)&dead_threads_non_alloc_bytes, m_alloc_context.alloc_limit - m_alloc_context.alloc_ptr);
+            InterlockedExchangeAdd64((LONG64*)&dead_threads_non_alloc_bytes, m_alloc_context.alloc_limit - m_alloc_context.alloc_ptr);
             GCHeapUtilities::GetGCHeap()->FixAllocContext(&m_alloc_context, NULL, NULL);
             m_alloc_context.init();
         }
@@ -3079,7 +3078,7 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
             m_alloc_context.init();
         }
 
-        FastInterlockOr((ULONG *) &m_State, TS_Dead);
+        SetThreadState(TS_Dead);
         ThreadStore::s_pThreadStore->m_DeadThreadCount++;
         ThreadStore::s_pThreadStore->IncrementDeadThreadCountForGCTrigger();
 
@@ -3091,7 +3090,7 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
                 ThreadStore::s_pThreadStore->m_BackgroundThreadCount--;
         }
 
-        FastInterlockAnd((ULONG *) &m_State, ~(TS_Unstarted | TS_Background));
+        ResetThreadState((Thread::ThreadState)(TS_Unstarted | TS_Background));
 
         //
         // If this thread was told to trip for debugging between the
@@ -3397,7 +3396,7 @@ void Thread::DoAppropriateWaitWorkerAlertableHelper(WaitMode mode)
     // a thread that's not in the interruptible state, we just record that fact.  So
     // we have to set TS_Interruptible before we test to see whether someone wants to
     // interrupt us or else we have a race condition that causes us to skip the APC.
-    FastInterlockOr((ULONG *) &m_State, TS_Interruptible);
+    SetThreadState(TS_Interruptible);
 
     if (HasThreadStateNC(TSNC_InRestoringSyncBlock))
     {
@@ -3411,7 +3410,7 @@ void Thread::DoAppropriateWaitWorkerAlertableHelper(WaitMode mode)
         // Safe to clear the interrupted state, no APC could have fired since we
         // reset m_UserInterrupt (which inhibits our APC callback from doing
         // anything).
-        FastInterlockAnd((ULONG *) &m_State, ~TS_Interrupted);
+        ResetThreadState(TS_Interrupted);
     }
 }
 
@@ -4184,7 +4183,7 @@ void WINAPI Thread::UserInterruptAPC(ULONG_PTR data)
         {
             // Set bit to indicate this routine was called (as opposed to other
             // generic APCs).
-            FastInterlockOr((ULONG *) &pCurThread->m_State, TS_Interrupted);
+            pCurThread->SetThreadState(TS_Interrupted);
         }
     }
 }
@@ -4198,7 +4197,7 @@ void Thread::UserInterrupt(ThreadInterruptMode mode)
     }
     CONTRACTL_END;
 
-    FastInterlockOr((DWORD*)&m_UserInterrupt, mode);
+    InterlockedOr(&m_UserInterrupt, mode);
 
     if (HasValidThreadHandle() &&
         HasThreadState (TS_Interruptible))
@@ -4231,7 +4230,7 @@ void Thread::UserSleep(INT32 time)
     // a thread that's not in the interruptible state, we just record that fact.  So
     // we have to set TS_Interruptible before we test to see whether someone wants to
     // interrupt us or else we have a race condition that causes us to skip the APC.
-    FastInterlockOr((ULONG *) &m_State, TS_Interruptible);
+    SetThreadState(TS_Interruptible);
 
     // If someone has interrupted us, we should not enter the wait.
     if (IsUserInterrupted())
@@ -4241,7 +4240,7 @@ void Thread::UserSleep(INT32 time)
 
     ThreadStateHolder tsh(TRUE, TS_Interruptible | TS_Interrupted);
 
-    FastInterlockAnd((ULONG *) &m_State, ~TS_Interrupted);
+    ResetThreadState(TS_Interrupted);
 
     DWORD dwTime = (DWORD)time;
 retry:
@@ -4324,7 +4323,7 @@ OBJECTREF Thread::GetExposedObject()
 
             // Increase the external ref count. We can't call IncExternalCount because we
             // already hold the thread lock and IncExternalCount won't be able to take it.
-            ULONG retVal = FastInterlockIncrement ((LONG*)&m_ExternalRefCount);
+            ULONG retVal = InterlockedIncrement ((LONG*)&m_ExternalRefCount);
 
             // Check to see if we need to store a strong pointer to the object.
             if (retVal > 1)
@@ -4663,7 +4662,7 @@ void Thread::SetBackground(BOOL isBack)
     {
         if (!IsBackground())
         {
-            FastInterlockOr((ULONG *) &m_State, TS_Background);
+            SetThreadState(TS_Background);
 
             // unstarted threads don't contribute to the background count
             if (!IsUnstarted())
@@ -4683,7 +4682,7 @@ void Thread::SetBackground(BOOL isBack)
     {
         if (IsBackground())
         {
-            FastInterlockAnd((ULONG *) &m_State, ~TS_Background);
+            ResetThreadState(TS_Background);
 
             // unstarted threads don't contribute to the background count
             if (!IsUnstarted())
@@ -4785,7 +4784,7 @@ void Thread::PrepareApartmentAndContext()
         // a different apartment state than the requested one. If we didn't clear
         // the requested apartment state, then we could end up with both TS_InSTA and
         // TS_InMTA set at the same time.
-        FastInterlockAnd ((ULONG *) &m_State, ~TS_InSTA & ~TS_InMTA);
+        ResetThreadState((Thread::ThreadState)(TS_InSTA | TS_InMTA));
 
         // Attempt to set the requested apartment state.
         SetApartment(aState);
@@ -4882,7 +4881,7 @@ Thread::ApartmentState Thread::GetApartmentRare(Thread::ApartmentState as)
                 // made MTA (if it hasn't been CoInitializeEx'd but CoInitialize
                 // has already been called on some other thread in the process.
                 if (as == AS_InSTA)
-                    FastInterlockOr((ULONG *) &m_State, AS_InSTA);
+                    SetThreadState(TS_InSTA);
             }
         }
     }
@@ -4935,7 +4934,7 @@ Thread::ApartmentState Thread::GetFinalApartment()
     {
         // On shutdown, do not use cached value.  Someone might have called
         // CoUninitialize.
-        FastInterlockAnd ((ULONG *) &m_State, ~TS_InSTA & ~TS_InMTA);
+        ResetThreadState((Thread::ThreadState)(TS_InSTA | TS_InMTA));
     }
 
     as = GetApartment();
@@ -4962,8 +4961,7 @@ VOID Thread::ResetApartment()
     CONTRACTL_END;
 
     // reset the TS_InSTA bit and TS_InMTA bit
-    ThreadState t_State = (ThreadState)(~(TS_InSTA | TS_InMTA));
-    FastInterlockAnd((ULONG *) &m_State, t_State);
+    ResetThreadState((Thread::ThreadState)(TS_InSTA | TS_InMTA));
 }
 
 // Attempt to set current thread's apartment state. The actual apartment state
@@ -5012,7 +5010,7 @@ Thread::ApartmentState Thread::SetApartment(ApartmentState state)
                 ::CoUninitialize();
 
                 ThreadState uninitialized = static_cast<ThreadState>(TS_InSTA | TS_InMTA | TS_CoInitialized);
-                FastInterlockAnd((ULONG *) &m_State, ~uninitialized);
+                ResetThreadState(uninitialized);
             }
 
 #ifdef FEATURE_COMINTEROP
@@ -5062,7 +5060,7 @@ Thread::ApartmentState Thread::SetApartment(ApartmentState state)
     if (m_OSThreadId != ::GetCurrentThreadId())
 #endif
     {
-        FastInterlockOr((ULONG *) &m_State, (state == AS_InSTA) ? TS_InSTA : TS_InMTA);
+        SetThreadState((state == AS_InSTA) ? TS_InSTA : TS_InMTA);
         return state;
     }
 
@@ -5104,14 +5102,14 @@ Thread::ApartmentState Thread::SetApartment(ApartmentState state)
         }
 
         // We succeeded in setting the apartment state to the requested state.
-        FastInterlockOr((ULONG *) &m_State, t_State);
+        SetThreadState(t_State);
     }
     else if (hr == RPC_E_CHANGED_MODE)
     {
         // We didn't manage to enforce the requested apartment state, but at least
         // we can work out what the state is now.  No need to actually do the CoInit --
         // obviously someone else already took care of that.
-        FastInterlockOr((ULONG *) &m_State, ((state == AS_InSTA) ? TS_InMTA : TS_InSTA));
+        SetThreadState((state == AS_InSTA) ? TS_InMTA : TS_InSTA);
     }
     else if (hr == E_OUTOFMEMORY)
     {
@@ -5388,13 +5386,13 @@ BOOL ThreadStore::RemoveThread(Thread *target)
         if (target->IsBackground())
             s_pThreadStore->m_BackgroundThreadCount--;
 
-        FastInterlockExchangeAddLong(
+        InterlockedExchangeAdd64(
             (LONGLONG *)&Thread::s_workerThreadPoolCompletionCountOverflow,
             target->m_workerThreadPoolCompletionCount);
-        FastInterlockExchangeAddLong(
+        InterlockedExchangeAdd64(
             (LONGLONG *)&Thread::s_ioThreadPoolCompletionCountOverflow,
             target->m_ioThreadPoolCompletionCount);
-        FastInterlockExchangeAddLong(
+        InterlockedExchangeAdd64(
             (LONGLONG *)&Thread::s_monitorLockContentionCountOverflow,
             target->m_monitorLockContentionCount);
 
@@ -5459,12 +5457,12 @@ void ThreadStore::TransferStartedThread(Thread *thread)
         s_pThreadStore->m_BackgroundThreadCount++;
 
     _ASSERTE(s_pThreadStore->m_PendingThreadCount > 0);
-    FastInterlockDecrement(&s_pThreadStore->m_PendingThreadCount);
+    InterlockedDecrement(&s_pThreadStore->m_PendingThreadCount);
 
     // As soon as we erase this bit, the thread becomes eligible for suspension,
     // stopping, interruption, etc.
-    FastInterlockAnd((ULONG *) &thread->m_State, ~Thread::TS_Unstarted);
-    FastInterlockOr((ULONG *) &thread->m_State, Thread::TS_LegalToJoin);
+    thread->ResetThreadState(Thread::TS_Unstarted);
+    thread->SetThreadState(Thread::TS_LegalToJoin);
 
     // One of the components of OtherThreadsComplete() has changed, so check whether
     // we should now exit the EE.
@@ -5486,7 +5484,7 @@ void ThreadStore::IncrementDeadThreadCountForGCTrigger()
     // Although all increments and decrements are usually done inside a lock, that is not sufficient to synchronize with a
     // background GC thread resetting this value, hence the interlocked operation. Ignore overflow; overflow would likely never
     // occur, the count is treated as unsigned, and nothing bad would happen if it were to overflow.
-    SIZE_T count = static_cast<SIZE_T>(FastInterlockIncrement(&m_DeadThreadCountForGCTrigger));
+    SIZE_T count = static_cast<SIZE_T>(InterlockedIncrement(&m_DeadThreadCountForGCTrigger));
 
     SIZE_T countThreshold = static_cast<SIZE_T>(s_DeadThreadCountThresholdForGCTrigger);
     if (count < countThreshold || countThreshold == 0)
@@ -5532,7 +5530,7 @@ void ThreadStore::DecrementDeadThreadCountForGCTrigger()
 
     // Although all increments and decrements are usually done inside a lock, that is not sufficient to synchronize with a
     // background GC thread resetting this value, hence the interlocked operation.
-    if (FastInterlockDecrement(&m_DeadThreadCountForGCTrigger) < 0)
+    if (InterlockedDecrement(&m_DeadThreadCountForGCTrigger) < 0)
     {
         m_DeadThreadCountForGCTrigger = 0;
     }
@@ -5546,7 +5544,7 @@ void ThreadStore::OnMaxGenerationGCStarted()
     // objects are still reachable due to references to the thread objects, they will not contribute to triggering a GC again.
     // Synchronize the store with increment/decrement operations occurring on different threads, and make the change visible to
     // other threads in order to prevent unnecessary GC triggers.
-    FastInterlockExchange(&m_DeadThreadCountForGCTrigger, 0);
+    InterlockedExchange(&m_DeadThreadCountForGCTrigger, 0);
 }
 
 bool ThreadStore::ShouldTriggerGCForDeadThreads()
@@ -5789,7 +5787,7 @@ void ThreadStore::WaitForOtherThreads()
     {
         TSLockHolder.Release();
 
-        FastInterlockOr((ULONG *) &pCurThread->m_State, Thread::TS_ReportDead);
+        pCurThread->SetThreadState(Thread::TS_ReportDead);
 
         DWORD ret = WAIT_OBJECT_0;
         while (CLREventWaitWithTry(&m_TerminationEvent, INFINITE, TRUE, &ret))
@@ -5928,7 +5926,7 @@ void Thread::HandleThreadInterrupt ()
     if ((m_UserInterrupt & TI_Interrupt) != 0)
     {
         ResetThreadState ((ThreadState)(TS_Interrupted | TS_Interruptible));
-        FastInterlockAnd ((DWORD*)&m_UserInterrupt, ~TI_Interrupt);
+        InterlockedAnd (&m_UserInterrupt, ~TI_Interrupt);
 
         COMPlusThrow(kThreadInterruptedException);
     }
@@ -6015,7 +6013,7 @@ void UniqueStackSetupMap()
                                      CrstUniqueStack,
                                      CrstFlags(CRST_REENTRANCY | CRST_UNSAFE_ANYMODE));
 
-        if (FastInterlockCompareExchangePointer(&g_pUniqueStackCrst,
+        if (InterlockedCompareExchangeT(&g_pUniqueStackCrst,
                                                 Attempt,
                                                 NULL) != NULL)
         {
@@ -8271,7 +8269,7 @@ void dbgOnly_IdentifySpecialEEThread()
 {
     WRAPPER_NO_CONTRACT;
 
-    LONG  ourCount = FastInterlockIncrement(&cnt_SpecialEEThreads);
+    LONG  ourCount = InterlockedIncrement(&cnt_SpecialEEThreads);
 
     _ASSERTE(ourCount < (LONG) ARRAY_SIZE(SpecialEEThreads));
     SpecialEEThreads[ourCount-1] = ::GetCurrentThreadId();

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -1068,13 +1068,13 @@ public:
     void SetThreadState(ThreadState ts)
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockOr((DWORD*)&m_State, ts);
+        InterlockedOr((LONG*)&m_State, ts);
     }
 
     void ResetThreadState(ThreadState ts)
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockAnd((DWORD*)&m_State, ~ts);
+        InterlockedAnd((LONG*)&m_State, ~ts);
     }
 
     BOOL HasThreadState(ThreadState ts)
@@ -1138,13 +1138,13 @@ public:
     void SetSyncBlockCleanup()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockOr((ULONG *)&m_ThreadTasks, TT_CleanupSyncBlock);
+        InterlockedOr((LONG*)&m_ThreadTasks, TT_CleanupSyncBlock);
     }
 
     void ResetSyncBlockCleanup()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockAnd((ULONG *)&m_ThreadTasks, ~TT_CleanupSyncBlock);
+        InterlockedAnd((LONG*)&m_ThreadTasks, ~TT_CleanupSyncBlock);
     }
 
 #ifdef FEATURE_COMINTEROP_APARTMENT_SUPPORT
@@ -1157,14 +1157,14 @@ public:
     void SetCoInitialized()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockOr((ULONG *)&m_State, TS_CoInitialized);
-        FastInterlockAnd((ULONG*)&m_ThreadTasks, ~TT_CallCoInitialize);
+        InterlockedOr((LONG*)&m_State, TS_CoInitialized);
+        InterlockedAnd((LONG*)&m_ThreadTasks, ~TT_CallCoInitialize);
     }
 
     void ResetCoInitialized()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockAnd((ULONG *)&m_State,~TS_CoInitialized);
+        ResetThreadState(TS_CoInitialized);
     }
 
 #ifdef FEATURE_COMINTEROP
@@ -1190,13 +1190,13 @@ public:
     void SetRequiresCoInitialize()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockOr((ULONG *)&m_ThreadTasks, TT_CallCoInitialize);
+        InterlockedOr((LONG*)&m_ThreadTasks, TT_CallCoInitialize);
     }
 
     void ResetRequiresCoInitialize()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockAnd((ULONG *)&m_ThreadTasks,~TT_CallCoInitialize);
+        InterlockedAnd((LONG*)&m_ThreadTasks,~TT_CallCoInitialize);
     }
 
     void CleanupCOMState();
@@ -1265,7 +1265,7 @@ public:
     void SetExecutingOnAltStack()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockOr((ULONG *) &m_State, TS_ExecutingOnAltStack);
+        SetThreadState(TS_ExecutingOnAltStack);
     }
 
     DWORD IsBackground()
@@ -2103,7 +2103,7 @@ public:
 #else   // _DEBUG
         return
 #endif //_DEBUG
-            FastInterlockIncrement((LONG*)&m_ExternalRefCount);
+            InterlockedIncrement((LONG*)&m_ExternalRefCount);
 
 #ifdef _DEBUG
         // This should never be called on a thread being destroyed
@@ -2121,7 +2121,7 @@ public:
         return
 #endif //_DEBUG
 
-            FastInterlockDecrement((LONG*)&m_ExternalRefCount);
+            InterlockedDecrement((LONG*)&m_ExternalRefCount);
 
 #ifdef _DEBUG
         // This should never cause the last reference on the thread to be released
@@ -2321,7 +2321,7 @@ public:
     void        SetIsThreadPoolThread()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockOr((ULONG *)&m_State, Thread::TS_TPWorkerThread);
+        SetThreadState(TS_TPWorkerThread);
     }
 
     // public suspend functions.  System ones are internal, like for GC.  User ones
@@ -2356,14 +2356,14 @@ private:
     static void AcquireAbortControl(Thread *pThread)
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockIncrement (&pThread->m_AbortController);
+        InterlockedIncrement (&pThread->m_AbortController);
     }
 
     static void ReleaseAbortControl(Thread *pThread)
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE (pThread->m_AbortController > 0);
-        FastInterlockDecrement (&pThread->m_AbortController);
+        InterlockedDecrement (&pThread->m_AbortController);
     }
 
     typedef Holder<Thread*, Thread::AcquireAbortControl, Thread::ReleaseAbortControl> AbortControlHolder;
@@ -2444,7 +2444,7 @@ public:
         if (IsRudeAbort()) {
             m_fRudeAbortInitiated = TRUE;
         }
-        FastInterlockOr((ULONG *)&m_State, TS_AbortInitiated);
+        SetThreadState(TS_AbortInitiated);
         // The following should be factored better, but I'm looking for a minimal V1 change.
         ResetUserInterrupted();
     }
@@ -2452,7 +2452,7 @@ public:
     inline void ResetAbortInitiated()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockAnd((ULONG *)&m_State, ~TS_AbortInitiated);
+        ResetThreadState(TS_AbortInitiated);
         m_fRudeAbortInitiated = FALSE;
     }
 
@@ -2822,13 +2822,13 @@ public:
     {
         WRAPPER_NO_CONTRACT;
         Thread *pThread = GetThread();
-        FastInterlockIncrement((LONG*)&pThread->m_PreventAsync);
+        InterlockedIncrement((LONG*)&pThread->m_PreventAsync);
     }
     static void        DecPreventAsync()
     {
         WRAPPER_NO_CONTRACT;
         Thread *pThread = GetThread();
-        FastInterlockDecrement((LONG*)&pThread->m_PreventAsync);
+        InterlockedDecrement((LONG*)&pThread->m_PreventAsync);
     }
 
     bool IsAsyncPrevented()
@@ -3100,7 +3100,7 @@ private:
             //
             ThreadState newState = (ThreadState)(oldState & ~(TS_DebugSuspendPending | TS_SyncSuspended));
 
-            if (FastInterlockCompareExchange((LONG *)&m_State, newState, oldState) == (LONG)oldState)
+            if (InterlockedCompareExchange((LONG *)&m_State, newState, oldState) == (LONG)oldState)
             {
                 break;
             }
@@ -3124,7 +3124,7 @@ public:
         if (m_State & TS_Hijacked)
         {
             *m_ppvHJRetAddrPtr = m_pvHJRetAddr;
-            FastInterlockAnd((ULONG *) &m_State, ~TS_Hijacked);
+            ResetThreadState(TS_Hijacked);
         }
 #endif
     }
@@ -3192,7 +3192,7 @@ private:
     void        ResetUserInterrupted()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockExchange(&m_UserInterrupt, 0);
+        InterlockedExchange(&m_UserInterrupt, 0);
     }
 
     void        HandleThreadInterrupt();
@@ -3264,7 +3264,7 @@ private:
             || m_OSThreadId == 0xbaadf00d
             || ::MatchThreadHandleToOsId(h, (DWORD)m_OSThreadId) );
 #endif
-        FastInterlockExchangePointer(&m_ThreadHandle, h);
+        InterlockedExchangeT(&m_ThreadHandle, h);
     }
 
     // We maintain a correspondence between this object, the ThreadId and ThreadHandle
@@ -4088,12 +4088,12 @@ public:
 
         if(HasPendingGCStressInstructionUpdate())
         {
-            *ppbDestCode = FastInterlockExchangePointer(&m_pbDestCode, NULL);
+            *ppbDestCode = InterlockedExchangeT(&m_pbDestCode, NULL);
 
             if(*ppbDestCode != NULL)
             {
                 result = true;
-                *ppbSrcCode = FastInterlockExchangePointer(&m_pbSrcCode, NULL);
+                *ppbSrcCode = InterlockedExchangeT(&m_pbSrcCode, NULL);
 
                 CONSISTENCY_CHECK(*ppbSrcCode != NULL);
             }
@@ -4141,7 +4141,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(!m_debuggerActivePatchSkipper.Load());
-        FastInterlockExchangePointer(m_debuggerActivePatchSkipper.GetPointer(), patchSkipper);
+        InterlockedExchangeT(m_debuggerActivePatchSkipper.GetPointer(), patchSkipper);
         _ASSERTE(m_debuggerActivePatchSkipper.Load());
     }
 
@@ -4149,7 +4149,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(m_debuggerActivePatchSkipper.Load());
-        FastInterlockExchangePointer(m_debuggerActivePatchSkipper.GetPointer(), NULL);
+        InterlockedExchangeT(m_debuggerActivePatchSkipper.GetPointer(), NULL);
         _ASSERTE(!m_debuggerActivePatchSkipper.Load());
     }
 
@@ -4968,9 +4968,9 @@ DWORD MsgWaitHelper(int numWaiters, HANDLE* phEvent, BOOL bWaitAll, DWORD millis
 inline void Thread::MarkForDebugSuspend(void)
 {
     WRAPPER_NO_CONTRACT;
-    if (!(m_State & TS_DebugSuspendPending))
+    if (!HasThreadState(TS_DebugSuspendPending))
     {
-        FastInterlockOr((ULONG *) &m_State, TS_DebugSuspendPending);
+        SetThreadState(TS_DebugSuspendPending);
         ThreadStore::TrapReturningThreads(TRUE);
     }
 }
@@ -4981,7 +4981,7 @@ inline void Thread::MarkForDebugSuspend(void)
 inline void Thread::IncrementTraceCallCount()
 {
     WRAPPER_NO_CONTRACT;
-    FastInterlockIncrement(&m_TraceCallCount);
+    InterlockedIncrement(&m_TraceCallCount);
     ThreadStore::TrapReturningThreads(TRUE);
 }
 
@@ -4989,7 +4989,7 @@ inline void Thread::DecrementTraceCallCount()
 {
     WRAPPER_NO_CONTRACT;
     ThreadStore::TrapReturningThreads(FALSE);
-    FastInterlockDecrement(&m_TraceCallCount);
+    InterlockedDecrement(&m_TraceCallCount);
 }
 
 // When we enter an Object.Wait() we are logically inside the synchronized
@@ -6092,7 +6092,7 @@ public:
         if (m_fNeed)
         {
             Thread *pThread = GetThread();
-            FastInterlockAnd((ULONG *) &pThread->m_State, ~m_state);
+            InterlockedAnd((LONG*)&pThread->m_State, ~m_state);
         }
     }
 private:

--- a/src/coreclr/vm/typedesc.cpp
+++ b/src/coreclr/vm/typedesc.cpp
@@ -506,7 +506,7 @@ OBJECTREF ParamTypeDesc::GetManagedClassObject()
         // Only the winner can set m_hExposedClassObject from NULL.
         LOADERHANDLE hExposedClassObject = pLoaderAllocator->AllocateHandle(refClass);
 
-        if (FastInterlockCompareExchangePointer(&m_hExposedClassObject, hExposedClassObject, static_cast<LOADERHANDLE>(NULL)))
+        if (InterlockedCompareExchangeT(&m_hExposedClassObject, hExposedClassObject, static_cast<LOADERHANDLE>(NULL)))
         {
             pLoaderAllocator->FreeHandle(hExposedClassObject);
         }
@@ -668,7 +668,7 @@ void TypeDesc::DoFullyLoad(Generics::RecursionGraph *pVisited, ClassLoadLevel le
     switch (level)
     {
         case CLASS_DEPENDENCIES_LOADED:
-            FastInterlockOr(&m_typeAndFlags, TypeDesc::enum_flag_DependenciesLoaded);
+            InterlockedOr((LONG*)&m_typeAndFlags, TypeDesc::enum_flag_DependenciesLoaded);
             break;
 
         case CLASS_LOADED:
@@ -1624,7 +1624,7 @@ OBJECTREF TypeVarTypeDesc::GetManagedClassObject()
         // Only the winner can set m_hExposedClassObject from NULL.
         LOADERHANDLE hExposedClassObject = pLoaderAllocator->AllocateHandle(refClass);
 
-        if (FastInterlockCompareExchangePointer(&m_hExposedClassObject, hExposedClassObject, static_cast<LOADERHANDLE>(NULL)))
+        if (InterlockedCompareExchangeT(&m_hExposedClassObject, hExposedClassObject, static_cast<LOADERHANDLE>(NULL)))
         {
             pLoaderAllocator->FreeHandle(hExposedClassObject);
         }

--- a/src/coreclr/vm/typedesc.h
+++ b/src/coreclr/vm/typedesc.h
@@ -145,7 +145,7 @@ public:
     VOID SetIsFullyLoaded()
     {
         LIMITED_METHOD_CONTRACT;
-        FastInterlockAnd(&m_typeAndFlags, ~TypeDesc::enum_flag_IsNotFullyLoaded);
+        InterlockedAnd((LONG*)&m_typeAndFlags, ~TypeDesc::enum_flag_IsNotFullyLoaded);
     }
 
     ClassLoadLevel GetLoadLevel();

--- a/src/coreclr/vm/typehash.h
+++ b/src/coreclr/vm/typehash.h
@@ -73,8 +73,8 @@ private:
 public:
     void            InitUnseal() { LIMITED_METHOD_CONTRACT; m_dwSealCount = 0; }
     bool            IsUnsealed() { LIMITED_METHOD_CONTRACT; return (m_dwSealCount == 0); }
-    void            Seal()   { LIMITED_METHOD_CONTRACT; FastInterlockIncrement(&m_dwSealCount); }
-    void            Unseal() { LIMITED_METHOD_CONTRACT; FastInterlockDecrement(&m_dwSealCount); }
+    void            Seal()   { LIMITED_METHOD_CONTRACT; InterlockedIncrement(&m_dwSealCount); }
+    void            Unseal() { LIMITED_METHOD_CONTRACT; InterlockedDecrement(&m_dwSealCount); }
 #endif  // _DEBUG
 
 private:

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -41,41 +41,6 @@ typedef unsigned __int64    U8;
 typedef float               R4;
 typedef double              R8;
 
-//
-// Forward the FastInterlock methods to the matching Win32 APIs. They are implemented
-// using compiler intrinsics so they are as fast as they can possibly be.
-//
-
-#define FastInterlockIncrement              InterlockedIncrement
-#define FastInterlockDecrement              InterlockedDecrement
-#define FastInterlockExchange               InterlockedExchange
-#define FastInterlockCompareExchange        InterlockedCompareExchange
-#define FastInterlockExchangeAdd            InterlockedExchangeAdd
-#define FastInterlockExchangeLong           InterlockedExchange64
-#define FastInterlockCompareExchangeLong    InterlockedCompareExchange64
-#define FastInterlockExchangeAddLong        InterlockedExchangeAdd64
-
-//
-// Forward FastInterlock[Compare]ExchangePointer to the
-// Utilcode Interlocked[Compare]ExchangeT.
-//
-#define FastInterlockExchangePointer        InterlockedExchangeT
-#define FastInterlockCompareExchangePointer InterlockedCompareExchangeT
-
-FORCEINLINE void FastInterlockOr(DWORD RAW_KEYWORD(volatile) *p, const int msk)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    InterlockedOr((LONG *)p, msk);
-}
-
-FORCEINLINE void FastInterlockAnd(DWORD RAW_KEYWORD(volatile) *p, const int msk)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    InterlockedAnd((LONG *)p, msk);
-}
-
 #ifndef TARGET_UNIX
 // Copied from malloc.h: don't want to bring in the whole header file.
 void * __cdecl _alloca(size_t);

--- a/src/coreclr/vm/win32threadpool.cpp
+++ b/src/coreclr/vm/win32threadpool.cpp
@@ -1274,14 +1274,14 @@ void ThreadpoolMgr::EnsureGateThreadRunning()
             // Prevent the gate thread from exiting, if it hasn't already done so.  If it has, we'll create it on the next iteration of
             // this loop.
             //
-            FastInterlockCompareExchange(&GateThreadStatus, GATE_THREAD_STATUS_REQUESTED, GATE_THREAD_STATUS_WAITING_FOR_REQUEST);
+            InterlockedCompareExchange(&GateThreadStatus, GATE_THREAD_STATUS_REQUESTED, GATE_THREAD_STATUS_WAITING_FOR_REQUEST);
             break;
 
         case GATE_THREAD_STATUS_NOT_RUNNING:
             //
             // We need to create a new gate thread
             //
-            if (FastInterlockCompareExchange(&GateThreadStatus, GATE_THREAD_STATUS_REQUESTED, GATE_THREAD_STATUS_NOT_RUNNING) == GATE_THREAD_STATUS_NOT_RUNNING)
+            if (InterlockedCompareExchange(&GateThreadStatus, GATE_THREAD_STATUS_REQUESTED, GATE_THREAD_STATUS_NOT_RUNNING) == GATE_THREAD_STATUS_NOT_RUNNING)
             {
                 if (!CreateGateThread())
                 {
@@ -1324,7 +1324,7 @@ bool ThreadpoolMgr::ShouldGateThreadKeepRunning()
     //
     // Switch to WAITING_FOR_REQUEST, and see if we had a request since the last check.
     //
-    LONG previousStatus = FastInterlockExchange(&GateThreadStatus, GATE_THREAD_STATUS_WAITING_FOR_REQUEST);
+    LONG previousStatus = InterlockedExchange(&GateThreadStatus, GATE_THREAD_STATUS_WAITING_FOR_REQUEST);
 
     if (previousStatus == GATE_THREAD_STATUS_WAITING_FOR_REQUEST)
     {
@@ -1361,7 +1361,7 @@ bool ThreadpoolMgr::ShouldGateThreadKeepRunning()
             // It looks like we shouldn't be running.  But another thread may now tell us to run.  If so, they will set GateThreadStatus
             // back to GATE_THREAD_STATUS_REQUESTED.
             //
-            previousStatus = FastInterlockCompareExchange(&GateThreadStatus, GATE_THREAD_STATUS_NOT_RUNNING, GATE_THREAD_STATUS_WAITING_FOR_REQUEST);
+            previousStatus = InterlockedCompareExchange(&GateThreadStatus, GATE_THREAD_STATUS_NOT_RUNNING, GATE_THREAD_STATUS_WAITING_FOR_REQUEST);
             if (previousStatus == GATE_THREAD_STATUS_WAITING_FOR_REQUEST)
                 return false;
         }

--- a/src/coreclr/vm/win32threadpool.h
+++ b/src/coreclr/vm/win32threadpool.h
@@ -147,7 +147,7 @@ public:
             // VolatileLoad may result in torn read
             Counts result;
 #ifndef DACCESS_COMPILE
-            result.AsLongLong = FastInterlockCompareExchangeLong(&counts.AsLongLong, 0, 0);
+            result.AsLongLong = InterlockedCompareExchange64(&counts.AsLongLong, 0, 0);
             ValidateCounts(result);
 #else
             result.AsLongLong = 0; //prevents prefast warning for DAC builds
@@ -180,7 +180,7 @@ public:
             LIMITED_METHOD_CONTRACT;
             Counts result;
 #ifndef DACCESS_COMPILE
-            result.AsLongLong = FastInterlockCompareExchangeLong(&counts.AsLongLong, newCounts.AsLongLong, oldCounts.AsLongLong);
+            result.AsLongLong = InterlockedCompareExchange64(&counts.AsLongLong, newCounts.AsLongLong, oldCounts.AsLongLong);
             if (result == oldCounts)
             {
                 // can only do validation on success; if we failed, it may have been due to a previous
@@ -699,7 +699,7 @@ public:
 
 	        DWORD dwSwitchCount = 0;
 
-	        while(lock != 0 || FastInterlockExchange( &lock, 1 ) != 0)
+	        while(lock != 0 || InterlockedExchange( &lock, 1 ) != 0)
 	        {
                 YieldProcessorNormalized(); // indicate to the processor that we are spinning
 


### PR DESCRIPTION
FastInterlock* operations were #defined as aliases to regular Interlock* operations. Deleted the FastInterlock* aliases and replaced usage with Interlocked* operations.