### PR TITLE
Fix bug in Tar preventing extraction of hardlinks or entries starting with `.\`

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -138,9 +138,9 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>0920468fa7db4ee8ea8bbcba186421cb92713adf</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Tar.TestData" Version="7.0.0-beta.22281.1">
+    <Dependency Name="System.Formats.Tar.TestData" Version="7.0.0-beta.22313.1">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
-      <Sha>0920468fa7db4ee8ea8bbcba186421cb92713adf</Sha>
+      <Sha>371af1f99788b76eae14b96aad4ab7ac9b373938</Sha>
     </Dependency>
     <Dependency Name="System.IO.Compression.TestData" Version="7.0.0-beta.22281.1">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,7 +120,7 @@
     <SystemRuntimeNumericsTestDataVersion>7.0.0-beta.22281.1</SystemRuntimeNumericsTestDataVersion>
     <SystemComponentModelTypeConverterTestDataVersion>7.0.0-beta.22281.1</SystemComponentModelTypeConverterTestDataVersion>
     <SystemDrawingCommonTestDataVersion>7.0.0-beta.22281.1</SystemDrawingCommonTestDataVersion>
-    <SystemFormatsTarTestDataVersion>7.0.0-beta.22281.1</SystemFormatsTarTestDataVersion>
+    <SystemFormatsTarTestDataVersion>7.0.0-beta.22313.1</SystemFormatsTarTestDataVersion>
     <SystemIOCompressionTestDataVersion>7.0.0-beta.22281.1</SystemIOCompressionTestDataVersion>
     <SystemIOPackagingTestDataVersion>7.0.0-beta.22281.1</SystemIOPackagingTestDataVersion>
     <SystemNetTestDataVersion>7.0.0-beta.22281.1</SystemNetTestDataVersion>

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -238,7 +238,7 @@ namespace System
 
         public static bool SupportsAlpn => s_supportsAlpn.Value;
         public static bool SupportsClientAlpn => SupportsAlpn || IsOSX || IsMacCatalyst || IsiOS || IstvOS;
-        public static bool SupportsHardLinkCreation => !PlatformDetection.IsAndroid;
+        public static bool SupportsHardLinkCreation => !IsAndroid;
 
         private static readonly Lazy<bool> s_supportsTls10 = new Lazy<bool>(GetTls10Support);
         private static readonly Lazy<bool> s_supportsTls11 = new Lazy<bool>(GetTls11Support);

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -238,6 +238,7 @@ namespace System
 
         public static bool SupportsAlpn => s_supportsAlpn.Value;
         public static bool SupportsClientAlpn => SupportsAlpn || IsOSX || IsMacCatalyst || IsiOS || IstvOS;
+        public static bool SupportsHardLinkCreation => !PlatformDetection.IsAndroid;
 
         private static readonly Lazy<bool> s_supportsTls10 = new Lazy<bool>(GetTls10Support);
         private static readonly Lazy<bool> s_supportsTls11 = new Lazy<bool>(GetTls11Support);

--- a/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
+++ b/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
@@ -17,6 +17,7 @@
     <Compile Include="TarFile\TarFile.CreateFromDirectory.Stream.Tests.cs" />
     <Compile Include="TarFile\TarFile.ExtractToDirectory.File.Tests.cs" />
     <Compile Include="TarFile\TarFile.ExtractToDirectory.Stream.Tests.cs" />
+    <Compile Include="TarReader\TarReader.ExtractToFile.Tests.cs" />
     <Compile Include="TarReader\TarReader.File.Tests.cs" />
     <Compile Include="TarReader\TarReader.GetNextEntry.Tests.cs" />
     <Compile Include="TarTestsBase.cs" />
@@ -52,6 +53,7 @@
   <!-- Unix specific files -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'windows'">
     <Compile Include="TarFile\TarFile.ExtractToDirectory.File.Tests.Unix.cs" />
+    <Compile Include="TarReader\TarReader.ExtractToFile.Tests.Unix.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntry.File.Tests.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Errors.cs" Link="Common\Interop\Unix\Interop.Errors.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.IOErrors.cs" Link="Common\Interop\Unix\Interop.IOErrors.cs" />

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -136,5 +136,28 @@ namespace System.Formats.Tar.Tests
             string filePath = Path.Join(segment2Path, "file.txt");
             Assert.True(File.Exists(filePath), $"{filePath}' does not exist.");
         }
+
+        [Fact]
+        public void ExtractArchiveWithEntriesThatStartWithSlashDotPrefix()
+        {
+            using TempDirectory root = new TempDirectory();
+
+            using MemoryStream archiveStream = GetStrangeTarMemoryStream("prefixDotSlashAndCurrentFolderEntry");
+
+            TarFile.ExtractToDirectory(archiveStream, root.Path, overwriteFiles: true);
+
+            archiveStream.Position = 0;
+
+            using TarReader reader = new TarReader(archiveStream, leaveOpen: false);
+
+            TarEntry entry;
+            while ((entry = reader.GetNextEntry()) != null)
+            {
+                // Normalize the path (remove redundant segments), remove trailing separators
+                // this is so the first entry can be skipped if it's the same as the root directory
+                string entryPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(Path.Join(root.Path, entry.Name)));
+                Assert.True(Path.Exists(entryPath), $"Entry was not extracted: {entryPath}");
+            }
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -97,8 +97,7 @@ namespace System.Formats.Tar.Tests
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         public void Extract_SymbolicLinkEntry_TargetInsideDirectory() => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.SymbolicLink);
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/68360", TestPlatforms.Android | TestPlatforms.LinuxBionic | TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [ConditionalFact(nameof(PlatformDetection.SupportsHardLinkCreation))]
         public void Extract_HardLinkEntry_TargetInsideDirectory() => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.HardLink);
 
         private void Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType entryType)

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -97,7 +97,7 @@ namespace System.Formats.Tar.Tests
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         public void Extract_SymbolicLinkEntry_TargetInsideDirectory() => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.SymbolicLink);
 
-        [ConditionalFact(nameof(PlatformDetection.SupportsHardLinkCreation))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsHardLinkCreation))]
         public void Extract_HardLinkEntry_TargetInsideDirectory() => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.HardLink);
 
         private void Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType entryType)

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.ExtractToFile.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.ExtractToFile.Tests.Unix.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace System.Formats.Tar.Tests
+{
+    public partial class TarReader_ExtractToFile_Tests : TarTestsBase
+    {
+        [Fact]
+        public void ExtractToFile_SpecialFile_Unelevated_Throws()
+        {
+            using TempDirectory root = new TempDirectory();
+            using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, TestTarFormat.ustar, "specialfiles");
+
+            using TarReader reader = new TarReader(ms);
+
+            string path = Path.Join(root.Path, "output");
+
+            // Block device requires elevation for writing
+            PosixTarEntry blockDevice = reader.GetNextEntry() as PosixTarEntry;
+            Assert.NotNull(blockDevice);
+            Assert.Throws<UnauthorizedAccessException>(() => blockDevice.ExtractToFile(path, overwrite: false));
+            Assert.False(File.Exists(path));
+
+            // Character device requires elevation for writing
+            PosixTarEntry characterDevice = reader.GetNextEntry() as PosixTarEntry;
+            Assert.NotNull(characterDevice);
+            Assert.Throws<UnauthorizedAccessException>(() => characterDevice.ExtractToFile(path, overwrite: false));
+            Assert.False(File.Exists(path));
+
+            // Fifo does not require elevation, should succeed
+            PosixTarEntry fifo = reader.GetNextEntry() as PosixTarEntry;
+            Assert.NotNull(fifo);
+            fifo.ExtractToFile(path, overwrite: false);
+            Assert.True(File.Exists(path));
+
+            Assert.Null(reader.GetNextEntry());
+        }
+    }
+}

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -556,6 +556,21 @@ namespace System.Formats.Tar.Tests
             Assert.Null(reader.GetNextEntry());
         }
 
+        [Fact]
+        public void ReadEntriesWithSlashDotPrefix()
+        {
+            using MemoryStream archiveStream = GetStrangeTarMemoryStream("prefixDotSlashAndCurrentFolderEntry");
+            using (TarReader reader = new TarReader(archiveStream, leaveOpen: false))
+            {
+                TarEntry entry;
+                while ((entry = reader.GetNextEntry()) != null)
+                {
+                    Assert.NotNull(entry);
+                    Assert.StartsWith("./", entry.Name);
+                }
+            }
+        }
+
         private void Verify_Archive_RegularFile(TarEntry file, TarEntryFormat format, IReadOnlyDictionary<string, string> gea, string expectedFileName, string expectedContents)
         {
             Assert.NotNull(file);

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -556,21 +556,6 @@ namespace System.Formats.Tar.Tests
             Assert.Null(reader.GetNextEntry());
         }
 
-        [Fact]
-        public void ReadEntriesWithSlashDotPrefix()
-        {
-            using MemoryStream archiveStream = GetStrangeTarMemoryStream("prefixDotSlashAndCurrentFolderEntry");
-            using (TarReader reader = new TarReader(archiveStream, leaveOpen: false))
-            {
-                TarEntry entry;
-                while ((entry = reader.GetNextEntry()) != null)
-                {
-                    Assert.NotNull(entry);
-                    Assert.StartsWith("./", entry.Name);
-                }
-            }
-        }
-
         private void Verify_Archive_RegularFile(TarEntry file, TarEntryFormat format, IReadOnlyDictionary<string, string> gea, string expectedFileName, string expectedContents)
         {
             Assert.NotNull(file);

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -96,24 +96,17 @@ namespace System.Formats.Tar.Tests
         }
 
         // MemoryStream containing the copied contents of the specified file. Meant for reading and writing.
-        protected static MemoryStream GetTarMemoryStream(CompressionMethod compressionMethod, TestTarFormat format, string testCaseName)
-        {
-            string path = GetTarFilePath(compressionMethod, format, testCaseName);
-            MemoryStream ms = new();
-            using (FileStream fs = File.OpenRead(path))
-            {
-                fs.CopyTo(ms);
-            }
-            ms.Seek(0, SeekOrigin.Begin);
-            return ms;
-        }
+        protected static MemoryStream GetTarMemoryStream(CompressionMethod compressionMethod, TestTarFormat format, string testCaseName) =>
+            GetMemoryStream(GetTarFilePath(compressionMethod, format, testCaseName));
 
         protected static string GetStrangeTarFilePath(string testCaseName) =>
             Path.Join(Directory.GetCurrentDirectory(), "strange", testCaseName + ".tar");
 
-        protected static MemoryStream GetStrangeTarMemoryStream(string testCaseName)
+        protected static MemoryStream GetStrangeTarMemoryStream(string testCaseName) =>
+            GetMemoryStream(GetStrangeTarFilePath(testCaseName));
+
+        private static MemoryStream GetMemoryStream(string path)
         {
-            string path = GetStrangeTarFilePath(testCaseName);
             MemoryStream ms = new();
             using (FileStream fs = File.OpenRead(path))
             {

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -108,6 +108,21 @@ namespace System.Formats.Tar.Tests
             return ms;
         }
 
+        protected static string GetStrangeTarFilePath(string testCaseName) =>
+            Path.Join(Directory.GetCurrentDirectory(), "strange", testCaseName + ".tar");
+
+        protected static MemoryStream GetStrangeTarMemoryStream(string testCaseName)
+        {
+            string path = GetStrangeTarFilePath(testCaseName);
+            MemoryStream ms = new();
+            using (FileStream fs = File.OpenRead(path))
+            {
+                fs.CopyTo(ms);
+            }
+            ms.Seek(0, SeekOrigin.Begin);
+            return ms;
+        }
+
         protected void SetCommonRegularFile(TarEntry regularFile, bool isV7RegularFile = false)
         {
             Assert.NotNull(regularFile);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/68360 
Fixes https://github.com/dotnet/runtime/issues/70516

Depends on a new asset file: https://github.com/dotnet/runtime-assets/pull/247

Two bug fixes in one PR:
- Hardlinks were not being extracted sometimes because the target path was detected as being outside the destination directory.
- Entries that either start with `.\` or have a final segment literally named `.\`, were failing to extract because they were detected as being outside the destination directory.

There were two root causes, both happening when generating the sanitized path:
- If there was a trailing separator, it was not being handled properly, causing the code to either think the root path was not the same, or not appending it to the rest of the entry's path correctly.
- The `.\` segment is a redundant segment, no matter where it is located. It should get removed always, and we should use `GetFullPath` for that.
