### PR TITLE
Simplify and improve SocketAddress.Equals

### DIFF
--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -186,22 +186,9 @@ namespace System.Net.Internals
             return Buffer.Length - IntPtr.Size;
         }
 
-        public override bool Equals(object? comparand)
-        {
-            SocketAddress? castedComparand = comparand as SocketAddress;
-            if (castedComparand == null || this.Size != castedComparand.Size)
-            {
-                return false;
-            }
-            for (int i = 0; i < this.Size; i++)
-            {
-                if (this[i] != castedComparand[i])
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
+        public override bool Equals(object? comparand) =>
+            comparand is SocketAddress other &&
+            Buffer.AsSpan(0, Size).SequenceEqual(other.Buffer.AsSpan(0, other.Size));
 
         public override int GetHashCode()
         {


### PR DESCRIPTION
Use SequenceEqual rather than an open-coded loop.

```C#
private SocketAddress _addr = new IPEndPoint(IPAddress.Parse("123.123.123.123"), 80).Serialize();
private SocketAddress _addr_same = new IPEndPoint(IPAddress.Parse("123.123.123.123"), 80).Serialize();
private SocketAddress _addr_notsame1 = new IPEndPoint(IPAddress.Parse("123.123.123.124"), 80).Serialize();
private SocketAddress _addr_notsame2 = new IPEndPoint(IPAddress.Parse("124.123.123.123"), 80).Serialize();
private SocketAddress _addr_notsame3 = new IPEndPoint(IPAddress.Parse("2620:1ec:c11::200"), 80).Serialize();

[Benchmark]
public bool Equals_Same() => _addr.Equals(_addr_same);

[Benchmark]
public bool Equals_NotSame1() => _addr.Equals(_addr_notsame1);

[Benchmark]
public bool Equals_NotSame2() => _addr.Equals(_addr_notsame2);

[Benchmark]
public bool Equals_NotSame3() => _addr.Equals(_addr_notsame3);
```

|          Method |         Toolchain |      Mean | Ratio |
|---------------- |------------------ |----------:|------:|
|     Equals_Same | \main\corerun.exe | 46.994 ns |  1.00 |
|     Equals_Same |   \pr\corerun.exe |  4.507 ns |  0.10 |
|                 |                   |           |       |
| Equals_NotSame1 | \main\corerun.exe | 24.946 ns |  1.00 |
| Equals_NotSame1 |   \pr\corerun.exe |  4.446 ns |  0.18 |
|                 |                   |           |       |
| Equals_NotSame2 | \main\corerun.exe | 15.960 ns |  1.00 |
| Equals_NotSame2 |   \pr\corerun.exe |  4.410 ns |  0.28 |
|                 |                   |           |       |
| Equals_NotSame3 | \main\corerun.exe |  1.933 ns |  1.00 |
| Equals_NotSame3 |   \pr\corerun.exe |  2.172 ns |  1.12 |