### PR TITLE
Mark simple.ilproj and nested.ilproj ilasm/ildasm roundtrip incompatible

### DIFF
--- a/src/tests/JIT/Directed/RVAInit/nested.ilproj
+++ b/src/tests/JIT/Directed/RVAInit/nested.ilproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- ildasm cannot support field RVAs precisely -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Directed/RVAInit/simple.ilproj
+++ b/src/tests/JIT/Directed/RVAInit/simple.ilproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- ildasm cannot support field RVAs precisely -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
ildasm does not support precisely disassembling field RVAs.

Fix #70876