### PR TITLE
JIT: fix loop alignment issue

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5199,25 +5199,41 @@ void Compiler::placeLoopAlignInstructions()
         {
             // Loop alignment is disabled for cold blocks
             assert((block->bbFlags & BBF_COLD) == 0);
+            BasicBlock* const loopTop = block->bbNext;
 
             // If jmp was not found, then block before the loop start is where align instruction will be added.
+            //
             if (bbHavingAlign == nullptr)
             {
-                bbHavingAlign = block;
-                JITDUMP("Marking " FMT_BB " before the loop with BBF_HAS_ALIGN for loop at " FMT_BB "\n", block->bbNum,
-                        block->bbNext->bbNum);
+                // In some odd cases we may see blocks within the loop before we see the
+                // top block of the loop. Just bail on aligning such loops.
+                //
+                if ((block->bbNatLoopNum != BasicBlock::NOT_IN_LOOP) && (block->bbNatLoopNum == loopTop->bbNatLoopNum))
+                {
+                    loopTop->unmarkLoopAlign(this DEBUG_ARG("loop block appears before top of loop"));
+                }
+                else
+                {
+                    bbHavingAlign = block;
+                    JITDUMP("Marking " FMT_BB " before the loop with BBF_HAS_ALIGN for loop at " FMT_BB "\n",
+                            block->bbNum, loopTop->bbNum);
+                }
             }
             else
             {
                 JITDUMP("Marking " FMT_BB " that ends with unconditional jump with BBF_HAS_ALIGN for loop at " FMT_BB
                         "\n",
-                        bbHavingAlign->bbNum, block->bbNext->bbNum);
+                        bbHavingAlign->bbNum, loopTop->bbNum);
             }
 
-            bbHavingAlign->bbFlags |= BBF_HAS_ALIGN;
+            if (bbHavingAlign != nullptr)
+            {
+                bbHavingAlign->bbFlags |= BBF_HAS_ALIGN;
+            }
+
             minBlockSoFar         = BB_MAX_WEIGHT;
             bbHavingAlign         = nullptr;
-            currentAlignedLoopNum = block->bbNext->bbNatLoopNum;
+            currentAlignedLoopNum = loopTop->bbNatLoopNum;
 
             if (--loopsToProcess == 0)
             {


### PR DESCRIPTION
When scanning to figure out which blocks should have alignment padding, we can
sometimes encounter a block in a loop before we see the block at the top of the
loop.. If so, remove alignment for that loop, otherwise the emitter code
handling alignment gets tripped up. Even if the emitter could handle this case,
it would be padding with the loop, not before it.

The problematic block reordering is done much earlier. At some point we need to
revisit this as it is making nonsensical ordering decisions. But we'll tolerate
it for now.

Fixes #70152.