### PR TITLE
Remove allocation in ImmutableArray Builder Sort

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/libraries/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <IsPackable>true</IsPackable>
@@ -109,6 +109,7 @@ System.Collections.Immutable.ImmutableStack&lt;T&gt;</PackageDescription>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
     <Reference Include="System.Collections" />
     <Reference Include="System.Linq" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Threading" />

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -933,11 +933,7 @@ namespace System.Collections.Immutable
 
                 if (Count > 1)
                 {
-                    // Array.Sort does not have an overload that takes both bounds and a Comparison.
-                    // We could special case _count == _elements.Length in order to try to avoid
-                    // the IComparer allocation, but the Array.Sort overload that takes a Comparison
-                    // allocates such an IComparer internally, anyway.
-                    Array.Sort(_elements, 0, _count, Comparer<T>.Create(comparison));
+                    Array.Sort(_elements, comparison);
                 }
             }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -933,11 +933,17 @@ namespace System.Collections.Immutable
 
                 if (Count > 1)
                 {
+#if NET6_0_OR_GREATER
+                    // MemoryExtensions.Sort is not available in .NET Framework / Standard 2.0.
+                    // But the overload with a Comparison argumrnt doesn't allocate.
+                    _elements.AsSpan(0, _count).Sort(comparison);
+#else
                     // Array.Sort does not have an overload that takes both bounds and a Comparison.
                     // We could special case _count == _elements.Length in order to try to avoid
                     // the IComparer allocation, but the Array.Sort overload that takes a Comparison
                     // allocates such an IComparer internally, anyway.
                     Array.Sort(_elements, 0, _count, Comparer<T>.Create(comparison));
+#endif
                 }
             }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -933,7 +933,7 @@ namespace System.Collections.Immutable
 
                 if (Count > 1)
                 {
-                    Array.Sort(_elements, comparison);
+                    Array.Sort(_elements, 0, _count, comparison);
                 }
             }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -935,7 +935,7 @@ namespace System.Collections.Immutable
                 {
 #if NET6_0_OR_GREATER
                     // MemoryExtensions.Sort is not available in .NET Framework / Standard 2.0.
-                    // But the overload with a Comparison argumrnt doesn't allocate.
+                    // But the overload with a Comparison argument doesn't allocate.
                     _elements.AsSpan(0, _count).Sort(comparison);
 #else
                     // Array.Sort does not have an overload that takes both bounds and a Comparison.


### PR DESCRIPTION
`ImmutableArray<T>.Builder.Sort(Comparison<T> comparison)` allocates a new instance of `Comparer<T>` using `comparison`. Then `ArraySortHelper<T>.Sort(Span<T> keys, IComparer<T>? comparer)` allocates a new delegate from `comparer.Compare`. Both allocations can be eliminated by calling `Array.Sort<T>(T[] array, Comparison<T> comparison)` directly.