### PR TITLE
Work around for UriFormatException caused by \\?\ prefix in the path

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -264,7 +264,7 @@ namespace System.Configuration
                 {
                     try
                     {
-                        if (Uri.TryCreate(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assembly.ManifestModule.Name), UriKind.RelativeOrAbsolute, out Uri codeBase))
+                        if (Uri.TryCreate(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assembly.ManifestModule.Name), UriKind.Absolute, out Uri codeBase))
                         {
                             // Certain platforms may not have support for crypto
                             hash = IdentityHelper.GetNormalizedUriHash(codeBase);

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -260,16 +260,13 @@ namespace System.Configuration
                 {
                     typeName = StrongNameDesc;
                 }
-                else
+                else if (Uri.TryCreate(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assembly.ManifestModule.Name), UriKind.Absolute, out Uri codeBase))
                 {
                     try
                     {
-                        if (Uri.TryCreate(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assembly.ManifestModule.Name), UriKind.Absolute, out Uri codeBase))
-                        {
-                            // Certain platforms may not have support for crypto
-                            hash = IdentityHelper.GetNormalizedUriHash(codeBase);
-                            typeName = UrlDesc;
-                        }
+                        // Certain platforms may not have support for crypto
+                        hash = IdentityHelper.GetNormalizedUriHash(codeBase);
+                        typeName = UrlDesc;
                     }
                     catch (PlatformNotSupportedException) { }
                 }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -248,7 +248,6 @@ namespace System.Configuration
             if (assembly != null && !isSingleFile)
             {
                 AssemblyName assemblyName = assembly.GetName();
-                Uri codeBase = new Uri(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assembly.ManifestModule.Name));
 
                 try
                 {
@@ -265,9 +264,12 @@ namespace System.Configuration
                 {
                     try
                     {
-                        // Certain platforms may not have support for crypto
-                        hash = IdentityHelper.GetNormalizedUriHash(codeBase);
-                        typeName = UrlDesc;
+                        if (Uri.TryCreate(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assembly.ManifestModule.Name), UriKind.RelativeOrAbsolute, out Uri codeBase))
+                        {
+                            // Certain platforms may not have support for crypto
+                            hash = IdentityHelper.GetNormalizedUriHash(codeBase);
+                            typeName = UrlDesc;
+                        }
                     }
                     catch (PlatformNotSupportedException) { }
                 }


### PR DESCRIPTION
When the path populated by `AppDomain.CurrentDomain.BaseDirectory` starts with `\\?\` (long path prefix) Uri constructor throws UriFormatException: `Invalid URI: The hostname could not be parsed` which causing WinForms designer failure:
![image](https://user-images.githubusercontent.com/45579687/174879908-f3e8615f-0ea2-49e3-b430-50fcc3411df9.png)

Moving the Uri creation code to where it is used and using `Uri.TryCreate` instead of the ctor

Please see the details from the issue: https://github.com/dotnet/runtime/issues/70318

Fixes https://github.com/dotnet/runtime/issues/70318