### PR TITLE
[wasm][aot] Enable `DataContractSerializerTests.DCS_DerivedTypeWithDifferentOverrides`

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1081,7 +1081,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/51679", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/60462", TestPlatforms.iOS | TestPlatforms.tvOS)]
     public static void DCS_DerivedTypeWithDifferentOverrides()
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/51679. It's passing locally with aot and aggressive trimming.