### PR TITLE
Pass CancellationToken to Http2Connection SetupAsync

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -214,15 +214,16 @@ namespace System.Net.Http
 
                 _expectingSettingsAck = true;
             }
-            catch (OperationCanceledException oce) when (oce.CancellationToken == cancellationToken)
-            {
-                Dispose();
-                // Note, AddHttp2ConnectionAsync handles this OCE separately so don't wrap it.
-                throw;
-            }
             catch (Exception e)
             {
                 Dispose();
+
+                if (e is OperationCanceledException oce && oce.CancellationToken == cancellationToken)
+                {
+                    // Note, AddHttp2ConnectionAsync handles this OCE separately so don't wrap it.
+                    throw;
+                }
+
                 throw new IOException(SR.net_http_http2_connection_not_established, e);
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1566,15 +1566,15 @@ namespace System.Net.Http
             {
                 await http2Connection.SetupAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch (OperationCanceledException oce) when (oce.CancellationToken == cancellationToken)
-            {
-                // Note, SetupAsync will dispose the connection if there is an exception.
-                // Note, AddHttp2ConnectionAsync handles this OCE separatly so don't wrap it.
-                throw;
-            }
             catch (Exception e)
             {
                 // Note, SetupAsync will dispose the connection if there is an exception.
+                if (e is OperationCanceledException oce && oce.CancellationToken == cancellationToken)
+                {
+                    // Note, AddHttp2ConnectionAsync handles this OCE separatly so don't wrap it.
+                    throw;
+                }
+
                 throw new HttpRequestException(SR.net_http_client_execution_error, e);
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1564,7 +1564,13 @@ namespace System.Net.Http
             Http2Connection http2Connection = new Http2Connection(this, stream);
             try
             {
-                await http2Connection.SetupAsync().ConfigureAwait(false);
+                await http2Connection.SetupAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException oce) when (oce.CancellationToken == cancellationToken)
+            {
+                // Note, SetupAsync will dispose the connection if there is an exception.
+                // Note, AddHttp2ConnectionAsync handles this OCE separatly so don't wrap it.
+                throw;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Don't wrap OCE because it is handled separately in `AddHttp2ConnectionAsync`:

https://github.com/dotnet/runtime/blob/665e9f7b7f64c313febdd682a25250e23d3e2dc2/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs#L685-L694

Fixes #70721