### PR TITLE
Fix Native Digits Support

### DIFF
--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoTests.cs
@@ -123,7 +123,7 @@ namespace System.Globalization.Tests
             yield return new object[] { "ur-IN",  new string[] { "\u06F0", "\u06F1", "\u06F2", "\u06F3", "\u06F4", "\u06F5", "\u06F6", "\u06F7", "\u06F8", "\u06F9" }};
         }
 
-        public static bool FullICUPlatform => PlatformDetection.IsIcuGlobalization && PlatformDetection.IsNotBrowser;
+        public static bool FullICUPlatform => PlatformDetection.ICUVersion.Major >= 66 && PlatformDetection.IsNotBrowser;
 
         [ConditionalTheory(nameof(FullICUPlatform))]
         [MemberData(nameof(NativeDigitTestData))]

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoTests.cs
@@ -115,5 +115,21 @@ namespace System.Globalization.Tests
             }
         }
 
+        public static IEnumerable<object[]> NativeDigitTestData()
+        {
+            yield return new object[] { "ccp-Cakm-BD", new string[] { "\U0001E950", "\U0001E951", "\U0001E952", "\U0001E953", "\U0001E954", "\U0001E955", "\U0001E956", "\U0001E957", "\U0001E958", "\U0001E959" }};
+            yield return new object[] { "ar-SA",  new string[] {"\u0660", "\u0661", "\u0662", "\u0663", "\u0664", "\u0665", "\u0666", "\u0667", "\u0668", "\u0669" }};
+            yield return new object[] { "en-US",  new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" }};
+            yield return new object[] { "ur-IN",  new string[] { "\u06F0", "\u06F1", "\u06F2", "\u06F3", "\u06F4", "\u06F5", "\u06F6", "\u06F7", "\u06F8", "\u06F9" }};
+        }
+
+        public static bool FullICUPlatform => PlatformDetection.IsIcuGlobalization && PlatformDetection.IsNotBrowser;
+
+        [ConditionalTheory(nameof(FullICUPlatform))]
+        [MemberData(nameof(NativeDigitTestData))]
+        public void TestNativeDigits(string cultureName, string[] nativeDigits)
+        {
+            Assert.Equal(nativeDigits, CultureInfo.GetCultureInfo(cultureName).NumberFormat.NativeDigits);
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2188,6 +2188,8 @@ namespace System.Globalization
 
             } while (ffffPos < digits.Length && index < 10);
 
+            Debug.Assert(index >= 10, $"Couldn't read native digits for '{_sWindowsName}' successfully.");
+
             return index < 10 ? NumberFormatInfo.s_asciiDigits : result;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2138,7 +2138,7 @@ namespace System.Globalization
         {
             string[] result = NumberFormatInfo.s_asciiDigits;
 
-            // LOCALE_SNATIVEDIGITS (array of 10 single character strings).
+            // NLS LOCALE_SNATIVEDIGITS (array of 10 single character strings). In case of ICU, the buffer can be longer.
             string digits = GetLocaleInfoCoreUserOverride(LocaleStringData.Digits);
 
             // if digits.Length < NumberFormatInfo.s_asciiDigits.Length means the native digits setting is messed up in the host machine.
@@ -2156,7 +2156,7 @@ namespace System.Globalization
                 return result;
             }
 
-            // None ASCII digits
+            // Non-ASCII digits
 
             // Check if values coming from ICU separated by 0xFFFF
             int ffffPos = digits.IndexOf('\uFFFF');
@@ -2171,6 +2171,8 @@ namespace System.Globalization
 
                 return result;
             }
+
+            // ICU case
 
             int start = 0;
             int index = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2181,7 +2181,7 @@ namespace System.Globalization
             {
                 result[index++] = digits.Substring(start, ffffPos - start);
                 start = ++ffffPos;
-                while (ffffPos < digits.Length && digits[ffffPos] != '\uFFFF')
+                while ((uint)ffffPos < (uint)digits.Length && digits[ffffPos] != '\uFFFF')
                 {
                     ffffPos++;
                 }

--- a/src/native/libs/System.Globalization.Native/pal_localeStringData.c
+++ b/src/native/libs/System.Globalization.Native/pal_localeStringData.c
@@ -25,10 +25,10 @@ static UErrorCode GetLocaleInfoDecimalFormatSymbol(const char* locale,
     UErrorCode status = U_ZERO_ERROR;
     UNumberFormat* pFormat = unum_open(UNUM_DECIMAL, NULL, 0, locale, NULL, &status);
 
-    int32_t l =  unum_getSymbol(pFormat, symbol, value, valueLength, &status);
+    int32_t lengthResult =  unum_getSymbol(pFormat, symbol, value, valueLength, &status);
     if (symbolLength != NULL)
     {
-        *symbolLength = l;
+        *symbolLength = lengthResult;
     }
     unum_close(pFormat);
     return status;
@@ -293,13 +293,12 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
             break;
         case LocaleString_Digits:
             {
-                // Native digit can be more than one character (e.g. ccp-Cakm-BD locale which using surrogate pairs to represent the native digit).
+                // Native digit can be more than one 16-bit character (e.g. ccp-Cakm-BD locale which using surrogate pairs to represent the native digit).
                 // We'll separate the native digits in the returned buffer by the character '\uFFFF'.
-                int charIndex = 0;
-                int symbolLength = 0;
-
+                int32_t symbolLength = 0;
                 status = GetDigitSymbol(locale, status, UNUM_ZERO_DIGIT_SYMBOL, 0, value, valueLength, &symbolLength);
-                charIndex += symbolLength;
+
+                int32_t charIndex = symbolLength;
 
                 if (U_SUCCESS(status) && (uint32_t)charIndex < (uint32_t)valueLength)
                 {

--- a/src/native/libs/System.Globalization.Native/pal_localeStringData.c
+++ b/src/native/libs/System.Globalization.Native/pal_localeStringData.c
@@ -19,11 +19,17 @@ Obtains the value of a DecimalFormatSymbols
 static UErrorCode GetLocaleInfoDecimalFormatSymbol(const char* locale,
                                                    UNumberFormatSymbol symbol,
                                                    UChar* value,
-                                                   int32_t valueLength)
+                                                   int32_t valueLength,
+                                                   int32_t* symbolLength)
 {
     UErrorCode status = U_ZERO_ERROR;
     UNumberFormat* pFormat = unum_open(UNUM_DECIMAL, NULL, 0, locale, NULL, &status);
-    unum_getSymbol(pFormat, symbol, value, valueLength, &status);
+
+    int32_t l =  unum_getSymbol(pFormat, symbol, value, valueLength, &status);
+    if (symbolLength != NULL)
+    {
+        *symbolLength = l;
+    }
     unum_close(pFormat);
     return status;
 }
@@ -39,14 +45,15 @@ static UErrorCode GetDigitSymbol(const char* locale,
                                  UNumberFormatSymbol symbol,
                                  int digit,
                                  UChar* value,
-                                 int32_t valueLength)
+                                 int32_t valueLength,
+                                 int32_t* symbolLength)
 {
     if (U_FAILURE(previousStatus))
     {
         return previousStatus;
     }
 
-    return GetLocaleInfoDecimalFormatSymbol(locale, symbol, value + digit, valueLength - digit);
+    return GetLocaleInfoDecimalFormatSymbol(locale, symbol, value + digit, valueLength - digit, symbolLength);
 }
 
 /*
@@ -279,26 +286,50 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
             }
             break;
         case LocaleString_ThousandSeparator:
-            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_GROUPING_SEPARATOR_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_GROUPING_SEPARATOR_SYMBOL, value, valueLength, NULL);
             break;
         case LocaleString_DecimalSeparator:
-            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_DECIMAL_SEPARATOR_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_DECIMAL_SEPARATOR_SYMBOL, value, valueLength, NULL);
             break;
         case LocaleString_Digits:
-            status = GetDigitSymbol(locale, status, UNUM_ZERO_DIGIT_SYMBOL, 0, value, valueLength);
-            // symbols UNUM_ONE_DIGIT to UNUM_NINE_DIGIT are contiguous
-            for (int32_t symbol = UNUM_ONE_DIGIT_SYMBOL; symbol <= UNUM_NINE_DIGIT_SYMBOL; symbol++)
             {
-                int charIndex = symbol - UNUM_ONE_DIGIT_SYMBOL + 1;
-                status = GetDigitSymbol(
-                    locale, status, (UNumberFormatSymbol)symbol, charIndex, value, valueLength);
+                // Native digit can be more than one character (e.g. ccp-Cakm-BD locale which using surrogate pairs to represent the native digit).
+                // We'll separate the native digits in the returned buffer by the character '\uFFFF'.
+                int charIndex = 0;
+                int symbolLength = 0;
+
+                status = GetDigitSymbol(locale, status, UNUM_ZERO_DIGIT_SYMBOL, 0, value, valueLength, &symbolLength);
+                charIndex += symbolLength;
+
+                if (U_SUCCESS(status) && (uint32_t)charIndex < (uint32_t)valueLength)
+                {
+                    value[charIndex++] = 0xFFFF;
+
+                    // symbols UNUM_ONE_DIGIT to UNUM_NINE_DIGIT are contiguous
+                    for (int32_t symbol = UNUM_ONE_DIGIT_SYMBOL; symbol <= UNUM_NINE_DIGIT_SYMBOL && charIndex < valueLength - 3; symbol++)
+                    {
+                        status = GetDigitSymbol(locale, status, (UNumberFormatSymbol)symbol, charIndex, value, valueLength, &symbolLength);
+                        charIndex += symbolLength;
+                        if (!U_SUCCESS(status) || (uint32_t)charIndex >= (uint32_t)valueLength)
+                        {
+                            break;
+                        }
+
+                        value[charIndex++] = 0xFFFF;
+                    }
+
+                    if ((uint32_t)charIndex < (uint32_t)valueLength)
+                    {
+                        value[charIndex] = 0;
+                    }
+                }
             }
             break;
         case LocaleString_MonetarySymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_CURRENCY_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_CURRENCY_SYMBOL, value, valueLength, NULL);
             break;
         case LocaleString_Iso4217MonetarySymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_INTL_CURRENCY_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_INTL_CURRENCY_SYMBOL, value, valueLength, NULL);
             break;
         case LocaleString_CurrencyEnglishName:
             status = GetLocaleCurrencyName(locale, false, value, valueLength);
@@ -307,11 +338,11 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
             status = GetLocaleCurrencyName(locale, true, value, valueLength);
             break;
         case LocaleString_MonetaryDecimalSeparator:
-            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MONETARY_SEPARATOR_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MONETARY_SEPARATOR_SYMBOL, value, valueLength, NULL);
             break;
         case LocaleString_MonetaryThousandSeparator:
             status =
-                GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MONETARY_GROUPING_SEPARATOR_SYMBOL, value, valueLength);
+                GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MONETARY_GROUPING_SEPARATOR_SYMBOL, value, valueLength, NULL);
             break;
         case LocaleString_AMDesignator:
             status = GetLocaleInfoAmPm(locale, true, value, valueLength);
@@ -320,10 +351,10 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
             status = GetLocaleInfoAmPm(locale, false, value, valueLength);
             break;
         case LocaleString_PositiveSign:
-            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_PLUS_SIGN_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_PLUS_SIGN_SYMBOL, value, valueLength, NULL);
             break;
         case LocaleString_NegativeSign:
-            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MINUS_SIGN_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MINUS_SIGN_SYMBOL, value, valueLength, NULL);
             break;
         case LocaleString_Iso639LanguageTwoLetterName:
             status = GetLocaleIso639LanguageTwoLetterName(locale, value, valueLength);
@@ -338,10 +369,10 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
             status = GetLocaleIso3166CountryCode(locale, value, valueLength);
             break;
         case LocaleString_NaNSymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_NAN_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_NAN_SYMBOL, value, valueLength, NULL);
             break;
         case LocaleString_PositiveInfinitySymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_INFINITY_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_INFINITY_SYMBOL, value, valueLength, NULL);
             break;
         case LocaleString_ParentName:
         {
@@ -358,10 +389,10 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
             break;
         }
         case LocaleString_PercentSymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_PERCENT_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_PERCENT_SYMBOL, value, valueLength, NULL);
             break;
         case LocaleString_PerMilleSymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_PERMILL_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_PERMILL_SYMBOL, value, valueLength, NULL);
             break;
         default:
             status = U_UNSUPPORTED_ERROR;


### PR DESCRIPTION
We always assumed the native digits one character. This was the case for NLS. Now in ICU, there are some locales which use native digits expressed as surrogate pairs. `ccp-Cakm-BD` locale is a good example of that which uses the native digits `"\U0001E950", "\U0001E951", "\U0001E952", "\U0001E953", "\U0001E954", "\U0001E955", "\U0001E956", "\U0001E957", "\U0001E958", "\U0001E959"`. This change is to allow reading the native digits correctly from ICU.