### PR TITLE
Fix #70849: Print LARGEJMP instruction on ARM64

### DIFF
--- a/src/coreclr/jit/emitarm.h
+++ b/src/coreclr/jit/emitarm.h
@@ -43,6 +43,14 @@ void emitDispAddrRR(regNumber reg1, regNumber reg2, emitAttr attr);
 void emitDispAddrRRI(regNumber reg1, regNumber reg2, int imm, emitAttr attr);
 void emitDispAddrPUW(regNumber reg, int imm, insOpts opt, emitAttr attr);
 void emitDispGC(emitAttr attr);
+void emitDispLargeJmp(instrDesc* id,
+                      bool       isNew,
+                      bool       doffs,
+                      bool       asmfm,
+                      unsigned   offs = 0,
+                      BYTE*      code = 0,
+                      size_t     sz   = 0,
+                      insGroup*  ig   = NULL);
 
 void emitDispInsHelp(instrDesc* id,
                      bool       isNew,

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -23,6 +23,10 @@ static bool strictArmAsm;
 
 const char* emitVectorRegName(regNumber reg);
 
+void emitDispInsHelp(
+    instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* pCode, size_t sz, insGroup* ig);
+void emitDispLargeJmp(
+    instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* pCode, size_t sz, insGroup* ig);
 void emitDispInst(instruction ins);
 void emitDispImm(ssize_t imm, bool addComma, bool alwaysHex = false);
 void emitDispFloatZero();
@@ -873,6 +877,8 @@ BYTE* emitOutputShortBranch(BYTE* dst, instruction ins, insFormat fmt, ssize_t d
 BYTE* emitOutputShortAddress(BYTE* dst, instruction ins, insFormat fmt, ssize_t distVal, regNumber reg);
 BYTE* emitOutputShortConstant(
     BYTE* dst, instruction ins, insFormat fmt, ssize_t distVal, regNumber reg, emitAttr opSize);
+BYTE* emitOutputVectorConstant(
+    BYTE* dst, ssize_t distVal, regNumber dstReg, regNumber addrReg, emitAttr opSize, emitAttr elemSize);
 
 /*****************************************************************************
  *


### PR DESCRIPTION
These changes address #70849 by implementing the special case of printing the LARGEJMP pseudo-instruction in `emitter::emitDispIns` on ARM64. To achieve functional and organizational parity between the ARM32 and ARM64 implementations, `emitter::emitDispIns` has been re-architected as so:
* On ARM64, the method's logic has been moved to `emitter::emitDispInsHelp` (just like on ARM32). The method now checks for the special LARGEJMP case, and calls the appropriate method.
* On both architectures, the logic for printing LARGEJMP instructions has been moved to its own method.