### PR TITLE
[coop] fix coop suspend timeout cue card

### DIFF
--- a/src/mono/mono/utils/mono-threads.c
+++ b/src/mono/mono/utils/mono-threads.c
@@ -292,7 +292,7 @@ dump_threads (void)
 	g_async_safe_printf ("\t0x6\t- blocking (BAD, unless there's no suspend initiator)\n");
 	g_async_safe_printf ("\t0x?07\t- blocking async suspended (GOOD)\n");
 	g_async_safe_printf ("\t0x?08\t- blocking self suspended (GOOD)\n");
-	g_async_safe_printf ("\t0x?09\t- blocking suspend requested (BAD in coop; GOOD in hybrid)\n");
+	g_async_safe_printf ("\t0x?09\t- blocking suspend requested (GOOD in coop; BAD in hybrid)\n");
 
 	FOREACH_THREAD_SAFE_ALL (info) {
 #ifdef TARGET_MACH


### PR DESCRIPTION
the BLOCKING_SUSPEND_REQUESTED state is treated as suspend in full
coop mode (the thread keeps running, but by definition it's not
allowed to access managed resources and it will self-suspend if it
tries to enter GC Unsafe mode by calling a runtime API or managed
code).
It is bad in hybrid suspend mode (the thread should be preemptively
suspended, but we timed out before the signal handler had a chance to
run).

The corresponding suspension logic in the code is:

https://github.com/dotnet/runtime/blob/3fc61ebb562afc327a8fc6de5c82d76e86bf6f5d/src/mono/mono/utils/mono-threads.c#L1149-L1158