### PR TITLE
Do not generate impossible instantiations for constrained generics in Mono AOT

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -12336,7 +12336,6 @@ should_emit_extra_method_for_generics (MonoMethod *method, gboolean reference_ty
 		gen_container = mono_method_get_generic_container (method);
 		gen_param_count = mono_method_signature_internal (method)->generic_param_count;
 	} else if (mono_class_is_gtd (method->klass)) {
-		MonoGenericContainer *gen_container_method = mono_method_get_generic_container (method);
 		gen_container = mono_class_get_generic_container (method->klass);
 		gen_param_count = gen_container->type_argc;
 	} else {

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -12310,12 +12310,12 @@ emit_unwind_info_sections_win32 (MonoAotCompile *acfg, const char *function_star
 /**
  * should_emit_extra_method_for_generics:
  * \param method The method to check for generic parameters.
- * \param reference_type Specifies which constraint type to look for.
+ * \param reference_type Specifies which constraint type to look for (TRUE - reference type, FALSE - value type).
  *
- * Tests whether a generic method or a method of a generic type requires generation of extra methods based its constraints.
+ * Tests whether a generic method or a method of a generic type requires generation of extra methods based on its constraints.
  * If a method has at least one generic parameter constrained to a reference type, then REF shared method must be generated.
- * On the other hand, if a method has at least one generic parameters constrained to a value type, then GSHAREDVT method must be generated.
- * Special case when extra methods are always generated is for generic methods of generic types.
+ * On the other hand, if a method has at least one generic parameter constrained to a value type, then GSHAREDVT method must be generated.
+ * A special case, when extra methods are always generated, is for generic methods of generic types.
  * 
  * Returns: TRUE - extra method should be generated, otherwise FALSE
  */
@@ -12327,8 +12327,8 @@ should_emit_extra_method_for_generics (MonoMethod *method, gboolean reference_ty
 	unsigned int gen_param_count;
 
 	if (method->is_generic && mono_class_is_gtd (method->klass)) {
-		// TODO: This is rarely encountered and would increase the complexity of covering such case.
-		// For now always generate extra methods for such case.
+		// TODO: This is rarely encountered and would increase the complexity of covering such cases.
+		// For now always generate extra methods.
 		return TRUE;
 	} else if (method->is_generic) {
 		gen_container = mono_method_get_generic_container (method);
@@ -12337,13 +12337,13 @@ should_emit_extra_method_for_generics (MonoMethod *method, gboolean reference_ty
 		gen_container = mono_class_get_generic_container (method->klass);
 		gen_param_count = gen_container->type_argc;
 	} else {
-		return FALSE; // not a generic
+		return FALSE; // Not a generic.
 	}
 	g_assert (gen_param_count != 0);
 
 	// Inverted logic - for example:
 	// if we are checking whether REF shared method should be generated (reference_type = TRUE),
-	// we are looking for at least one constraint which is not a value type constraint
+	// we are looking for at least one constraint which is not a value type constraint.
 	gboolean should_emit = FALSE;
 	unsigned int gen_constraint_mask = reference_type ? GENERIC_PARAMETER_ATTRIBUTE_VALUE_TYPE_CONSTRAINT : GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT;
 	for (unsigned int i = 0; i < gen_param_count; i++) {

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -12316,7 +12316,10 @@ emit_unwind_info_sections_win32 (MonoAotCompile *acfg, const char *function_star
  * extra methods should be generated for the method.
  * For example: If a method has at least one generic parameter constrained to a reference type (reference_type=TRUE), then REF shared method must be generated.
  * On the other hand, if a method has at least one generic parameters constrained to a value type (reference_type=FALSE), then GSHAREDVT method must be generated.
- * Special case is when there are no constrains specified, then extra methods must be generated.
+ * Special cases when extra methods are always generated: 
+ * 	- method of generic type is generic
+ *  - no constraints specified
+ *  - new() constraint specified
  * 
  * Returns: TRUE - extra method should be generated, otherwise FALSE
  */
@@ -12345,7 +12348,9 @@ should_emit_extra_method_for_generics (MonoMethod *method, gboolean reference_ty
 
 	for (unsigned int i = 0; i < gen_param_count; i++) {
 		gen_param = mono_generic_container_get_param (gen_container, i);
-		if ((gen_param->info.flags & gen_constraint_mask) || (gen_param->info.flags == GENERIC_PARAMETER_ATTRIBUTE_NO_SPECIAL_CONSTRAINT))
+		if (gen_param->info.flags == GENERIC_PARAMETER_ATTRIBUTE_NO_SPECIAL_CONSTRAINT || 
+			gen_param->info.flags == GENERIC_PARAMETER_ATTRIBUTE_CONSTRUCTOR_CONSTRAINT || 
+			(gen_param->info.flags & gen_constraint_mask))
 			return TRUE;
 	}
 	return FALSE;


### PR DESCRIPTION
This change improves the AOTed code size by reducing the number of generated methods for generics.
It covers the following cases:
- if a generic method or a method of a generic type has all type parameters constrained to value types - it will not generate REF shared methods
- if a generic method or a method of a generic type has all type parameters constrained to reference types - it will not generate GSHAREDVT shared methods

After testing the impact of this change on the [HelloWorld app](https://github.com/dotnet/runtime/blob/main/src/mono/sample/iOS/Program.csproj) built for `iOSSimulator` the code size is reduced by `~2%`
App was build with:
``` bash
AOT=true MONO_ARCH=arm64 MONO_CONFIG=Release make run-sim
```
and compared between branches `main - Size A` and `ios-size-reduction - Size B` giving the following results:

| Files | Size A | Size B | diff | % |
|:----|----:|----:|----:|----:|
| HelloiOS | 19539824 | 19158672 | -381152 | -1,95% |
| System.Private.CoreLib.dll-llvm.o | 6870572 | 6734416 | -136156 | -1,98% |


Fixes #54850