### PR TITLE
Generate method bodies for delegate Invoke methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -46,11 +46,10 @@ namespace ILCompiler.DependencyAnalysis
             var mdManager = (UsageBasedMetadataManager)factory.MetadataManager;
             if (_type.IsDelegate)
             {
-                // A delegate type metadata is rather useless without the Invoke method.
-                // If someone reflects on a delegate, chances are they're going to look at the signature.
-                // The libraries (e.g. System.Linq.Expressions) also have trimming warning suppressions
+                // We've decided as a policy that delegate Invoke methods will be generated in full.
+                // The libraries (e.g. System.Linq.Expressions) have trimming warning suppressions
                 // in places where they assume IL-level trimming (where the method cannot be removed).
-                // So we ask for a full reflectable method with its method body instead of just the
+                // We ask for a full reflectable method with its method body instead of just the
                 // metadata.
                 var invokeMethod = _type.GetMethod("Invoke", null);
                 if (!mdManager.IsReflectionBlocked(invokeMethod))

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -48,9 +48,13 @@ namespace ILCompiler.DependencyAnalysis
             {
                 // A delegate type metadata is rather useless without the Invoke method.
                 // If someone reflects on a delegate, chances are they're going to look at the signature.
+                // The libraries (e.g. System.Linq.Expressions) also have trimming warning suppressions
+                // in places where they assume IL-level trimming (where the method cannot be removed).
+                // So we ask for a full reflectable method with its method body instead of just the
+                // metadata.
                 var invokeMethod = _type.GetMethod("Invoke", null);
                 if (!mdManager.IsReflectionBlocked(invokeMethod))
-                    dependencies.Add(factory.MethodMetadata(invokeMethod), "Delegate invoke method metadata");
+                    dependencies.Add(factory.ReflectableMethod(invokeMethod), "Delegate invoke method");
             }
 
             if (_type.IsEnum)

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Reflection;
@@ -31,6 +32,7 @@ internal static class ReflectionTest
         TestVirtualDelegateTargets.Run();
         TestRunClassConstructor.Run();
         TestFieldMetadata.Run();
+        TestLinqInvocation.Run();
 #if !OPTIMIZED_MODE_WITHOUT_SCANNER
         TestContainment.Run();
         TestInterfaceMethod.Run();
@@ -1856,6 +1858,19 @@ internal static class ReflectionTest
                 throw new Exception();
 #endif
             static Type GetAtom3() => typeof(Atom3);
+        }
+    }
+
+    class TestLinqInvocation
+    {
+        delegate void RunMeDelegate();
+
+        static void RunMe() { }
+
+        public static void Run()
+        {
+            Expression<Action<RunMeDelegate>> ex = (RunMeDelegate m) => m();
+            ex.Compile()(RunMe);
         }
     }
 


### PR DESCRIPTION
There is an invalid (with hindsight) dataflow warning suppression in System.Linq.Expressions that assumes we'll always have an invocable method body for delegate Invoke method. We need one in IL. We don't in native code.

Emulate what IL Linker does and generate a method body. This is a size regression.

Invalid suppression: https://github.com/dotnet/runtime/blob/3b2883b097a773715ca84056885e0ca1488da36e/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs#L906-L912

Fixes #70880.

Cc @dotnet/ilc-contrib 