### PR TITLE
Do not reuse implicit byrefs for by-value args

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4119,7 +4119,7 @@ void Compiler::fgMakeOutgoingStructArgCopy(GenTreeCall* call, CallArg* arg)
     //
     // We don't need a copy if this is the last use of an implicit by-ref local.
     //
-    if (opts.OptimizationEnabled())
+    if (opts.OptimizationEnabled() && arg->AbiInfo.PassedByRef)
     {
         GenTreeLclVar* const lcl = argx->IsImplicitByrefParameterValue(this);
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70954/Runtime_70954.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70954/Runtime_70954.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public unsafe class Runtime_70954
+{
+    public static int Main()
+    {
+        return Problem(default) ? 101 : 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Problem(ImplicitByRefStruct a)
+    {
+        return CallForThreeByteStruct(a.ThreeByteStruct) != 0;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static byte CallForThreeByteStruct(ThreeByteStruct arg0) => arg0.Bytes[0];
+
+    struct ImplicitByRefStruct
+    {
+        public ThreeByteStruct ThreeByteStruct;
+        public fixed byte Fill[16];
+    }
+
+    struct ThreeByteStruct
+    {
+        public fixed byte Bytes[3];
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70954/Runtime_70954.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70954/Runtime_70954.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #70954.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1833237&view=ms.vss-build-web.run-extensions-tab) as expected.