### PR TITLE
[wasm][aot] Enabled `System.Globalization.Extensions.Tests`

### DIFF
--- a/src/libraries/System.Globalization.Extensions/tests/IdnMapping/IdnMappingIdnaConformanceTests.cs
+++ b/src/libraries/System.Globalization.Extensions/tests/IdnMapping/IdnMappingIdnaConformanceTests.cs
@@ -21,7 +21,6 @@ namespace System.Globalization.Tests
         /// There are some others that failed which have been commented out and marked in the dataset as "GETASCII DOES FAILS ON WINDOWS 8.1"
         /// Same applies to Windows 10 >= 10.0.15063 in the IdnaTest_9.txt file
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/58708", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowserOnWindows), nameof(PlatformDetection.IsMonoAOT))]
         public void GetAscii_Success()
         {
             Assert.All(Factory.GetDataset().Where(e => e.ASCIIResult.Success), entry =>
@@ -52,7 +51,6 @@ namespace System.Globalization.Tests
         /// Same applies to Windows 10 >= 10.0.15063 in the IdnaTest_9.txt file
         /// </summary>
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/58708", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowserOnWindows), nameof(PlatformDetection.IsMonoAOT))]
         public void GetUnicode_Success()
         {
             Assert.All(Factory.GetDataset().Where(e => e.UnicodeResult.Success && e.UnicodeResult.ValidDomainName), entry =>
@@ -85,7 +83,6 @@ namespace System.Globalization.Tests
         /// Same applies to Windows 10 >= 10.0.15063 in the IdnaTest_9.txt file
         /// </remarks>
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // https://github.com/dotnet/runtime/issues/22409
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/58708", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowserOnWindows), nameof(PlatformDetection.IsMonoAOT))]
         public void GetAscii_Invalid()
         {
             Assert.All(Factory.GetDataset().Where(entry => !entry.ASCIIResult.Success), entry =>
@@ -115,7 +112,6 @@ namespace System.Globalization.Tests
         /// Same applies to Windows 10 >= 10.0.15063 in the IdnaTest_9.txt file
         /// </remarks>
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/58708", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowserOnWindows), nameof(PlatformDetection.IsMonoAOT))]
         public void GetUnicode_Invalid()
         {
             Assert.All(Factory.GetDataset().Where(entry => !entry.UnicodeResult.Success), entry =>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/58708.

Tested with: 
`dotnet build /t:Test src/libraries/System.Globalization.Extensions/tests /p:TargetOS=Browser /p:Configuration=Release /p:RunAOTCompilation=true /p:BrowserHost=Windows `

result:
```
  info: === TEST EXECUTION SUMMARY ===
  info: Total: 290, Errors: 0, Failed: 0, Skipped: 0, Time: 25.209501s
```