### PR TITLE
Expect UnauthorizedAccessException in tvOS if extracting fifo from tar without elevation

### DIFF
--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.Unix.cs
@@ -9,7 +9,7 @@ namespace System.Formats.Tar.Tests
 {
     public partial class TarFile_ExtractToDirectory_File_Tests : TarTestsBase
     {
-        [Fact]
+        [ConditionalFact(nameof(IsUnixButNotSuperUser))]
         public void Extract_SpecialFiles_Unix_Unelevated_ThrowsUnauthorizedAccess()
         {
             string originalFileName = GetTarFilePath(CompressionMethod.Uncompressed, TestTarFormat.ustar, "specialfiles");

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.Unix.cs
@@ -10,7 +10,7 @@ namespace System.Formats.Tar.Tests
 {
     public partial class TarFile_ExtractToDirectoryAsync_File_Tests : TarTestsBase
     {
-        [Fact]
+        [ConditionalFact(nameof(IsUnixButNotSuperUser))]
         public async Task Extract_SpecialFiles_Unix_Unelevated_ThrowsUnauthorizedAccess_Async()
         {
             using (TempDirectory root = new TempDirectory())

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.TarEntry.ExtractToFile.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.TarEntry.ExtractToFile.Tests.Unix.cs
@@ -11,35 +11,34 @@ namespace System.Formats.Tar.Tests
     {
         [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.tvOS)] // https://github.com/dotnet/runtime/issues/68360
         [ConditionalFact(nameof(IsUnixButNotSuperUser))]
-        public async Task SpecialFile_Unelevated_Throws_Async()
+        public void SpecialFile_Unelevated_Throws()
         {
             using TempDirectory root = new TempDirectory();
             using MemoryStream ms = GetTarMemoryStream(CompressionMethod.Uncompressed, TestTarFormat.ustar, "specialfiles");
 
-            TarReader reader = new TarReader(ms);
-            await using (reader)
+            using (TarReader reader = new TarReader(ms))
             {
                 string path = Path.Join(root.Path, "output");
 
                 // Block device requires elevation for writing
-                PosixTarEntry blockDevice = await reader.GetNextEntryAsync() as PosixTarEntry;
+                PosixTarEntry blockDevice = reader.GetNextEntry() as PosixTarEntry;
                 Assert.NotNull(blockDevice);
-                await Assert.ThrowsAsync<UnauthorizedAccessException>(() => blockDevice.ExtractToFileAsync(path, overwrite: false));
+                Assert.Throws<UnauthorizedAccessException>(() => blockDevice.ExtractToFile(path, overwrite: false));
                 Assert.False(File.Exists(path));
 
                 // Character device requires elevation for writing
-                PosixTarEntry characterDevice = await reader.GetNextEntryAsync() as PosixTarEntry;
+                PosixTarEntry characterDevice = reader.GetNextEntry() as PosixTarEntry;
                 Assert.NotNull(characterDevice);
-                await Assert.ThrowsAsync<UnauthorizedAccessException>(() => characterDevice.ExtractToFileAsync(path, overwrite: false));
+                Assert.Throws<UnauthorizedAccessException>(() => characterDevice.ExtractToFile(path, overwrite: false));
                 Assert.False(File.Exists(path));
 
                 // Fifo does not require elevation, should succeed
-                PosixTarEntry fifo = await reader.GetNextEntryAsync() as PosixTarEntry;
+                PosixTarEntry fifo = reader.GetNextEntry() as PosixTarEntry;
                 Assert.NotNull(fifo);
-                await fifo.ExtractToFileAsync(path, overwrite: false);
+                fifo.ExtractToFile(path, overwrite: false);
                 Assert.True(File.Exists(path));
 
-                Assert.Null(await reader.GetNextEntryAsync());
+                Assert.Null(reader.GetNextEntry());
             }
         }
     }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.TarEntry.ExtractToFile.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.TarEntry.ExtractToFile.Tests.Unix.cs
@@ -10,7 +10,7 @@ namespace System.Formats.Tar.Tests
     public partial class TarReader_TarEntry_ExtractToFile_Tests : TarTestsBase
     {
         [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.tvOS)] // https://github.com/dotnet/runtime/issues/68360
-        [Fact]
+        [ConditionalFact(nameof(IsUnixButNotSuperUser))]
         public async Task SpecialFile_Unelevated_Throws_Async()
         {
             using TempDirectory root = new TempDirectory();

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.TarEntry.ExtractToFileAsync.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.TarEntry.ExtractToFileAsync.Tests.Unix.cs
@@ -10,7 +10,7 @@ namespace System.Formats.Tar.Tests
     public partial class TarReader_TarEntry_ExtractToFileAsync_Tests : TarTestsBase
     {
         [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.tvOS)] // https://github.com/dotnet/runtime/issues/68360
-        [Fact]
+        [ConditionalFact(nameof(IsUnixButNotSuperUser))]
         public async Task SpecialFile_Unelevated_Throws_Async()
         {
             using (TempDirectory root = new TempDirectory())

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -101,6 +101,8 @@ namespace System.Formats.Tar.Tests
         }
         protected static bool IsRemoteExecutorSupportedAndOnUnixAndSuperUser => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndSuperUser;
 
+        protected static bool IsUnixButNotSuperUser => !PlatformDetection.IsWindows && !PlatformDetection.IsSuperUser;
+
         protected static string GetTestCaseUnarchivedFolderPath(string testCaseName) =>
             Path.Join(Directory.GetCurrentDirectory(), "unarchived", testCaseName);
 


### PR DESCRIPTION
I saw a tvOS failure in [one of my PRs](https://dev.azure.com/dnceng/public/_build/results?buildId=1840021&view=ms.vss-test-web.build-test-results-tab&runId=48593844&resultId=100888&paneView=dotnet-dnceng.dnceng-build-release-tasks.helix-test-information-tab). I had not seen it before, so I'm unsure if it's intermittent or consistent.

The `ExtractToFile_SpecialFile_Unelevated_Throws` method threw `UnauthorizedAccessException` when attempting to extract the fifo from the archive into disk:

https://github.com/dotnet/runtime/blame/051b4828c7d3a0cad3289830ef9fd2120f45bb2b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.ExtractToFile.Tests.Unix.cs#L39

In other Unix platforms, extracting fifos does not throw, but apparently it does on tvOS. 

Here's the callstack:

```
[14:55:07.7170830] 2022-06-22 14:55:07.706 System.Formats.Tar.Tests[58680:78698627]    Exception messages: System.UnauthorizedAccessException : Access to the path '/private/var/mobile/Containers/Data/Application/11374FD2-B51C-49C4-844D-F40F062ACE94/tmp/1pslf5q1.gf2/output' is denied.
[14:55:07.7171130] ---- System.IO.IOException : Operation not permitted
[14:55:07.7189880] 2022-06-22 14:55:07.708 System.Formats.Tar.Tests[58680:78698627]    Exception stack traces:    at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
[14:55:07.7190220]    at System.Formats.Tar.TarEntry.ExtractAsFifo(String destinationFileName)
[14:55:07.7190300] 2022-06-22 14:55:07.708 System.Formats.Tar.Tests[58680:78698627]    at System.Formats.Tar.TarEntry.ExtractToFileInternal(String filePath, String linkTargetPath, Boolean overwrite)
[14:55:07.7190360]    at System.Formats.Tar.TarEntry.ExtractToFile(String destinationFileName, Boolean overwrite)
[14:55:07.7201670] 2022-06-22 14:55:07.709 System.Formats.Tar.Tests[58680:78698627]    at System.Formats.Tar.Tests.TarReader_ExtractToFile_Tests.ExtractToFile_SpecialFile_Unelevated_Throws()
```