### PR TITLE
[iOS][Android] Fix crash in Exception.CaptureDispatchState

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Exception.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Exception.Mono.cs
@@ -68,37 +68,31 @@ namespace System
         {
             MonoStackFrame[]? stackFrames;
 
-            if (_traceIPs != null)
+            // Make sure foreignExceptionFrames does not change at this point.
+            // Otherwise, the Array.Copy into combinedStackFrames can fail due to size differences
+            //
+            // See https://github.com/dotnet/runtime/issues/70081
+            lock(frameLock)
             {
-                stackFrames = Diagnostics.StackTrace.get_trace(this, 0, true);
-                if (stackFrames.Length > 0)
-                    stackFrames[stackFrames.Length - 1].isLastFrameFromForeignException = true;
-
-                if (foreignExceptionsFrames != null)
+                if (_traceIPs != null)
                 {
-                    MonoStackFrame[] combinedStackFrames;
-                    int fefLength;
+                    stackFrames = Diagnostics.StackTrace.get_trace(this, 0, true);
+                    if (stackFrames.Length > 0)
+                        stackFrames[stackFrames.Length - 1].isLastFrameFromForeignException = true;
 
-                    // Make sure foreignExceptionFrames does not change at this point.
-                    // Otherwise, the Array.Copy into combinedStackFrames can fail due to size differences
-                    //
-                    // See https://github.com/dotnet/runtime/issues/70081
-                    lock(frameLock)
+                    if (foreignExceptionsFrames != null)
                     {
-                        fefLength = foreignExceptionsFrames.Length;
+                        var combinedStackFrames = new MonoStackFrame[stackFrames.Length + foreignExceptionsFrames.Length];
+                        Array.Copy(foreignExceptionsFrames, 0, combinedStackFrames, 0, foreignExceptionsFrames.Length);
+                        Array.Copy(stackFrames, 0, combinedStackFrames, foreignExceptionsFrames.Length, stackFrames.Length);
 
-                        combinedStackFrames = new MonoStackFrame[stackFrames.Length + fefLength];
-                        Array.Copy(foreignExceptionsFrames, 0, combinedStackFrames, 0, fefLength);
+                        stackFrames = combinedStackFrames;
                     }
-
-                    Array.Copy(stackFrames, 0, combinedStackFrames, fefLength, stackFrames.Length);
-
-                    stackFrames = combinedStackFrames;
                 }
-            }
-            else
-            {
-                stackFrames = foreignExceptionsFrames;
+                else
+                {
+                    stackFrames = foreignExceptionsFrames;
+                }
             }
 
             return new DispatchState(stackFrames);

--- a/src/mono/System.Private.CoreLib/src/System/Exception.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Exception.Mono.cs
@@ -68,31 +68,30 @@ namespace System
         {
             MonoStackFrame[]? stackFrames;
 
-            // Make sure foreignExceptionFrames does not change at this point.
-            // Otherwise, the Array.Copy into combinedStackFrames can fail due to size differences
-            //
-            // See https://github.com/dotnet/runtime/issues/70081
-            lock(frameLock)
+            if (_traceIPs != null)
             {
-                if (_traceIPs != null)
-                {
-                    stackFrames = Diagnostics.StackTrace.get_trace(this, 0, true);
-                    if (stackFrames.Length > 0)
-                        stackFrames[stackFrames.Length - 1].isLastFrameFromForeignException = true;
+                stackFrames = Diagnostics.StackTrace.get_trace(this, 0, true);
+                if (stackFrames.Length > 0)
+                    stackFrames[stackFrames.Length - 1].isLastFrameFromForeignException = true;
 
-                    if (foreignExceptionsFrames != null)
-                    {
-                        var combinedStackFrames = new MonoStackFrame[stackFrames.Length + foreignExceptionsFrames.Length];
-                        Array.Copy(foreignExceptionsFrames, 0, combinedStackFrames, 0, foreignExceptionsFrames.Length);
-                        Array.Copy(stackFrames, 0, combinedStackFrames, foreignExceptionsFrames.Length, stackFrames.Length);
+                // Make sure foreignExceptionsFrames does not change at this point.
+                // Otherwise, the Array.Copy into combinedStackFrames can fail due to size differences
+                //
+                // See https://github.com/dotnet/runtime/issues/70081
+                MonoStackFrame[]? feFrames = foreignExceptionsFrames;
 
-                        stackFrames = combinedStackFrames;
-                    }
-                }
-                else
+                if (feFrames != null)
                 {
-                    stackFrames = foreignExceptionsFrames;
+                    var combinedStackFrames = new MonoStackFrame[stackFrames.Length + feFrames.Length];
+                    Array.Copy(feFrames, 0, combinedStackFrames, 0, feFrames.Length);
+                    Array.Copy(stackFrames, 0, combinedStackFrames, feFrames.Length, stackFrames.Length);
+
+                    stackFrames = combinedStackFrames;
                 }
+            }
+            else
+            {
+                stackFrames = foreignExceptionsFrames;
             }
 
             return new DispatchState(stackFrames);
@@ -100,14 +99,8 @@ namespace System
 
         internal void RestoreDispatchState(in DispatchState state)
         {
-            // Isolate so we can safely update foreignExceptionFrames and CaptureDispatchState can read the correct values
-            //
-            // See https://github.com/dotnet/runtime/issues/70081
-            lock(frameLock)
-            {
-                foreignExceptionsFrames = state.StackFrames;
-                _stackTraceString = null;
-            }
+            foreignExceptionsFrames = state.StackFrames;
+            _stackTraceString = null;
         }
 
         // Returns true if setting the _remoteStackTraceString field is legal, false if not (immutable exception).


### PR DESCRIPTION
There is a crash in `Exception.CaptureDispatchState` when called from one thread at the same time another calls into `Exception.RestoreDispatchState`. The reason for the crash is due to the way we do not update `foreignExceptionFrames` in a thread-safe way.  `foreignExceptionFrames` is used in both methods and can crash when the size changes before the array is copied.

Fixes https://github.com/dotnet/runtime/issues/70081