### PR TITLE
[release/6.0] Fixing the handling of Positive NaN in Math.Min for float/double

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -979,7 +979,7 @@ namespace System
             //
             // It propagates NaN inputs back to the caller and
             // otherwise returns the lesser of the inputs. It
-            // treats +0 as lesser than -0 as per the specification.
+            // treats -0 as lesser than +0 as per the specification.
 
             if (val1 != val2)
             {
@@ -1036,7 +1036,7 @@ namespace System
             //
             // It propagates NaN inputs back to the caller and
             // otherwise returns the lesser of the inputs. It
-            // treats +0 as lesser than -0 as per the specification.
+            // treats -0 as lesser than +0 as per the specification.
 
             if (val1 != val2)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -831,8 +831,8 @@ namespace System
             // This matches the IEEE 754:2019 `maximum` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
+            // otherwise returns the greater of the inputs. It
+            // treats +0 as greater than -0 as per the specification.
 
             if (val1 != val2)
             {
@@ -888,8 +888,8 @@ namespace System
             // This matches the IEEE 754:2019 `maximum` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
+            // otherwise returns the greater of the inputs. It
+            // treats +0 as greater than -0 as per the specification.
 
             if (val1 != val2)
             {
@@ -941,8 +941,8 @@ namespace System
             // This matches the IEEE 754:2019 `maximumMagnitude` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
+            // otherwise returns the input with a greater magnitude.
+            // It treats +0 as greater than -0 as per the specification.
 
             double ax = Abs(x);
             double ay = Abs(y);
@@ -978,12 +978,17 @@ namespace System
             // This matches the IEEE 754:2019 `minimum` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
+            // otherwise returns the lesser of the inputs. It
+            // treats +0 as lesser than -0 as per the specification.
 
-            if (val1 != val2 && !double.IsNaN(val1))
+            if (val1 != val2)
             {
-                return val1 < val2 ? val1 : val2;
+                if (!double.IsNaN(val1))
+                {
+                    return val1 < val2 ? val1 : val2;
+                }
+
+                return val1;
             }
 
             return double.IsNegative(val1) ? val1 : val2;
@@ -1030,12 +1035,17 @@ namespace System
             // This matches the IEEE 754:2019 `minimum` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the larger of the inputs. It
-            // treats +0 as larger than -0 as per the specification.
+            // otherwise returns the lesser of the inputs. It
+            // treats +0 as lesser than -0 as per the specification.
 
-            if (val1 != val2 && !float.IsNaN(val1))
+            if (val1 != val2)
             {
-                return val1 < val2 ? val1 : val2;
+                if (!float.IsNaN(val1))
+                {
+                    return val1 < val2 ? val1 : val2;
+                }
+
+                return val1;
             }
 
             return float.IsNegative(val1) ? val1 : val2;
@@ -1078,8 +1088,8 @@ namespace System
             // This matches the IEEE 754:2019 `minimumMagnitude` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
+            // otherwise returns the input with a lesser magnitude.
+            // It treats +0 as lesser than -0 as per the specification.
 
             double ax = Abs(x);
             double ay = Abs(y);

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1089,7 +1089,7 @@ namespace System
             //
             // It propagates NaN inputs back to the caller and
             // otherwise returns the input with a lesser magnitude.
-            // It treats +0 as lesser than -0 as per the specification.
+            // It treats -0 as lesser than +0 as per the specification.
 
             double ax = Abs(x);
             double ay = Abs(y);

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -216,8 +216,8 @@ namespace System
             // This matches the IEEE 754:2019 `maximumMagnitude` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
+            // otherwise returns the input with a greater magnitude.
+            // It treats +0 as greater than -0 as per the specification.
 
             float ax = Abs(x);
             float ay = Abs(y);
@@ -246,8 +246,8 @@ namespace System
             // This matches the IEEE 754:2019 `minimumMagnitude` function
             //
             // It propagates NaN inputs back to the caller and
-            // otherwise returns the input with a larger magnitude.
-            // It treats +0 as larger than -0 as per the specification.
+            // otherwise returns the input with a lesser magnitude.
+            // It treats +0 as lesser than -0 as per the specification.
 
             float ax = Abs(x);
             float ay = Abs(y);

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -247,7 +247,7 @@ namespace System
             //
             // It propagates NaN inputs back to the caller and
             // otherwise returns the input with a lesser magnitude.
-            // It treats +0 as lesser than -0 as per the specification.
+            // It treats -0 as lesser than +0 as per the specification.
 
             float ax = Abs(x);
             float ay = Abs(y);

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -1103,6 +1103,29 @@ namespace System.Tests
         public static void Max_Double_NotNetFramework(double x, double y, double expectedResult)
         {
             AssertEqual(expectedResult, Math.Max(x, y), 0.0);
+
+            if (double.IsNaN(x))
+            {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
+                ulong bits = BitConverter.DoubleToUInt64Bits(x);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                x = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertEqual(expectedResult, Math.Max(x, y), 0.0);
+            }
+
+            if (double.IsNaN(y))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(y);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                y = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertEqual(expectedResult, Math.Max(x, y), 0.0);
+            }
         }
 
         [Fact]
@@ -1161,6 +1184,29 @@ namespace System.Tests
         public static void Max_Single_NotNetFramework(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, Math.Max(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, Math.Max(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, Math.Max(x, y), 0.0f);
+            }
         }
 
         [Fact]
@@ -1226,6 +1272,29 @@ namespace System.Tests
         public static void Min_Double_NotNetFramework(double x, double y, double expectedResult)
         {
             AssertEqual(expectedResult, Math.Min(x, y), 0.0);
+
+            if (double.IsNaN(x))
+            {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
+                ulong bits = BitConverter.DoubleToUInt64Bits(x);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                x = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertEqual(expectedResult, Math.Min(x, y), 0.0);
+            }
+
+            if (double.IsNaN(y))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(y);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                y = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertEqual(expectedResult, Math.Min(x, y), 0.0);
+            }
         }
 
         [Fact]
@@ -1284,6 +1353,29 @@ namespace System.Tests
         public static void Min_Single_NotNetFramework(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, Math.Min(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, Math.Min(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, Math.Min(x, y), 0.0f);
+            }
         }
 
         [Fact]
@@ -2853,6 +2945,29 @@ namespace System.Tests
         public static void MaxMagnitude(double x, double y, double expectedResult)
         {
             AssertEqual(expectedResult, Math.MaxMagnitude(x, y), 0.0);
+
+            if (double.IsNaN(x))
+            {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
+                ulong bits = BitConverter.DoubleToUInt64Bits(x);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                x = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertEqual(expectedResult, Math.MaxMagnitude(x, y), 0.0);
+            }
+
+            if (double.IsNaN(y))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(y);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                y = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertEqual(expectedResult, Math.MaxMagnitude(x, y), 0.0);
+            }
         }
 
         [Theory]
@@ -2866,6 +2981,29 @@ namespace System.Tests
         public static void MinMagnitude(double x, double y, double expectedResult)
         {
             AssertEqual(expectedResult, Math.MinMagnitude(x, y), 0.0);
+
+            if (double.IsNaN(x))
+            {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
+                ulong bits = BitConverter.DoubleToUInt64Bits(x);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                x = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertEqual(expectedResult, Math.MinMagnitude(x, y), 0.0);
+            }
+
+            if (double.IsNaN(y))
+            {
+                ulong bits = BitConverter.DoubleToUInt64Bits(y);
+                bits ^= BitConverter.DoubleToUInt64Bits(-0.0);
+                y = BitConverter.UInt64BitsToDouble(bits);
+
+                AssertEqual(expectedResult, Math.MinMagnitude(x, y), 0.0);
+            }
         }
 
         [Theory]
@@ -2934,7 +3072,7 @@ namespace System.Tests
         [InlineData( 9.267056966972586,        2,                             37.06822786789034,        CrossPlatformMachineEpsilon * 100)]
         [InlineData( 0.5617597462207241,       5,                             17.97631187906317,        CrossPlatformMachineEpsilon * 100)]
         [InlineData( 0.7741522965913037,       6,                             49.545746981843436,       CrossPlatformMachineEpsilon * 100)]
-        [InlineData( -0.6787637026394024,      7,                             -86.88175393784351,       CrossPlatformMachineEpsilon * 100)]        
+        [InlineData( -0.6787637026394024,      7,                             -86.88175393784351,       CrossPlatformMachineEpsilon * 100)]
         [InlineData( -6.531673581913484,       1,                             -13.063347163826968,      CrossPlatformMachineEpsilon * 100)]
         [InlineData( 9.267056966972586,        2,                             37.06822786789034,        CrossPlatformMachineEpsilon * 100)]
         [InlineData( 0.5617597462207241,       5,                             17.97631187906317,        CrossPlatformMachineEpsilon * 100)]

--- a/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
@@ -1224,6 +1224,29 @@ namespace System.Tests
         public static void Max(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.Max(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, MathF.Max(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, MathF.Max(x, y), 0.0f);
+            }
         }
 
         [Theory]
@@ -1237,6 +1260,29 @@ namespace System.Tests
         public static void MaxMagnitude(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.MaxMagnitude(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, MathF.MaxMagnitude(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, MathF.MaxMagnitude(x, y), 0.0f);
+            }
         }
 
         [Theory]
@@ -1250,6 +1296,29 @@ namespace System.Tests
         public static void Min(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.Min(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, MathF.Min(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, MathF.Min(x, y), 0.0f);
+            }
         }
 
         [Theory]
@@ -1263,6 +1332,29 @@ namespace System.Tests
         public static void MinMagnitude(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.MinMagnitude(x, y), 0.0f);
+
+            if (float.IsNaN(x))
+            {
+                // Toggle the sign of the NaN to validate both +NaN and -NaN behave the same.
+                // Negate should work as well but the JIT may constant fold or do other tricks
+                // and normalize to a single NaN form so we do bitwise tricks to ensure we test
+                // the right thing.
+
+                uint bits = BitConverter.SingleToUInt32Bits(x);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                x = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, MathF.MinMagnitude(x, y), 0.0f);
+            }
+
+            if (float.IsNaN(y))
+            {
+                uint bits = BitConverter.SingleToUInt32Bits(y);
+                bits ^= BitConverter.SingleToUInt32Bits(-0.0f);
+                y = BitConverter.UInt32BitsToSingle(bits);
+
+                AssertEqual(expectedResult, MathF.MinMagnitude(x, y), 0.0f);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Backport of #70795

/cc @tannergooding 

## Customer Impact

A customer reported this issue as https://github.com/dotnet/runtime/issues/70775

Math.Max and Math.Min are expected to propagate `NaN` back to the caller if either input is `NaN`. In .NET 6, this was regressed such that `Math.Min` would not propagate a positive `NaN` back to the caller which breaks this expectation.

This was not caught because `double.NaN`, the `NaN` returned by most hardware, and the `NaN` that the C# compiler and JIT compiler normalizes to is a negative `NaN`.

`Math.Max` was working as expected but tests explicitly validating its behavior in the face of positive NaN are included.

## Testing

To help ensure the behavior of the `Max`, `MaxMagnitude`, `Min`, and `MinMagnitude` tests validating both `positive` and `negative` `NaN` were added. This is achieved by explicitly toggling the sign-bit via a bitwise manipulation to help ensure that JIT optimizations (current or future) don't kick in.

The customer that reported the issue in https://github.com/dotnet/runtime/issues/70775 was asked to validate the fix as well and was able to confirm that it does indeed fix their issue.

## Risk

`Min` will take a small perf hit bringing it inline with `Max` (previously it was slightly faster).

It is not expected that anyone would be depending on the accidental break, but its possible that someone raises an issue.