### PR TITLE
Disable W^X on macOS under Rosetta emulation

### DIFF
--- a/src/coreclr/minipal/Unix/doublemapping.cpp
+++ b/src/coreclr/minipal/Unix/doublemapping.cpp
@@ -23,6 +23,18 @@
 
 #if defined(TARGET_OSX) && defined(TARGET_AMD64)
 #include <mach/mach.h>
+#include <sys/sysctl.h>
+
+bool IsProcessTranslated()
+{
+   int ret = 0;
+   size_t size = sizeof(ret);
+   if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1)
+   {
+      return false;
+   }
+   return ret != 0;
+}
 #endif // TARGET_OSX && TARGET_AMD64
 
 #ifndef TARGET_OSX
@@ -65,6 +77,15 @@ bool VMToOSInterface::CreateDoubleMemoryMapper(void** pHandle, size_t *pMaxExecu
     *pMaxExecutableCodeSize = MaxDoubleMappedSize;
     *pHandle = (void*)(size_t)fd;
 #else // !TARGET_OSX
+
+#ifdef TARGET_AMD64
+    if (IsProcessTranslated())
+    {
+        // Rosetta doesn't support double mapping correctly
+        return false;
+    }
+#endif // TARGET_AMD64
+
     *pMaxExecutableCodeSize = SIZE_MAX;
     *pHandle = NULL;
 #endif // !TARGET_OSX

--- a/src/coreclr/minipal/Unix/doublemapping.cpp
+++ b/src/coreclr/minipal/Unix/doublemapping.cpp
@@ -33,7 +33,7 @@ bool IsProcessTranslated()
    {
       return false;
    }
-   return ret != 0;
+   return ret == 1;
 }
 #endif // TARGET_OSX && TARGET_AMD64
 

--- a/src/coreclr/utilcode/executableallocator.cpp
+++ b/src/coreclr/utilcode/executableallocator.cpp
@@ -249,7 +249,8 @@ bool ExecutableAllocator::Initialize()
     {
         if (!VMToOSInterface::CreateDoubleMemoryMapper(&m_doubleMemoryMapperHandle, &m_maxExecutableCodeSize))
         {
-            return false;
+            g_isWXorXEnabled = false;
+            return true;
         }
 
         m_CriticalSection = ClrCreateCriticalSection(CrstExecutableAllocatorLock,CrstFlags(CRST_UNSAFE_ANYMODE | CRST_DEBUGGER_THREAD));


### PR DESCRIPTION
Apple has informed us that double mapping doesn't work properly
on Rosetta emulation. This change disables W^X if Rosetta is detected.

Close #70910

It also fixes a problem with W^X not being able to work on WSL1 and some Linux distro with kernel older than 3.17
Close #70758