### PR TITLE
Remove SString::UIndex and SString::UIterator as they are never used.

### DIFF
--- a/src/coreclr/inc/sstring.h
+++ b/src/coreclr/inc/sstring.h
@@ -105,15 +105,10 @@ private:
 
   protected:
     class Index;
-    class UIndex;
 
     friend class Index;
-    friend class UIndex;
 
   public:
-
-    // UIterator is character-level assignable.
-    class UIterator;
 
     // CIterators/Iterator'string must be modified by SString APIs.
     class CIterator;
@@ -325,53 +320,6 @@ private:
     // CIterator and Iterator are cheap to create, but allow only read-only
     // access to the string.
     //
-    // UIterator forces a unicode conversion, but allows
-    // assignment to individual string characters.  They are also a bit more
-    // efficient once created.
-
-    // ------------------------------------------------------------------
-    // UIterator:
-    // ------------------------------------------------------------------
-
- protected:
-
-    class EMPTY_BASES_DECL UIndex : public SBuffer::Index
-    {
-        friend class SString;
-        friend class Indexer<WCHAR, UIterator>;
-
-      protected:
-
-        UIndex();
-        UIndex(SString *string, SCOUNT_T index);
-        WCHAR &GetAt(SCOUNT_T delta) const;
-        void Skip(SCOUNT_T delta);
-        SCOUNT_T Subtract(const UIndex &i) const;
-        CHECK DoCheck(SCOUNT_T delta) const;
-
-        WCHAR *GetUnicode() const;
-    };
-
- public:
-
-    class EMPTY_BASES_DECL UIterator : public UIndex, public Indexer<WCHAR, UIterator>
-    {
-        friend class SString;
-
-    public:
-        UIterator()
-        {
-        }
-
-        UIterator(SString *string, int index)
-          : UIndex(string, index)
-        {
-        }
-    };
-
-    UIterator BeginUnicode();
-    UIterator EndUnicode();
-
     // For CIterator & Iterator, we try our best to iterate the string without
     // modifying it. (Currently, we do require an ASCII or Unicode string
     // for simple WCHAR retrival, but you could imagine being more flexible

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -1907,44 +1907,6 @@ inline void SString::ConvertToIteratable() const
 }
 
 //-----------------------------------------------------------------------------
-// Create iterators on the string.
-//-----------------------------------------------------------------------------
-
-inline SString::UIterator SString::BeginUnicode()
-{
-    SS_CONTRACT(SString::UIterator)
-    {
-        GC_NOTRIGGER;
-        PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckValue(RETVAL));
-        THROWS;
-    }
-    SS_CONTRACT_END;
-
-    ConvertToUnicode();
-    EnsureWritable();
-
-    SS_RETURN UIterator(this, 0);
-}
-
-inline SString::UIterator SString::EndUnicode()
-{
-    SS_CONTRACT(SString::UIterator)
-    {
-        GC_NOTRIGGER;
-        PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckValue(RETVAL));
-        THROWS;
-    }
-    SS_CONTRACT_END;
-
-    ConvertToUnicode();
-    EnsureWritable();
-
-    SS_RETURN UIterator(this, GetCount());
-}
-
-//-----------------------------------------------------------------------------
 // Create CIterators on the string.
 //-----------------------------------------------------------------------------
 
@@ -2133,74 +2095,6 @@ inline WCHAR SString::Index::operator[](int index) const
         return *(CHAR*)&GetAt(index);
     else
         return *(WCHAR*)&GetAt(index);
-}
-
-//-----------------------------------------------------------------------------
-// Iterator support routines
-//-----------------------------------------------------------------------------
-
-inline SString::UIndex::UIndex()
-{
-    LIMITED_METHOD_CONTRACT;
-}
-
-inline SString::UIndex::UIndex(SString *string, SCOUNT_T index)
-  : SBuffer::Index(string, index*sizeof(WCHAR))
-{
-    SS_CONTRACT_VOID
-    {
-        GC_NOTRIGGER;
-        PRECONDITION(CheckPointer(string));
-        PRECONDITION(string->IsRepresentation(REPRESENTATION_UNICODE));
-        PRECONDITION(DoCheck(0));
-        SS_POSTCONDITION(CheckPointer(this));
-        NOTHROW;
-        CANNOT_TAKE_LOCK;
-    }
-    SS_CONTRACT_END;
-
-    SS_RETURN;
-}
-
-inline WCHAR &SString::UIndex::GetAt(SCOUNT_T delta) const
-{
-    LIMITED_METHOD_CONTRACT;
-
-    return ((WCHAR*)m_ptr)[delta];
-}
-
-inline void SString::UIndex::Skip(SCOUNT_T delta)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    m_ptr += delta * sizeof(WCHAR);
-}
-
-inline SCOUNT_T SString::UIndex::Subtract(const UIndex &i) const
-{
-    WRAPPER_NO_CONTRACT;
-
-    return (SCOUNT_T) (GetUnicode() - i.GetUnicode());
-}
-
-inline CHECK SString::UIndex::DoCheck(SCOUNT_T delta) const
-{
-    CANNOT_HAVE_CONTRACT;
-#if _DEBUG
-    const SString *string = (const SString *) GetContainerDebug();
-
-    CHECK(GetUnicode() + delta >= string->GetRawUnicode());
-    CHECK(GetUnicode() + delta <= string->GetRawUnicode() + string->GetCount());
-#endif
-
-    CHECK_OK;
-}
-
-inline WCHAR *SString::UIndex::GetUnicode() const
-{
-    LIMITED_METHOD_CONTRACT;
-
-    return (WCHAR*) m_ptr;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This is based on work in https://github.com/dotnet/runtime/pull/69748.