### PR TITLE
Base64 library tests: use full encoding map

### DIFF
--- a/src/libraries/System.Memory/tests/Base64/Base64TestHelper.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64TestHelper.cs
@@ -72,7 +72,7 @@ namespace System.Buffers.Text.Tests
             var rnd = new Random(seed);
             for (int i = 0; i < bytes.Length; i++)
             {
-                int index = (byte)rnd.Next(0, s_encodingMap.Length - 1);    // Do not pick '='
+                int index = (byte)rnd.Next(0, s_encodingMap.Length);
                 bytes[i] = s_encodingMap[index];
             }
         }


### PR DESCRIPTION
InitializeDecodableBytes is skipping the last entry in the map,
due to assuming it is an = sign.

This was spotted whilst upstreaming:
https://github.com/dotnet/performance/pull/2479