### PR TITLE
Improve and simplify `MakeTmpArgNode`

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4441,12 +4441,6 @@ public:
     {
         return roundUp(GetStackByteSize(), TARGET_POINTER_SIZE) / TARGET_POINTER_SIZE;
     }
-
-    // Can we replace the struct type of this node with a primitive type for argument passing?
-    bool TryPassAsPrimitive() const
-    {
-        return !IsSplit() && ((NumRegs == 1) || (ByteSize <= TARGET_POINTER_SIZE));
-    }
 };
 
 struct NewCallArg


### PR DESCRIPTION
Use the ABI info stored in the call arg instead of bespoke logic and do not address-expose temps which will be passed by value.

We're expecting diffs:
1) GC info: `GT_LCL_VAR_ADDR`s are typed `TYP_I_IMPL` as opposed to `TYP_BYREF`.
2) Improvements from the lack of address-exposure, especially on ARM (regressions from CSE/etc).
3) One small Unix x64 regression because the old code would retype an on-stack arg to `long`/`int` even if the "base type" of it was `double`/`float`, and FP `mov`s are slightly larger than GPR ones.

Also fixes a potential LA-specific bug where we could retype `struct { float, int }` as `TYP_LONG`.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1834951&view=ms.vss-build-web.run-extensions-tab).