### PR TITLE
Tighten checks in `areArgumentsContiguous`

### DIFF
--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -1685,7 +1685,15 @@ bool Compiler::areArrayElementsContiguous(GenTree* op1, GenTree* op2)
 //
 bool Compiler::areArgumentsContiguous(GenTree* op1, GenTree* op2)
 {
-    if (op1->OperIs(GT_IND) && op2->OperIs(GT_IND))
+    if (op1->TypeGet() != op2->TypeGet())
+    {
+        return false;
+    }
+
+    assert(!op1->TypeIs(TYP_STRUCT));
+
+    if (op1->OperIs(GT_IND) && op1->AsIndir()->Addr()->OperIs(GT_INDEX_ADDR) && op2->OperIs(GT_IND) &&
+        op2->AsIndir()->Addr()->OperIs(GT_INDEX_ADDR))
     {
         return areArrayElementsContiguous(op1, op2);
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70824/Runtime_70824.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70824/Runtime_70824.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+public unsafe class Runtime_70824
+{
+    public static int Main()
+    {
+        long lng = 2;
+        float flt = 3;
+        Vector2 vtor = new Vector2(4, 5);
+        float[] arr = new float[] { 6, 7 };
+
+        if (ProblemWithTypes(&lng, &flt, vtor))
+        {
+            return 101;
+        }
+        if (ProblemWithAddrs(&flt, arr, vtor))
+        {
+            return 102;
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ProblemWithTypes(long* p1, float* pF, Vector2 vtor)
+    {
+        *pF = vtor.X;
+        *p1 = (long)*pF;
+
+        return *p1 != (long)*pF;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ProblemWithAddrs(float* pF, float[] arr, Vector2 vtor)
+    {
+        *pF = vtor.X;
+        arr[0] = vtor.Y;
+
+        arr[1] = vtor.X;
+        *pF = vtor.Y;
+
+        return arr[0] != vtor.Y || *pF != vtor.Y;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70824/Runtime_70824.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70824/Runtime_70824.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
For unclear reasons, in #69917 I assumed the callers guaranteed these, which is simply not the case.

Fixes #70824.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1828781&view=ms.vss-build-web.run-extensions-tab), modulo a small TP regression, as expected.