### PR TITLE
Append the function pointer type

### DIFF
--- a/src/coreclr/utilcode/prettyprintsig.cpp
+++ b/src/coreclr/utilcode/prettyprintsig.cpp
@@ -788,8 +788,12 @@ static HRESULT PrettyPrintTypeA(
         break;
 
     case ELEMENT_TYPE_FNPTR:
-        IfFailGo(appendStrA(out, "fnptr "));
-        IfFailGo(PrettyPrintSigWorkerInternal(typePtr, (typeEnd - typePtr), "", out,pIMDI));
+        {
+            IfFailGo(appendStrA(out, "fnptr "));
+            CQuickBytes qbOut;
+            IfFailGo(PrettyPrintSigWorkerInternal(typePtr, (typeEnd - typePtr), "", &qbOut,pIMDI));
+            IfFailGo(appendStrA(out, (char *)qbOut.Ptr()));
+        }
         break;
 
     case ELEMENT_TYPE_NATIVE_VALUETYPE_ZAPSIG:


### PR DESCRIPTION
The issue here was the recursion into `PrettyPrintSigWorkerInternal`
that would reset the buffer. Now, we pass in a new buffer and append
it when we return.

Fixes #60829

/cc @mangod9 