### PR TITLE
Additional policy for limiting RTT PINGs in SocketsHttpHandler

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1217,6 +1217,9 @@ namespace System.Net.Http
                 FrameHeader.WriteTo(span, FrameHeader.PingLength, FrameType.Ping, state.isAck ? FrameFlags.Ack: FrameFlags.None, streamId: 0);
                 BinaryPrimitives.WriteInt64BigEndian(span.Slice(FrameHeader.Size), state.pingContent);
 
+                // RTT PING bookeeping
+                state.thisRef._rttEstimator.OnPingSent();
+
                 return true;
             });
 
@@ -1566,6 +1569,9 @@ namespace System.Net.Http
                     span = span.Slice(current.Length);
                     if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.http2Stream.StreamId, $"Wrote HEADERS frame. Length={current.Length}, flags={flags}");
 
+                    // RTT PING bookeeping
+                    s.thisRef._rttEstimator.OnDataOrHeadersOrWindowUpdateSent();
+
                     // Copy CONTINUATION frames, if any.
                     while (remaining.Length > 0)
                     {
@@ -1634,6 +1640,9 @@ namespace System.Net.Http
                         FrameHeader.WriteTo(writeBuffer.Span, s.current.Length, FrameType.Data, FrameFlags.None, s.streamId);
                         s.current.CopyTo(writeBuffer.Slice(FrameHeader.Size));
 
+                        // RTT PING bookeeping
+                        s.thisRef._rttEstimator.OnDataOrHeadersOrWindowUpdateSent();
+
                         return s.flush;
                     }, cancellationToken).ConfigureAwait(false);
                 }
@@ -1667,6 +1676,9 @@ namespace System.Net.Http
                 Span<byte> span = writeBuffer.Span;
                 FrameHeader.WriteTo(span, FrameHeader.WindowUpdateLength, FrameType.WindowUpdate, FrameFlags.None, s.streamId);
                 BinaryPrimitives.WriteInt32BigEndian(span.Slice(FrameHeader.Size), s.amount);
+
+                // RTT PING bookeeping
+                s.thisRef._rttEstimator.OnDataOrHeadersOrWindowUpdateSent();
 
                 return true;
             });

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2StreamWindowManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2StreamWindowManager.cs
@@ -138,36 +138,45 @@ namespace System.Net.Http
         // Assuming that the network characteristics of the connection wouldn't change much within its lifetime, we are maintaining a running minimum value.
         // The more PINGs we send, the more accurate is the estimation of MinRtt, however we should be careful not to send too many of them,
         // to avoid triggering the server's PING flood protection which may result in an unexpected GOAWAY.
-        // With most servers we are fine to send PINGs, as long as we are reading their data, this rule is well formalized for gRPC:
-        // https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md
-        // As a rule of thumb, we can send send a PING whenever we receive DATA or HEADERS, however, there are some servers which allow receiving only
-        // a limited amount of PINGs within a given timeframe.
-        // To deal with the conflicting requirements:
-        // - We send an initial burst of 'InitialBurstCount' PINGs, to get a relatively good estimation fast
-        // - Afterwards, we send PINGs with the maximum frequency of 'PingIntervalInSeconds' PINGs per second
         //
-        // Threading:
-        // OnInitialSettingsSent() is called during initialization, all other methods are triggered by HttpConnection.ProcessIncomingFramesAsync(),
-        // therefore the assumption is that the invocation of RttEstimator's methods is sequential, and there is no race beetween them.
-        // Http2StreamWindowManager is reading MinRtt from another concurrent thread, therefore its value has to be changed atomically.
+        // Several strategies have been implemented to conform with real life servers.
+        // 1. With most servers we are fine to send PINGs as long as we are reading their data, a rule formalized by a gRPC spec:
+        // https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md
+        // According to this rule, we are OK to send a PING whenever we receive DATA or HEADERS, since the servers conforming to this doc
+        // will reset their unsolicited ping counter whenever they *send* DATA or HEADERS.
+        // 2. Some servers allow receiving only a limited amount of PINGs within a given timeframe.
+        // To deal with this, we send an initial burst of 'InitialBurstCount' PINGs, to get a relatively good estimation fast. Afterwards,
+        // we send PINGs each 'PingIntervalInSeconds' second, to maintain our estimation without triggering these servers.
+        // 3. Some servers in google's backends reset their unsolicited ping counter when they *receive* DATA, HEADERS, or WINDOW_UPDATE,
+        // allowing up to 4 unsolicited PINGs. To deal with these servers, we maitain a counter '_sendPolicyCounter'.
+        //
+        // Threading and synchronization:
+        // - OnInitialSettingsSent() is called during initialization
+        // - OnDataOrHeadersOrWindowUpdateSent() and OnPingSent() are called from Http2Connection.ProcessOutgoingFramesAsync(),
+        //   access to _sendPolicyCounter has to be synchronized with OnDataOrHeadersReceived().
+        // - The XyzReceived() methods are invoked from HttpConnection.ProcessIncomingFramesAsync(),
+        //   therefore the the invocation of those methods is sequential, and there is no race beetween them.
+        // - Http2StreamWindowManager is reading MinRtt from another concurrent thread, therefore its value has to be changed atomically.
         private struct RttEstimator
         {
             private enum State
             {
                 Disabled,
-                Init,
-                Waiting,
-                PingSent,
+                Init,     // Waiting for SETTINGS ACK before starting to send PING-s
+                Waiting,  // Waiting to receive DATA or HEADERS so we can send a PING
+                PingSent, // Do not send RTT PING while there is another, unacknowledged RTT PING in-flight
                 TerminatingMayReceivePingAck
             }
 
-            private const double PingIntervalInSeconds = 2;
+            private const int MaxPingsWithoutSending = 4; // Number of PING-s allowed to send without also sending DATA, HEADERS or WINDOW_UPDATE
             private const int InitialBurstCount = 4;
+            private const double PingIntervalInSeconds = 2;
             private static readonly long PingIntervalInTicks = (long)(PingIntervalInSeconds * Stopwatch.Frequency);
 
             private State _state;
             private long _pingSentTimestamp;
-            private long _pingCounter;
+            private long _pingPayloadCounter; // count the negative PING payload values for RTT PING-s
+            private int _sendPolicyCounter; // count the number of PING-s sent without also sending DATA, HEADERS or WINDOW_UPDATE
             private int _initialBurst;
             private long _minRtt;
 
@@ -197,6 +206,7 @@ namespace System.Net.Http
             internal void OnDataOrHeadersReceived(Http2Connection connection)
             {
                 if (_state != State.Waiting) return;
+                if (_sendPolicyCounter >= MaxPingsWithoutSending) return;
 
                 long now = Stopwatch.GetTimestamp();
                 bool initial = _initialBurst > 0;
@@ -205,9 +215,9 @@ namespace System.Net.Http
                     if (initial) _initialBurst--;
 
                     // Send a PING
-                    _pingCounter--;
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace($"[FlowControl] Sending RTT PING with payload {_pingCounter}");
-                    connection.LogExceptions(connection.SendPingAsync(_pingCounter, isAck: false));
+                    _pingPayloadCounter--;
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace($"[FlowControl] Sending RTT PING with payload {_pingPayloadCounter}");
+                    connection.LogExceptions(connection.SendPingAsync(_pingPayloadCounter, isAck: false));
                     _pingSentTimestamp = now;
                     _state = State.PingSent;
                 }
@@ -230,9 +240,9 @@ namespace System.Net.Http
                 // RTT PINGs always carry negative payload, positive values indicate a response to KeepAlive PING.
                 Debug.Assert(payload < 0);
 
-                if (_pingCounter != payload)
+                if (_pingPayloadCounter != payload)
                 {
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace($"[FlowControl] Unexpected RTT PING ACK payload {payload}, should be {_pingCounter}.");
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace($"[FlowControl] Unexpected RTT PING ACK payload {payload}, should be {_pingPayloadCounter}.");
                     ThrowProtocolError();
                 }
 
@@ -252,6 +262,10 @@ namespace System.Net.Http
                     _state = State.Disabled;
                 }
             }
+
+            internal void OnPingSent() => Interlocked.Increment(ref _sendPolicyCounter);
+
+            internal void OnDataOrHeadersOrWindowUpdateSent() => Interlocked.Exchange(ref _sendPolicyCounter, 0);
 
             private void RefreshRtt(Http2Connection connection)
             {


### PR DESCRIPTION
This PR implements an additional policy for limiting RTT/BDP PINGs to comply with the PING accounting mechanism of a specific server in google's backends.

Long story short, we need to make sure we do not send more than 4 PINGs without also sending DATA, HEADERS or WINDOW_UPDATE.

Thanks to the update mentioned in https://github.com/grpc/grpc-dotnet/pull/1765, I believe #62216 would only occur in extreme corner cases which I was able to emulate in a functional test, but cannot reproduce in real life. I think the fix is still valuable to make 100% sure we are compliant with google's backends and avoid rare sporadic bugs in the future, but I don't think we need to backport it to 6.0.

Fixes #62216.

Contributes to #69870 by making `SocketsHttpHandler_Http2FlowControl_Test` tests conditional on `SocketsHttpHandler.IsSupported`.