### PR TITLE
Separate out char marshalling rules to a separate MarshallingGeneratorFactory.

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -341,7 +341,6 @@ namespace Microsoft.Interop
                     generatorFactory = new UnsupportedMarshallingFactory();
                 }
 
-
                 // The presence of System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute is tied to TFM,
                 // so we use TFM in the generator factory key instead of the Compilation as the compilation changes on every keystroke.
                 IAssemblySymbol coreLibraryAssembly = env.Compilation.GetSpecialType(SpecialType.System_Object).ContainingAssembly;
@@ -349,10 +348,18 @@ namespace Microsoft.Interop
                 bool runtimeMarshallingDisabled = disabledRuntimeMarshallingAttributeType is not null
                     && env.Compilation.Assembly.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, disabledRuntimeMarshallingAttributeType));
 
-                InteropGenerationOptions interopGenerationOptions = new(options.UseMarshalType, runtimeMarshallingDisabled);
+                // Since the char type can go into the P/Invoke signature here, we use can only use it when
+                // runtime marshalling is disabled.
+                generatorFactory = new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: runtimeMarshallingDisabled);
+
+                InteropGenerationOptions interopGenerationOptions = new(options.UseMarshalType);
                 generatorFactory = new MarshalAsMarshallingGeneratorFactory(interopGenerationOptions, generatorFactory);
 
-                IMarshallingGeneratorFactory elementFactory = new AttributedMarshallingModelGeneratorFactory(generatorFactory, new AttributedMarshallingModelOptions(runtimeMarshallingDisabled));
+                IMarshallingGeneratorFactory elementFactory = new AttributedMarshallingModelGeneratorFactory(
+                    // Since the char type in an array will not be part of the P/Invoke signature, we can
+                    // use the regular blittable marshaller in all cases.
+                    new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: true),
+                    new AttributedMarshallingModelOptions(runtimeMarshallingDisabled));
                 // We don't need to include the later generator factories for collection elements
                 // as the later generator factories only apply to parameters.
                 generatorFactory = new AttributedMarshallingModelGeneratorFactory(generatorFactory, elementFactory, new AttributedMarshallingModelOptions(runtimeMarshallingDisabled));

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Interop
                 bool runtimeMarshallingDisabled = disabledRuntimeMarshallingAttributeType is not null
                     && env.Compilation.Assembly.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, disabledRuntimeMarshallingAttributeType));
 
-                // Since the char type can go into the P/Invoke signature here, we use can only use it when
+                // Since the char type can go into the P/Invoke signature here, we can only use it when
                 // runtime marshalling is disabled.
                 generatorFactory = new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: runtimeMarshallingDisabled);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/InteropGenerationOptions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/InteropGenerationOptions.cs
@@ -7,5 +7,5 @@ using System.Text;
 
 namespace Microsoft.Interop
 {
-    public readonly record struct InteropGenerationOptions(bool UseMarshalType, bool RuntimeMarshallingDisabled);
+    public readonly record struct InteropGenerationOptions(bool UseMarshalType);
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedTypeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedTypeInfo.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Interop
         public static readonly SpecialTypeInfo Byte = new("byte", "byte", SpecialType.System_Byte);
         public static readonly SpecialTypeInfo Int32 = new("int", "int", SpecialType.System_Int32);
         public static readonly SpecialTypeInfo Void = new("void", "void", SpecialType.System_Void);
+        public static readonly SpecialTypeInfo String = new("string", "string", SpecialType.System_String);
+        public static readonly SpecialTypeInfo Boolean = new("bool", "bool", SpecialType.System_Boolean);
 
         public bool Equals(SpecialTypeInfo? other)
         {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
@@ -304,9 +304,8 @@ namespace Microsoft.Interop
                 numElementsExpression = GetNumElementsExpressionFromMarshallingInfo(info, collectionInfo.ElementCountInfo, context);
             }
 
-            bool enableArrayPinning = elementMarshaller is BlittableMarshaller;
-            bool treatElementAsBlittable = enableArrayPinning || elementMarshaller is Utf16CharMarshaller;
-            if (treatElementAsBlittable)
+            bool elementIsBlittable = elementMarshaller is BlittableMarshaller;
+            if (elementIsBlittable)
             {
                 marshallingStrategy = new LinearCollectionWithBlittableElementsMarshalling(marshallingStrategy, collectionInfo.ElementType.Syntax, numElementsExpression);
             }
@@ -331,13 +330,13 @@ namespace Microsoft.Interop
                 return new ArrayMarshaller(
                     new CustomNativeTypeMarshallingGenerator(marshallingStrategy, enableByValueContentsMarshalling: true),
                     elementInfo,
-                    enableArrayPinning);
+                    elementIsBlittable);
             }
 
             IMarshallingGenerator marshallingGenerator = new CustomNativeTypeMarshallingGenerator(marshallingStrategy, enableByValueContentsMarshalling: false);
 
             // Elements in the collection must be blittable to use the pinnable marshaller.
-            if (collectionInfo.PinningFeatures.HasFlag(CustomTypeMarshallerPinning.ManagedType) && treatElementAsBlittable)
+            if (collectionInfo.PinningFeatures.HasFlag(CustomTypeMarshallerPinning.ManagedType) && elementIsBlittable)
             {
                 return new PinnableManagedValueMarshaller(marshallingGenerator);
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshallingGeneratorFactory.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Interop
+{
+    public sealed class CharMarshallingGeneratorFactory : IMarshallingGeneratorFactory
+    {
+        private static readonly IMarshallingGenerator s_blittable = new BlittableMarshaller();
+        private static readonly IMarshallingGenerator s_utf16Char = new Utf16CharMarshaller();
+
+        private readonly IMarshallingGeneratorFactory _inner;
+        private readonly bool _useBlittableMarshallerForUtf16;
+
+        public CharMarshallingGeneratorFactory(IMarshallingGeneratorFactory inner, bool useBlittableMarshallerForUtf16)
+        {
+            _inner = inner;
+            _useBlittableMarshallerForUtf16 = useBlittableMarshallerForUtf16;
+        }
+
+        public IMarshallingGenerator Create(TypePositionInfo info, StubCodeContext context)
+        {
+            if (info.ManagedType is SpecialTypeInfo { SpecialType: SpecialType.System_Char })
+            {
+                return CreateCharMarshaller(info, context);
+            }
+
+            return _inner.Create(info, context);
+        }
+
+        private IMarshallingGenerator CreateCharMarshaller(TypePositionInfo info, StubCodeContext context)
+        {
+            MarshallingInfo marshalInfo = info.MarshallingAttributeInfo;
+            if (marshalInfo is NoMarshallingInfo)
+            {
+                // [Compat] Require explicit marshalling information.
+                throw new MarshallingNotSupportedException(info, context)
+                {
+                    NotSupportedDetails = SR.MarshallingStringOrCharAsUndefinedNotSupported
+                };
+            }
+
+            // Explicit MarshalAs takes precedence over string encoding info
+            if (marshalInfo is MarshalAsInfo marshalAsInfo)
+            {
+                switch (marshalAsInfo.UnmanagedType)
+                {
+                    case UnmanagedType.I2:
+                    case UnmanagedType.U2:
+                        // If runtime marshalling is disabled, we treat UTF-16 char as blittable
+                        return _useBlittableMarshallerForUtf16 ? s_blittable : s_utf16Char;
+                }
+            }
+            else if (marshalInfo is MarshallingInfoStringSupport marshalStringInfo)
+            {
+                switch (marshalStringInfo.CharEncoding)
+                {
+                    case CharEncoding.Utf16:
+                        // If runtime marshalling is disabled, we treat UTF-16 char as blittable
+                        return _useBlittableMarshallerForUtf16 ? s_blittable : s_utf16Char;
+                    case CharEncoding.Utf8:
+                        throw new MarshallingNotSupportedException(info, context) // [Compat] UTF-8 is not supported for char
+                        {
+                            NotSupportedDetails = string.Format(SR.MarshallingCharAsSpecifiedStringMarshallingNotSupported, nameof(CharEncoding.Utf8))
+                        };
+                    case CharEncoding.Custom:
+                        throw new MarshallingNotSupportedException(info, context)
+                        {
+                            NotSupportedDetails = SR.MarshallingCharAsStringMarshallingCustomNotSupported
+                        };
+                }
+            }
+
+            throw new MarshallingNotSupportedException(info, context);
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshallingGeneratorFactory.cs
@@ -52,7 +52,6 @@ namespace Microsoft.Interop
                 {
                     case UnmanagedType.I2:
                     case UnmanagedType.U2:
-                        // If runtime marshalling is disabled, we treat UTF-16 char as blittable
                         return _useBlittableMarshallerForUtf16 ? s_blittable : s_utf16Char;
                 }
             }
@@ -61,7 +60,6 @@ namespace Microsoft.Interop
                 switch (marshalStringInfo.CharEncoding)
                 {
                     case CharEncoding.Utf16:
-                        // If runtime marshalling is disabled, we treat UTF-16 char as blittable
                         return _useBlittableMarshallerForUtf16 ? s_blittable : s_utf16Char;
                     case CharEncoding.Utf8:
                         throw new MarshallingNotSupportedException(info, context) // [Compat] UTF-8 is not supported for char

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/UnsupportedMarshallingFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/UnsupportedMarshallingFactory.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Interop
         }
 
         public UnsupportedMarshallingFactory()
-            :this(DefaultTypeToErrorMessageMap)
+            : this(DefaultTypeToErrorMessageMap)
         {
 
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/UnsupportedMarshallingFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/UnsupportedMarshallingFactory.cs
@@ -31,14 +31,14 @@ namespace Microsoft.Interop
 
         }
 
-        public UnsupportedMarshallingFactory(ImmutableDictionary<ManagedTypeInfo, string> customTypeToErrorMessageMap)
+        private UnsupportedMarshallingFactory(ImmutableDictionary<ManagedTypeInfo, string> customTypeToErrorMessageMap)
         {
             CustomTypeToErrorMessageMap = customTypeToErrorMessageMap;
         }
 
         public ImmutableDictionary<ManagedTypeInfo, string> CustomTypeToErrorMessageMap { get; }
 
-        public static ImmutableDictionary<ManagedTypeInfo, string> DefaultTypeToErrorMessageMap { get; } =
+        private static ImmutableDictionary<ManagedTypeInfo, string> DefaultTypeToErrorMessageMap { get; } =
             ImmutableDictionary.CreateRange(new Dictionary<ManagedTypeInfo, string>
             {
                 { SpecialTypeInfo.String, SR.MarshallingStringOrCharAsUndefinedNotSupported },

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/UnsupportedMarshallingFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/UnsupportedMarshallingFactory.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 
@@ -12,7 +15,34 @@ namespace Microsoft.Interop
             TypePositionInfo info,
             StubCodeContext context)
         {
+            if (info.MarshallingAttributeInfo is NoMarshallingInfo && CustomTypeToErrorMessageMap.TryGetValue(info.ManagedType, out string errorMessage))
+            {
+                throw new MarshallingNotSupportedException(info, context)
+                {
+                    NotSupportedDetails = errorMessage
+                };
+            }
             throw new MarshallingNotSupportedException(info, context);
         }
+
+        public UnsupportedMarshallingFactory()
+            :this(DefaultTypeToErrorMessageMap)
+        {
+
+        }
+
+        public UnsupportedMarshallingFactory(ImmutableDictionary<ManagedTypeInfo, string> customTypeToErrorMessageMap)
+        {
+            CustomTypeToErrorMessageMap = customTypeToErrorMessageMap;
+        }
+
+        public ImmutableDictionary<ManagedTypeInfo, string> CustomTypeToErrorMessageMap { get; }
+
+        public static ImmutableDictionary<ManagedTypeInfo, string> DefaultTypeToErrorMessageMap { get; } =
+            ImmutableDictionary.CreateRange(new Dictionary<ManagedTypeInfo, string>
+            {
+                { SpecialTypeInfo.String, SR.MarshallingStringOrCharAsUndefinedNotSupported },
+                { SpecialTypeInfo.Boolean, SR.MarshallingBoolAsUndefinedNotSupported },
+            });
     }
 }


### PR DESCRIPTION
Separate marshalling for char out to a separate marshalling generator that allows us to always return the blittable marshaller for char collection elements.

This allows us to remove the AttributedMarshallingModel's special case for the char marshaller. Now it can exclusively special-case blittable marshalling and it doesn't need to know about char marshalling rules.

Also, fold in our custom "not supported" marshalling messages into the UnsupportedMarshallingFactory class so we can get the MarshalAsMarshallingGeneratorFactory closer to only supporting MarshalAs-style rules (no knowledge of the new attributed marshalling model)