### PR TITLE
Fix the heuristics for L3 cache size for Arm64

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -876,7 +876,7 @@ done:
     return result;
 }
 
-#define CHECK_CACHE_SIZE(CACHE_LEVEL) if (size > cacheSize) { cacheSize = size; cacheLevel = CACHE_LEVEL; }
+#define UPDATE_CACHE_SIZE_AND_LEVEL(CACHE_LEVEL) if (size > cacheSize) { cacheSize = size; cacheLevel = CACHE_LEVEL; }
 
 static size_t GetLogicalProcessorCacheSizeFromOS()
 {
@@ -886,19 +886,19 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 
 #ifdef _SC_LEVEL1_DCACHE_SIZE
     size = ( size_t) sysconf(_SC_LEVEL1_DCACHE_SIZE);
-    CHECK_CACHE_SIZE(1)
+    UPDATE_CACHE_SIZE_AND_LEVEL(1)
 #endif
 #ifdef _SC_LEVEL2_CACHE_SIZE
     size = ( size_t) sysconf(_SC_LEVEL2_CACHE_SIZE);
-    CHECK_CACHE_SIZE(2)
+    UPDATE_CACHE_SIZE_AND_LEVEL(2)
 #endif
 #ifdef _SC_LEVEL3_CACHE_SIZE
     size = ( size_t) sysconf(_SC_LEVEL3_CACHE_SIZE);
-    CHECK_CACHE_SIZE(3)
+    UPDATE_CACHE_SIZE_AND_LEVEL(3)
 #endif
 #ifdef _SC_LEVEL4_CACHE_SIZE
     size = ( size_t) sysconf(_SC_LEVEL4_CACHE_SIZE);
-    CHECK_CACHE_SIZE(4)
+    UPDATE_CACHE_SIZE_AND_LEVEL(4)
 #endif
 
 #if defined(TARGET_LINUX) && !defined(HOST_ARM) && !defined(HOST_X86)
@@ -926,7 +926,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 
                 if (ReadMemoryValueFromFile(path_to_level_file, &level))
                 {
-                    CHECK_CACHE_SIZE(level)
+                    UPDATE_CACHE_SIZE_AND_LEVEL(level)
                 }
                 else
                 {

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -915,10 +915,14 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
         int index = 40;
         for (int i = 0; i < 5; i++)
         {
+            assert(path_to_size_file[index] == '-');
             path_to_size_file[index] = (char)(48 + i);
+
             if (ReadMemoryValueFromFile(path_to_size_file, &size))
             {
+                assert(path_to_level_file[index] == '-');
                 path_to_level_file[index] = (char)(48 + i);
+                
                 if (ReadMemoryValueFromFile(path_to_level_file, &level))
                 {
                     CHECK_CACHE_SIZE(level)

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -913,16 +913,17 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
         char path_to_size_file[] =  "/sys/devices/system/cpu/cpu0/cache/index-/size";
         char path_to_level_file[] =  "/sys/devices/system/cpu/cpu0/cache/index-/level";
         int index = 40;
+        assert(path_to_size_file[index] == '-');
+        assert(path_to_level_file[index] == '-');
+
         for (int i = 0; i < 5; i++)
         {
-            assert(path_to_size_file[index] == '-');
             path_to_size_file[index] = (char)(48 + i);
 
             if (ReadMemoryValueFromFile(path_to_size_file, &size))
             {
-                assert(path_to_level_file[index] == '-');
                 path_to_level_file[index] = (char)(48 + i);
-                
+
                 if (ReadMemoryValueFromFile(path_to_level_file, &level))
                 {
                     CHECK_CACHE_SIZE(level)

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -910,12 +910,16 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
         // this method to determine cache size.
         //
         size_t level;
+        char path_to_size_file[] =  "/sys/devices/system/cpu/cpu0/cache/index-/size";
+        char path_to_level_file[] =  "/sys/devices/system/cpu/cpu0/cache/index-/level";
+        int index = 40;
         for (int i = 0; i < 5; i++)
         {
-            string path_to_index = "/sys/devices/system/cpu/cpu0/cache/index" + to_string(i);
-            if (ReadMemoryValueFromFile((path_to_index + "/size").c_str(), &size))
+            path_to_size_file[index] = (char)(48 + i);
+            if (ReadMemoryValueFromFile(path_to_size_file, &size))
             {
-                if (ReadMemoryValueFromFile((path_to_index + "/level").c_str(), &level))
+                path_to_level_file[index] = (char)(48 + i);
+                if (ReadMemoryValueFromFile(path_to_level_file, &level))
                 {
                     CHECK_CACHE_SIZE(level)
                 }

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -403,7 +403,6 @@ size_t GetLogicalProcessorCacheSizeFromOS()
 {
     size_t cache_size = 0;
     size_t cache_level = 0;
-    uint32_t totalCPUCount = 0;
 
     DWORD nEntries = 0;
 
@@ -433,10 +432,6 @@ size_t GetLogicalProcessorCacheSizeFromOS()
                     cache_level = pslpi[i].Cache.Level;
                 }
             }
-            else if (pslpi[i].Relationship == RelationProcessorCore)
-            {
-                totalCPUCount++;
-            }
         }
         cache_size = last_cache_size;
     }
@@ -448,6 +443,8 @@ Exit:
 #if defined(TARGET_ARM64)
     if (cache_level != 3)
     {
+        uint32_t totalCPUCount = GCToOSInterface::GetTotalProcessorCount();
+
         // We expect to get the L3 cache size for Arm64 but currently expected to be missing that info
         // from most of the machines.
         // Hence, just use the following heuristics at best depending on the CPU count

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -402,6 +402,8 @@ SYSTEM_LOGICAL_PROCESSOR_INFORMATION *GetLPI(PDWORD nEntries)
 size_t GetLogicalProcessorCacheSizeFromOS()
 {
     size_t cache_size = 0;
+    size_t cache_level = 0;
+
     DWORD nEntries = 0;
 
     // Try to use GetLogicalProcessorInformation API and get a valid pointer to the SLPI array if successful.  Returns NULL
@@ -424,7 +426,11 @@ size_t GetLogicalProcessorCacheSizeFromOS()
         {
             if (pslpi[i].Relationship == RelationCache)
             {
-                last_cache_size = max(last_cache_size, pslpi[i].Cache.Size);
+                if (last_cache_size < pslpi[i].Cache.Size)
+                {
+                    last_cache_size = pslpi[i].Cache.Size;
+                    cache_level = pslpi[i].Cache.Level;
+                }
             }
         }
         cache_size = last_cache_size;
@@ -433,6 +439,36 @@ Exit:
 
     if(pslpi)
         delete[] pslpi;  // release the memory allocated for the SLPI array.
+
+#if defined(TARGET_ARM64)
+    if (cache_level != 3)
+    {
+        // We expect to get the L3 cache size for Arm64 but currently expected to be missing that info
+        // from most of the machines.
+        // Hence, just use the following heuristics at best depending on the CPU count
+        // 1 ~ 4   :  4 MB
+        // 5 ~ 16  :  8 MB
+        // 17 ~ 64 : 16 MB
+        // 65+     : 32 MB
+        uint32_t logicalCPUs = GetTotalProcessorCount();
+        if (logicalCPUs < 5)
+        {
+            cacheSize = 4;
+        }
+        else if (logicalCPUs < 17)
+        {
+            cacheSize = 8;
+        }
+        else if (logicalCPUs < 65)
+        {
+            cacheSize = 16;
+        }
+        else
+        {
+            cacheSize = 32;
+        }
+    }
+#endif // TARGET_ARM64
 
     return cache_size;
 }
@@ -835,11 +871,6 @@ size_t GCToOSInterface::GetCacheSizePerLogicalCpu(bool trueSize)
     size_t maxSize, maxTrueSize;
 
     maxSize = maxTrueSize = GetLogicalProcessorCacheSizeFromOS() ; // Returns the size of the highest level processor cache
-
-#if defined(TARGET_ARM64)
-    // Bigger gen0 size helps arm64 targets
-    maxSize = maxTrueSize * 3;
-#endif
 
     s_maxSize = maxSize;
     s_maxTrueSize = maxTrueSize;

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -403,6 +403,7 @@ size_t GetLogicalProcessorCacheSizeFromOS()
 {
     size_t cache_size = 0;
     size_t cache_level = 0;
+    uint32_t totalCPUCount = 0;
 
     DWORD nEntries = 0;
 
@@ -432,6 +433,10 @@ size_t GetLogicalProcessorCacheSizeFromOS()
                     cache_level = pslpi[i].Cache.Level;
                 }
             }
+            else if (pslpi[i].Relationship == RelationProcessorCore)
+            {
+                totalCPUCount++;
+            }
         }
         cache_size = last_cache_size;
     }
@@ -450,25 +455,24 @@ Exit:
         // 5 ~ 16  :  8 MB
         // 17 ~ 64 : 16 MB
         // 65+     : 32 MB
-        uint32_t logicalCPUs = GetTotalProcessorCount();
-        if (logicalCPUs < 5)
+        if (totalCPUCount < 5)
         {
-            cacheSize = 4;
+            cache_size = 4;
         }
-        else if (logicalCPUs < 17)
+        else if (totalCPUCount < 17)
         {
-            cacheSize = 8;
+            cache_size = 8;
         }
-        else if (logicalCPUs < 65)
+        else if (totalCPUCount < 65)
         {
-            cacheSize = 16;
+            cache_size = 16;
         }
         else
         {
-            cacheSize = 32;
+            cache_size = 32;
         }
 
-        cacheSize *= 1024;
+        cache_size *= (1024 * 1024);
     }
 #endif // TARGET_ARM64
 
@@ -877,7 +881,7 @@ size_t GCToOSInterface::GetCacheSizePerLogicalCpu(bool trueSize)
     s_maxSize = maxSize;
     s_maxTrueSize = maxTrueSize;
 
-    // printf("GetCacheSizePerLogicalCpu returns %d, adjusted size %d\n", maxSize, maxTrueSize);
+    // printf("GetCacheSizePerLogicalCpu returns %zu, adjusted size %zu\n", maxSize, maxTrueSize);
     return trueSize ? maxTrueSize : maxSize;
 }
 

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -467,6 +467,8 @@ Exit:
         {
             cacheSize = 32;
         }
+
+        cacheSize *= 1024;
     }
 #endif // TARGET_ARM64
 
@@ -875,7 +877,7 @@ size_t GCToOSInterface::GetCacheSizePerLogicalCpu(bool trueSize)
     s_maxSize = maxSize;
     s_maxTrueSize = maxTrueSize;
 
-    //    printf("GetCacheSizePerLogicalCpu returns %d, adjusted size %d\n", maxSize, maxTrueSize);
+    // printf("GetCacheSizePerLogicalCpu returns %d, adjusted size %d\n", maxSize, maxTrueSize);
     return trueSize ? maxTrueSize : maxSize;
 }
 

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -543,19 +543,25 @@ size_t
 PALAPI
 PAL_GetLogicalProcessorCacheSizeFromOS()
 {
+    size_t cacheLevel = 0;
     size_t cacheSize = 0;
+    size_t size;
 
 #ifdef _SC_LEVEL1_DCACHE_SIZE
-    cacheSize = std::max(cacheSize, (size_t)sysconf(_SC_LEVEL1_DCACHE_SIZE));
+    size = ( size_t) sysconf(_SC_LEVEL1_DCACHE_SIZE);
+    CHECK_CACHE_SIZE(1)
 #endif
 #ifdef _SC_LEVEL2_CACHE_SIZE
-    cacheSize = std::max(cacheSize, (size_t)sysconf(_SC_LEVEL2_CACHE_SIZE));
+    size = ( size_t) sysconf(_SC_LEVEL2_CACHE_SIZE);
+    CHECK_CACHE_SIZE(2)
 #endif
 #ifdef _SC_LEVEL3_CACHE_SIZE
-    cacheSize = std::max(cacheSize, (size_t)sysconf(_SC_LEVEL3_CACHE_SIZE));
+    size = ( size_t) sysconf(_SC_LEVEL3_CACHE_SIZE);
+    CHECK_CACHE_SIZE(3)
 #endif
 #ifdef _SC_LEVEL4_CACHE_SIZE
-    cacheSize = std::max(cacheSize, (size_t)sysconf(_SC_LEVEL4_CACHE_SIZE));
+    size = ( size_t) sysconf(_SC_LEVEL4_CACHE_SIZE);
+    CHECK_CACHE_SIZE(4)
 #endif
 
 #if defined(TARGET_LINUX) && !defined(HOST_ARM) && !defined(HOST_X86)
@@ -566,25 +572,30 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
         // for the platform. Currently musl and arm64 should be only cases to use
         // this method to determine cache size.
         //
-        size_t size;
-
-        if(ReadMemoryValueFromFile("/sys/devices/system/cpu/cpu0/cache/index0/size", &size))
-            cacheSize = std::max(cacheSize, size);
-        if(ReadMemoryValueFromFile("/sys/devices/system/cpu/cpu0/cache/index1/size", &size))
-            cacheSize = std::max(cacheSize, size);
-        if(ReadMemoryValueFromFile("/sys/devices/system/cpu/cpu0/cache/index2/size", &size))
-            cacheSize = std::max(cacheSize, size);
-        if(ReadMemoryValueFromFile("/sys/devices/system/cpu/cpu0/cache/index3/size", &size))
-            cacheSize = std::max(cacheSize, size);
-        if(ReadMemoryValueFromFile("/sys/devices/system/cpu/cpu0/cache/index4/size", &size))
-            cacheSize = std::max(cacheSize, size);
+        size_t level;
+        for (int i = 0; i < 5; i++)
+        {
+            string path_to_index = "/sys/devices/system/cpu/cpu0/cache/index" + to_string(i);
+            if (ReadMemoryValueFromFile((path_to_index + "/size").c_str(), &size))
+            {
+                if (ReadMemoryValueFromFile((path_to_index + "/level").c_str(), &level))
+                {
+                    CHECK_CACHE_SIZE(level)
+                }
+                else
+                {
+                    cacheSize = std::max(cacheSize, size);
+                }
+            }
+        }
     }
 #endif
 
 #if (defined(HOST_ARM64) || defined(HOST_LOONGARCH64)) && !defined(TARGET_OSX)
-    if (cacheSize == 0)
+    if ((cacheSize == 0) || (cacheLevel != 3))
     {
-        // It is currently expected to be missing cache size info
+        // We expect to get the L3 cache size for Arm64 but  currently expected to be missing that info
+        // from most of the machines with an exceptions on some machines.
         //
         // _SC_LEVEL*_*CACHE_SIZE is not yet present.  Work is in progress to enable this for arm64
         //
@@ -599,12 +610,30 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
         // If we use recent high core count chips as a guide for state of the art, we find
         // total L3 cache to be 1-2MB/core.  As always, there are exceptions.
 
-        // Estimate cache size based on CPU count
-        // Assume lower core count are lighter weight parts which are likely to have smaller caches
-        // Assume L3$/CPU grows linearly from 256K to 1.5M/CPU as logicalCPUs grows from 2 to 12 CPUs
+        // Hence, just use the following heuristics at best depending on the CPU count
+        // 1 ~ 4   :  4 MB
+        // 5 ~ 16  :  8 MB
+        // 17 ~ 64 : 16 MB
+        // 65+     : 32 MB
         DWORD logicalCPUs = PAL_GetLogicalCpuCountFromOS();
+        if (logicalCPUs < 5)
+        {
+            cacheSize = 4;
+        }
+        else if (logicalCPUs < 17)
+        {
+            cacheSize = 8;
+        }
+        else if (logicalCPUs < 65)
+        {
+            cacheSize = 16;
+        }
+        else
+        {
+            cacheSize = 32;
+        }
 
-        cacheSize = logicalCPUs*std::min(1536, std::max(256, (int)logicalCPUs*128))*1024;
+        cacheSize = cacheSize * 1024;
     }
 #endif
 
@@ -621,11 +650,10 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
             || sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;
-
         if (success)
         {
-            _ASSERTE(cacheSizeFromSysctl > 0);
-            cacheSize = (size_t) cacheSizeFromSysctl;
+            assert(cacheSizeFromSysctl > 0);
+            cacheSize = ( size_t) cacheSizeFromSysctl;
         }
     }
 #endif

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -580,10 +580,14 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
         int index = 40;
         for (int i = 0; i < 5; i++)
         {
+            assert(path_to_size_file[index] == '-');
             path_to_size_file[index] = (char)(48 + i);
+
             if (ReadMemoryValueFromFile(path_to_size_file, &size))
             {
+                assert(path_to_level_file[index] == '-');
                 path_to_level_file[index] = (char)(48 + i);
+
                 if (ReadMemoryValueFromFile(path_to_level_file, &level))
                 {
                     CHECK_CACHE_SIZE(level)

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -652,7 +652,7 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
         // 5 ~ 16  :  8 MB
         // 17 ~ 64 : 16 MB
         // 65+     : 32 MB
-        DWORD logicalCPUs = g_totalCpuCount;
+        DWORD logicalCPUs = PAL_GetLogicalCpuCountFromOS();
         if (logicalCPUs < 5)
         {
             cacheSize = 4;

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -539,7 +539,7 @@ done:
     return result;
 }
 
-#define CHECK_CACHE_SIZE(CACHE_LEVEL) if (size > cacheSize) { cacheSize = size; cacheLevel = CACHE_LEVEL; }
+#define UPDATE_CACHE_SIZE_AND_LEVEL(CACHE_LEVEL) if (size > cacheSize) { cacheSize = size; cacheLevel = CACHE_LEVEL; }
 
 size_t
 PALAPI
@@ -551,19 +551,19 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
 
 #ifdef _SC_LEVEL1_DCACHE_SIZE
     size = ( size_t) sysconf(_SC_LEVEL1_DCACHE_SIZE);
-    CHECK_CACHE_SIZE(1)
+    UPDATE_CACHE_SIZE_AND_LEVEL(1)
 #endif
 #ifdef _SC_LEVEL2_CACHE_SIZE
     size = ( size_t) sysconf(_SC_LEVEL2_CACHE_SIZE);
-    CHECK_CACHE_SIZE(2)
+    UPDATE_CACHE_SIZE_AND_LEVEL(2)
 #endif
 #ifdef _SC_LEVEL3_CACHE_SIZE
     size = ( size_t) sysconf(_SC_LEVEL3_CACHE_SIZE);
-    CHECK_CACHE_SIZE(3)
+    UPDATE_CACHE_SIZE_AND_LEVEL(3)
 #endif
 #ifdef _SC_LEVEL4_CACHE_SIZE
     size = ( size_t) sysconf(_SC_LEVEL4_CACHE_SIZE);
-    CHECK_CACHE_SIZE(4)
+    UPDATE_CACHE_SIZE_AND_LEVEL(4)
 #endif
 
 #if defined(TARGET_LINUX) && !defined(HOST_ARM) && !defined(HOST_X86)
@@ -591,7 +591,7 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
 
                 if (ReadMemoryValueFromFile(path_to_level_file, &level))
                 {
-                    CHECK_CACHE_SIZE(level)
+                    UPDATE_CACHE_SIZE_AND_LEVEL(level)
                 }
                 else
                 {

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -575,12 +575,16 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
         // this method to determine cache size.
         //
         size_t level;
+        char path_to_size_file[] =  "/sys/devices/system/cpu/cpu0/cache/index-/size";
+        char path_to_level_file[] =  "/sys/devices/system/cpu/cpu0/cache/index-/level";
+        int index = 40;
         for (int i = 0; i < 5; i++)
         {
-            string path_to_index = "/sys/devices/system/cpu/cpu0/cache/index" + to_string(i);
-            if (ReadMemoryValueFromFile((path_to_index + "/size").c_str(), &size))
+            path_to_size_file[index] = (char)(48 + i);
+            if (ReadMemoryValueFromFile(path_to_size_file, &size))
             {
-                if (ReadMemoryValueFromFile((path_to_index + "/level").c_str(), &level))
+                path_to_level_file[index] = (char)(48 + i);
+                if (ReadMemoryValueFromFile(path_to_level_file, &level))
                 {
                     CHECK_CACHE_SIZE(level)
                 }

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -539,6 +539,8 @@ done:
     return result;
 }
 
+#define CHECK_CACHE_SIZE(CACHE_LEVEL) if (size > cacheSize) { cacheSize = size; cacheLevel = CACHE_LEVEL; }
+
 size_t
 PALAPI
 PAL_GetLogicalProcessorCacheSizeFromOS()
@@ -652,7 +654,7 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
             || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;
         if (success)
         {
-            assert(cacheSizeFromSysctl > 0);
+            _ASSERTE(cacheSizeFromSysctl > 0);
             cacheSize = ( size_t) cacheSizeFromSysctl;
         }
     }

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -578,14 +578,15 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
         char path_to_size_file[] =  "/sys/devices/system/cpu/cpu0/cache/index-/size";
         char path_to_level_file[] =  "/sys/devices/system/cpu/cpu0/cache/index-/level";
         int index = 40;
+        assert(path_to_size_file[index] == '-');
+        assert(path_to_level_file[index] == '-');
+
         for (int i = 0; i < 5; i++)
         {
-            assert(path_to_size_file[index] == '-');
             path_to_size_file[index] = (char)(48 + i);
 
             if (ReadMemoryValueFromFile(path_to_size_file, &size))
             {
-                assert(path_to_level_file[index] == '-');
                 path_to_level_file[index] = (char)(48 + i);
 
                 if (ReadMemoryValueFromFile(path_to_level_file, &level))

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -578,8 +578,8 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
         char path_to_size_file[] =  "/sys/devices/system/cpu/cpu0/cache/index-/size";
         char path_to_level_file[] =  "/sys/devices/system/cpu/cpu0/cache/index-/level";
         int index = 40;
-        assert(path_to_size_file[index] == '-');
-        assert(path_to_level_file[index] == '-');
+        _ASSERTE(path_to_size_file[index] == '-');
+        _ASSERTE(path_to_level_file[index] == '-');
 
         for (int i = 0; i < 5; i++)
         {

--- a/src/coreclr/vm/gcenv.os.cpp
+++ b/src/coreclr/vm/gcenv.os.cpp
@@ -588,6 +588,7 @@ SYSTEM_LOGICAL_PROCESSOR_INFORMATION *IsGLPISupported( PDWORD nEntries )
 size_t GetLogicalProcessorCacheSizeFromOS()
 {
     size_t cache_size = 0;
+    size_t cache_level = 0;
     DWORD nEntries = 0;
 
     // Try to use GetLogicalProcessorInformation API and get a valid pointer to the SLPI array if successful.  Returns NULL
@@ -608,9 +609,10 @@ size_t GetLogicalProcessorCacheSizeFromOS()
 
         for (DWORD i=0; i < nEntries; i++)
         {
-            if (pslpi[i].Relationship == RelationCache)
+            if (last_cache_size < pslpi[i].Cache.Size)
             {
-                last_cache_size = max(last_cache_size, pslpi[i].Cache.Size);
+                last_cache_size = pslpi[i].Cache.Size;
+                cache_level = pslpi[i].Cache.Level;
             }
         }
         cache_size = last_cache_size;
@@ -619,6 +621,36 @@ size_t GetLogicalProcessorCacheSizeFromOS()
 Exit:
     if(pslpi)
         delete[] pslpi;  // release the memory allocated for the SLPI array.
+
+#if defined(TARGET_ARM64)
+    if (cache_level != 3)
+    {
+        // We expect to get the L3 cache size for Arm64 but currently expected to be missing that info
+        // from most of the machines.
+        // Hence, just use the following heuristics at best depending on the CPU count
+        // 1 ~ 4   :  4 MB
+        // 5 ~ 16  :  8 MB
+        // 17 ~ 64 : 16 MB
+        // 65+     : 32 MB
+        uint32_t logicalCPUs = GetTotalProcessorCount();
+        if (logicalCPUs < 5)
+        {
+            cacheSize = 4;
+        }
+        else if (logicalCPUs < 17)
+        {
+            cacheSize = 8;
+        }
+        else if (logicalCPUs < 65)
+        {
+            cacheSize = 16;
+        }
+        else
+        {
+            cacheSize = 32;
+        }
+    }
+#endif // TARGET_ARM64
 
     return cache_size;
 }
@@ -645,11 +677,6 @@ size_t GCToOSInterface::GetCacheSizePerLogicalCpu(bool trueSize)
     size_t maxSize, maxTrueSize;
 
     maxSize = maxTrueSize = GetLogicalProcessorCacheSizeFromOS() ; // Returns the size of the highest level processor cache
-
-#if defined(TARGET_ARM64)
-    // Bigger gen0 size helps arm64 targets
-    maxSize = maxTrueSize * 3;
-#endif
 
     s_maxSize = maxSize;
     s_maxTrueSize = maxTrueSize;

--- a/src/coreclr/vm/gcenv.os.cpp
+++ b/src/coreclr/vm/gcenv.os.cpp
@@ -589,7 +589,6 @@ size_t GetLogicalProcessorCacheSizeFromOS()
 {
     size_t cache_size = 0;
     size_t cache_level = 0;
-    uint32_t totalCPUCount = 0;
     DWORD nEntries = 0;
 
     // Try to use GetLogicalProcessorInformation API and get a valid pointer to the SLPI array if successful.  Returns NULL
@@ -618,10 +617,6 @@ size_t GetLogicalProcessorCacheSizeFromOS()
                     cache_level = pslpi[i].Cache.Level;
                 }
             }
-            else if (pslpi[i].Relationship == RelationProcessorCore)
-            {
-                totalCPUCount++;
-            }
         }
         cache_size = last_cache_size;
     }
@@ -633,6 +628,8 @@ Exit:
 #if defined(TARGET_ARM64)
     if (cache_level != 3)
     {
+        uint32_t totalCPUCount = GCToOSInterface::GetTotalProcessorCount();
+
         // We expect to get the L3 cache size for Arm64 but currently expected to be missing that info
         // from most of the machines.
         // Hence, just use the following heuristics at best depending on the CPU count

--- a/src/coreclr/vm/gcenv.os.cpp
+++ b/src/coreclr/vm/gcenv.os.cpp
@@ -649,6 +649,8 @@ Exit:
         {
             cacheSize = 32;
         }
+
+        cacheSize *= 1024;
     }
 #endif // TARGET_ARM64
 
@@ -681,7 +683,7 @@ size_t GCToOSInterface::GetCacheSizePerLogicalCpu(bool trueSize)
     s_maxSize = maxSize;
     s_maxTrueSize = maxTrueSize;
 
-    //    printf("GetCacheSizePerLogicalCpu returns %d, adjusted size %d\n", maxSize, maxTrueSize);
+    // printf("GetCacheSizePerLogicalCpu returns %d, adjusted size %d\n", maxSize, maxTrueSize);
     return trueSize ? maxTrueSize : maxSize;
 }
 


### PR DESCRIPTION
While L3 cache size is undetermined on Arm64 machines, if we don't get it, use a fixed heuristics based upon the core count.

```
1 ~ 4   :  4 MB
5 ~ 16  :  8 MB
17 ~ 64 : 16 MB
65+     : 32 MB
```

This led to removing the obscure heuristics we have currently that just multiplies the cache size by 3.

```c++
#if defined(HOST_ARM64)
    // Bigger gen0 size helps arm64 targets
    maxSize = maxTrueSize * 3;
#endif
```