### PR TITLE
Add missing call to initiate thread abort with CET

### DIFF
--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -5878,7 +5878,7 @@ void HandleSuspensionForInterruptedThread(CONTEXT *interruptedContext)
 
         frame.Pop(pThread);
 
-        // TODO: Windows - Raise thread abort exception if ready for abort
+        pThread->HandleThreadAbort();
     }
     else
     {


### PR DESCRIPTION
In my recent PR to make ThreadAbort work with CET enabled, one key line of
the change somehow slipped out of the change. This change adds that
missing line that actually initiates the thread abort after interruption
at a safe point.