### PR TITLE
Delete StaticallyLinked property from Microsoft.NETCore.Native.Unix.props

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -89,7 +89,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-ldl" />
       <LinkerArg Include="-lm" />
       <LinkerArg Include="-lz" />
-      <LinkerArg Include="-static" Condition="'$(StaticallyLinked)' == 'true'" />
       <LinkerArg Include="-lrt" Condition="'$(TargetOS)' != 'OSX'" />
       <LinkerArg Include="-licucore" Condition="'$(TargetOS)' == 'OSX'" />
       <LinkerArg Include="-dynamiclib" Condition="'$(TargetOS)' == 'OSX' and '$(NativeLib)' == 'Shared'" />


### PR DESCRIPTION
This option has many issues. Anybody trying to experiment with static linking can add `<LinkerArg Include="-static" />` into the local file.