### PR TITLE
Make SuperPMI more explicit about JIT in error messages

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -371,7 +371,8 @@ int __cdecl main(int argc, char* argv[])
         st3.Start();
         res = jit->CompileMethod(mc, reader->GetMethodContextIndex(), collectThroughput, &baseMetrics);
         st3.Stop();
-        LogDebug("Method %d compiled in %fms, result %d", reader->GetMethodContextIndex(), st3.GetMilliseconds(), res);
+        LogDebug("Method %d compiled%s in %fms, result %d",
+            reader->GetMethodContextIndex(), (o.nameOfJit2 == nullptr) ? "" : " by JIT1", st3.GetMilliseconds(), res);
 
         totalBaseMetrics.AggregateFrom(baseMetrics);
 
@@ -406,8 +407,8 @@ int __cdecl main(int argc, char* argv[])
             if (res2 == JitInstance::RESULT_ERROR)
             {
                 errorCount2++;
-                LogError("Method %d of size %d failed to load and compile correctly by JIT2.",
-                         reader->GetMethodContextIndex(), mc->methodSize);
+                LogError("Method %d of size %d failed to load and compile correctly by JIT2 (%s).",
+                         reader->GetMethodContextIndex(), mc->methodSize, o.nameOfJit2);
                 if (errorCount2 == o.failureLimit)
                 {
                     LogError("More than %d methods compilation failed by JIT2. Skip compiling remaining methods.", o.failureLimit);
@@ -565,11 +566,13 @@ int __cdecl main(int argc, char* argv[])
             if (res == JitInstance::RESULT_ERROR)
             {
                 errorCount++;
-                LogError("main method %d of size %d failed to load and compile correctly.",
-                         reader->GetMethodContextIndex(), mc->methodSize);
+                LogError("Method %d of size %d failed to load and compile correctly%s (%s).",
+                         reader->GetMethodContextIndex(), mc->methodSize,
+                         (o.nameOfJit2 == nullptr) ? "" : " by JIT1", o.nameOfJit);
                 if (errorCount == o.failureLimit)
                 {
-                    LogError("More than %d methods failed. Skip compiling remaining methods.", o.failureLimit);
+                    LogError("More than %d methods failed%s. Skip compiling remaining methods.",
+                        o.failureLimit, (o.nameOfJit2 == nullptr) ? "" : " by JIT1");
                     break;
                 }
                 if ((o.reproName != nullptr) && (o.indexCount == -1))


### PR DESCRIPTION
This makes it easier to figure out which JIT failed in asmdiffs scenarios.

e.g.,
```
[10:40:50] ERROR: Method 3673 of size 3107 failed to load and compile correctly by JIT2 (C:\gh\runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\clrjit_universal_arm64_x64.dll).
[10:40:50] ERROR: Method 3673 of size 3107 failed to load and compile correctly by JIT1 (C:\gh\runtime2\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\clrjit_universal_arm64_x64.dll).
```