### PR TITLE
Mirror Microsoft.Diagnostics.NETCore.Client

### DIFF
--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
@@ -11,9 +11,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <IsShipping>true</IsShipping>
+    <BuildingOutsideDiagnostics>false</BuildingOutsideDiagnostics>
+    <BuildingOutsideDiagnostics Condition="'$(GitHubRepositoryName)' != 'diagnostics'">true</BuildingOutsideDiagnostics>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(GitHubRepositoryName)' == 'runtime'">
+  <PropertyGroup Condition="$(BuildingOutsideDiagnostics)">
     <DefineConstants>$(DefineConstants);DIAGNOSTICS_RUNTIME</DefineConstants>
     <NoWarn>CS1591,CS8073,CS0162</NoWarn>
   </PropertyGroup>
@@ -36,6 +38,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Condition="'$(GitHubRepositoryName)' == 'runtime'" Include="**/*.cs" />
+    <Compile Condition="$(BuildingOutsideDiagnostics)" Include="**/*.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Microsoft.Diagnostics.NETCore.Client change to allow future branches to build correctly in runtimelab