### PR TITLE
[release/6.0] fixed distroRid having the last version digit for alpine (#62942)

### DIFF
--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -41,7 +41,7 @@ initNonPortableDistroRid()
             # We have forced __PortableBuild=0. This is because -portablebuld
             # has been passed as false.
             if (( isPortable == 0 )); then
-                if [ "${ID}" = "rhel" ]; then
+                if [[ "${ID}" == "rhel" || "${ID}" == "alpine" ]]; then
                     # remove the last version digit
                     VERSION_ID="${VERSION_ID%.*}"
                 fi


### PR DESCRIPTION
init-distro-id.sh generates incorrect DistroRid on Alpine. While the expected DistroRid (alpine-x.xx-xxx) should only include macro version, init-distro-id.sh includes the micro version. This patches it to cut off the trailing subversion off of VERSION_ID by treating it the same way RHEL's VERSION_ID is treated.

Made as part of Alpine Linux dotnet31 / dotnet5 packaging project, see https://github.com/dotnet/source-build/issues/2695

Backport of https://github.com/dotnet/runtime/pull/62942

cc @agocke @ayakael @bartonjs @crummel  @ericstj @hoyosjs 