### PR TITLE
Do not CSE constant operands for `GT_SIMD` vector constructors

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -8348,9 +8348,6 @@ inline bool GenTree::IsVectorCreate() const
         switch (AsSIMD()->GetSIMDIntrinsicId())
         {
             case SIMDIntrinsicInit:
-            case SIMDIntrinsicInitFixed:
-            case SIMDIntrinsicInitArray:
-            case SIMDIntrinsicInitArrayX:
             case SIMDIntrinsicInitN:
                 return true;
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -8343,6 +8343,21 @@ inline bool GenTree::IsVectorCreate() const
 #endif // FEATURE_HW_INTRINSICS
 
 #ifdef FEATURE_SIMD
+    if (OperIs(GT_SIMD))
+    {
+        switch (AsSIMD()->GetSIMDIntrinsicId())
+        {
+            case SIMDIntrinsicInit:
+            case SIMDIntrinsicInitFixed:
+            case SIMDIntrinsicInitArray:
+            case SIMDIntrinsicInitArrayX:
+            case SIMDIntrinsicInitN:
+                return true;
+
+            default:
+                return false;
+        }
+    }
     return OperIs(GT_SIMD);
 #else
     return false;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -8355,7 +8355,6 @@ inline bool GenTree::IsVectorCreate() const
                 return false;
         }
     }
-    return OperIs(GT_SIMD);
 #else
     return false;
 #endif // FEATURE_SIMD

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -8333,6 +8333,7 @@ inline bool GenTree::IsVectorCreate() const
             case NI_Vector256_Create:
 #elif defined(TARGET_ARMARCH)
             case NI_Vector64_Create:
+#endif
                 return true;
 
             default:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -8355,9 +8355,9 @@ inline bool GenTree::IsVectorCreate() const
                 return false;
         }
     }
-#else
-    return false;
 #endif // FEATURE_SIMD
+
+    return false;
 }
 
 //-------------------------------------------------------------------

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1733,6 +1733,7 @@ public:
     inline bool IsIntegralConst(ssize_t constVal) const;
     inline bool IsFloatPositiveZero() const;
     inline bool IsVectorZero() const;
+    inline bool IsVectorCreate() const;
     inline bool IsVectorAllBitsSet() const;
     inline bool IsVectorConst();
 
@@ -8311,6 +8312,40 @@ inline bool GenTree::IsFloatPositiveZero() const
 inline bool GenTree::IsVectorZero() const
 {
     return IsCnsVec() && AsVecCon()->IsZero();
+}
+
+//-------------------------------------------------------------------
+// IsVectorCreate: returns true if this node is the creation of a vector.
+//                 Does not include "Unsafe" method calls.
+//
+// Returns:
+//     True if this node is the creation of a vector
+//
+inline bool GenTree::IsVectorCreate() const
+{
+#ifdef FEATURE_HW_INTRINSICS
+    if (OperIs(GT_HWINTRINSIC))
+    {
+        switch (AsHWIntrinsic()->GetHWIntrinsicId())
+        {
+            case NI_Vector128_Create:
+#if defined(TARGET_XARCH)
+            case NI_Vector256_Create:
+#elif defined(TARGET_ARMARCH)
+            case NI_Vector64_Create:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+#endif // FEATURE_HW_INTRINSICS
+
+#ifdef FEATURE_SIMD
+    return OperIs(GT_SIMD);
+#else
+    return false;
+#endif // FEATURE_SIMD
 }
 
 //-------------------------------------------------------------------

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13881,7 +13881,7 @@ GenTree* Compiler::fgMorphMultiOp(GenTreeMultiOp* multiOp)
         bool allArgsAreConst = true;
         for (GenTree* arg : multiOp->Operands())
         {
-            if (!arg->OperIsConst() || arg->OperIs(GT_CNS_VEC))
+            if (!arg->OperIsConst())
             {
                 allArgsAreConst = false;
                 break;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13807,6 +13807,21 @@ GenTree* Compiler::fgMorphMultiOp(GenTreeMultiOp* multiOp)
     }
 #endif
 
+#if defined(FEATURE_SIMD)
+    if (multiOp->OperIs(GT_SIMD))
+    {
+        dontCseConstArguments = true;
+        for (GenTree* arg : multiOp->Operands())
+        {
+            if (!arg->OperIsConst())
+            {
+                dontCseConstArguments = false;
+                break;
+            }
+        }
+    }
+#endif
+
     for (GenTree** use : multiOp->UseEdges())
     {
         *use = fgMorphTree(*use);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13881,7 +13881,7 @@ GenTree* Compiler::fgMorphMultiOp(GenTreeMultiOp* multiOp)
         bool allArgsAreConst = true;
         for (GenTree* arg : multiOp->Operands())
         {
-            if (!arg->OperIsConst())
+            if (!arg->OperIsConst() || arg->OperIs(GT_CNS_VEC))
             {
                 allArgsAreConst = false;
                 break;


### PR DESCRIPTION
**Description**
If a `GT_SIMD` op contains all constants and is an `Init`/`InitN`, then mark each constant as `DoNotCSE`. This logic already exists for `GT_HWINTRINSIC` nodes when creating vectors.

**Acceptance Criteria**
- [x] CI passes

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1840616&view=ms.vss-build-web.run-extensions-tab)