### PR TITLE
Fix failure building two libraries tests

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
@@ -374,7 +374,12 @@ namespace Internal.TypeSystem.Ecma
                     && stringComparer.Equals(methodDefinition.Name, ".ctor"))
                 {
                     var method = (EcmaMethod)_module.GetObject(handle);
-                    if (method.Signature.Length != 0)
+                    MethodSignature sig = method.Signature;
+
+                    if (sig.Length != 0)
+                        continue;
+
+                    if ((sig.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) == MethodSignatureFlags.CallingConventionVarargs)
                         continue;
 
                     return method;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -625,7 +625,7 @@ namespace ILCompiler.Dataflow
                                 && !systemTypeValue.RepresentedType.Type.IsGenericDefinition
                                 && !systemTypeValue.RepresentedType.Type.ContainsSignatureVariables(treatGenericParameterLikeSignatureVariable: true))
                             {
-                                if (systemTypeValue.RepresentedType.Type.IsDefType)
+                                if (systemTypeValue.RepresentedType.Type.IsDelegate)
                                 {
                                     _reflectionMarker.Dependencies.Add(_factory.DelegateMarshallingData((DefType)systemTypeValue.RepresentedType.Type), "Marshal API");
                                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -264,6 +264,8 @@ namespace Internal.IL
             var method = (MethodDesc)_canonMethodIL.GetObject(token);
 
             _compilation.TypeSystemContext.EnsureLoadableMethod(method);
+            if ((method.Signature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) == MethodSignatureFlags.CallingConventionVarargs)
+                ThrowHelper.ThrowBadImageFormatException();
 
             _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _compilation.NodeFactory, _canonMethodIL, method);
 


### PR DESCRIPTION
Microsoft.CSharp was hitting an issue due to a vararg constructor. We don't support varargs. They shouldn't make it into the dependency graph. We are already checking in many places. We were erroneously thinking a vararg constructor with no mandatory arguments is a default constructor.

Runtime.InteropServices were crashing because we got a MulticastDelegate type into a codepath that expects a MulticastDelegate descendant.