### PR TITLE
Collections contain stale object IDs

### DIFF
--- a/src/tests/profiler/native/gcprofiler/gcprofiler.cpp
+++ b/src/tests/profiler/native/gcprofiler/gcprofiler.cpp
@@ -70,6 +70,9 @@ HRESULT GCProfiler::GarbageCollectionStarted(int cGenerations, BOOL generationCo
         printf("GCProfiler::GarbageCollectionStarted: FAIL: Expected GCStart <= GCFinish+2. GCStart=%d, GCFinish=%d\n", (int)_gcStarts, (int)_gcFinishes);
     }
 
+    _objectReferencesSeen = {};
+    _rootReferencesSeen = {};
+
     return S_OK;
 }
 
@@ -84,9 +87,9 @@ HRESULT GCProfiler::GarbageCollectionFinished()
         printf("GCProfiler::GarbageCollectionFinished: FAIL: Expected GCStart >= GCFinish. Start=%d, Finish=%d\n", (int)_gcStarts, (int)_gcFinishes);
     }
 
-    _pohObjectsSeenObjectReferences += NumPOHObjectsSeen(_objectReferencesSeen);
-    _pohObjectsSeenRootReferences += NumPOHObjectsSeen(_rootReferencesSeen);
-    
+    _pohObjectsSeenObjectReferences += NumPOHObjectsSeen(std::move(_objectReferencesSeen));
+    _pohObjectsSeenRootReferences += NumPOHObjectsSeen(std::move(_rootReferencesSeen));
+
     return S_OK;
 }
 


### PR DESCRIPTION
It looks like the collections contain stale
ObjectID values. These collections should
be purged or updated between GCs.

Fixes #67630