### PR TITLE
Disable hot/cold splitting on Unix NativeAOT

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3199,6 +3199,14 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 
     opts.compProcedureSplitting = jitFlags->IsSet(JitFlags::JIT_FLAG_PROCSPLIT) || enableFakeSplitting;
 
+#ifdef FEATURE_CFI_SUPPORT
+    // Hot/cold splitting is not being tested on NativeAOT.
+    if (generateCFIUnwindCodes())
+    {
+        opts.compProcedureSplitting = false;
+    }
+#endif // FEATURE_CFI_SUPPORT
+
 #ifdef TARGET_LOONGARCH64
     // Hot/cold splitting is not being tested on LoongArch64.
     opts.compProcedureSplitting = false;

--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -268,13 +268,6 @@ void Compiler::unwindEmitFuncCFI(FuncInfoDsc* func, void* pHotCode, void* pColdC
     DWORD          unwindCodeBytes = 0;
     BYTE*          pUnwindBlock    = nullptr;
 
-#ifdef DEBUG
-    if (JitConfig.JitFakeProcedureSplitting())
-    {
-        pColdCode = nullptr;
-    }
-#endif // DEBUG
-
     if (func->startLoc == nullptr)
     {
         startOffset = 0;


### PR DESCRIPTION
Follow-up to #70708. Because we have yet to test hot/cold splitting on NativeAOT, we should disable the feature if `generateCFIUnwindCodes()` is true.