### PR TITLE
Assign proper VNs to "shared constant" CSE defs

### DIFF
--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -2962,9 +2962,9 @@ public:
         do
         {
             /* Process the next node in the list */
-            GenTree*    exp  = lst->tslTree;
-            Statement*  stmt = lst->tslStmt;
-            BasicBlock* blk  = lst->tslBlock;
+            GenTree* const    exp  = lst->tslTree;
+            Statement* const  stmt = lst->tslStmt;
+            BasicBlock* const blk  = lst->tslBlock;
 
             /* Advance to the next node in the list */
             lst = lst->tslNext;
@@ -3212,9 +3212,9 @@ public:
                     noway_assert(asg->AsOp()->gtOp2 == val);
                 }
 
-                // assign the proper Value Numbers
-                asg->gtVNPair.SetBoth(ValueNumStore::VNForVoid()); // The GT_ASG node itself is $VN.Void
-                asg->AsOp()->gtOp1->gtVNPair = val->gtVNPair;      // The dest op is the same as 'val'
+                // Assign the proper Value Numbers.
+                asg->gtVNPair                = ValueNumStore::VNPForVoid(); // The GT_ASG node itself is $VN.Void.
+                asg->AsOp()->gtOp1->gtVNPair = ValueNumStore::VNPForVoid(); // As is the LHS.
 
                 noway_assert(asg->AsOp()->gtOp1->gtOper == GT_LCL_VAR);
 
@@ -3263,7 +3263,7 @@ public:
                         cseUse->SetDoNotCSE();
                     }
                 }
-                cseUse->gtVNPair = val->gtVNPair; // The 'cseUse' is equal to 'val'
+                cseUse->gtVNPair = exp->gtVNPair; // The 'cseUse' is equal to the original expression.
 
                 /* Create a comma node for the CSE assignment */
                 cse           = m_pCompiler->gtNewOperNode(GT_COMMA, expTyp, origAsg, cseUse);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70790/Runtime_70790.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70790/Runtime_70790.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Runtime_70790
+{
+    private static readonly nint s_intType = typeof(int).TypeHandle.Value;
+
+    public static int Main()
+    {
+        RuntimeHelpers.RunClassConstructor(typeof(Runtime_70790).TypeHandle);
+
+        object a = 1u;
+        object b = 2u;
+        if (Problem(a, b))
+        {
+            return 101;
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Problem(object a, object b)
+    {
+        if (a.GetType() == typeof(int))
+        {
+            return true;
+        }
+
+        JitUse(b.GetType() == typeof(int));
+        JitUse(s_intType - 300);
+
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void JitUse<T>(T arg) { }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70790/Runtime_70790.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70790/Runtime_70790.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <!-- Force-enable CSE of constants -->
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set DOTNET_JitConstCSE=3
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export DOTNET_JitConstCSE=3
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
They must be those of the original expression, not the "base" constant CSE creates.

Fixes #70790.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1829263&view=results) - caused by different assertions.