### PR TITLE
#69800 disable failing test on android

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -37,6 +37,7 @@ namespace System
         public static bool IsFreeBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
         public static bool IsAndroid => RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
+        public static bool IsNotAndroid => !IsAndroid;
         public static bool IsiOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"));
         public static bool IstvOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"));
         public static bool IsMacCatalyst => RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
@@ -86,8 +86,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Equal(new Guid("1B33498A-7B7D-4DDA-9C13-F6AA4AB449A6"), (Guid)jObject["MyGuid"]);
         }
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69800", TestPlatforms.Android)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotX86Process))]
         public static void ExplicitOperators_FromValues()
         {
             Assert.Equal(1, (short)(JsonNode)(short)1);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
@@ -87,6 +87,7 @@ namespace System.Text.Json.Nodes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/69800", TestPlatforms.Android)]
         public static void ExplicitOperators_FromValues()
         {
             Assert.Equal(1, (short)(JsonNode)(short)1);


### PR DESCRIPTION
Disabling ExplicitOperators_FromValues  on android for the issue #69800