### PR TITLE
Fix -cmakeargs option handling in build.sh

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -392,7 +392,7 @@ while [[ $# > 0 ]]; do
         echo "No cmake args supplied." 1>&2
         exit 1
       fi
-      cmakeargs="${cmakeargs} ${opt} $2"
+      cmakeargs="${cmakeargs} $2"
       shift 2
       ;;
 


### PR DESCRIPTION
PR #67108 (commit 7d562f9d2a4285881ae1c412aecb164dc9370013) tried to
unify how -cmakeargs is passed to build.sh and build.cmd. That commit
has modified src/coreclr/runtime.proj to always include an additional
-cmakeargs argument. However, on Linux, the main ./build.sh command
already includes one. That results in an additional -cmakeargs argument,
which makes the build fail.

Fix that by making build.sh do what build.cmd does: not add the additional
-cmakeargs argument.

Without this change:

    $ ./build.sh -cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE
    ...
      Commencing CoreCLR Repo build
      __DistroRid: linux-x64
      Setting up directories for build
      Checking prerequisites...
      Commencing build of "install" target in "CoreCLR component" for Linux.x64.Debug in runtime/artifacts/obj/coreclr/Linux.x64.Debug
      Invoking "runtime/eng/native/gen-buildsys.sh" "runtime/src/coreclr" "runtime/artifacts/obj/coreclr/Linux.x64.Debug" x64 clang Debug ""  -DCLR_CMAKE_PGO_INSTRUMENT=0 -DCLR_CMAKE_OPTDATA_PATH= -DCLR_CMAKE_PGO_OPTIMIZE=0 -DFEATURE_DISTRO_AGNOSTIC_SSL=1  -cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE
      ~/devel/dotnet/runtime/artifacts/obj/coreclr/Linux.x64.Debug ~/devel/dotnet/runtime/src/coreclr
      Not searching for unused variables given on the command line.
      CMake Error: Unknown argument -cmakeargs
      CMake Error: Run 'cmake --help' for all supported options.
      ~/devel/dotnet/runtime/src/coreclr
      Unable to find generated build files for "CoreCLR component" project!

Now:

    $ ./build.sh -cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE
    ...
      __DistroRid: linux-x64
      Setting up directories for build
      Checking prerequisites...
      Commencing build of "install" target in "CoreCLR component" for Linux.x64.Debug in runtime/artifacts/obj/coreclr/Linux.x64.Debug
      Invoking "runtime/eng/native/gen-buildsys.sh" "runtime/src/coreclr" "runtime/artifacts/obj/coreclr/Linux.x64.Debug" x64 clang Debug ""  -DCLR_CMAKE_PGO_INSTRUMENT=0 -DCLR_CMAKE_OPTDATA_PATH= -DCLR_CMAKE_PGO_OPTIMIZE=0 -DFEATURE_DISTRO_AGNOSTIC_SSL=1  -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE
      runtime/artifacts/obj/coreclr/Linux.x64.Debug runtime/src/coreclr
      Not searching for unused variables given on the command line.
    ...