### PR TITLE
[wasm] Wasm.Build.Tests: disable tests failing on CI

### DIFF
--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -97,6 +97,8 @@ jobs:
     platforms:
       - Browser_wasm_firefox
     browser: firefox
+    # ff tests are unstable currently
+    shouldContinueOnError: true
     alwaysRun: ${{ variables.isRollingBuild }}
 
 #

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
@@ -82,6 +82,7 @@ namespace Wasm.Build.Tests
         [InlineData("Debug", false)]
         [InlineData("Release", true)]
         [InlineData("Release", false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/70985", TestPlatforms.Linux)]
         public void NativeBuild_WithDeployOnBuild_UsedByVS(string config, bool nativeRelink)
         {
             string id = $"blz_deploy_on_build_{config}_{nativeRelink}";
@@ -143,6 +144,7 @@ namespace Wasm.Build.Tests
         [Theory]
         [InlineData("Debug")]
         [InlineData("Release")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/70985", TestPlatforms.Linux)]
         public void WithNativeReference_AOTInProjectFile(string config)
         {
             string id = $"blz_nativeref_aot_{config}";
@@ -160,6 +162,7 @@ namespace Wasm.Build.Tests
         [Theory]
         [InlineData("Debug")]
         [InlineData("Release")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/70985", TestPlatforms.Linux)]
         public void WithNativeReference_AOTOnCommandLine(string config)
         {
             string id = $"blz_nativeref_aot_{config}";


### PR DESCRIPTION
.. due to being oomkill'ed.

And don't fail the debugger tests on Firefox job in `runtime-staging` if the tests fail, because they are known to be unstable.
This affects rolling builds.