### PR TITLE
[mono][wasm] Add a minimal version of gsharedvt for llvmonly, enabled…

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Delegate.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Delegate.Mono.cs
@@ -70,6 +70,7 @@ namespace System
         private DelegateData data;
 
         private bool method_is_virtual;
+        private bool bound;
         #endregion
 
         [RequiresUnreferencedCode("The target method might be removed")]

--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -2010,9 +2010,18 @@ emit_delegate_invoke_internal_ilgen (MonoMethodBuilder *mb, MonoMethodSignature 
 
 	/*static methods with bound first arg can have null target and still be bound*/
 	if (!static_method_with_first_arg_bound) {
+		/* if bound */
+		mono_mb_emit_ldarg (mb, 0);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoDelegate, bound));
+		/* bound: MonoBoolean */
+		mono_mb_emit_byte (mb, CEE_LDIND_I1);
+		int pos_bound = mono_mb_emit_branch (mb, CEE_BRTRUE);
+
 		/* if target != null */
 		mono_mb_emit_ldloc (mb, local_target);
 		pos0 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		mono_mb_patch_branch (mb, pos_bound);
 
 		/* then call this->method_ptr nonstatic */
 		if (callvirt) {

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -836,6 +836,7 @@ struct _MonoDelegate {
 	MonoReflectionMethod *original_method_info;
 	MonoObject *data;
 	MonoBoolean method_is_virtual;
+	MonoBoolean bound;
 };
 
 typedef struct _MonoMulticastDelegate MonoMulticastDelegate;

--- a/src/mono/mono/metadata/object-offsets.h
+++ b/src/mono/mono/metadata/object-offsets.h
@@ -87,6 +87,7 @@ DECL_OFFSET(MonoDelegate, invoke_impl)
 DECL_OFFSET(MonoDelegate, method)
 DECL_OFFSET(MonoDelegate, method_code)
 DECL_OFFSET(MonoDelegate, method_is_virtual)
+DECL_OFFSET(MonoDelegate, bound)
 DECL_OFFSET(MonoDelegate, extra_arg)
 
 DECL_OFFSET(MonoInternalThread, tid)

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -8772,6 +8772,8 @@ is_concrete_type (MonoType *t)
 	MonoClass *klass;
 	int i;
 
+	if (m_type_is_byref (t))
+		return TRUE;
 	if (t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR)
 		return FALSE;
 	if (t->type == MONO_TYPE_GENERICINST) {

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14224,6 +14224,9 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 	}
 #endif
 
+	if (acfg->aot_opts.llvm_only)
+		acfg->jit_opts |= MONO_OPT_GSHAREDVT;
+
 	if (acfg->jit_opts & MONO_OPT_GSHAREDVT)
 		mono_set_generic_sharing_vt_supported (TRUE);
 

--- a/src/mono/mono/mini/llvmonly-runtime.c
+++ b/src/mono/mono/mini/llvmonly-runtime.c
@@ -803,6 +803,9 @@ mini_llvmonly_init_delegate (MonoDelegate *del, MonoDelegateTrampInfo *info)
 
 	WrapperSubtype subtype = mono_marshal_get_delegate_invoke_subtype (info->invoke, del);
 
+	if (subtype == WRAPPER_SUBTYPE_DELEGATE_INVOKE_BOUND)
+		del->bound = TRUE;
+
 	ftndesc = info->invoke_impl;
 	if (G_UNLIKELY (!ftndesc) || subtype != WRAPPER_SUBTYPE_NONE) {
 		MonoMethod *invoke_impl = mono_marshal_get_delegate_invoke (info->invoke, del);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -9268,6 +9268,9 @@ calli_end:
 
 			context_used = mini_class_check_context_used (cfg, klass);
 
+			if (cfg->gsharedvt_min && mini_is_gsharedvt_variable_klass (klass))
+				GSHAREDVT_FAILURE (il_op);
+
 			if (mini_is_gsharedvt_klass (klass)) {
 				res = handle_unbox_gsharedvt (cfg, klass, *sp);
 				inline_costs += 2;

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -4066,6 +4066,7 @@ emit_entry_bb (EmitContext *ctx, LLVMBuilderRef builder)
 			LLVMSetValueName (ctx->addresses [reg]->value, name);
 			LLVMTypeRef el_t = type_to_llvm_type (ctx, ainfo->type);
 			LLVMBuildStore (builder, LLVMBuildLoad2 (builder, el_t, convert (ctx, arg, pointer_type (el_t)), ""), ctx->addresses [reg]->value);
+			ctx->values [reg] = NULL;
 			break;
 		}
 		case LLVMArgGsharedvtVariable:

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -79,9 +79,8 @@ get_storage (MonoType *type, gboolean is_return)
 		if (!mono_type_generic_inst_is_valuetype (type))
 			return ArgOnStack;
 
-		if (mini_is_gsharedvt_type (type)) {
+		if (mini_is_gsharedvt_variable_type (type))
 			return ArgGsharedVTOnStack;
-		}
 		/* fall through */
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_TYPEDBYREF: {

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3306,7 +3306,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, JitFlags flags, int parts
 		return cfg;
 	}
 
-	if (cfg->llvm_only && cfg->interp && !cfg->interp_entry_only && !cfg->gsharedvt && header->num_clauses) {
+	if (cfg->llvm_only && cfg->interp && !cfg->interp_entry_only && header->num_clauses) {
 		cfg->deopt = TRUE;
 		/* Can't reconstruct inlined state */
 		cfg->disable_inline = TRUE;

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3261,6 +3261,18 @@ mini_method_compile (MonoMethod *method, guint32 opts, JitFlags flags, int parts
 		cfg->gsctx_context = context;
 
 		cfg->gsharedvt = TRUE;
+		if (cfg->llvm_only) {
+			/*
+			 * Enable a minimal version of gsharedvt where only
+			 * methods which don't really depend on their generic
+			 * arguments are supported, like List<T>.get_Count ().
+			 * - no signatures or locals with variable length types
+			 * - no calls with signatures with variable length types
+			 * etc.
+			 */
+			cfg->gsharedvt_min = TRUE;
+		}
+
 		if (!cfg->llvm_only) {
 			cfg->disable_llvm = TRUE;
 			cfg->exception_message = g_strdup ("gsharedvt");

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1482,6 +1482,7 @@ typedef struct {
 	guint            no_inline : 1;
 	guint            gshared : 1;
 	guint            gsharedvt : 1;
+	guint            gsharedvt_min : 1;
 	guint            r4fp : 1;
 	guint            llvm_only : 1;
 	guint            interp : 1;


### PR DESCRIPTION
… by default.

In this version, variable length arguments/locals are not supported. This means
that these compiled methods don't have the overhead of gsharedvt, i.e. wrappers,
dynamically allocated/copied locals, etc. They have similar performance to normal
generic sharing.

This can handle methods like List<T>.get_Item (), System.GC:AllocateArray<T>, etc.