### PR TITLE
[mono] Extend MonoAOTCompiler Task

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -40,6 +40,7 @@
     <BuildMonoAOTCrossCompiler Condition="'$(TargetsiOS)' == 'true'">true</BuildMonoAOTCrossCompiler>
     <BuildMonoAOTCrossCompiler Condition="'$(TargetstvOS)' == 'true'">true</BuildMonoAOTCrossCompiler>
     <BuildMonoAOTCrossCompiler Condition="'$(TargetsMacCatalyst)' == 'true'">true</BuildMonoAOTCrossCompiler>
+    <BuildMonoAOTCrossCompiler Condition="'$(TargetsOSX)' == 'true'">true</BuildMonoAOTCrossCompiler>
     <BuildMonoAOTCrossCompiler Condition="'$(TargetsBrowser)' == 'true'">true</BuildMonoAOTCrossCompiler>
     <BuildMonoAOTCrossCompiler Condition="'$(TargetsAndroid)' == 'true'">true</BuildMonoAOTCrossCompiler>
     <MonoObjCrossDir>$([MSBuild]::NormalizeDirectory('$(MonoObjDir)', 'cross'))</MonoObjCrossDir>

--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -3,4 +3,30 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
+
+  <UsingTask TaskName="MonoAOTCompiler"
+             AssemblyFile="$(MonoAOTCompilerTasksAssemblyPath)" />
+
+  <Target Name="AOTCompileApp" Condition="'$(RunAOTCompilation)' == 'true'" AfterTargets="CopyFilesToPublishDirectory">
+    <PropertyGroup>
+      <_AotOutputType>Library</_AotOutputType>
+      <_AotLibraryFormat>Dylib</_AotLibraryFormat>
+      <UseAotDataFile>false</UseAotDataFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <AotInputAssemblies Include="$(PublishDir)\*.dll" />
+    </ItemGroup>
+
+    <MonoAOTCompiler
+      CompilerBinaryPath="@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier','$(TargetOS.ToLowerInvariant())-$(TargetArchitecture.ToLowerInvariant())'))"
+      OutputType="$(_AotOutputType)"
+      LibraryFormat="$(_AotLibraryFormat)"
+      Assemblies="@(AotInputAssemblies)"
+      OutputDir="$(PublishDir)"
+      IntermediateOutputPath="$(IntermediateOutputPath)"
+      UseAotDataFile="$(UseAotDataFile)">
+      <Output TaskParameter="CompiledAssemblies" ItemName="BundleAssemblies" />
+    </MonoAOTCompiler>
+  </Target>
 </Project>

--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -25,7 +25,10 @@
       Assemblies="@(AotInputAssemblies)"
       OutputDir="$(PublishDir)"
       IntermediateOutputPath="$(IntermediateOutputPath)"
-      UseAotDataFile="$(UseAotDataFile)">
+      UseAotDataFile="$(UseAotDataFile)"
+      NetTracePath="$(NetTracePath)"
+      PgoBinaryPath="$(PgoBinaryPath)"
+      MibcProfilePath="$(MibcProfilePath)">
       <Output TaskParameter="CompiledAssemblies" ItemName="BundleAssemblies" />
     </MonoAOTCompiler>
   </Target>

--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -26,6 +26,7 @@
       OutputDir="$(PublishDir)"
       IntermediateOutputPath="$(IntermediateOutputPath)"
       UseAotDataFile="$(UseAotDataFile)"
+      CacheFilePath="$(IntermediateOutputPath)aot_compiler_cache.json"
       NetTracePath="$(NetTracePath)"
       PgoBinaryPath="$(PgoBinaryPath)"
       MibcProfilePath="$(MibcProfilePath)">

--- a/src/mono/sample/HelloWorld/Makefile
+++ b/src/mono/sample/HelloWorld/Makefile
@@ -4,6 +4,7 @@ DOTNET_Q_ARGS=--nologo -v:q -consoleloggerparameters:NoSummary
 
 MONO_CONFIG ?=Debug
 MONO_ARCH=x64
+AOT?=false
 
 OS := $(shell uname -s)
 ifeq ($(OS),Darwin)
@@ -12,10 +13,10 @@ else
 	TARGET_OS=linux
 endif
 
-MONO_ENV_OPTIONS ?=--llvm
+MONO_ENV_OPTIONS ?=
 
 publish:
-	$(DOTNET) publish -c $(MONO_CONFIG) -r $(TARGET_OS)-$(MONO_ARCH)
+	$(DOTNET) publish -c $(MONO_CONFIG) -r $(TARGET_OS)-$(MONO_ARCH) /p:RunAOTCompilation=$(AOT)
 
 run: publish
 	COMPlus_DebugWriteToStdErr=1 \

--- a/src/mono/sample/HelloWorld/Makefile
+++ b/src/mono/sample/HelloWorld/Makefile
@@ -6,6 +6,10 @@ MONO_CONFIG ?=Debug
 MONO_ARCH=x64
 AOT?=false
 
+#NET_TRACE_PATH=<path-to-trace-of-sample>
+#PGO_BINARY_PATH=<path-to-dotnet-pgo-executable>
+#MIBC_PROFILE_PATH=<path-to-mibc-for-sample>
+
 OS := $(shell uname -s)
 ifeq ($(OS),Darwin)
 	TARGET_OS=osx
@@ -16,7 +20,13 @@ endif
 MONO_ENV_OPTIONS ?=
 
 publish:
-	$(DOTNET) publish -c $(MONO_CONFIG) -r $(TARGET_OS)-$(MONO_ARCH) /p:RunAOTCompilation=$(AOT)
+	$(DOTNET) publish \
+	-c $(MONO_CONFIG) \
+	-r $(TARGET_OS)-$(MONO_ARCH) \
+	/p:RunAOTCompilation=$(AOT) \
+	'/p:NetTracePath="$(NET_TRACE_PATH)"' \
+	'/p:PgoBinaryPath="$(PGO_BINARY_PATH)"' \
+	'/p:MibcProfilePath="$(MIBC_PROFILE_PATH)"'
 
 run: publish
 	COMPlus_DebugWriteToStdErr=1 \


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/69512

In effort to make the dotnet-pgo based Profiled AOT story on mono more seamless (i.e. less steps for users), the MonoAOTCompiler itself can call a dotnet-pgo executable and inherently process a `.nettrace`, and ultimately feeding into https://github.com/dotnet/runtime/pull/70194.

-----------

This PR makes the following changes:
1. Extends the mono HelloWorld desktop sample to use AOT Compilation
2. Extends the MonoAOTCompiler Task to invoke dotnet-pgo and process a .nettrace
a) Allows for cache usage to avoid generating the same .mibc from the same source .nettrace

----------

## Example workflow with Desktop mono HelloWorld sample

### Generating a .nettrace
`make run`
`DOTNET_DiagnosticPorts="~/myport,suspend" <path-to-HelloWorld-executable> (e.g. ../../../../artifacts/bin/HelloWorld/arm64/Release/osx-arm64/publish/HelloWorld)`
*in a separate tab*
`dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:0x1F000080018:5 --diagnostic-port ~/myport --output <output .nettrace file>`

### Utilizing the .nettrace
In the makefile
Set `AOT?=true`
Set `NET_TRACE_PATH=` to the output .nettrace file
Set `PGO_BINARY_PATH=` to the dotnet-pgo executable
`make run`