### PR TITLE
Update apphost error dialog text to put question last

### DIFF
--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -168,10 +168,10 @@ namespace
         }
 
         dialogMsg.append(
-            _X("Would you like to download it now?\n\n")
             _X("Learn about "));
         dialogMsg.append(error_code == StatusCode::FrameworkMissingFailure ? _X("framework resolution:") : _X("runtime installation:"));
-        dialogMsg.append(_X("\n") DOTNET_APP_LAUNCH_FAILED_URL);
+        dialogMsg.append(_X("\n") DOTNET_APP_LAUNCH_FAILED_URL _X("\n\n")
+            _X("Would you like to download it now?"));
 
         assert(url.length() > 0);
         assert(is_gui_application());


### PR DESCRIPTION
We had the question/call to action followed by the doc link and then the yes/no buttons corresponding to the question. As @RussKie pointed out, that placement was not helpful.

cc @richlander 

Reordered to:
![image](https://user-images.githubusercontent.com/47805090/175135959-adef05fc-3150-44a9-a6fb-49123bc00d73.png)
![image](https://user-images.githubusercontent.com/47805090/175135983-06eec056-5e33-4a7a-8948-ca453de7e2e2.png)
