### PR TITLE
Fix arm64 funclet frame type 5

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -642,6 +642,7 @@ protected:
     virtual void SetSaveFpLrWithAllCalleeSavedRegisters(bool value);
     virtual bool IsSaveFpLrWithAllCalleeSavedRegisters() const;
     bool         genSaveFpLrWithAllCalleeSavedRegisters;
+    bool         genForceFuncletFrameType5;
 #endif // TARGET_ARM64
 
     //-------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -1431,7 +1431,9 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
         }
         else
         {
-            // Nothing to do here; the first SP adjustment will be done by saving the callee-saved registers.
+            assert(genFuncletInfo.fiSpDelta1 < 0);
+            assert(genFuncletInfo.fiSpDelta1 >= -240);
+            genStackPointerAdjustment(genFuncletInfo.fiSpDelta1, REG_NA, nullptr, /* reportUnwindData */ true);
         }
     }
 

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -4651,7 +4651,7 @@ void CodeGen::genPushCalleeSavedRegisters()
     //      |-----------------------|
     //      |Callee saved registers | // not including FP/LR; multiple of 8 bytes
     //      |-----------------------|
-    //      |    MonitorAcquired    |
+    //      |    MonitorAcquired    | // 8 bytes; for synchronized methods
     //      |-----------------------|
     //      |        PSP slot       | // 8 bytes (omitted in NativeAOT ABI)
     //      |-----------------------|
@@ -4684,7 +4684,7 @@ void CodeGen::genPushCalleeSavedRegisters()
     //      |-----------------------|
     //      |Callee saved registers | // not including FP/LR; multiple of 8 bytes
     //      |-----------------------|
-    //      |    MonitorAcquired    |
+    //      |    MonitorAcquired    | // 8 bytes; for synchronized methods
     //      |-----------------------|
     //      |        PSP slot       | // 8 bytes (omitted in NativeAOT ABI)
     //      |-----------------------|

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -137,6 +137,7 @@ CodeGen::CodeGen(Compiler* theCompiler) : CodeGenInterface(theCompiler)
 
 #ifdef TARGET_ARM64
     genSaveFpLrWithAllCalleeSavedRegisters = false;
+    genForceFuncletFrameType5              = false;
 #endif // TARGET_ARM64
 }
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -603,6 +603,8 @@ CONFIG_STRING(JitFunctionFile, W("JitFunctionFile"))
 //    1: disable frames that save FP/LR registers with the callee-saved registers (at the top of the frame)
 //    2: force all frames to use the frame types that save FP/LR registers with the callee-saved registers (at the top
 //    of the frame)
+//    3: force all frames to use the frame types that save FP/LR registers with the callee-saved registers (at the top
+//    of the frame) and also force using the large funclet frame variation (frame 5) if possible.
 CONFIG_INTEGER(JitSaveFpLrWithCalleeSavedRegisters, W("JitSaveFpLrWithCalleeSavedRegisters"), 0)
 #endif // defined(TARGET_ARM64)
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -6385,7 +6385,7 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
     {
         codeGen->SetSaveFpLrWithAllCalleeSavedRegisters(false); // Disable using new frames
     }
-    else if (opts.compJitSaveFpLrWithCalleeSavedRegisters == 2)
+    else if ((opts.compJitSaveFpLrWithCalleeSavedRegisters == 2) || (opts.compJitSaveFpLrWithCalleeSavedRegisters == 3))
     {
         codeGen->SetSaveFpLrWithAllCalleeSavedRegisters(true); // Force using new frames
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66089/Runtime_66089.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66089/Runtime_66089.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Test arm64 funclet frame type 5: frames with large outgoing argument space
+// where FP/LR are stored at the top of the frame due to the need for a GS
+// cookie.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class Runtime_66089
+{
+    public static unsafe int Main()
+    {
+        int* foo = stackalloc int[30];
+        try
+        {
+            Console.WriteLine("try");
+            throw new Exception();
+        }
+        catch (Exception)
+        {
+            Console.WriteLine("catch");
+            foo[0] = 10;
+            ManyArgs(new Guid(foo[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+        }
+        Console.WriteLine("after");
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ManyArgs(
+        Guid g0 = default,
+        Guid g1 = default,
+        Guid g2 = default,
+        Guid g3 = default,
+        Guid g4 = default,
+        Guid g5 = default,
+        Guid g6 = default,
+        Guid g7 = default,
+        Guid g8 = default,
+        Guid g9 = default,
+        Guid g10 = default,
+        Guid g11 = default,
+        Guid g12 = default,
+        Guid g13 = default,
+        Guid g14 = default,
+        Guid g15 = default,
+        Guid g16 = default,
+        Guid g17 = default,
+        Guid g18 = default,
+        Guid g19 = default,
+        Guid g20 = default,
+        Guid g21 = default,
+        Guid g22 = default,
+        Guid g23 = default,
+        Guid g24 = default,
+        Guid g25 = default,
+        Guid g26 = default,
+        Guid g27 = default,
+        Guid g28 = default,
+        Guid g29 = default,
+        Guid g30 = default,
+        Guid g31 = default,
+        Guid g32 = default,
+        Guid g33 = default,
+        Guid g34 = default,
+        Guid g35 = default,
+        Guid g36 = default,
+        Guid g37 = default,
+        Guid g38 = default,
+        Guid g39 = default,
+        Guid g40 = default,
+        Guid g41 = default)
+    {
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66089/Runtime_66089.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66089/Runtime_66089.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Add the appropriate subtract of SP before saving callee-saved registers. It's possible that in some cases this could be folded in to the initial callee-saved register save as a pre-indexed addressing mode. This isn't done, to avoid extra complexity.

Funclet frame type 5 is very rare, so add code to force using it during stress.

Fixes #66089

No [SPMI diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1832558&view=ms.vss-build-web.run-extensions-tab)