### PR TITLE
Revert Arcade update & Workload Manifest change

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,6 +9,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-emsdk -->
+    <add key="darc-pub-dotnet-emsdk-52e9452" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-52e9452f/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-wcf -->
     <!--  End: Package sources from dotnet-wcf -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,77 +26,77 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201201-01">
       <Uri>https://github.com/microsoft/vstest</Uri>
@@ -142,37 +142,37 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>6c6b7f90677142ad7bd829eb28d3bcf8ad775dd7</Sha>
     </Dependency>
-    <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.22316.1">
+    <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.21416.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>
-      <Sha>0f10ab4748ab03f248985e664aea7ec9df55b3f4</Sha>
+      <Sha>cea4a95e1505e737e768c8094d6aa880f5442ab7</Sha>
     </Dependency>
-    <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="11.1.0-alpha.1.22316.1">
+    <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="11.1.0-alpha.1.21416.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>
-      <Sha>0f10ab4748ab03f248985e664aea7ec9df55b3f4</Sha>
+      <Sha>cea4a95e1505e737e768c8094d6aa880f5442ab7</Sha>
     </Dependency>
-    <Dependency Name="runtime.linux-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.22316.1">
+    <Dependency Name="runtime.linux-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.21416.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>
-      <Sha>0f10ab4748ab03f248985e664aea7ec9df55b3f4</Sha>
+      <Sha>cea4a95e1505e737e768c8094d6aa880f5442ab7</Sha>
     </Dependency>
-    <Dependency Name="runtime.linux-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="11.1.0-alpha.1.22316.1">
+    <Dependency Name="runtime.linux-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="11.1.0-alpha.1.21416.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>
-      <Sha>0f10ab4748ab03f248985e664aea7ec9df55b3f4</Sha>
+      <Sha>cea4a95e1505e737e768c8094d6aa880f5442ab7</Sha>
     </Dependency>
-    <Dependency Name="runtime.win-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.22316.1">
+    <Dependency Name="runtime.win-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.21416.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>
-      <Sha>0f10ab4748ab03f248985e664aea7ec9df55b3f4</Sha>
+      <Sha>cea4a95e1505e737e768c8094d6aa880f5442ab7</Sha>
     </Dependency>
-    <Dependency Name="runtime.win-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="11.1.0-alpha.1.22316.1">
+    <Dependency Name="runtime.win-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="11.1.0-alpha.1.21416.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>
-      <Sha>0f10ab4748ab03f248985e664aea7ec9df55b3f4</Sha>
+      <Sha>cea4a95e1505e737e768c8094d6aa880f5442ab7</Sha>
     </Dependency>
-    <Dependency Name="runtime.osx.10.12-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.22316.1">
+    <Dependency Name="runtime.osx.10.12-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.21416.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>
-      <Sha>0f10ab4748ab03f248985e664aea7ec9df55b3f4</Sha>
+      <Sha>cea4a95e1505e737e768c8094d6aa880f5442ab7</Sha>
     </Dependency>
-    <Dependency Name="runtime.osx.10.12-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="11.1.0-alpha.1.22316.1">
+    <Dependency Name="runtime.osx.10.12-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="11.1.0-alpha.1.21416.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>
-      <Sha>0f10ab4748ab03f248985e664aea7ec9df55b3f4</Sha>
+      <Sha>cea4a95e1505e737e768c8094d6aa880f5442ab7</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-rc.1.21415.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -218,9 +218,9 @@
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>e9669dc84ecd668d3bbb748758103e23b394ffef</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="6.0.0-beta.22314.7">
+    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="6.0.0-beta.22161.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fdd3a242bc813f371023adff4e4c05c0be705d2a</Sha>
+      <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.MIBC.Runtime" Version="1.0.0-prerelease.21416.5">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,21 +41,21 @@
     <!-- SDK dependencies -->
     <MicrosoftDotNetCompatibilityVersion>1.1.0-preview.22164.17</MicrosoftDotNetCompatibilityVersion>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatVersion>6.0.0-beta.22314.7</MicrosoftDotNetApiCompatVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.22314.7</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.22314.7</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>6.0.0-beta.22314.7</MicrosoftDotNetGenAPIVersion>
-    <MicrosoftDotNetGenFacadesVersion>6.0.0-beta.22314.7</MicrosoftDotNetGenFacadesVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.22314.7</MicrosoftDotNetXUnitExtensionsVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.22314.7</MicrosoftDotNetXUnitConsoleRunnerVersion>
-    <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.22314.7</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.22314.7</MicrosoftDotNetBuildTasksInstallersVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.22314.7</MicrosoftDotNetBuildTasksPackagingVersion>
-    <MicrosoftDotNetBuildTasksTemplatingVersion>6.0.0-beta.22314.7</MicrosoftDotNetBuildTasksTemplatingVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>6.0.0-beta.22314.7</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.22314.7</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.22314.7</MicrosoftDotNetVersionToolsTasksVersion>
-    <MicrosoftDotNetPackageTestingVersion>6.0.0-beta.22314.7</MicrosoftDotNetPackageTestingVersion>
+    <MicrosoftDotNetApiCompatVersion>6.0.0-beta.22161.1</MicrosoftDotNetApiCompatVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.22161.1</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.22161.1</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftDotNetGenAPIVersion>6.0.0-beta.22161.1</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenFacadesVersion>6.0.0-beta.22161.1</MicrosoftDotNetGenFacadesVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.22161.1</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.22161.1</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.22161.1</MicrosoftDotNetBuildTasksArchivesVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.22161.1</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.22161.1</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>6.0.0-beta.22161.1</MicrosoftDotNetBuildTasksTemplatingVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>6.0.0-beta.22161.1</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.22161.1</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.22161.1</MicrosoftDotNetVersionToolsTasksVersion>
+    <MicrosoftDotNetPackageTestingVersion>6.0.0-beta.22161.1</MicrosoftDotNetPackageTestingVersion>
     <!-- NuGet dependencies -->
     <NuGetBuildTasksPackVersion>6.0.0-preview.1.102</NuGetBuildTasksPackVersion>
     <!-- Installer dependencies -->
@@ -161,14 +161,14 @@
     <!-- MsQuic -->
     <SystemNetMsQuicTransportVersion>6.0.0-preview.7.21417.1</SystemNetMsQuicTransportVersion>
     <!-- Mono LLVM -->
-    <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.22316.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
-    <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.22316.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
-    <runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.22316.1</runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
-    <runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.22316.1</runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
-    <runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.22316.1</runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
-    <runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.22316.1</runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
-    <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.22316.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
-    <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.22316.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
+    <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.21416.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
+    <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.21416.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
+    <runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.21416.1</runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
+    <runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.21416.1</runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
+    <runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.21416.1</runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
+    <runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.21416.1</runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
+    <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.21416.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
+    <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.21416.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
     <!-- emscripten / Node -->
     <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60100Version>
     <MicrosoftNETWorkloadEmscriptenManifest60200Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60200Version>

--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -43,8 +43,8 @@ steps:
     # In that case, add variables to allow the download of internal runtimes if the specified versions are not found
     # in the default public locations.
     internalRuntimeDownloadArgs=
-    if [ '$(dotnetbuilds-internal-container-read-token-base64)' != '$''(dotnetbuilds-internal-container-read-token-base64)' ]; then
-      internalRuntimeDownloadArgs='/p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64) --runtimesourcefeed https://dotnetbuilds.blob.core.windows.net/internal --runtimesourcefeedkey $(dotnetbuilds-internal-container-read-token-base64)'
+    if [ '$(dotnetclimsrc-read-sas-token-base64)' != '$''(dotnetclimsrc-read-sas-token-base64)' ]; then
+      internalRuntimeDownloadArgs='/p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64) --runtimesourcefeed https://dotnetclimsrc.blob.core.windows.net/dotnet --runtimesourcefeedkey $(dotnetclimsrc-read-sas-token-base64)'
     fi
 
     buildConfig=Release

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.103",
+    "version": "6.0.106",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.103"
+    "dotnet": "6.0.106"
   },
   "native-tools": {
     "cmake": "3.16.4",

--- a/global.json
+++ b/global.json
@@ -1,21 +1,21 @@
 {
   "sdk": {
-    "version": "6.0.106",
+    "version": "6.0.103",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.106"
+    "dotnet": "6.0.103"
   },
   "native-tools": {
     "cmake": "3.16.4",
     "python3": "3.7.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.22314.7",
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.22314.7",
-    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.22314.7",
-    "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.22314.7",
+    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.22161.1",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.22161.1",
+    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.22161.1",
+    "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.22161.1",
     "Microsoft.Build.NoTargets": "3.1.0",
     "Microsoft.Build.Traversal": "3.0.23",
     "Microsoft.NET.Sdk.IL": "6.0.0-rc.1.21415.6"

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -8,7 +8,8 @@
     <MicrosoftDotNetBuildTasksInstallersTaskAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersVersion)\tools\$(MicrosoftDotNetBuildTasksInstallersTaskTargetFramework)\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
   </PropertyGroup>
 
-  <UsingTask AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Workloads)\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll" TaskName="CreateVisualStudioWorkload" />
+  <UsingTask AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Workloads)\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll" TaskName="GenerateManifestMsi" />
+  <UsingTask AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Workloads)\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll" TaskName="GenerateVisualStudioWorkload" />
   <UsingTask TaskName="GenerateMsiVersion" AssemblyFile="$(MicrosoftDotNetBuildTasksInstallersTaskAssembly)" />
   <UsingTask TaskName="CreateLightCommandPackageDrop" AssemblyFile="$(MicrosoftDotNetBuildTasksInstallersTaskAssembly)" />
 
@@ -47,12 +48,6 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <ItemDefinitionGroup>
-    <!-- Visual Studio components must be versioned. Build tasks will fall back to cobbling a version number from
-         the manifest information unless it's overridden. -->
-    <ComponentResources Version="$(FileVersion)" />
-  </ItemDefinitionGroup>
-
   <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GetVersionProps;_GenerateMsiVersionString">
     <ItemGroup>
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
@@ -79,6 +74,20 @@
                           Description=".NET runtime components for Mac Catalyst execution."/>
       <ComponentResources Include="runtimes-windows" Title=".NET Windows Runtimes"
                           Description=".NET runtime components for Windows execution."/>
+
+      <!-- Visual Studio components must be versioned. Build tasks will fall back to cobbling a version number from
+           the manifest information unless it's overridden. -->
+      <ComponentVersions Include="microsoft-net-runtime-mono-tooling" Version="$(FileVersion)" />
+      <ComponentVersions Include="wasm-tools" Version="$(FileVersion)" />
+      <ComponentVersions Include="microsoft-net-runtime-android" Version="$(FileVersion)" />
+      <ComponentVersions Include="microsoft-net-runtime-android-aot" Version="$(FileVersion)" />
+      <ComponentVersions Include="microsoft-net-runtime-ios" Version="$(FileVersion)" />
+      <ComponentVersions Include="microsoft-net-runtime-tvos" Version="$(FileVersion)" />
+      <ComponentVersions Include="microsoft-net-runtime-maccatalyst" Version="$(FileVersion)" />
+      <ComponentVersions Include="runtimes-ios" Version="$(FileVersion)" />
+      <ComponentVersions Include="runtimes-tvos" Version="$(FileVersion)" />
+      <ComponentVersions Include="runtimes-maccatalyst" Version="$(FileVersion)" />
+      <ComponentVersions Include="runtimes-windows" Version="$(FileVersion)" />
     </ItemGroup>
 
     <!-- BAR requires having version information in blobs -->
@@ -97,28 +106,49 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ManifestPackages Include="$(PackageSource)Microsoft.NET.Workload.Mono.ToolChain.Manifest-*.nupkg" MsiVersion="$(MsiVersion)"/>
+      <ManifestPackages Include="$(PackageSource)Microsoft.NET.Workload.Mono.ToolChain.Manifest-*.nupkg" />
     </ItemGroup>
 
-    <CreateVisualStudioWorkload BaseIntermediateOutputPath="$(WorkloadIntermediateOutputPath)"
-                                BaseOutputPath="$(WorkloadOutputPath)"
-                                ComponentResources="$(ComponentResources)"
-                                PackageSource="$(PackageSource)"
-                                ShortNames="@(ShortNames)"
-                                WorkloadManifestPackageFiles="@(ManifestPackages)"
-                                WixToolsetPath="$(WixToolsetPath)">
+    <GenerateManifestMsi
+        IntermediateBaseOutputPath="$(IntermediateOutputPath)"
+        OutputPath="$(OutputPath)"
+        MsiVersion="$(MsiVersion)"
+        WixToolsetPath="$(WixToolsetPath)"
+        WorkloadManifestPackage="%(ManifestPackages.Identity)"
+        ShortNames="@(ShortNames)" >
+      <Output TaskParameter="Msis" ItemName="ManifestMsis" />
+    </GenerateManifestMsi>
+
+    <GenerateVisualStudioWorkload IntermediateBaseOutputPath="$(WorkloadIntermediateOutputPath)"
+                                  WixToolsetPath="$(WixToolsetPath)"
+                                  GenerateMsis="true"
+                                  ComponentVersions="@(ComponentVersions)"
+                                  OutputPath="$(WorkloadOutputPath)"
+                                  PackagesPath="$(PackageSource)"
+                                  ShortNames="@(ShortNames)"
+                                  WorkloadPackages="@(ManifestPackages)">
       <Output TaskParameter="SwixProjects" ItemName="SwixProjects" />
       <Output TaskParameter="Msis" ItemName="Msis" />
-    </CreateVisualStudioWorkload>
+    </GenerateVisualStudioWorkload>
 
     <!-- Build all the SWIX projects. This requires full framework MSBuild-->
-    <MSBuild Projects="@(SwixProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath)%(SwixProjects.SdkFeatureBand)" />
+    <MSBuild Projects="%(ManifestMsis.SwixProject)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
+    <MSBuild Projects="@(SwixProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
 
     <!-- Gather .wixobj files for post-build signing. We'll have to batch since we generated multiple MSIs in the previous step. -->
+    <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(ManifestMsis.WixObj);_Msi=%(ManifestMsis.Identity)" Targets="CreateWixPack" />
     <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(Msis.WixObj);_Msi=%(Msis.Identity)" Targets="CreateWixPack" />
+
+    <!-- Build the Visual Studio manifest project. -->
+    <ItemGroup>
+      <VisualStudioManifestProjects Include="mono_wasm_mobile.vsmanproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(VisualStudioManifestProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath);OutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
 
     <!-- Build all the MSI payload packages for NuGet. -->
     <ItemGroup>
+      <MsiPackageProjects Include="%(ManifestMsis.PackageProject)" />
       <MsiPackageProjects Include="%(Msis.PackageProject)" />
     </ItemGroup>
 


### PR DESCRIPTION
Reverts https://github.com/dotnet/runtime/pull/71046 & https://github.com/dotnet/runtime/pull/68871, but keeps the SDK update to 6.0.106. Needed to unblock 6.0