### PR TITLE
[Android] Make sure AdditionalTimeZoneChecks trait is added to xunit-excludes

### DIFF
--- a/eng/testing/tests.props
+++ b/eng/testing/tests.props
@@ -10,18 +10,6 @@
     <TestSingleFile Condition="'$(TestNativeAot)' == 'true'">true</TestSingleFile>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Default and user defined categories -->
-    <_withCategories Condition="'$(WithCategories)' != ''">;$(WithCategories.Trim(';'))</_withCategories>
-    <_withoutCategories Condition="'$(WithoutCategories)' != ''">;$(WithoutCategories.Trim(';'))</_withoutCategories>
-
-    <TestScope Condition="'$(TestScope)' == '' and '$(Outerloop)' == 'true'">all</TestScope>
-    <_withCategories Condition="'$(TestScope)' == 'outerloop'">$(_withCategories);OuterLoop</_withCategories>
-    <_withoutCategories Condition="'$(ArchiveTests)' == 'true'">$(_withoutCategories);IgnoreForCI</_withoutCategories>
-    <_withoutCategories Condition="'$(TestScope)' == '' or '$(TestScope)' == 'innerloop'">$(_withoutCategories);OuterLoop</_withoutCategories>
-    <_withoutCategories Condition="!$(_withCategories.Contains('failing'))">$(_withoutCategories);failing</_withoutCategories>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(TargetsMobile)' == 'true'">
     <!-- Test runners are built as part of libs.pretest so we need to use libraries configuration -->
     <AppleTestRunnerDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleTestRunner', '$(Configuration)', '$(NetCoreAppCurrent)'))</AppleTestRunnerDir>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -36,6 +36,18 @@
     <RunScriptHost Condition="'$(RunScriptWindowsCmd)' != 'true'">$(RunScriptHostDir)dotnet</RunScriptHost>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Default and user defined categories -->
+    <_withCategories Condition="'$(WithCategories)' != ''">;$(WithCategories.Trim(';'))</_withCategories>
+    <_withoutCategories Condition="'$(WithoutCategories)' != ''">;$(WithoutCategories.Trim(';'))</_withoutCategories>
+
+    <TestScope Condition="'$(TestScope)' == '' and '$(Outerloop)' == 'true'">all</TestScope>
+    <_withCategories Condition="'$(TestScope)' == 'outerloop'">$(_withCategories);OuterLoop</_withCategories>
+    <_withoutCategories Condition="'$(ArchiveTests)' == 'true'">$(_withoutCategories);IgnoreForCI</_withoutCategories>
+    <_withoutCategories Condition="'$(TestScope)' == '' or '$(TestScope)' == 'innerloop'">$(_withoutCategories);OuterLoop</_withoutCategories>
+    <_withoutCategories Condition="!$(_withCategories.Contains('failing'))">$(_withoutCategories);failing</_withoutCategories>
+  </PropertyGroup>
+
   <!-- For both tests.mobile.targets and tests.wasm.targets -->
   <PropertyGroup>
     <_MonoAotCrossCompilerPath>$([MSBuild]::NormalizePath($(MonoAotCrossDir), 'mono-aot-cross'))</_MonoAotCrossCompilerPath>


### PR DESCRIPTION
The trait is supposed to be included in System.Runtime tests by default, but wasn't because the `_withoutCategories` property was in tests.props. As a result, the property was resolved before the .csproj properties.  This fix moves the property definition to tests.targets.

Fixes https://github.com/dotnet/runtime/issues/70482