### PR TITLE
Fixing the handling of Positive NaN in Math.Min for float/double

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1040,9 +1040,14 @@ namespace System
             // otherwise returns the larger of the inputs. It
             // treats +0 as larger than -0 as per the specification.
 
-            if (val1 != val2 && !double.IsNaN(val1))
+            if (val1 != val2)
             {
-                return val1 < val2 ? val1 : val2;
+                if (!double.IsNaN(val1))
+                {
+                    return val1 < val2 ? val1 : val2;
+                }
+
+                return val1;
             }
 
             return double.IsNegative(val1) ? val1 : val2;
@@ -1093,9 +1098,14 @@ namespace System
             // otherwise returns the larger of the inputs. It
             // treats +0 as larger than -0 as per the specification.
 
-            if (val1 != val2 && !float.IsNaN(val1))
+            if (val1 != val2)
             {
-                return val1 < val2 ? val1 : val2;
+                if (!float.IsNaN(val1))
+                {
+                    return val1 < val2 ? val1 : val2;
+                }
+
+                return val1;
             }
 
             return float.IsNegative(val1) ? val1 : val2;

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -888,8 +888,8 @@ namespace System
             // This matches the IEEE 754:2019 `maximum` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
+            // otherwise returns the greater of the inputs. It
+            // treats +0 as greater than -0 as per the specification.
 
             if (val1 != val2)
             {
@@ -946,8 +946,8 @@ namespace System
             // This matches the IEEE 754:2019 `maximum` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
+            // otherwise returns the greater of the inputs. It
+            // treats +0 as greater than -0 as per the specification.
 
             if (val1 != val2)
             {
@@ -999,8 +999,8 @@ namespace System
             // This matches the IEEE 754:2019 `maximumMagnitude` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
+            // otherwise returns the input with a greater magnitude.
+            // It treats +0 as greater than -0 as per the specification.
 
             double ax = Abs(x);
             double ay = Abs(y);
@@ -1037,8 +1037,8 @@ namespace System
             // This matches the IEEE 754:2019 `minimum` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
+            // otherwise returns the lesser of the inputs. It
+            // treats +0 as lesser than -0 as per the specification.
 
             if (val1 != val2)
             {
@@ -1095,8 +1095,8 @@ namespace System
             // This matches the IEEE 754:2019 `minimum` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
+            // otherwise returns the lesser of the inputs. It
+            // treats +0 as lesser than -0 as per the specification.
 
             if (val1 != val2)
             {
@@ -1148,8 +1148,8 @@ namespace System
             // This matches the IEEE 754:2019 `minimumMagnitude` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
+            // otherwise returns the input with a lesser magnitude.
+            // It treats +0 as lesser than -0 as per the specification.
 
             double ax = Abs(x);
             double ay = Abs(y);

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -252,8 +252,8 @@ namespace System
             // This matches the IEEE 754:2019 `maximumMagnitude` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
+            // otherwise returns the input with a greater magnitude.
+            // It treats +0 as greater than -0 as per the specification.
 
             float ax = Abs(x);
             float ay = Abs(y);
@@ -282,8 +282,8 @@ namespace System
             // This matches the IEEE 754:2019 `minimumMagnitude` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
+            // otherwise returns the input with a lesser magnitude.
+            // It treats +0 as lesser than -0 as per the specification.
 
             float ax = Abs(x);
             float ay = Abs(y);

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -799,6 +799,11 @@ namespace System.Tests
 
             if (double.IsNaN(x))
             {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
                 ulong bits = BitConverter.DoubleToUInt64Bits(x);
                 bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
                 x = BitConverter.UInt64BitsToDouble(bits);
@@ -875,6 +880,11 @@ namespace System.Tests
 
             if (float.IsNaN(x))
             {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
                 uint bits = BitConverter.SingleToUInt32Bits(x);
                 bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
                 x = BitConverter.UInt32BitsToSingle(bits);
@@ -958,6 +968,11 @@ namespace System.Tests
 
             if (double.IsNaN(x))
             {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
                 ulong bits = BitConverter.DoubleToUInt64Bits(x);
                 bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
                 x = BitConverter.UInt64BitsToDouble(bits);
@@ -1034,6 +1049,11 @@ namespace System.Tests
 
             if (float.IsNaN(x))
             {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
                 uint bits = BitConverter.SingleToUInt32Bits(x);
                 bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
                 x = BitConverter.UInt32BitsToSingle(bits);
@@ -2641,6 +2661,11 @@ namespace System.Tests
 
             if (double.IsNaN(x))
             {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
                 ulong bits = BitConverter.DoubleToUInt64Bits(x);
                 bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
                 x = BitConverter.UInt64BitsToDouble(bits);
@@ -2682,6 +2707,11 @@ namespace System.Tests
 
             if (double.IsNaN(x))
             {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
                 ulong bits = BitConverter.DoubleToUInt64Bits(x);
                 bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
                 x = BitConverter.UInt64BitsToDouble(bits);
@@ -2765,7 +2795,7 @@ namespace System.Tests
         [InlineData( 9.267056966972586,        2,                             37.06822786789034,        CrossPlatformMachineEpsilon * 100)]
         [InlineData( 0.5617597462207241,       5,                             17.97631187906317,        CrossPlatformMachineEpsilon * 100)]
         [InlineData( 0.7741522965913037,       6,                             49.545746981843436,       CrossPlatformMachineEpsilon * 100)]
-        [InlineData( -0.6787637026394024,      7,                             -86.88175393784351,       CrossPlatformMachineEpsilon * 100)]        
+        [InlineData( -0.6787637026394024,      7,                             -86.88175393784351,       CrossPlatformMachineEpsilon * 100)]
         [InlineData( -6.531673581913484,       1,                             -13.063347163826968,      CrossPlatformMachineEpsilon * 100)]
         [InlineData( 9.267056966972586,        2,                             37.06822786789034,        CrossPlatformMachineEpsilon * 100)]
         [InlineData( 0.5617597462207241,       5,                             17.97631187906317,        CrossPlatformMachineEpsilon * 100)]

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -796,6 +796,24 @@ namespace System.Tests
         public static void Max_Double_NotNetFramework(double x, double y, double expectedResult)
         {
             AssertExtensions.Equal(expectedResult, Math.Max(x, y), 0.0);
+
+            if (double.IsNaN(x))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(x);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                x = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Max(x, y), 0.0);
+            }
+
+            if (double.IsNaN(y))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(y);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                y = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Max(x, y), 0.0);
+            }
         }
 
         [Fact]
@@ -854,6 +872,24 @@ namespace System.Tests
         public static void Max_Single_NotNetFramework(float x, float y, float expectedResult)
         {
             AssertExtensions.Equal(expectedResult, Math.Max(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Max(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Max(x, y), 0.0f);
+            }
         }
 
         [Fact]
@@ -919,6 +955,24 @@ namespace System.Tests
         public static void Min_Double_NotNetFramework(double x, double y, double expectedResult)
         {
             AssertExtensions.Equal(expectedResult, Math.Min(x, y), 0.0);
+
+            if (double.IsNaN(x))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(x);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                x = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Min(x, y), 0.0);
+            }
+
+            if (double.IsNaN(y))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(y);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                y = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Min(x, y), 0.0);
+            }
         }
 
         [Fact]
@@ -977,6 +1031,24 @@ namespace System.Tests
         public static void Min_Single_NotNetFramework(float x, float y, float expectedResult)
         {
             AssertExtensions.Equal(expectedResult, Math.Min(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Min(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Min(x, y), 0.0f);
+            }
         }
 
         [Fact]
@@ -2566,6 +2638,24 @@ namespace System.Tests
         public static void MaxMagnitude(double x, double y, double expectedResult)
         {
             AssertExtensions.Equal(expectedResult, Math.MaxMagnitude(x, y), 0.0);
+
+            if (double.IsNaN(x))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(x);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                x = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.MaxMagnitude(x, y), 0.0);
+            }
+
+            if (double.IsNaN(y))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(y);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                y = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.MaxMagnitude(x, y), 0.0);
+            }
         }
 
         [Theory]
@@ -2589,6 +2679,24 @@ namespace System.Tests
         public static void MinMagnitude(double x, double y, double expectedResult)
         {
             AssertExtensions.Equal(expectedResult, Math.MinMagnitude(x, y), 0.0);
+
+            if (double.IsNaN(x))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(x);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                x = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.MinMagnitude(x, y), 0.0);
+            }
+
+            if (double.IsNaN(y))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(y);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                y = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.MinMagnitude(x, y), 0.0);
+            }
         }
 
         [Theory]

--- a/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
@@ -1090,6 +1090,24 @@ namespace System.Tests
         public static void Max(float x, float y, float expectedResult)
         {
             AssertExtensions.Equal(expectedResult, MathF.Max(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Max(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Max(x, y), 0.0f);
+            }
         }
 
         [Theory]
@@ -1113,6 +1131,24 @@ namespace System.Tests
         public static void MaxMagnitude(float x, float y, float expectedResult)
         {
             AssertExtensions.Equal(expectedResult, MathF.MaxMagnitude(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.MaxMagnitude(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.MaxMagnitude(x, y), 0.0f);
+            }
         }
 
         [Theory]
@@ -1136,6 +1172,24 @@ namespace System.Tests
         public static void Min(float x, float y, float expectedResult)
         {
             AssertExtensions.Equal(expectedResult, MathF.Min(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Min(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.Min(x, y), 0.0f);
+            }
         }
 
         [Theory]
@@ -1159,6 +1213,24 @@ namespace System.Tests
         public static void MinMagnitude(float x, float y, float expectedResult)
         {
             AssertExtensions.Equal(expectedResult, MathF.MinMagnitude(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.MinMagnitude(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertExtensions.Equal(expectedResult, Math.MinMagnitude(x, y), 0.0f);
+            }
         }
 
         [Theory]

--- a/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
@@ -1093,6 +1093,11 @@ namespace System.Tests
 
             if (float.IsNaN(x))
             {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
                 uint bits = BitConverter.SingleToUInt32Bits(x);
                 bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
                 x = BitConverter.UInt32BitsToSingle(bits);
@@ -1134,6 +1139,11 @@ namespace System.Tests
 
             if (float.IsNaN(x))
             {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
                 uint bits = BitConverter.SingleToUInt32Bits(x);
                 bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
                 x = BitConverter.UInt32BitsToSingle(bits);


### PR DESCRIPTION
This resolves #70775