### PR TITLE
[wasm] Enabled WasmTestOnBrowser run on Windows for Browser.

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
@@ -287,6 +287,7 @@ namespace Microsoft.VisualBasic.FileIO.Tests
 
         // Can't get current directory on OSX before setting it.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/70887", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
         public void CurrentDirectoryGet()
         {
             var CurrentDirectory = System.IO.Directory.GetCurrentDirectory();
@@ -299,6 +300,7 @@ namespace Microsoft.VisualBasic.FileIO.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50572", TestPlatforms.Android)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52851", TestPlatforms.MacCatalyst)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/70887", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
         public void CurrentDirectorySet()
         {
             var SavedCurrentDirectory = System.IO.Directory.GetCurrentDirectory();

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
@@ -287,7 +287,6 @@ namespace Microsoft.VisualBasic.FileIO.Tests
 
         // Can't get current directory on OSX before setting it.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/70887", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
         public void CurrentDirectoryGet()
         {
             var CurrentDirectory = System.IO.Directory.GetCurrentDirectory();
@@ -300,7 +299,6 @@ namespace Microsoft.VisualBasic.FileIO.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50572", TestPlatforms.Android)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52851", TestPlatforms.MacCatalyst)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/70887", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
         public void CurrentDirectorySet()
         {
             var SavedCurrentDirectory = System.IO.Directory.GetCurrentDirectory();

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -364,13 +364,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BrowserHost)' == 'windows' and '$(Scenario)' == 'WasmTestOnBrowser' and '$(RunDisabledWasmTestsOnWindows)' != 'true'">
-    <!-- Issue: https://github.com/dotnet/runtime/issues/55429 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.VisualBasic.Core\tests\Microsoft.VisualBasic.Core.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO\tests\System.IO.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Memory\tests\System.Memory.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\Writers\XmlWriterApi\System.Xml.RW.XmlWriterApi.Tests.csproj" />
+    <!-- Issue: https://github.com/dotnet/runtime/issues/52843 -->
     <ProjectExclusions Include="$(RepoRoot)\src\tests\BuildWasmApps\Wasm.Build.Tests\Wasm.Build.Tests.csproj" />
   </ItemGroup>
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -363,11 +363,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BrowserHost)' == 'windows' and '$(Scenario)' == 'WasmTestOnBrowser' and '$(RunDisabledWasmTestsOnWindows)' != 'true'">
-    <!-- Issue: https://github.com/dotnet/runtime/issues/52843 -->
-    <ProjectExclusions Include="$(RepoRoot)\src\tests\BuildWasmApps\Wasm.Build.Tests\Wasm.Build.Tests.csproj" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' and '$(RunDisabledAppleSiliconTests)' != 'true'">
     <!-- ActiveIssue Apple Silicon No usable version of libssl was found https://github.com/dotnet/runtime/issues/49083 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/55429.

It looks that it fixes https://github.com/dotnet/runtime/issues/70887 as well because the tests described there are failing only for Debug. CI is clean.