### PR TITLE
Do not use full memory barrier for osx/arm64

### DIFF
--- a/src/coreclr/gc/env/gcenv.interlocked.inl
+++ b/src/coreclr/gc/env/gcenv.interlocked.inl
@@ -13,13 +13,12 @@
 #ifndef _MSC_VER
 __forceinline void Interlocked::ArmInterlockedOperationBarrier()
 {
-#ifdef HOST_ARM64
+#if defined(HOST_ARM64) || defined(HOST_LOONGARCH64)
+    #if !defined(HOST_OSX)
     // See PAL_ArmInterlockedOperationBarrier() in the PAL
     __sync_synchronize();
-#endif // HOST_ARM64
-#ifdef HOST_LOONGARCH64
-    __sync_synchronize();
-#endif //HOST_LOONGARCH64
+    #endif // !HOST_OSX
+#endif // HOST_ARM64 || HOST_LOONGARCH64
 }
 #endif // !_MSC_VER
 

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -3447,7 +3447,8 @@ BitScanReverse64(
 
 FORCEINLINE void PAL_ArmInterlockedOperationBarrier()
 {
-#ifdef HOST_ARM64
+#if defined(HOST_ARM64) || defined(HOST_LOONGARCH64)
+    #if !defined(HOST_OSX)
     // On arm64, most of the __sync* functions generate a code sequence like:
     //   loop:
     //     ldaxr (load acquire exclusive)
@@ -3460,10 +3461,10 @@ FORCEINLINE void PAL_ArmInterlockedOperationBarrier()
     // require the load to occur after the store. This memory barrier should be used following a call to a __sync* function to
     // prevent that reordering. Code generated for arm32 includes a 'dmb' after 'cbnz', so no issue there at the moment.
     __sync_synchronize();
-#endif // HOST_ARM64
-#ifdef HOST_LOONGARCH64
-    __sync_synchronize();
-#endif
+    #else
+    // For OSX Arm64, the default Arm architecture is v8.1 which uses atomic instructions that don't need a full barrier.
+    #endif // !HOST_OSX
+#endif// HOST_ARM64 || HOST_LOONGARCH64
 }
 
 /*++


### PR DESCRIPTION
MacOS M1+ are on Arm v8.5 which has support for atomic instructions, and we don't have to emit full barrier if that is the case.

Refereces: 
- https://github.com/llvm/llvm-project/blob/5ba0a9571b3ee3bc76f65e16549012a440d5a0fb/llvm/include/llvm/Support/AArch64TargetParser.def#L256-L257
- https://cpufun.substack.com/p/more-m1-fun-hardware-information
- https://gist.github.com/EgorBo/8690fe0a52082bf89f43f662a9696af0