### PR TITLE
[release/6.0] Include all error messsages to DllNotFoundException

### DIFF
--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -51,6 +51,7 @@ namespace
             LIMITED_METHOD_CONTRACT;
             m_hr = E_FAIL;
             m_priorityOfLastError = 0;
+            m_message = SString(SString::Utf8, "\n");
         }
 
         VOID TrackErrorCode()
@@ -135,7 +136,18 @@ namespace
 
         void SetMessage(LPCSTR message)
         {
+#ifdef TARGET_UNIX
+            //Append dlerror() messages
+            SString new_message = SString(SString::Utf8, message);
+            SString::Iterator i = m_message.Begin();
+            if (!m_message.Find(i, new_message))
+            {
+                m_message += new_message;
+                m_message += SString(SString::Utf8, "\n");
+            }
+#else
             m_message = SString(SString::Utf8, message);
+#endif
         }
 
         HRESULT m_hr;


### PR DESCRIPTION
Backport of #70964
Please consider backporting this to release/6.0.