### PR TITLE
Avoid OOMing in very large functions when checking LIR

### DIFF
--- a/src/coreclr/jit/smallhash.h
+++ b/src/coreclr/jit/smallhash.h
@@ -500,7 +500,7 @@ public:
     //
     // Returns:
     //    True if the key was removed from the table; false otherwise.
-    bool TryRemove(const TKey& key, TValue* value)
+    bool TryRemove(const TKey& key, TValue* value = nullptr)
     {
         unsigned hash = TKeyInfo::GetHashCode(key);
 
@@ -543,8 +543,25 @@ public:
 
         m_numFullBuckets--;
 
-        *value = bucket->m_value;
+        if (value != nullptr)
+        {
+            *value = bucket->m_value;
+        }
+
         return true;
+    }
+
+    //------------------------------------------------------------------------
+    // HashTableBase::Remove: removes a key from the hash table and asserts
+    //                        that it did exist in the the table.
+    //
+    // Arguments:
+    //    key   - The key to remove from the table.
+    //
+    void Remove(const TKey& key)
+    {
+        bool removed = TryRemove(key);
+        assert(removed);
     }
 
     //------------------------------------------------------------------------


### PR DESCRIPTION
For quite some time now we've had the problem that the ARM-targeting x86-hosted AltJit would run out of memory when compiling one particular method context in the `coreclr_tests` collection. For me locally this meant that when running:
```
./spmi linux-arm
```
An assert window would always pop up and had to be canceled.

For me, under the debugger, the memory usage for the method in question would eventually (by codegen) reach 2.1 GB and crash. With this change, it only reaches ~1.2GB (a combination of IR, LSRA data structures and `instrDesc`s) and completes successfully.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1836859&view=ms.vss-build-web.run-extensions-tab).