### PR TITLE
Update ValueStringBuilder grow logic

### DIFF
--- a/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
+++ b/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
@@ -294,8 +294,17 @@ namespace System.Text
             Debug.Assert(additionalCapacityBeyondPos > 0);
             Debug.Assert(_pos > _chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
 
-            // Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative
-            char[] poolArray = ArrayPool<char>.Shared.Rent((int)Math.Max((uint)(_pos + additionalCapacityBeyondPos), (uint)_chars.Length * 2));
+            const uint ArrayMaxLength = 0x7FFFFFC7; // same as Array.MaxLength
+
+            // Increase to at least the required size (_pos + additionalCapacityBeyondPos), but try
+            // to double the size if possible, bounding the doubling to not go beyond the max array length.
+            int newCapacity = (int)Math.Max(
+                (uint)(_pos + additionalCapacityBeyondPos),
+                Math.Min((uint)_chars.Length * 2, ArrayMaxLength));
+
+            // Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative.
+            // This could also go negative if the actual required length wraps around.
+            char[] poolArray = ArrayPool<char>.Shared.Rent(newCapacity);
 
             _chars.Slice(0, _pos).CopyTo(poolArray);
 


### PR DESCRIPTION
Handle the case where _chars.Length * 2 is too large to be an array but _pos + additionalCapacityBeyondPos is small enough to be an array. Noted by @GrabYourPitchforks. 