### PR TITLE
Windows/Arm64: Use 8.1 atomic instructions if they are available

### DIFF
--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -25,12 +25,12 @@
 UINT32 g_nClrInstanceId = 0;
 
 #if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
-bool g_atomic_present = false;
+// Flag to check if atomics feature is available on
+// the machine
+bool g_arm64_atomics_present = false;
 #endif
 
 #endif //!DACCESS_COMPILE
-
-
 
 //*****************************************************************************
 // Convert a string of hex digits into a hex value of the specified # of bytes.

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -23,9 +23,14 @@
 
 #ifndef DACCESS_COMPILE
 UINT32 g_nClrInstanceId = 0;
+
+#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
+bool g_atomic_present = false;
+#endif
+
 #endif //!DACCESS_COMPILE
 
-bool g_atomic_present = false;
+
 
 //*****************************************************************************
 // Convert a string of hex digits into a hex value of the specified # of bytes.

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -25,6 +25,8 @@
 UINT32 g_nClrInstanceId = 0;
 #endif //!DACCESS_COMPILE
 
+bool g_atomic_present = false;
+
 //*****************************************************************************
 // Convert a string of hex digits into a hex value of the specified # of bytes.
 //*****************************************************************************

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1566,6 +1566,7 @@ void EEJitManager::SetCpuInfo()
     if (IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE))
     {
         CPUCompileFlags.Set(InstructionSet_Atomics);
+        g_arm64_atomics_present = true;
     }
 
     // PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE (43)
@@ -1575,10 +1576,6 @@ void EEJitManager::SetCpuInfo()
     }
 
 #endif // HOST_64BIT
-    if (CPUCompileFlags.IsSet(InstructionSet_Atomics))
-    {
-        g_atomic_present = true;
-    }
     if (GetDataCacheZeroIDReg() == 4)
     {
         // DCZID_EL0<4> (DZP) indicates whether use of DC ZVA instructions is permitted (0) or prohibited (1).

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1575,6 +1575,10 @@ void EEJitManager::SetCpuInfo()
     }
 
 #endif // HOST_64BIT
+    if (CPUCompileFlags.IsSet(InstructionSet_Atomics))
+    {
+        g_atomic_present = true;
+    }
     if (GetDataCacheZeroIDReg() == 4)
     {
         // DCZID_EL0<4> (DZP) indicates whether use of DC ZVA instructions is permitted (0) or prohibited (1).

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -1652,7 +1652,11 @@ AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelperSpin(Thread* pCurTh
             }
 
             LONG newValue = oldValue | tid;
+#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
+            if (FastInterlockedCompareExchangeAcquire((LONG*)&m_SyncBlockValue, newValue, oldValue) == oldValue)
+#else
             if (InterlockedCompareExchangeAcquire((LONG*)&m_SyncBlockValue, newValue, oldValue) == oldValue)
+#endif
             {
                 return AwareLock::EnterHelperResult_Entered;
             }

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -382,13 +382,21 @@ private:
         LockState CompareExchange(LockState toState, LockState fromState)
         {
             LIMITED_METHOD_CONTRACT;
+#if defined(TARGET_ARM64)
+            return (UINT32)FastInterlockedCompareExchange((LONG *)&m_state, (LONG)toState, (LONG)fromState);
+#else
             return (UINT32)InterlockedCompareExchange((LONG *)&m_state, (LONG)toState, (LONG)fromState);
+#endif
         }
 
         LockState CompareExchangeAcquire(LockState toState, LockState fromState)
         {
             LIMITED_METHOD_CONTRACT;
+#if defined(TARGET_ARM64)
+            return (UINT32)FastInterlockedCompareExchangeAcquire((LONG *)&m_state, (LONG)toState, (LONG)fromState);
+#else
             return (UINT32)InterlockedCompareExchangeAcquire((LONG *)&m_state, (LONG)toState, (LONG)fromState);
+#endif
         }
 
     public:

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -382,7 +382,7 @@ private:
         LockState CompareExchange(LockState toState, LockState fromState)
         {
             LIMITED_METHOD_CONTRACT;
-#if defined(TARGET_ARM64)
+#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
             return (UINT32)FastInterlockedCompareExchange((LONG *)&m_state, (LONG)toState, (LONG)fromState);
 #else
             return (UINT32)InterlockedCompareExchange((LONG *)&m_state, (LONG)toState, (LONG)fromState);
@@ -392,7 +392,7 @@ private:
         LockState CompareExchangeAcquire(LockState toState, LockState fromState)
         {
             LIMITED_METHOD_CONTRACT;
-#if defined(TARGET_ARM64)
+#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
             return (UINT32)FastInterlockedCompareExchangeAcquire((LONG *)&m_state, (LONG)toState, (LONG)fromState);
 #else
             return (UINT32)InterlockedCompareExchangeAcquire((LONG *)&m_state, (LONG)toState, (LONG)fromState);

--- a/src/coreclr/vm/syncblk.inl
+++ b/src/coreclr/vm/syncblk.inl
@@ -602,7 +602,7 @@ FORCEINLINE AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelper(Thread
         }
 
         LONG newValue = oldValue | tid;
-#if defined(TARGET_ARM64)
+#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
         if (FastInterlockedCompareExchangeAcquire((LONG*)&m_SyncBlockValue, newValue, oldValue) == oldValue)
 #else   
         if (InterlockedCompareExchangeAcquire((LONG*)&m_SyncBlockValue, newValue, oldValue) == oldValue)
@@ -654,7 +654,7 @@ FORCEINLINE AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelper(Thread
         return AwareLock::EnterHelperResult_UseSlowPath;
     }
 
-#if defined(TARGET_ARM64)
+#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
     if (FastInterlockedCompareExchangeAcquire((LONG*)&m_SyncBlockValue, newValue, oldValue) == oldValue)
 #else
     if (InterlockedCompareExchangeAcquire((LONG*)&m_SyncBlockValue, newValue, oldValue) == oldValue)
@@ -732,7 +732,7 @@ FORCEINLINE AwareLock::LeaveHelperAction ObjHeader::LeaveObjMonitorHelper(Thread
             // We are leaving the lock
             DWORD newValue = (syncBlockValue & (~SBLK_MASK_LOCK_THREADID));
 
-#if defined(TARGET_ARM64)
+#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
             if (FastInterlockedCompareExchangeRelease((LONG*)&m_SyncBlockValue, newValue, syncBlockValue) != (LONG)syncBlockValue)
 #else
             if (InterlockedCompareExchangeRelease((LONG*)&m_SyncBlockValue, newValue, syncBlockValue) != (LONG)syncBlockValue)
@@ -745,7 +745,7 @@ FORCEINLINE AwareLock::LeaveHelperAction ObjHeader::LeaveObjMonitorHelper(Thread
         {
             // recursion and ThinLock
             DWORD newValue = syncBlockValue - SBLK_LOCK_RECLEVEL_INC;
-#if defined(TARGET_ARM64)
+#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
             if (FastInterlockedCompareExchangeRelease((LONG*)&m_SyncBlockValue, newValue, syncBlockValue) != (LONG)syncBlockValue)
 #else
             if (InterlockedCompareExchangeRelease((LONG*)&m_SyncBlockValue, newValue, syncBlockValue) != (LONG)syncBlockValue)

--- a/src/coreclr/vm/syncblk.inl
+++ b/src/coreclr/vm/syncblk.inl
@@ -602,7 +602,11 @@ FORCEINLINE AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelper(Thread
         }
 
         LONG newValue = oldValue | tid;
+#if defined(TARGET_ARM64)
+        if (FastInterlockedCompareExchangeAcquire((LONG*)&m_SyncBlockValue, newValue, oldValue) == oldValue)
+#else   
         if (InterlockedCompareExchangeAcquire((LONG*)&m_SyncBlockValue, newValue, oldValue) == oldValue)
+#endif
         {
             return AwareLock::EnterHelperResult_Entered;
         }
@@ -650,7 +654,11 @@ FORCEINLINE AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelper(Thread
         return AwareLock::EnterHelperResult_UseSlowPath;
     }
 
+#if defined(TARGET_ARM64)
+    if (FastInterlockedCompareExchangeAcquire((LONG*)&m_SyncBlockValue, newValue, oldValue) == oldValue)
+#else
     if (InterlockedCompareExchangeAcquire((LONG*)&m_SyncBlockValue, newValue, oldValue) == oldValue)
+#endif
     {
         return AwareLock::EnterHelperResult_Entered;
     }
@@ -723,7 +731,12 @@ FORCEINLINE AwareLock::LeaveHelperAction ObjHeader::LeaveObjMonitorHelper(Thread
         {
             // We are leaving the lock
             DWORD newValue = (syncBlockValue & (~SBLK_MASK_LOCK_THREADID));
+
+#if defined(TARGET_ARM64)
+            if (FastInterlockedCompareExchangeRelease((LONG*)&m_SyncBlockValue, newValue, syncBlockValue) != (LONG)syncBlockValue)
+#else
             if (InterlockedCompareExchangeRelease((LONG*)&m_SyncBlockValue, newValue, syncBlockValue) != (LONG)syncBlockValue)
+#endif
             {
                 return AwareLock::LeaveHelperAction_Yield;
             }
@@ -732,7 +745,11 @@ FORCEINLINE AwareLock::LeaveHelperAction ObjHeader::LeaveObjMonitorHelper(Thread
         {
             // recursion and ThinLock
             DWORD newValue = syncBlockValue - SBLK_LOCK_RECLEVEL_INC;
+#if defined(TARGET_ARM64)
+            if (FastInterlockedCompareExchangeRelease((LONG*)&m_SyncBlockValue, newValue, syncBlockValue) != (LONG)syncBlockValue)
+#else
             if (InterlockedCompareExchangeRelease((LONG*)&m_SyncBlockValue, newValue, syncBlockValue) != (LONG)syncBlockValue)
+#endif
             {
                 return AwareLock::LeaveHelperAction_Yield;
             }

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -27,7 +27,9 @@
 
 #ifndef DACCESS_COMPILE
 #if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
-extern bool g_atomic_present;
+// Flag to check if atomics feature is available on
+// the machine
+extern bool g_arm64_atomics_present;
 #endif
 #endif
 
@@ -91,7 +93,7 @@ FORCEINLINE LONG  FastInterlockedCompareExchange(
     LONG Exchange,
     LONG Comperand)
 {
-    if (g_atomic_present)
+    if (g_arm64_atomics_present)
     {
         return (LONG) __casal32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);
     }
@@ -106,7 +108,7 @@ FORCEINLINE LONGLONG  FastInterlockedCompareExchange64(
     IN LONGLONG Exchange,
     IN LONGLONG Comperand)
 {
-    if (g_atomic_present)
+    if (g_arm64_atomics_present)
     {
         return (LONGLONG) __casal64((unsigned __int64*) Destination, (unsigned  __int64)Comperand, (unsigned __int64)Exchange);
     }
@@ -122,7 +124,7 @@ FORCEINLINE LONG FastInterlockedCompareExchangeAcquire(
   IN LONG Comperand
 )
 {
-    if (g_atomic_present)
+    if (g_arm64_atomics_present)
     {
         return (LONG) __casa32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);
     }
@@ -138,7 +140,7 @@ FORCEINLINE LONG FastInterlockedCompareExchangeRelease(
   IN LONG Comperand
 )
 {
-    if (g_atomic_present)
+    if (g_arm64_atomics_present)
     {
         return (LONG) __casl32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);
     }

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -78,7 +78,6 @@ BOOL inline FitsInU4(unsigned __int64 val)
 #define FastInterlockedCompareExchange64 InterlockedCompareExchange64
 #define FastInterlockedCompareExchangeAcquire InterlockedCompareExchangeAcquire
 #define FastInterlockedCompareExchangeRelease InterlockedCompareExchangeRelease
-
 #else
 
 #if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
@@ -88,7 +87,6 @@ FORCEINLINE LONG  FastInterlockedCompareExchange(
     LONG Exchange,
     LONG Comperand)
 {
-    printf("g_atomic_present (FastInterlockedCompareExchange)= %d\n", g_atomic_present);
     if (g_atomic_present)
     {
         return (LONG) __casal32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);
@@ -104,7 +102,6 @@ FORCEINLINE LONGLONG  FastInterlockedCompareExchange64(
     IN LONGLONG Exchange,
     IN LONGLONG Comperand)
 {
-    printf("g_atomic_present (FastInterlockedCompareExchange64)= %d\n", g_atomic_present);
     if (g_atomic_present)
     {
         return (LONGLONG) __casal64((unsigned __int64*) Destination, (unsigned  __int64)Comperand, (unsigned __int64)Exchange);
@@ -121,7 +118,6 @@ FORCEINLINE LONG FastInterlockedCompareExchangeAcquire(
   IN LONG Comperand
 )
 {
-    printf("g_atomic_present (FastInterlockedCompareExchangeAcquire)= %d\n", g_atomic_present);
     if (g_atomic_present)
     {
         return (LONG) __casa32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);
@@ -138,7 +134,6 @@ FORCEINLINE LONG FastInterlockedCompareExchangeRelease(
   IN LONG Comperand
 )
 {
-    printf("g_atomic_present (FastInterlockedCompareExchangeRelease)= %d\n", g_atomic_present);
     if (g_atomic_present)
     {
         return (LONG) __casl32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -25,6 +25,8 @@
 #define MAX_CACHE_LINE_SIZE 64
 #endif
 
+extern bool g_atomic_present;
+
 #ifndef TARGET_UNIX
 // Copied from malloc.h: don't want to bring in the whole header file.
 void * __cdecl _alloca(size_t);
@@ -71,6 +73,76 @@ BOOL inline FitsInU4(unsigned __int64 val)
     return val == (unsigned __int64)(unsigned __int32)val;
 }
 
+
+#if defined(TARGET_ARM64)
+
+FORCEINLINE LONG  FastInterlockedCompareExchange(
+    LONG volatile *Destination,
+    LONG Exchange,
+    LONG Comperand)
+{
+    printf("g_atomic_present (FastInterlockedCompareExchange)= %d\n", g_atomic_present);
+    if (g_atomic_present)
+    {
+        return (LONG) __casal32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);
+    }
+    else
+    {
+        return InterlockedCompareExchange(Destination, Exchange, Comperand);
+    }
+}
+
+FORCEINLINE LONGLONG  FastInterlockedCompareExchange64(
+    IN OUT LONGLONG volatile *Destination,
+    IN LONGLONG Exchange,
+    IN LONGLONG Comperand)
+{
+    printf("g_atomic_present (FastInterlockedCompareExchange64)= %d\n", g_atomic_present);
+    if (g_atomic_present)
+    {
+        return (LONGLONG) __casal64((unsigned __int64*) Destination, (unsigned  __int64)Comperand, (unsigned __int64)Exchange);
+    }
+    else
+    {
+        return InterlockedCompareExchange64(Destination, Exchange, Comperand);
+    }
+}
+
+FORCEINLINE LONG FastInterlockedCompareExchangeAcquire(
+  IN OUT LONG volatile *Destination,
+  IN LONG Exchange,
+  IN LONG Comperand
+)
+{
+    printf("g_atomic_present (FastInterlockedCompareExchangeAcquire)= %d\n", g_atomic_present);
+    if (g_atomic_present)
+    {
+        return (LONG) __casa32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);
+    }
+    else
+    {
+        return InterlockedCompareExchangeAcquire(Destination, Exchange, Comperand);
+    }
+}
+
+FORCEINLINE LONG FastInterlockedCompareExchangeRelease(
+  IN OUT LONG volatile *Destination,
+  IN LONG Exchange,
+  IN LONG Comperand
+)
+{
+    printf("g_atomic_present (FastInterlockedCompareExchangeRelease)= %d\n", g_atomic_present);
+    if (g_atomic_present)
+    {
+        return (LONG) __casl32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);
+    }
+    else
+    {
+        return InterlockedCompareExchangeRelease(Destination, Exchange, Comperand);
+    }
+}
+
+#endif // TARGET_ARM64
 
 
 //************************************************************************

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -73,8 +73,15 @@ BOOL inline FitsInU4(unsigned __int64 val)
     return val == (unsigned __int64)(unsigned __int32)val;
 }
 
+#if defined(DACCESS_COMPILE)
+#define FastInterlockedCompareExchange InterlockedCompareExchange
+#define FastInterlockedCompareExchange64 InterlockedCompareExchange64
+#define FastInterlockedCompareExchangeAcquire InterlockedCompareExchangeAcquire
+#define FastInterlockedCompareExchangeRelease InterlockedCompareExchangeRelease
 
-#if defined(TARGET_ARM64)
+#else
+
+#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
 
 FORCEINLINE LONG  FastInterlockedCompareExchange(
     LONG volatile *Destination,
@@ -142,7 +149,9 @@ FORCEINLINE LONG FastInterlockedCompareExchangeRelease(
     }
 }
 
-#endif // TARGET_ARM64
+#endif // defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
+
+#endif //defined(DACCESS_COMPILE)
 
 
 //************************************************************************

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -81,7 +81,6 @@ BOOL inline FitsInU4(unsigned __int64 val)
 
 #if defined(DACCESS_COMPILE)
 #define FastInterlockedCompareExchange InterlockedCompareExchange
-#define FastInterlockedCompareExchange64 InterlockedCompareExchange64
 #define FastInterlockedCompareExchangeAcquire InterlockedCompareExchangeAcquire
 #define FastInterlockedCompareExchangeRelease InterlockedCompareExchangeRelease
 #else
@@ -100,21 +99,6 @@ FORCEINLINE LONG  FastInterlockedCompareExchange(
     else
     {
         return InterlockedCompareExchange(Destination, Exchange, Comperand);
-    }
-}
-
-FORCEINLINE LONGLONG  FastInterlockedCompareExchange64(
-    IN OUT LONGLONG volatile *Destination,
-    IN LONGLONG Exchange,
-    IN LONGLONG Comperand)
-{
-    if (g_arm64_atomics_present)
-    {
-        return (LONGLONG) __casal64((unsigned __int64*) Destination, (unsigned  __int64)Comperand, (unsigned __int64)Exchange);
-    }
-    else
-    {
-        return InterlockedCompareExchange64(Destination, Exchange, Comperand);
     }
 }
 

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -25,7 +25,11 @@
 #define MAX_CACHE_LINE_SIZE 64
 #endif
 
+#ifndef DACCESS_COMPILE
+#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
 extern bool g_atomic_present;
+#endif
+#endif
 
 #ifndef TARGET_UNIX
 // Copied from malloc.h: don't want to bring in the whole header file.


### PR DESCRIPTION
Currently, the base version for armarch is v8.0. However, starting v8.1, there are faster `atomic` instructions that takes less instructions and do not need full barrier. See example: https://godbolt.org/z/x1o9Ybh66. This restricts the machine that supports the CPU feature from using these faster instructions. As part of this PR, added a flag `g_arm64_atomics_present` that is set at the startup when we get the CPU capability info. Below APIs are rewritten such that it checks this flag and use the faster instructions if atomic support is available on the machine:

- InterlockedCompareExchange
- InterlockedCompareExchangeAcquire
- InterlockedCompareExchangeRelease

Finally, the usage of these APIs at certain hot code paths (mostly in `syncblk.*` files) are replaced with the rewritten APIs.

This does introduce an extra check for the flag, but it is cheaper than any other alternative like function pointer. With function pointer, there has to be an extra call and it has to go through CFG which makes it more expensive.

Clang [added a flag](https://reviews.llvm.org/rG4d7df43ffdb460dddb2877a886f75f45c3fee188) `-moutline-atomics` recently that would emit such check during compilation so the faster machines can take advantage of it while still maintaining compatibility with the older machines. See an example [here](https://mysqlonarm.github.io/ARM-LSE-and-MySQL/). Unfortunately, we are still on clang9 and hopefully, this PR and the improvements I share below will motivate us to move to newer compiler on Linux to have this taken care by compiler. Hence, for now I just introduced this on Windows. The MSVC story on windows is slightly different. It doesn't have an equivalent flag like `-moutline-atomics` so the only option to generate faster atomic instructions would be to use `/arch:armv8.1` as mentioned [here](https://devblogs.microsoft.com/cppblog/msvc-backend-updates-in-visual-studio-2022-version-17-2/), which unfortunately we cannot do. So the choice was to add such check manually in our codebase to take advantage of the atomic instructions.

## Benchmark
I tested this PR with following C# code:

```c#
namespace Monitor_Lock  
{  
    class Program  
    {  
        static readonly object _object = new object();  
        static long result = 0;
  
        static void TestLock()  
        {
            for (int i = 0; i < 10000; i++)
            {
                lock (_object)  
                {  
                    result += i;
                }
            }
        }  
  
        static void Main(string[] args)      
        {
            Stopwatch sw = new Stopwatch();
            int count = int.Parse(args[0]);
            List<Thread> threads = new List<Thread>();
            sw.Start();
            for (int i = 0; i < count; i++)  
            {  
                ThreadStart start = new ThreadStart(TestLock);  
                Thread thread = new Thread(start);
                threads.Add(thread);
                thread.Start();
            }
            for (int i = 0; i < count; i++)
            {
                threads[i].Join();
            }
            sw.Stop();
            Console.WriteLine($"{count} threads took {sw.Elapsed.TotalMilliseconds} msec.");
        }
    }  
}  
```

## Results

### Ampere (v8.1 supported)

As part of the experiments, I ran this program on a 80-core Windows Ampere machine with varying number of thread counts and for each thread count, performed 5 iterations. Below is the AVG/MIN/MAX duration for running this test. 

Average duration:

| Threads AVG. | main      | PR        | Diff    |
|--------------|-----------|-----------|---------|
| 1            | 3.4344    | 3.4844    | 1.46%   |
| 2            | 4.47042   | 4.5869    | 2.61%   |
| 4            | 7.64708   | 6.0626    | -20.72% |
| 8            | 12.4943   | 9.6475    | -22.78% |
| 16           | 21.71328  | 20.94708  | -3.53%  |
| 32           | 42.86546  | 38.87922  | -9.30%  |
| 64           | 83.62778  | 70.58204  | -15.60% |
| 80           | 101.097   | 82.45124  | -18.44% |
| 128          | 167.65336 | 141.48888 | -15.61% |
| 256          | 316.17956 | 279.4261  | -11.62% |

Minimum duration:

| Threads MIN. | main     | PR       | Diff    |
|--------------|----------|----------|---------|
| 1            | 3.4012   | 3.4082   | 0.21%   |
| 2            | 4.3022   | 4.1128   | -4.40%  |
| 4            | 7.0673   | 5.7692   | -18.37% |
| 8            | 10.4781  | 8.4221   | -19.62% |
| 16           | 18.6477  | 16.4685  | -11.69% |
| 32           | 36.0364  | 33.6191  | -6.71%  |
| 64           | 71.2875  | 65.0999  | -8.68%  |
| 80           | 92.3571  | 72.0427  | -22.00% |
| 128          | 158.3358 | 134.0232 | -15.36% |
| 256          | 288.162  | 268.1084 | -6.96%  |

Maximum duration:

| Threads MAX. | main     | PR       | Diff    |
|--------------|----------|----------|---------|
| 1            | 3.4906   | 3.69     | 5.71%   |
| 2            | 4.6457   | 5.1342   | 10.52%  |
| 4            | 8.6484   | 6.6577   | -23.02% |
| 8            | 13.6105  | 11.0653  | -18.70% |
| 16           | 24.0912  | 24.7727  | 2.83%   |
| 32           | 49.7276  | 48.7453  | -1.98%  |
| 64           | 344.3766 | 298.0459 | -13.45% |
| 80           | 113.6214 | 89.741   | -21.02% |
| 128          | 178.9653 | 145.3084 | -18.81% |
| 256          | 344.3766 | 298.0459 | -13.45% |

Overall, I see generous improvements from 10-20% in synchronization methods. It is little puzzling why 16 threads would just show slight performance improvement and I will check with few people offline.

### Qualcomm (v8.1 not supported)

I also verified on 46-core Windows Qualcomm machine that doesn't have atomic instruction to make sure that we don't regress because of the extra flag checks. Here are the numbers (just posting the average)

| Threads | main (avg) | PR (avg) | diff   |
|---------|------------|----------|--------|
| 1       | 4.9163     | 4.97444  | 1.18%  |
| 2       | 7.31232    | 7.4033   | 1.24%  |
| 4       | 10.77444   | 11.34458 | 5.29%  |
| 8       | 17.89266   | 18.59982 | 3.95%  |
| 16      | 31.76536   | 31.9401  | 0.55%  |
| 32      | 59.63574   | 58.14956 | -2.49% |
| 46      | 82.8319    | 81.73412 | -1.33% |
| 64      | 115.20062  | 114.6887 | -0.44% |
| 128     | 223.50822  | 221.9457 | -0.70% |
| 256     | 448.14158  | 441.6222 | -1.45% |

Overall, the numbers are within error margin.


Here is how the code looks like (taken from windbg screenshots)

## In Action

Before:

![image](https://user-images.githubusercontent.com/12488060/174402366-40fd05c9-b947-41af-a490-22c291b151f0.png)

After:

![image](https://user-images.githubusercontent.com/12488060/174402372-c3a0b5f5-313e-49c1-8a6a-25d1ea9cbe35.png)

## Next steps
- If this is convincing enough, we should start the process to upgrade our Linux compiler from clang9 to clang12 or clang13.
- I will start adding few more APIs so we can optimize some of the hot code paths in GC.
