### PR TITLE
Delete `fgMorphGetStructAddr`

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5698,7 +5698,6 @@ private:
     GenTree* fgMorphOneAsgBlockOp(GenTree* tree);
     GenTree* fgMorphInitBlock(GenTree* tree);
     GenTree* fgMorphPromoteLocalInitBlock(GenTreeLclVar* destLclNode, GenTree* initVal, unsigned blockSize);
-    GenTree* fgMorphGetStructAddr(GenTree** pTree, CORINFO_CLASS_HANDLE clsHnd, bool isRValue = false);
     GenTree* fgMorphBlockOperand(GenTree* tree, var_types asgType, ClassLayout* blockLayout, bool isBlkReqd);
     GenTree* fgMorphCopyBlock(GenTree* tree);
     GenTree* fgMorphStoreDynBlock(GenTreeStoreDynBlk* tree);


### PR DESCRIPTION
After #68986, we do not need it in block morphing.

Includes additional cleanup of dead/unnecessary block morphing code.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1837267&view=ms.vss-build-web.run-extensions-tab) - couple positive ones on x86 where we keep the block copy when assigning to a promoted SIMD.

<details>
<summary>Sample IR diff</summary>

```diff
-               [000083] -A-X-+-----                         *  COMMA     void
-               [000076] -A-X-------                         +--*  COMMA     void
-               [000071] -A---------                         |  +--*  ASG       byref
-               [000070] D------N---                         |  |  +--*  LCL_VAR   byref  V12 tmp10
-               [000067] -A---------                         |  |  \--*  COMMA     byref
-               [000065] -A---------                         |  |     +--*  ASG       simd8  (copy)
-               [000063] D------N---                         |  |     |  +--*  LCL_VAR   simd8 <System.Numerics.Vector2> V11 tmp9
-               [000011] -----+-N---                         |  |     |  \--*  CNS_VEC   simd8 <0x00000000, 0x00000000>
-               [000069] -----------                         |  |     \--*  ADDR      byref
-               [000066] -------N---                         |  |        \--*  LCL_VAR   simd8 <System.Numerics.Vector2> V11 tmp9
-               [000075] -A-X-------                         |  \--*  ASG       float
-               [000072] D------N---                         |     +--*  LCL_VAR   float  V07 tmp5
-               [000074] ---X-------                         |     \--*  IND       float
-               [000073] -----------                         |        \--*  LCL_VAR   byref  V12 tmp10         Zero Fseq[X]
-               [000082] -A-X-------                         \--*  ASG       float
-               [000077] D------N---                            +--*  LCL_VAR   float  V08 tmp6
-               [000081] ---X-------                            \--*  IND       float
-               [000080] -----------                               \--*  ADD       byref
-               [000078] -----------                                  +--*  LCL_VAR   byref  V12 tmp10
-               [000079] -----------                                  \--*  CNS_INT   int    4 Fseq[Y]
+               [000014] -A---+-----                         *  ASG       simd8  (copy)
+               [000012] D----+-N---                         +--*  LCL_VAR   simd8 <System.Numerics.Vector2>(P) V03 tmp1
+                                                            +--*    float  V03.X (offs=0x00) -> V07 tmp5
+                                                            +--*    float  V03.Y (offs=0x04) -> V08 tmp6
+               [000011] -----+-----                         \--*  CNS_VEC   simd8 <0x00000000, 0x00000000>
```
</details>