### PR TITLE
Remove not needed code

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
@@ -138,20 +138,6 @@ namespace Microsoft.Extensions.DependencyModel
 
             string depsJsonFile = Path.ChangeExtension(assemblyLocation, DepsJsonExtension);
             bool depsJsonFileExists = _fileSystem.File.Exists(depsJsonFile);
-
-            if (!depsJsonFileExists)
-            {
-                // in some cases (like .NET Framework shadow copy) the Assembly Location
-                // and CodeBase will be different, so also try the CodeBase
-                string? assemblyCodeBase = GetNormalizedCodeBasePath(assembly);
-                if (!string.IsNullOrEmpty(assemblyCodeBase) &&
-                    assemblyLocation != assemblyCodeBase)
-                {
-                    depsJsonFile = Path.ChangeExtension(assemblyCodeBase, DepsJsonExtension);
-                    depsJsonFileExists = _fileSystem.File.Exists(depsJsonFile);
-                }
-            }
-
             return depsJsonFileExists ?
                 depsJsonFile :
                 null;
@@ -160,9 +146,7 @@ namespace Microsoft.Extensions.DependencyModel
         [RequiresAssemblyFiles]
         private static string? GetNormalizedCodeBasePath(Assembly assembly)
         {
-#pragma warning disable SYSLIB0012 // CodeBase is obsolete
-            if (Uri.TryCreate(assembly.CodeBase, UriKind.Absolute, out Uri? codeBase)
-#pragma warning restore SYSLIB0012 // CodeBase is obsolete
+            if (Uri.TryCreate(assembly.Location, UriKind.Absolute, out Uri? codeBase)
                 && codeBase.IsFile)
             {
                 return codeBase.LocalPath;

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
@@ -138,6 +138,22 @@ namespace Microsoft.Extensions.DependencyModel
 
             string depsJsonFile = Path.ChangeExtension(assemblyLocation, DepsJsonExtension);
             bool depsJsonFileExists = _fileSystem.File.Exists(depsJsonFile);
+
+#if !NETSTANDARD2_0
+            if (!depsJsonFileExists)
+            {
+                // in some cases (like .NET Framework shadow copy) the Assembly Location
+                // and CodeBase will be different, so also try the CodeBase
+                string? assemblyCodeBase = GetNormalizedCodeBasePath(assembly);
+                if (!string.IsNullOrEmpty(assemblyCodeBase) &&
+                    assemblyLocation != assemblyCodeBase)
+                {
+                    depsJsonFile = Path.ChangeExtension(assemblyCodeBase, DepsJsonExtension);
+                    depsJsonFileExists = _fileSystem.File.Exists(depsJsonFile);
+                }
+            }
+#endif
+
             return depsJsonFileExists ?
                 depsJsonFile :
                 null;

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
@@ -162,7 +162,9 @@ namespace Microsoft.Extensions.DependencyModel
         [RequiresAssemblyFiles]
         private static string? GetNormalizedCodeBasePath(Assembly assembly)
         {
-            if (Uri.TryCreate(assembly.Location, UriKind.Absolute, out Uri? codeBase)
+#pragma warning disable SYSLIB0012 // CodeBase is obsolete
+            if (Uri.TryCreate(assembly.CodeBase, UriKind.Absolute, out Uri? codeBase)
+#pragma warning restore SYSLIB0012 // CodeBase is obsolete
                 && codeBase.IsFile)
             {
                 return codeBase.LocalPath;

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextLoader.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Extensions.DependencyModel
             string depsJsonFile = Path.ChangeExtension(assemblyLocation, DepsJsonExtension);
             bool depsJsonFileExists = _fileSystem.File.Exists(depsJsonFile);
 
-#if !NETSTANDARD2_0
+#if !NETCOREAPP5_0_OR_GREATER && !NETSTANDARD2_0
             if (!depsJsonFileExists)
             {
                 // in some cases (like .NET Framework shadow copy) the Assembly Location


### PR DESCRIPTION
If I read this correctly Location and CodeBase are the same, so not need to keep using it.
https://github.com/dotnet/runtime/blob/2ce8130f4bf4b02393b95719edb0f9d5c6ee1776/src/coreclr/vm/peassembly.cpp#L886

Without that, it blow-up in NativeAOT context