### PR TITLE
Normalize Watson crash buckets between .NET Core/.NET Framework

### DIFF
--- a/src/coreclr/vm/dwbucketmanager.hpp
+++ b/src/coreclr/vm/dwbucketmanager.hpp
@@ -451,13 +451,14 @@ void BaseBucketParamsManager::GetAppName(_Out_writes_(maxLength) WCHAR* targetPa
     }
     CONTRACTL_END;
 
-    HMODULE hModule = WszGetModuleHandle(NULL);
     PathString appPath;
-
-
     if (GetCurrentModuleFileName(appPath) == S_OK)
     {
-        CopyStringToBucket(targetParam, maxLength, appPath);
+        // Get just the module name; remove the path
+        const WCHAR* appName = wcsrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
+        appName = appName ? appName + 1 : appPath;
+
+        CopyStringToBucket(targetParam, maxLength, appName);
     }
     else
     {
@@ -475,10 +476,7 @@ void BaseBucketParamsManager::GetAppVersion(_Out_writes_(maxLength) WCHAR* targe
     }
     CONTRACTL_END;
 
-    HMODULE hModule = WszGetModuleHandle(NULL);
     PathString appPath;
-
-
     WCHAR verBuf[23] = {0};
     USHORT major, minor, build, revision;
 


### PR DESCRIPTION
The Watson crash bucket code gets the program app name and if greater than 32 characters is hashed and written as based 64 encoded string. This has been done ever since .NET Framework. There was a bug introduced in .NET Core when the long file name support has added that changed the GetCurrentModuleFileName util function from getting just the module name without the path on Framework to returning the full path name. This caused the app name to always be hashed and encoded as hex bytes.

The fix was to parse off the path and just use the module name.

Issue: https://github.com/dotnet/runtime/issues/61580