### PR TITLE
Fix illumos-x64 build

### DIFF
--- a/src/libraries/Common/src/Interop/SunOS/procfs/Interop.ProcFsStat.TryReadProcessStatusInfo.cs
+++ b/src/libraries/Common/src/Interop/SunOS/procfs/Interop.ProcFsStat.TryReadProcessStatusInfo.cs
@@ -16,6 +16,7 @@ internal static partial class Interop
         /// true if the process status was read; otherwise, false.
         /// </returns>
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadProcessStatusInfo", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool TryReadProcessStatusInfo(int pid, ProcessStatusInfo* processStatus);
 
         internal struct ProcessStatusInfo

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -3132,6 +3132,7 @@ int32_t SystemNative_SendFile(intptr_t out_fd, intptr_t in_fd, int64_t offset, i
     int outfd = ToFileDescriptor(out_fd);
     int infd = ToFileDescriptor(in_fd);
     off_t offtOffset = (off_t)offset;
+    int savedErrno;
 
 #if HAVE_SENDFILE_4
     ssize_t res;
@@ -3251,7 +3252,7 @@ int32_t SystemNative_SendFile(intptr_t out_fd, intptr_t in_fd, int64_t offset, i
     return Error_SUCCESS;
 
 error:
-    int savedErrno = errno;
+    savedErrno = errno;
     free(buffer);
     return SystemNative_ConvertErrorPlatformToPal(savedErrno);
 


### PR DESCRIPTION
Tested with:

```sh
$ docker run -e ROOTFS_DIR=/crossrootfs/x64 -v $(pwd):/runtime  \
   mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-illumos-20220531132048-f13d79e \
   /runtime/build.sh -arch x64 -os illumos -cross -gcc -c Release
```