### PR TITLE
Catch (more) mismatched args in `fgMorphArgs`

### DIFF
--- a/src/tests/JIT/Directed/StructABI/TypeMismatchedArgs.cs
+++ b/src/tests/JIT/Directed/StructABI/TypeMismatchedArgs.cs
@@ -41,6 +41,11 @@ public unsafe class TypeMismatchedArgs
             return 105;
         }
 
+        if (ProblemWithRegFileMismatch_Win_x64(12, 13))
+        {
+            return 106;
+        }
+
         return 100;
     }
 
@@ -87,6 +92,21 @@ public unsafe class TypeMismatchedArgs
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ProblemWithRegFileMismatch_Win_x64(double dbl, float flt)
+    {
+        if (CallForDblStruct(*(DblStruct*)&dbl) != dbl)
+        {
+            return true;
+        }
+        if (CallForFltStruct(*(FltStruct*)&flt) != flt)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static float CallForVector4(Vector4 value) => value.X;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -97,6 +117,12 @@ public unsafe class TypeMismatchedArgs
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static long CallForSplitStructWithFourLongs(int arg0, int arg1, StructWithFourLongs splitArg) => splitArg.LongOne;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CallForDblStruct(DblStruct value) => value.Dbl;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static float CallForFltStruct(FltStruct value) => value.Flt;
 }
 
 [StructLayout(LayoutKind.Explicit)]
@@ -169,4 +195,14 @@ struct FourDoublesHfaStruct
     public double SecondDblValue;
     public double ThirdDblValue;
     public double FourthDblValue;
+}
+
+struct DblStruct
+{
+    public double Dbl;
+}
+
+struct FltStruct
+{
+    public float Flt;
 }


### PR DESCRIPTION
When we have a struct passed as a primitive, we must ensure it gets morphed into a tree that either:
1) Has a type that is ABI-compatible with that primitive.
2) Has the original type, in which case lowering is expected to handle the mismatch.

For the particular case of `long <-> double` and `int <-> float` mismatches, `fgMorphArgs` was failing to uphold this invariant.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1829130&view=ms.vss-build-web.run-extensions-tab) as expected.