### PR TITLE
SPMI: add ability to filter during collection

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitcompiler.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitcompiler.cpp
@@ -36,6 +36,23 @@ CorJitResult interceptor_ICJC::compileMethod(ICorJitInfo*                comp,  
                                              uint32_t* nativeSizeOfCode            /* OUT */
                                              )
 {
+    // See if we are filtering the collection (currently by simple substring match)
+    //
+    char* filter = GetEnvironmentVariableWithDefaultA("SuperPMIShimFilter", "");
+
+    if (strlen(filter) > 0)
+    {
+        bool collect = false;
+        const char* className = nullptr;
+        const char* methodName = comp->getMethodName(info->ftn, &className);
+        collect |= strstr(methodName, filter) != nullptr);
+        collect |= strstr(className, filter) != nullptr);
+        if (!collect)
+        {
+            return original_ICorJitCompiler->compileMethod(comp, info, flags, nativeEntry, nativeSizeOfCode);
+        }
+    }
+
     auto* mc = new MethodContext();
     interceptor_ICJI our_ICorJitInfo(this, comp, mc);
 

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitcompiler.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitcompiler.cpp
@@ -38,15 +38,14 @@ CorJitResult interceptor_ICJC::compileMethod(ICorJitInfo*                comp,  
 {
     // See if we are filtering the collection (currently by simple substring match)
     //
-    char* filter = GetEnvironmentVariableWithDefaultA("SuperPMIShimFilter", "");
-
+    static char* filter = GetEnvironmentVariableWithDefaultA("SuperPMIShimFilter", "");
     if (strlen(filter) > 0)
     {
         bool collect = false;
         const char* className = nullptr;
-        const char* methodName = comp->getMethodName(info->ftn, &className);
-        collect |= strstr(methodName, filter) != nullptr);
-        collect |= strstr(className, filter) != nullptr);
+        const char* methodName = comp->getMethodNameFromMetadata(info->ftn, &className, nullptr, nullptr);
+        collect |= (methodName != nullptr) && strstr(methodName, filter) != nullptr;
+        collect |= (className != nullptr) && strstr(className, filter) != nullptr;
         if (!collect)
         {
             return original_ICorJitCompiler->compileMethod(comp, info, flags, nativeEntry, nativeSizeOfCode);

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitcompiler.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitcompiler.cpp
@@ -38,14 +38,13 @@ CorJitResult interceptor_ICJC::compileMethod(ICorJitInfo*                comp,  
 {
     // See if we are filtering the collection (currently by simple substring match)
     //
-    static char* filter = GetEnvironmentVariableWithDefaultA("SuperPMIShimFilter", "");
-    if (strlen(filter) > 0)
+    if (g_collectionFilter != nullptr)
     {
         bool collect = false;
         const char* className = nullptr;
         const char* methodName = comp->getMethodNameFromMetadata(info->ftn, &className, nullptr, nullptr);
-        collect |= (methodName != nullptr) && strstr(methodName, filter) != nullptr;
-        collect |= (className != nullptr) && strstr(className, filter) != nullptr;
+        collect |= (methodName != nullptr) && strstr(methodName, g_collectionFilter) != nullptr;
+        collect |= (className != nullptr) && strstr(className, g_collectionFilter) != nullptr;
         if (!collect)
         {
             return original_ICorJitCompiler->compileMethod(comp, info, flags, nativeEntry, nativeSizeOfCode);

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
@@ -26,6 +26,7 @@ WCHAR*         g_HomeDirectory      = nullptr;
 WCHAR*         g_DefaultRealJitPath = nullptr;
 MethodContext* g_globalContext      = nullptr;
 bool           g_initialized        = false;
+char*          g_collectionFilter   = nullptr;
 
 void SetDefaultPaths()
 {
@@ -77,6 +78,16 @@ void SetLogFilePath()
     {
         // If the environment variable isn't set, we don't enable file logging
         g_logFilePath = GetEnvironmentVariableWithDefaultA("SuperPMIShimLogFilePath", nullptr);
+    }
+}
+
+void SetCollectionFilter()
+{
+    g_collectionFilter = GetEnvironmentVariableWithDefaultA("SuperPMIShimFilter", nullptr);
+
+    if (g_collectionFilter != nullptr)
+    {
+        fprintf(stderr, "*** SPMI filter '%s'\n", g_collectionFilter);
     }
 }
 
@@ -140,6 +151,7 @@ extern "C" DLLEXPORT void jitStartup(ICorJitHost* host)
     SetDefaultPaths();
     SetLibName();
     SetDebugDumpVariables();
+    SetCollectionFilter();
 
     if (!LoadRealJitLib(g_hRealJit, g_realJitPath))
     {

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.h
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.h
@@ -9,6 +9,7 @@
 
 class MethodContext;
 extern MethodContext* g_globalContext;
+extern char*          g_collectionFilter;
 
 void DebugBreakorAV(int val);
 


### PR DESCRIPTION
If SuperPMIShimFilter is set, only collect contexts for methods where the class
or method name contains the string in the filter.

Note if no methods pass the filter we end up with an emtpy MC file.