### PR TITLE
[NativeAOT] Enable dynamic linking of ucrt for release runtime

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
+++ b/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
@@ -11,6 +11,11 @@
 
   <Target Name="Build">
     <Copy SourceFiles="@(Content)" DestinationFolder="$(OutputPath)" />
+
+    <!-- Create breadcrumb to disable dynamic linking of release crt for debug runtime -->
+    <WriteLinesToFile
+      File="$(RuntimeBinDir)/aotsdk/debugcrt.txt"
+      Condition="'$(TargetsWindows)'=='true' and '$(Configuration)' != 'Release'" />
   </Target>
 
   <Target Name="Restore" />

--- a/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
+++ b/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
@@ -14,7 +14,7 @@
 
     <!-- Create breadcrumb to disable dynamic linking of release crt for debug runtime -->
     <WriteLinesToFile
-      File="$(RuntimeBinDir)/aotsdk/debugcrt.txt"
+      File="$(RuntimeBinDir)/aotsdk/debugucrt.txt"
       Condition="'$(TargetsWindows)'=='true' and '$(Configuration)' != 'Release'" />
   </Target>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -86,6 +86,12 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Condition="'$(ControlFlowGuard)' == 'Guard'" Include="/guard:cf" />
     </ItemGroup>
 
+    <ItemGroup Condition="!Exists('$(IlcSdkPath)debugucrt.txt')">
+      <!-- Force ucrt to be dynamically linked for release runtime -->
+      <LinkerArg Include="/NODEFAULTLIB:libucrt.lib" />
+      <LinkerArg Include="/DEFAULTLIB:ucrt.lib" />
+    </ItemGroup>
+
     <ItemGroup Condition="'$(Configuration)' != 'Debug'">
       <LinkerArg Include="/OPT:REF" />
       <LinkerArg Include="/OPT:ICF" />


### PR DESCRIPTION
This is enabled for release runtime only, same as how we do it for regular CoreCLR builds.