### PR TITLE
Use hash/hmac one shots in NTLM

### DIFF
--- a/src/libraries/Common/src/System/Net/NTAuthentication.Managed.cs
+++ b/src/libraries/Common/src/System/Net/NTAuthentication.Managed.cs
@@ -498,7 +498,7 @@ namespace System.Net
             {
                 IntPtr cbtData = _channelBinding.DangerousGetHandle();
                 int cbtDataSize = _channelBinding.Size;
-                int written = MD5.HashData(new Span<byte>((void *)cbtData, cbtDataSize), hashBuffer);
+                int written = MD5.HashData(new Span<byte>((void*)cbtData, cbtDataSize), hashBuffer);
                 Debug.Assert(written == MD5.HashSizeInBytes);
             }
             else


### PR DESCRIPTION
We can use the one-shot HMAC / Hash implementations in a few places.