### PR TITLE
Adjust regions range dynamically based on memory limits

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43947,18 +43947,15 @@ HRESULT GCHeap::Initialize()
     gc_heap::regions_range = (size_t)GCConfig::GetGCRegionRange();
     if (gc_heap::regions_range == 0)
     {
-        if (gc_heap::regions_range == 0)
+        if (gc_heap::heap_hard_limit)
         {
-            if (gc_heap::heap_hard_limit)
-            {
-                gc_heap::regions_range = 2 * gc_heap::heap_hard_limit;
-            }
-            else
-            {
-                gc_heap::regions_range = max(274877906944L, (size_t)(2 * gc_heap::total_physical_mem));
-            }
-            gc_heap::regions_range = align_on_page(gc_heap::regions_range);
+            gc_heap::regions_range = 2 * gc_heap::heap_hard_limit;
         }
+        else
+        {
+            gc_heap::regions_range = max(((size_t)256 * 1024 * 1024 * 1024), (size_t)(2 * gc_heap::total_physical_mem));
+        }
+        gc_heap::regions_range = align_on_page(gc_heap::regions_range);
     }
     // TODO: Set config after config API is merged.
 #endif //USE_REGIONS

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43855,11 +43855,6 @@ HRESULT GCHeap::Initialize()
     {
         gc_heap::total_physical_mem = GCToOSInterface::GetPhysicalMemoryLimit (&gc_heap::is_restricted_physical_mem);
     }
-
-#ifdef USE_REGIONS
-    gc_heap::regions_range = (size_t)GCConfig::GetGCRegionRange();
-#endif //USE_REGIONS
-
 #ifdef HOST_64BIT
     gc_heap::heap_hard_limit = (size_t)GCConfig::GetGCHeapHardLimit();
     gc_heap::heap_hard_limit_oh[soh] = (size_t)GCConfig::GetGCHeapHardLimitSOH();
@@ -43947,6 +43942,26 @@ HRESULT GCHeap::Initialize()
     {
         return CLR_E_GC_LARGE_PAGE_MISSING_HARD_LIMIT;
     }
+
+#ifdef USE_REGIONS
+    gc_heap::regions_range = (size_t)GCConfig::GetGCRegionRange();
+    if (gc_heap::regions_range == 0)
+    {
+        if (gc_heap::regions_range == 0)
+        {
+            if (gc_heap::heap_hard_limit)
+            {
+                gc_heap::regions_range = 2 * gc_heap::heap_hard_limit;
+            }
+            else
+            {
+                gc_heap::regions_range = max(274877906944L, (size_t)(2 * gc_heap::total_physical_mem));
+            }
+            gc_heap::regions_range = align_on_page(gc_heap::regions_range);
+        }
+    }
+    // TODO: Set config after config API is merged.
+#endif //USE_REGIONS
 
 #endif //HOST_64BIT
 

--- a/src/coreclr/gc/gcconfig.h
+++ b/src/coreclr/gc/gcconfig.h
@@ -103,7 +103,7 @@ public:
     INT_CONFIG   (GCHeapHardLimit,        "GCHeapHardLimit",        "System.GC.HeapHardLimit",        0,                 "Specifies a hard limit for the GC heap")                                                 \
     INT_CONFIG   (GCHeapHardLimitPercent, "GCHeapHardLimitPercent", "System.GC.HeapHardLimitPercent", 0,                 "Specifies the GC heap usage as a percentage of the total memory")                        \
     INT_CONFIG   (GCTotalPhysicalMemory,  "GCTotalPhysicalMemory",  NULL,                             0,                 "Specifies what the GC should consider to be total physical memory")                      \
-    INT_CONFIG   (GCRegionRange,          "GCRegionRange",          NULL,                             274877906944L,     "Specifies the range for the GC heap")                                                    \
+    INT_CONFIG   (GCRegionRange,          "GCRegionRange",          NULL,                             0,                 "Specifies the range for the GC heap")                                                    \
     INT_CONFIG   (GCRegionSize,           "GCRegionSize",           NULL,                             4194304,           "Specifies the size for a basic GC region")                                               \
     STRING_CONFIG(LogFile,                "GCLogFile",              NULL,                                                "Specifies the name of the GC log file")                                                  \
     STRING_CONFIG(ConfigLogFile,          "GCConfigLogFile",        NULL,                                                "Specifies the name of the GC config log file")                                           \


### PR DESCRIPTION
This change fixes the working set regression when running the JSON TechEmpower benchmark on Linux under a container. Here is a summary of the performance data:

**Segments:**
Max Working Set (MB) | 93

**Regions before fix:**
Max Working Set (MB) | 172

**Regions after fix:**
Max Working Set (MB) | 95

There is no significant difference between regions after fix and segment on other metrics we measured.

**Cause of the regression:**
In the GC, we assumed that `GCToOSInterface::VirtualReserve` is essentially free because all it does is that it tells the operating system what virtual address range is not available for other uses within the process. This assumption holds on Windows, but on Linux, the APIs are emulated, and for each page we reserve, we use 1 byte to describe that page so that it can satisfy other needs (e.g. VirtualQuery)

On a 64-bit system, the address space is huge, and therefore the GC reserved 256G by default. That translate to 64M of memory used just to track those pages. But we are running under a container of 512MB, we will never ever need those pages.

**Solution:**
The proper root cause fix is to avoid those tracking bytes, that work is tracked as part of #31721 and is currently out of the scope of .NET 7. In the meantime, there is no need to reserve 256G of memory on a container of 512MB. In this change, I made that reserve limit dynamic, depending on the machine. This will also fix issue #70718 because if you have a large physical memory, our reserve limit would be adjusted accordingly.

