### PR TITLE
Avoid delegate allocation in TraceSourceLoggerProvider.GetOrAddTraceSource

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/TraceSourceLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/TraceSourceLoggerProvider.cs
@@ -53,10 +53,9 @@ namespace Microsoft.Extensions.Logging.TraceSource
             return new TraceSourceLogger(GetOrAddTraceSource(name));
         }
 
-        private DiagnosticsTraceSource GetOrAddTraceSource(string name)
-        {
-            return _sources.GetOrAdd(name, InitializeTraceSource);
-        }
+        private DiagnosticsTraceSource GetOrAddTraceSource(string name) =>
+            _sources.TryGetValue(name, out DiagnosticsTraceSource? source) ? source :
+            _sources.GetOrAdd(name, InitializeTraceSource(name));
 
         private DiagnosticsTraceSource InitializeTraceSource(string traceSourceName)
         {


### PR DESCRIPTION
Every call to GetOrAddTraceSource was allocating a new delegate instance.