### PR TITLE
Remove SString ANSI representation.

### DIFF
--- a/src/coreclr/debug/ee/rcthread.cpp
+++ b/src/coreclr/debug/ee/rcthread.cpp
@@ -548,13 +548,12 @@ static LONG _debugFilter(LPEXCEPTION_POINTERS ep, PVOID pv)
         // We can't really use SStrings on the helper thread; though if we're at this point, we've already died.
         // So go ahead and risk it and use them anyways.
         SString sStack;
-        StackScratchBuffer buffer;
         GetStackTraceAtContext(sStack, ep->ContextRecord);
         const CHAR *string = NULL;
 
         EX_TRY
         {
-            string = sStack.GetANSI(buffer);
+            string = sStack.GetUTF8();
         }
         EX_CATCH
         {

--- a/src/coreclr/inc/debugmacros.h
+++ b/src/coreclr/inc/debugmacros.h
@@ -26,7 +26,7 @@ extern "C" {
 class SString;
 bool GetStackTraceAtContext(SString & s, struct _CONTEXT * pContext);
 
-bool _DbgBreakCheck(LPCSTR szFile, int iLine, LPCSTR szExpr, BOOL fConstrained = FALSE);
+bool _DbgBreakCheck(LPCSTR szFile, int iLine, LPCUTF8 szExpr, BOOL fConstrained = FALSE);
 
 extern VOID ANALYZER_NORETURN DbgAssertDialog(const char *szFile, int iLine, const char *szExpr);
 

--- a/src/coreclr/inc/debugmacros.h
+++ b/src/coreclr/inc/debugmacros.h
@@ -26,7 +26,7 @@ extern "C" {
 class SString;
 bool GetStackTraceAtContext(SString & s, struct _CONTEXT * pContext);
 
-bool _DbgBreakCheck(LPCSTR szFile, int iLine, LPCUTF8 szExpr, BOOL fConstrained = FALSE);
+bool _DbgBreakCheck(LPCSTR szFile, int iLine, LPCSTR szExpr, BOOL fConstrained = FALSE);
 
 extern VOID ANALYZER_NORETURN DbgAssertDialog(const char *szFile, int iLine, const char *szExpr);
 

--- a/src/coreclr/inc/sstring.h
+++ b/src/coreclr/inc/sstring.h
@@ -812,20 +812,6 @@ public:
         SetUTF8(string, count);
     }
 
-    FORCEINLINE InlineSString(enum tagANSI dummytag, const ANSI *string)
-      : SString(m_inline, SBUFFER_PADDED_SIZE(MEMSIZE))
-    {
-        WRAPPER_NO_CONTRACT;
-        SetANSI(string);
-    }
-
-    FORCEINLINE InlineSString(enum tagANSI dummytag, const ANSI *string, COUNT_T count)
-      : SString(m_inline, SBUFFER_PADDED_SIZE(MEMSIZE))
-    {
-        WRAPPER_NO_CONTRACT;
-        SetANSI(string, count);
-    }
-
     FORCEINLINE InlineSString(WCHAR character)
       : SString(m_inline, SBUFFER_PADDED_SIZE(MEMSIZE))
     {

--- a/src/coreclr/inc/sstring.h
+++ b/src/coreclr/inc/sstring.h
@@ -82,7 +82,6 @@ private:
         REPRESENTATION_UNICODE  = 0x04, // 100
         REPRESENTATION_ASCII    = 0x01, // 001
         REPRESENTATION_UTF8     = 0x03, // 011
-        REPRESENTATION_ANSI     = 0x07, // 111
 
         REPRESENTATION_VARIABLE_MASK    = 0x02,
         REPRESENTATION_SINGLE_MASK      = 0x01,
@@ -118,8 +117,7 @@ private:
     enum tagUTF8Literal { Utf8Literal };
     enum tagLiteral { Literal };
     enum tagUTF8 { Utf8 };
-    enum tagANSI { Ansi };
-    enum tagASCII {Ascii };
+    enum tagASCII { Ascii };
 
     static void Startup();
     static CHECK CheckStartup();
@@ -141,8 +139,6 @@ private:
     SString(enum tagASCII dummyTag, const ASCII *string, COUNT_T count);
     SString(enum tagUTF8 dummytag, const UTF8 *string);
     SString(enum tagUTF8 dummytag, const UTF8 *string, COUNT_T count);
-    SString(enum tagANSI dummytag, const ANSI *string);
-    SString(enum tagANSI dummytag, const ANSI *string, COUNT_T count);
     SString(WCHAR character);
 
     // NOTE: Literals MUST be read-only never-freed strings.
@@ -167,7 +163,6 @@ private:
     void Set(const WCHAR *string);
     void SetASCII(const ASCII *string);
     void SetUTF8(const UTF8 *string);
-    void SetANSI(const ANSI *string);
     void SetAndConvertToUTF8(const WCHAR* string);
 
     // Set this string to a copy of the first count chars of the given string
@@ -180,7 +175,6 @@ private:
     void SetASCII(const ASCII *string, COUNT_T count);
 
     void SetUTF8(const UTF8 *string, COUNT_T count);
-    void SetANSI(const ANSI *string, COUNT_T count);
 
     // Set this string to the unicode character
     void Set(WCHAR character);
@@ -476,36 +470,12 @@ private:
     // Helper function to convert string in-place to lower-case (no allocation overhead for SString instance)
     static void LowerCase(__inout_z LPWSTR wszString);
 
-    // These routines will use the given scratch string if necessary
-    // to perform a conversion to the desired representation
-
-    // Use a local declaration of InlineScratchBuffer or StackScratchBuffer for parameters of
-    // AbstractScratchBuffer.
-    class AbstractScratchBuffer;
-
-    // These routines will use the given scratch buffer if necessary
-    // to perform a conversion to the desired representation.  Note that
-    // the lifetime of the pointer return is limited by BOTH the
-    // scratch string and the source (this) string.
-    //
-    // Typical usage:
-    //
-    // SString *s = ...;
-    // {
-    //   StackScratchBuffer buffer;
-    //   const ANSI *ansi = s->GetANSI(buffer);
-    //   CallFoo(ansi);
-    // }
-    // // No more pointers to returned buffer allowed.
-    const ANSI *GetANSI(AbstractScratchBuffer &scratch) const;
-
     // You can always get a UTF8 string.  This will force a conversion
     // if necessary.
     const UTF8 *GetUTF8() const;
 
     // Converts/copies into the given output string
     void ConvertToUnicode(SString &dest) const;
-    void ConvertToANSI(SString &dest) const;
     COUNT_T ConvertToUTF8(SString &dest) const;
 
     //-------------------------------------------------------------------
@@ -522,7 +492,7 @@ private:
 
     // example usage:
     // void GetName(SString & str) {
-    //      char * p = str.OpenANSIBuffer(3);
+    //      char * p = str.OpenUTF8Buffer(3);
     //      strcpy(p, "Cat");
     //      str.CloseBuffer();
     // }
@@ -544,7 +514,6 @@ private:
     // Open the raw buffer for writing countChars characters (not including the null).
     WCHAR *OpenUnicodeBuffer(COUNT_T maxCharCount);
     UTF8 *OpenUTF8Buffer(COUNT_T maxSingleCharCount);
-    ANSI *OpenANSIBuffer(COUNT_T maxSingleCharCount);
 
     //Returns the unicode string, the caller is reponsible for lifetime of the string
     WCHAR *GetCopyOfUnicodeString();
@@ -915,35 +884,6 @@ typedef InlineSString<2 * 260> LongPathString;
 // ================================================================================
 
 #define SL(_literal) SString(SString::Literal, _literal)
-
-// ================================================================================
-// ScratchBuffer classes are used by the GetXXX() routines to allocate scratch space in.
-// ================================================================================
-
-class EMPTY_BASES_DECL SString::AbstractScratchBuffer : private SString
-{
-  protected:
-    // Do not use this class directly - use
-    // ScratchBuffer or StackScratchBuffer.
-    AbstractScratchBuffer(void *buffer, COUNT_T size);
-};
-
-template <COUNT_T MEMSIZE>
-class EMPTY_BASES_DECL ScratchBuffer : public SString::AbstractScratchBuffer
-{
-  private:
-    DAC_ALIGNAS(::SString::AbstractScratchBuffer)
-    BYTE m_inline[MEMSIZE];
-
-  public:
-    ScratchBuffer()
-    : AbstractScratchBuffer((void *)m_inline, MEMSIZE)
-    {
-        WRAPPER_NO_CONTRACT;
-    }
-};
-
-typedef ScratchBuffer<256> StackScratchBuffer;
 
 // ================================================================================
 // Special contract definition - THROWS_UNLESS_NORMALIZED

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -327,41 +327,6 @@ inline SString::SString(tagUTF8 dummytag, const UTF8 *string, COUNT_T count)
     SS_RETURN;
 }
 
-inline SString::SString(tagANSI dummytag, const ANSI *string)
-  : SBuffer(Immutable, s_EmptyBuffer, sizeof(s_EmptyBuffer))
-{
-    SS_CONTRACT_VOID
-    {
-        SS_CONSTRUCTOR_CHECK;
-        PRECONDITION(CheckPointer(string, NULL_OK));
-        THROWS;
-        GC_NOTRIGGER;
-    }
-    SS_CONTRACT_END;
-
-    SetANSI(string);
-
-    SS_RETURN;
-}
-
-inline SString::SString(tagANSI dummytag, const ANSI *string, COUNT_T count)
-  : SBuffer(Immutable, s_EmptyBuffer, sizeof(s_EmptyBuffer))
-{
-    SS_CONTRACT_VOID
-    {
-        SS_CONSTRUCTOR_CHECK;
-        PRECONDITION(CheckPointer(string, NULL_OK));
-        PRECONDITION(CheckCount(count));
-        THROWS;
-        GC_NOTRIGGER;
-    }
-    SS_CONTRACT_END;
-
-    SetANSI(string, count);
-
-    SS_RETURN;
-}
-
 inline SString::SString(WCHAR character)
   : SBuffer(Immutable, s_EmptyBuffer, sizeof(s_EmptyBuffer))
 {
@@ -1574,8 +1539,7 @@ inline CHECK SString::CheckRepresentation(int representation)
     CHECK(representation == REPRESENTATION_EMPTY
           || representation == REPRESENTATION_UNICODE
           || representation == REPRESENTATION_ASCII
-          || representation == REPRESENTATION_UTF8
-          || representation == REPRESENTATION_ANSI);
+          || representation == REPRESENTATION_UTF8);
     CHECK((representation & REPRESENTATION_MASK) == representation);
 
     CHECK_OK;
@@ -1682,31 +1646,6 @@ inline WCHAR *SString::GetCopyOfUnicodeString()
     wcscpy_s(buffer, GetCount() + 1, GetUnicode());
 
     SS_RETURN buffer.Extract();
-}
-
-//----------------------------------------------------------------------------
-// Return a writeable buffer that can store 'countChars'+1 ansi characters.
-// Call CloseBuffer when done.
-//----------------------------------------------------------------------------
-inline ANSI *SString::OpenANSIBuffer(COUNT_T countChars)
-{
-    SS_CONTRACT(ANSI*)
-    {
-        GC_NOTRIGGER;
-        PRECONDITION(CheckPointer(this));
-        PRECONDITION(CheckCount(countChars));
-#if _DEBUG
-        SS_POSTCONDITION(IsBufferOpen());
-#endif
-        SS_POSTCONDITION(GetRawCount() == countChars);
-        SS_POSTCONDITION(GetRepresentation() == REPRESENTATION_ANSI || countChars == 0);
-        SS_POSTCONDITION(CheckPointer(RETVAL));
-        THROWS;
-    }
-    SS_CONTRACT_END;
-
-    OpenBuffer(REPRESENTATION_ANSI, countChars);
-    SS_RETURN GetRawANSI();
 }
 
 //----------------------------------------------------------------------------
@@ -2114,24 +2053,6 @@ inline WCHAR SString::Index::operator[](int index) const
         return *(CHAR*)&GetAt(index);
     else
         return *(WCHAR*)&GetAt(index);
-}
-
-//-----------------------------------------------------------------------------
-// Opaque scratch buffer class routines
-//-----------------------------------------------------------------------------
-inline SString::AbstractScratchBuffer::AbstractScratchBuffer(void *buffer, COUNT_T size)
-  : SString(buffer, size)
-{
-    SS_CONTRACT_VOID
-    {
-        GC_NOTRIGGER;
-        PRECONDITION(CheckPointer(buffer));
-        PRECONDITION(CheckCount(size));
-        NOTHROW;
-    }
-    SS_CONTRACT_END;
-
-    SS_RETURN;
 }
 
 #ifdef _MSC_VER

--- a/src/coreclr/utilcode/check.cpp
+++ b/src/coreclr/utilcode/check.cpp
@@ -135,7 +135,7 @@ void CHECK::Trigger(LPCSTR reason)
 #if _DEBUG
     DbgAssertDialog((char*)m_file, m_line, (char *)messageString);
 #else
-    OutputDebugStringA(messageString);
+    OutputDebugStringUtf8(messageString);
     DebugBreak();
 #endif
 

--- a/src/coreclr/utilcode/check.cpp
+++ b/src/coreclr/utilcode/check.cpp
@@ -107,14 +107,11 @@ void CHECK::Trigger(LPCSTR reason)
     STATIC_CONTRACT_GC_NOTRIGGER;
 
     const char *messageString = NULL;
-    NewHolder<StackScratchBuffer> pScratch(NULL);
     NewHolder<StackSString> pMessage(NULL);
 
     EX_TRY
     {
         FAULT_NOT_FATAL();
-
-        pScratch = new StackScratchBuffer();
         pMessage = new StackSString();
 
         pMessage->AppendASCII(reason);
@@ -127,7 +124,7 @@ void CHECK::Trigger(LPCSTR reason)
         pMessage->AppendASCII(m_condition);
 #endif
 
-        messageString = pMessage->GetANSI(*pScratch);
+        messageString = pMessage->GetUTF8();
     }
     EX_CATCH
     {
@@ -260,8 +257,7 @@ LPCSTR CHECK::AllocateDynamicMessage(const SString &s)
     STATIC_CONTRACT_GC_NOTRIGGER;
 
     // Make a copy of it.
-    StackScratchBuffer buffer;
-    const char * pMsg = s.GetANSI(buffer);
+    const char * pMsg = s.GetUTF8();
 
     // Must copy that into our own field.
     size_t len = strlen(pMsg) + 1;

--- a/src/coreclr/utilcode/debug.cpp
+++ b/src/coreclr/utilcode/debug.cpp
@@ -204,7 +204,7 @@ VOID DECLSPEC_NORETURN TerminateOnAssert()
 VOID LogAssert(
     LPCSTR      szFile,
     int         iLine,
-    LPCSTR      szExpr
+    LPCUTF8     szExpr
 )
 {
     STATIC_CONTRACT_NOTHROW;
@@ -322,7 +322,7 @@ static const char * szLowMemoryAssertMessage = "Assert failure (unable to format
 bool _DbgBreakCheck(
     LPCSTR      szFile,
     int         iLine,
-    LPCSTR      szExpr,
+    LPCUTF8     szExpr,
     BOOL        fConstrained)
 {
     STATIC_CONTRACT_THROWS;
@@ -387,7 +387,7 @@ bool _DbgBreakCheck(
         OutputDebugStringA("\n");
         OutputDebugStringA(szFile);
         OutputDebugStringA("\n");
-        OutputDebugStringA(szExpr);
+        OutputDebugStringUtf8(szExpr);
         OutputDebugStringA("\n");
         printf(szLowMemoryAssertMessage);
         printf("\n");

--- a/src/coreclr/utilcode/debug.cpp
+++ b/src/coreclr/utilcode/debug.cpp
@@ -383,12 +383,12 @@ bool _DbgBreakCheck(
     else
     {
         // Note: we cannot convert to unicode or concatenate in this situation.
-        OutputDebugStringA(szLowMemoryAssertMessage);
-        OutputDebugStringA("\n");
-        OutputDebugStringA(szFile);
-        OutputDebugStringA("\n");
+        OutputDebugStringUtf8(szLowMemoryAssertMessage);
+        OutputDebugStringUtf8("\n");
+        OutputDebugStringUtf8(szFile);
+        OutputDebugStringUtf8("\n");
         OutputDebugStringUtf8(szExpr);
-        OutputDebugStringA("\n");
+        OutputDebugStringUtf8("\n");
         printf(szLowMemoryAssertMessage);
         printf("\n");
         printf(szFile);

--- a/src/coreclr/utilcode/debug.cpp
+++ b/src/coreclr/utilcode/debug.cpp
@@ -204,7 +204,7 @@ VOID DECLSPEC_NORETURN TerminateOnAssert()
 VOID LogAssert(
     LPCSTR      szFile,
     int         iLine,
-    LPCUTF8     szExpr
+    LPCSTR      szExpr
 )
 {
     STATIC_CONTRACT_NOTHROW;

--- a/src/coreclr/utilcode/debug.cpp
+++ b/src/coreclr/utilcode/debug.cpp
@@ -624,7 +624,7 @@ bool GetStackTraceAtContext(SString & s, CONTEXT * pContext)
         // If we have a supplied context, then don't skip any frames. Else we'll
         // be using the current context, so skip this frame.
         const int cSkip = (pContext == NULL) ? 1 : 0;
-        char * szString = s.OpenANSIBuffer(cchMaxAssertStackLevelStringLen * cTotal);
+        char * szString = s.OpenUTF8Buffer(cchMaxAssertStackLevelStringLen * cTotal);
         GetStringFromStackLevels(cSkip, cTotal, szString, pContext);
         s.CloseBuffer((COUNT_T) strlen(szString));
 

--- a/src/coreclr/utilcode/loaderheap.cpp
+++ b/src/coreclr/utilcode/loaderheap.cpp
@@ -1617,8 +1617,7 @@ void UnlockedLoaderHeap::UnlockedBackoutMem(void *pMem,
                 LoaderHeapSniffer::PitchSniffer(&message);
             }
 
-            StackScratchBuffer scratch;
-            DbgAssertDialog(szFile, lineNum, (char*) message.GetANSI(scratch));
+            DbgAssertDialog(szFile, lineNum, (char*) message.GetUTF8());
 
         }
     }
@@ -2231,8 +2230,7 @@ void LoaderHeapSniffer::ValidateFreeList(UnlockedLoaderHeap *pHeap)
 
         }
 
-        StackScratchBuffer scratch;
-        DbgAssertDialog(__FILE__, __LINE__, (char*) message.GetANSI(scratch));
+        DbgAssertDialog(__FILE__, __LINE__, (char*) message.GetUTF8());
 
     }
 

--- a/src/coreclr/utilcode/sstring.cpp
+++ b/src/coreclr/utilcode/sstring.cpp
@@ -1818,7 +1818,7 @@ void SString::VPrintf(const CHAR *format, va_list args)
         if (result >=0)
         {
             // Succeeded in writing. Now resize -
-            Resize(result, GetRepresentation(), PRESERVE);
+            Resize(result, REPRESENTATION_UTF8, PRESERVE);
             SString sss(Utf8, format);
             INDEBUG(CheckForFormatStringGlobalizationIssues(sss, *this));
             RETURN;
@@ -1837,7 +1837,7 @@ void SString::VPrintf(const CHAR *format, va_list args)
     {
         // Double the previous guess - eventually we will get enough space
         guess *= 2;
-        Resize(guess, GetRepresentation());
+        Resize(guess, REPRESENTATION_UTF8);
 
         // Clear errno to avoid false alarms
         errno = 0;
@@ -1849,7 +1849,7 @@ void SString::VPrintf(const CHAR *format, va_list args)
         if (result >= 0)
         {
             // Succeed in writing. Shrink the buffer to fit exactly.
-            Resize(result, GetRepresentation(), PRESERVE);
+            Resize(result, REPRESENTATION_UTF8, PRESERVE);
             SString sss(Utf8, format);
             INDEBUG(CheckForFormatStringGlobalizationIssues(sss, *this));
             RETURN;

--- a/src/coreclr/utilcode/sstring.cpp
+++ b/src/coreclr/utilcode/sstring.cpp
@@ -417,59 +417,6 @@ void SString::SetUTF8(const UTF8 *string, COUNT_T count)
 }
 
 //-----------------------------------------------------------------------------
-// Set this string to a copy of the given ANSI string
-//-----------------------------------------------------------------------------
-void SString::SetANSI(const ANSI *string)
-{
-    SS_CONTRACT_VOID
-    {
-        INSTANCE_CHECK;
-        PRECONDITION(CheckPointer(string, NULL_OK));
-        THROWS;
-        GC_NOTRIGGER;
-    }
-    SS_CONTRACT_END;
-
-    if (string == NULL || *string == 0)
-        Clear();
-    else
-    {
-        Resize((COUNT_T) strlen(string), REPRESENTATION_ANSI);
-        strcpy_s(GetRawANSI(), GetBufferSizeInCharIncludeNullChar(), string);
-    }
-
-    SS_RETURN;
-}
-
-//-----------------------------------------------------------------------------
-// Set this string to a copy of the first count characters of the given
-// ANSI string.
-//-----------------------------------------------------------------------------
-void SString::SetANSI(const ANSI *string, COUNT_T count)
-{
-    SS_CONTRACT_VOID
-    {
-        INSTANCE_CHECK;
-        PRECONDITION(CheckPointer(string, NULL_OK));
-        PRECONDITION(CheckCount(count));
-        THROWS;
-        GC_NOTRIGGER;
-    }
-    SS_CONTRACT_END;
-
-    if (count == 0)
-        Clear();
-    else
-    {
-        Resize(count, REPRESENTATION_ANSI);
-        strncpy_s(GetRawANSI(), GetBufferSizeInCharIncludeNullChar(), string, count);
-        GetRawANSI()[count] = 0;
-    }
-
-    SS_RETURN;
-}
-
-//-----------------------------------------------------------------------------
 // Set this string to a copy of the given UTF16 string transcoded to UTF8
 //-----------------------------------------------------------------------------
 void SString::SetAndConvertToUTF8(const WCHAR *string)
@@ -868,10 +815,6 @@ void SString::ConvertToUnicode(SString &s) const
         ConvertASCIIToUnicode(s);
         RETURN;
 
-    case REPRESENTATION_ANSI:
-        page = CP_ACP;
-        break;
-
     default:
         UNREACHABLE();
     }
@@ -883,58 +826,6 @@ void SString::ConvertToUnicode(SString &s) const
     s.Resize(length-1, REPRESENTATION_UNICODE);
 
     length = WszMultiByteToWideChar(page, 0, GetRawANSI(), GetRawCount()+1, s.GetRawUnicode(), length);
-    if (length == 0)
-        ThrowLastError();
-
-    RETURN;
-}
-
-//-----------------------------------------------------------------------------
-// Set s to be a copy of this string's contents, but in the ANSI format.
-//-----------------------------------------------------------------------------
-void SString::ConvertToANSI(SString &s) const
-{
-    CONTRACT_VOID
-    {
-        PRECONDITION(s.Check());
-        POSTCONDITION(s.IsRepresentation(REPRESENTATION_ANSI));
-        THROWS;
-        GC_NOTRIGGER;
-    }
-    CONTRACT_END;
-
-    switch (GetRepresentation())
-    {
-    case REPRESENTATION_EMPTY:
-        s.Clear();
-        RETURN;
-
-    case REPRESENTATION_ASCII:
-    case REPRESENTATION_ANSI:
-        s.Set(*this);
-        RETURN;
-
-    case REPRESENTATION_UTF8:
-        // No direct conversion to ANSI
-        ConvertToUnicode();
-        FALLTHROUGH;
-
-    case REPRESENTATION_UNICODE:
-        break;
-
-    default:
-        UNREACHABLE();
-    }
-
-    // @todo: use WC_NO_BEST_FIT_CHARS
-    COUNT_T length = WszWideCharToMultiByte(CP_ACP, 0, GetRawUnicode(), GetRawCount()+1,
-                                        NULL, 0, NULL, NULL);
-
-    s.Resize(length-1, REPRESENTATION_ANSI);
-
-    // @todo: use WC_NO_BEST_FIT_CHARS
-    length = WszWideCharToMultiByte(CP_ACP, 0, GetRawUnicode(), GetRawCount()+1,
-                                    s.GetRawANSI(), length, NULL, NULL);
     if (length == 0)
         ThrowLastError();
 
@@ -965,11 +856,6 @@ COUNT_T SString::ConvertToUTF8(SString &s) const
     case REPRESENTATION_UTF8:
         s.Set(*this);
         RETURN s.GetRawCount()+1;
-
-    case REPRESENTATION_ANSI:
-        // No direct conversion from ANSI to UTF8
-        ConvertToUnicode();
-        FALLTHROUGH;
 
     case REPRESENTATION_UNICODE:
         break;
@@ -1109,7 +995,6 @@ BOOL SString::Find(CIterator &i, const SString &s) const
         }
         break;
 
-    case REPRESENTATION_ANSI:
     case REPRESENTATION_ASCII:
         {
             COUNT_T count = source.GetRawCount();
@@ -1179,7 +1064,6 @@ BOOL SString::Find(CIterator &i, WCHAR c) const
         }
         break;
 
-    case REPRESENTATION_ANSI:
     case REPRESENTATION_ASCII:
         {
             const CHAR *start = i.GetASCII();
@@ -1250,7 +1134,6 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
         }
         break;
 
-    case REPRESENTATION_ANSI:
     case REPRESENTATION_ASCII:
         {
             COUNT_T count = source.GetRawCount();
@@ -1327,7 +1210,6 @@ BOOL SString::FindBack(CIterator &i, WCHAR c) const
         }
         break;
 
-    case REPRESENTATION_ANSI:
     case REPRESENTATION_ASCII:
         {
             const CHAR *start = GetRawASCII() + GetRawCount() - 1;
@@ -1456,7 +1338,6 @@ int SString::Compare(const SString &s) const
         break;
 
     case REPRESENTATION_ASCII:
-    case REPRESENTATION_ANSI:
         result = strncmp(GetRawASCII(), source.GetRawASCII(), smaller);
         break;
 
@@ -1517,7 +1398,6 @@ int SString::CompareCaseInsensitive(const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-    case REPRESENTATION_ANSI:
         result = CaseCompareHelper(GetRawUnicode(), source.GetRawUnicode(), smaller, FALSE, TRUE);
         break;
 
@@ -1571,7 +1451,6 @@ BOOL SString::Equals(const SString &s) const
         RETURN (wcsncmp(GetRawUnicode(), source.GetRawUnicode(), count) == 0);
 
     case REPRESENTATION_ASCII:
-    case REPRESENTATION_ANSI:
         RETURN (strncmp(GetRawASCII(), source.GetRawASCII(), count) == 0);
 
     case REPRESENTATION_EMPTY:
@@ -1612,7 +1491,6 @@ BOOL SString::EqualsCaseInsensitive(const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-    case REPRESENTATION_ANSI:
         RETURN (CaseCompareHelper(GetRawUnicode(), source.GetRawUnicode(), count, FALSE, TRUE) == 0);
 
     case REPRESENTATION_ASCII:
@@ -1661,7 +1539,6 @@ BOOL SString::Match(const CIterator &i, const SString &s) const
         RETURN (wcsncmp(i.GetUnicode(), source.GetRawUnicode(), count) == 0);
 
     case REPRESENTATION_ASCII:
-    case REPRESENTATION_ANSI:
         RETURN (strncmp(i.GetASCII(), source.GetRawASCII(), count) == 0);
 
     case REPRESENTATION_EMPTY:
@@ -1703,7 +1580,6 @@ BOOL SString::MatchCaseInsensitive(const CIterator &i, const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-    case REPRESENTATION_ANSI:
         RETURN (CaseCompareHelper(i.GetUnicode(), source.GetRawUnicode(), count, FALSE, TRUE) == 0);
 
     case REPRESENTATION_ASCII:
@@ -1824,26 +1700,6 @@ void SString::UpperCase()
 }
 
 //-----------------------------------------------------------------------------
-// Get a const pointer to the internal buffer as an ANSI string.
-//-----------------------------------------------------------------------------
-const CHAR *SString::GetANSI(AbstractScratchBuffer &scratch) const
-{
-    SS_CONTRACT(const CHAR *)
-    {
-        INSTANCE_CHECK_NULL;
-        THROWS;
-        GC_NOTRIGGER;
-    }
-    SS_CONTRACT_END;
-
-    if (IsRepresentation(REPRESENTATION_ANSI))
-        SS_RETURN GetRawANSI();
-
-    ConvertToANSI((SString&)scratch);
-    SS_RETURN ((SString&)scratch).GetRawANSI();
-}
-
-//-----------------------------------------------------------------------------
 // Safe version of sprintf.
 // Prints formatted ansi text w/ var args to this buffer.
 //-----------------------------------------------------------------------------
@@ -1939,6 +1795,7 @@ void SString::VPrintf(const CHAR *format, va_list args)
     CONTRACT_VOID
     {
         INSTANCE_CHECK;
+        PRECONDITION(GetRepresentation() == REPRESENTATION_ASCII || GetRepresentation() == REPRESENTATION_UTF8);
         PRECONDITION(CheckPointer(format));
         THROWS;
         GC_NOTRIGGER;
@@ -1953,14 +1810,14 @@ void SString::VPrintf(const CHAR *format, va_list args)
     {
         // First, try to use the existing buffer
         va_copy(ap, args);
-        int result = _vsnprintf_s(GetRawANSI(), GetRawCount()+1, _TRUNCATE, format, ap);
+        int result = _vsnprintf_s(GetRawUTF8(), GetRawCount()+1, _TRUNCATE, format, ap);
         va_end(ap);
 
         if (result >=0)
         {
             // Succeeded in writing. Now resize -
-            Resize(result, REPRESENTATION_ANSI, PRESERVE);
-            SString sss(Ansi, format);
+            Resize(result, GetRepresentation(), PRESERVE);
+            SString sss(Utf8, format);
             INDEBUG(CheckForFormatStringGlobalizationIssues(sss, *this));
             RETURN;
         }
@@ -1978,20 +1835,20 @@ void SString::VPrintf(const CHAR *format, va_list args)
     {
         // Double the previous guess - eventually we will get enough space
         guess *= 2;
-        Resize(guess, REPRESENTATION_ANSI);
+        Resize(guess, GetRepresentation());
 
         // Clear errno to avoid false alarms
         errno = 0;
 
         va_copy(ap, args);
-        int result = _vsnprintf_s(GetRawANSI(), GetRawCount()+1, _TRUNCATE, format, ap);
+        int result = _vsnprintf_s(GetRawUTF8(), GetRawCount()+1, _TRUNCATE, format, ap);
         va_end(ap);
 
         if (result >= 0)
         {
             // Succeed in writing. Shrink the buffer to fit exactly.
-            Resize(result, REPRESENTATION_ANSI, PRESERVE);
-            SString sss(Ansi, format);
+            Resize(result, GetRepresentation(), PRESERVE);
+            SString sss(Utf8, format);
             INDEBUG(CheckForFormatStringGlobalizationIssues(sss, *this));
             RETURN;
         }
@@ -2303,7 +2160,6 @@ const SString &SString::GetCompatibleString(const SString &s, SString &scratch, 
         return scratch;
 
     case REPRESENTATION_UTF8:
-    case REPRESENTATION_ANSI:
         // These should all be impossible since we have an CIterator on us.
     default:
         UNREACHABLE_MSG("Unexpected string representation");
@@ -2337,13 +2193,6 @@ const SString &SString::GetCompatibleString(const SString &s, SString &scratch) 
     {
     case REPRESENTATION_EMPTY:
         return s;
-
-    case REPRESENTATION_ANSI:
-        if (s.IsRepresentation(REPRESENTATION_ANSI))
-            return s;
-
-        s.ConvertToANSI(scratch);
-        return scratch;
 
     case REPRESENTATION_ASCII:
         if (s.IsRepresentation(REPRESENTATION_ASCII))
@@ -2512,7 +2361,6 @@ void * SString::DacGetRawContent() const
         case REPRESENTATION_UNICODE:
         case REPRESENTATION_UTF8:
         case REPRESENTATION_ASCII:
-        case REPRESENTATION_ANSI:
             // Note: no need to call DacInstantiateString because we know the exact length already.
             return SBuffer::DacGetRawContent();
 
@@ -2631,7 +2479,6 @@ bool SString::DacGetUnicode(COUNT_T                                   cBufChars,
             iPage = CP_UTF8;
             FALLTHROUGH;
         case REPRESENTATION_ASCII:
-        case REPRESENTATION_ANSI:
             // iPage defaults to CP_ACP.
             if (pcNeedChars)
             {

--- a/src/coreclr/utilcode/sstring.cpp
+++ b/src/coreclr/utilcode/sstring.cpp
@@ -1795,12 +1795,14 @@ void SString::VPrintf(const CHAR *format, va_list args)
     CONTRACT_VOID
     {
         INSTANCE_CHECK;
-        PRECONDITION(GetRepresentation() == REPRESENTATION_ASCII || GetRepresentation() == REPRESENTATION_UTF8);
         PRECONDITION(CheckPointer(format));
         THROWS;
         GC_NOTRIGGER;
     }
     CONTRACT_END;
+
+    // This method overrides the content of the SString, so it can come in with any format.
+    // We're going to change the representation here.
 
     va_list ap;
     // sprintf gives us no means to know how many characters are written

--- a/src/coreclr/vm/binder.cpp
+++ b/src/coreclr/vm/binder.cpp
@@ -801,8 +801,7 @@ static void FCallCheckSignature(MethodDesc* pMD, PCODE pImpl)
             size_t len = pUnmanagedTypeEnd - pUnmanagedArg;
             // generate the unmanaged argument signature to show them in the error message if possible
             StackSString ssUnmanagedType(SString::Ascii, pUnmanagedArg, (COUNT_T)len);
-            StackScratchBuffer buffer;
-            const char * pUnManagedType = ssUnmanagedType.GetANSI(buffer);
+            const char * pUnManagedType = ssUnmanagedType.GetUTF8();
 
             if (expectedType != NULL)
             {

--- a/src/coreclr/vm/encee.cpp
+++ b/src/coreclr/vm/encee.cpp
@@ -568,9 +568,8 @@ PCODE EditAndContinueModule::JitUpdatedFunction( MethodDesc *pMD,
             errorMessage.AppendASCII("**Error: Probable rude edit.**\n\n"
                                 "EnCModule::JITUpdatedFunction JIT failed with the following exception:\n\n");
             errorMessage.Append(exceptionMessage);
-            StackScratchBuffer buffer;
-            DbgAssertDialog(__FILE__, __LINE__, errorMessage.GetANSI(buffer));
-            LOG((LF_ENC, LL_INFO100, errorMessage.GetANSI(buffer)));
+            DbgAssertDialog(__FILE__, __LINE__, errorMessage.GetUTF8());
+            LOG((LF_ENC, LL_INFO100, errorMessage.GetUTF8()));
         }
 #endif
     } EX_END_CATCH(SwallowAllExceptions)

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -7163,11 +7163,10 @@ VEH_ACTION WINAPI CLRVectoredExceptionHandlerPhase3(PEXCEPTION_POINTERS pExcepti
                     //
 #if defined(_DEBUG)
                     const char * pStack = "<stack not available>";
-                    StackScratchBuffer buffer;
                     SString sStack;
                     if (GetStackTraceAtContext(sStack, pContext))
                     {
-                        pStack = sStack.GetANSI(buffer);
+                        pStack = sStack.GetUTF8();
                     }
 
                     DWORD tid = GetCurrentThreadId();

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -8038,7 +8038,7 @@ void CEEInfo::reportInliningDecision (CORINFO_METHOD_HANDLE inlinerHnd,
         {
             const char * str = (reason ? reason : "");
             SString strReason;
-            strReason.SetANSI(str);
+            strReason.SetUTF8(str);
 
 
             FireEtwMethodJitInliningFailed(methodBeingCompiledNames[0].GetUnicode(),
@@ -8287,7 +8287,7 @@ void CEEInfo::reportTailCallDecision (CORINFO_METHOD_HANDLE callerHnd,
         {
             const char * str = (reason ? reason : "");
             SString strReason;
-            strReason.SetANSI(str);
+            strReason.SetUTF8(str);
 
             FireEtwMethodJitTailCallFailed(methodBeingCompiledNames[0].GetUnicode(),
                                            methodBeingCompiledNames[1].GetUnicode(),

--- a/src/coreclr/vm/mlinfo.cpp
+++ b/src/coreclr/vm/mlinfo.cpp
@@ -3252,12 +3252,11 @@ VOID MarshalInfo::DumpMarshalInfo(Module* pModule, SigPointer sig, const SigType
     if (LoggingOn(LF_MARSHALER, LL_INFO10))
     {
         SString logbuf;
-        StackScratchBuffer scratch;
 
         IMDInternalImport *pInternalImport = pModule->GetMDImport();
 
         logbuf.AppendASCII("------------------------------------------------------------\n");
-        LOG((LF_MARSHALER, LL_INFO10, logbuf.GetANSI(scratch)));
+        LOG((LF_MARSHALER, LL_INFO10, logbuf.GetUTF8()));
         logbuf.Clear();
 
         logbuf.AppendASCII("Managed type: ");
@@ -3275,7 +3274,7 @@ VOID MarshalInfo::DumpMarshalInfo(Module* pModule, SigPointer sig, const SigType
         }
 
         logbuf.AppendASCII("\n");
-        LOG((LF_MARSHALER, LL_INFO10, logbuf.GetANSI(scratch)));
+        LOG((LF_MARSHALER, LL_INFO10, logbuf.GetUTF8()));
         logbuf.Clear();
 
         logbuf.AppendASCII("NativeType  : ");
@@ -3363,7 +3362,7 @@ VOID MarshalInfo::DumpMarshalInfo(Module* pModule, SigPointer sig, const SigType
                         strLen = CPackedLen::GetLength(pvNativeType, (void const **)&pvNativeType);
                         if (strLen)
                         {
-                            BYTE* p = (BYTE*)logbuf.OpenANSIBuffer(strLen);
+                            BYTE* p = (BYTE*)logbuf.OpenUTF8Buffer(strLen);
                             memcpyNoGCRefs(p, pvNativeType, strLen);
                             logbuf.CloseBuffer();
                             logbuf.AppendASCII("\0");
@@ -3379,7 +3378,7 @@ VOID MarshalInfo::DumpMarshalInfo(Module* pModule, SigPointer sig, const SigType
                         strLen = CPackedLen::GetLength(pvNativeType, (void const **)&pvNativeType);
                         if (strLen)
                         {
-                            BYTE* p = (BYTE*)logbuf.OpenANSIBuffer(strLen);
+                            BYTE* p = (BYTE*)logbuf.OpenUTF8Buffer(strLen);
                             memcpyNoGCRefs(p, pvNativeType, strLen);
                             logbuf.CloseBuffer();
                             logbuf.AppendASCII("\0");
@@ -3395,7 +3394,7 @@ VOID MarshalInfo::DumpMarshalInfo(Module* pModule, SigPointer sig, const SigType
                         strLen = CPackedLen::GetLength(pvNativeType, (void const **)&pvNativeType);
                         if (strLen)
                         {
-                            BYTE* p = (BYTE*)logbuf.OpenANSIBuffer(strLen);
+                            BYTE* p = (BYTE*)logbuf.OpenUTF8Buffer(strLen);
                             memcpyNoGCRefs(p, pvNativeType, strLen);
                             logbuf.CloseBuffer();
                             logbuf.AppendASCII("\0");
@@ -3410,7 +3409,7 @@ VOID MarshalInfo::DumpMarshalInfo(Module* pModule, SigPointer sig, const SigType
                         strLen = CPackedLen::GetLength(pvNativeType, (void const **)&pvNativeType);
                         if (strLen)
                         {
-                            BYTE* p = (BYTE*)logbuf.OpenANSIBuffer(strLen);
+                            BYTE* p = (BYTE*)logbuf.OpenUTF8Buffer(strLen);
                             memcpyNoGCRefs(p, pvNativeType, strLen);
                             logbuf.CloseBuffer();
                             logbuf.AppendASCII("\0");
@@ -3430,7 +3429,7 @@ VOID MarshalInfo::DumpMarshalInfo(Module* pModule, SigPointer sig, const SigType
             }
         }
         logbuf.AppendASCII("\n");
-        LOG((LF_MARSHALER, LL_INFO10, logbuf.GetANSI(scratch)));
+        LOG((LF_MARSHALER, LL_INFO10, logbuf.GetUTF8()));
         logbuf.Clear();
 
         logbuf.AppendASCII("MarshalType : ");
@@ -3490,7 +3489,7 @@ VOID MarshalInfo::DumpMarshalInfo(Module* pModule, SigPointer sig, const SigType
 
         logbuf.AppendASCII("\n");
 
-        LOG((LF_MARSHALER, LL_INFO10, logbuf.GetANSI(scratch)));
+        LOG((LF_MARSHALER, LL_INFO10, logbuf.GetUTF8()));
         logbuf.Clear();
     }
 } // MarshalInfo::DumpMarshalInfo

--- a/src/coreclr/vm/perfinfo.cpp
+++ b/src/coreclr/vm/perfinfo.cpp
@@ -85,8 +85,7 @@ void PerfInfo::WriteLine(SString& type, SString& value)
 
     EX_TRY
     {
-        StackScratchBuffer scratch;
-        const char* strLine = line.GetANSI(scratch);
+        const char* strLine = line.GetUTF8();
         ULONG inCount = line.GetCount();
         ULONG outCount;
 

--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -343,6 +343,7 @@ void PerfMap::LogStubs(const char* stubType, const char* stubOwner, PCODE pCode,
             stubType = "?";
         }
 
+        SString name;
         // Build the map file line.
         name.Printf("stub<%d> %s<%s>", ++(s_Current->m_StubsMapped), stubType, stubOwner);
         SString line;

--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -160,8 +160,7 @@ void PerfMap::WriteLine(SString& line)
     {
         // Write the line.
         // The PAL already takes a lock when writing, so we don't need to do so here.
-        StackScratchBuffer scratch;
-        const char * strLine = line.GetANSI(scratch);
+        const char * strLine = line.GetUTF8();
         ULONG inCount = line.GetCount();
         ULONG outCount;
         m_FileStream->Write(strLine, inCount, &outCount);
@@ -203,17 +202,16 @@ void PerfMap::LogMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize, cons
         pMethod->GetFullMethodInfo(name);
 
         // Build the map file line.
-        StackScratchBuffer scratch;
         if (optimizationTier != nullptr && s_ShowOptimizationTiers)
         {
             name.AppendPrintf("[%s]", optimizationTier);
         }
         SString line;
-        line.Printf(FMT_CODE_ADDR " %x %s\n", pCode, codeSize, name.GetANSI(scratch));
+        line.Printf(FMT_CODE_ADDR " %x %s\n", pCode, codeSize, name.GetUTF8());
 
         // Write the line.
         WriteLine(line);
-        PAL_PerfJitDump_LogMethod((void*)pCode, codeSize, name.GetANSI(scratch), nullptr, nullptr);
+        PAL_PerfJitDump_LogMethod((void*)pCode, codeSize, name.GetUTF8(), nullptr, nullptr);
     }
     EX_CATCH{} EX_END_CATCH(SwallowAllExceptions);
 }
@@ -298,8 +296,6 @@ void PerfMap::LogPreCompiledMethod(MethodDesc * pMethod, PCODE pCode)
         SString name;
         pMethod->GetFullMethodInfo(name);
 
-        StackScratchBuffer scratch;
-
         if (s_ShowOptimizationTiers)
         {
             name.Append(W("[PreJIT]"));
@@ -309,7 +305,7 @@ void PerfMap::LogPreCompiledMethod(MethodDesc * pMethod, PCODE pCode)
         // Emit an entry for each section if it is used.
         if (methodRegionInfo.hotSize > 0)
         {
-            PAL_PerfJitDump_LogMethod((void*)methodRegionInfo.hotStartAddress, methodRegionInfo.hotSize, name.GetANSI(scratch), nullptr, nullptr);
+            PAL_PerfJitDump_LogMethod((void*)methodRegionInfo.hotStartAddress, methodRegionInfo.hotSize, name.GetUTF8(), nullptr, nullptr);
         }
 
         if (methodRegionInfo.coldSize > 0)
@@ -319,7 +315,7 @@ void PerfMap::LogPreCompiledMethod(MethodDesc * pMethod, PCODE pCode)
                 pMethod->GetFullMethodInfo(name);
                 name.Append(W("[PreJit-cold]"));
             }
-            PAL_PerfJitDump_LogMethod((void*)methodRegionInfo.coldStartAddress, methodRegionInfo.coldSize, name.GetANSI(scratch), nullptr, nullptr);
+            PAL_PerfJitDump_LogMethod((void*)methodRegionInfo.coldStartAddress, methodRegionInfo.coldSize, name.GetUTF8(), nullptr, nullptr);
         }
     }
     EX_CATCH{} EX_END_CATCH(SwallowAllExceptions);
@@ -348,15 +344,13 @@ void PerfMap::LogStubs(const char* stubType, const char* stubOwner, PCODE pCode,
         }
 
         // Build the map file line.
-        StackScratchBuffer scratch;
-        SString name;
         name.Printf("stub<%d> %s<%s>", ++(s_Current->m_StubsMapped), stubType, stubOwner);
         SString line;
-        line.Printf(FMT_CODE_ADDR " %x %s\n", pCode, codeSize, name.GetANSI(scratch));
+        line.Printf(FMT_CODE_ADDR " %x %s\n", pCode, codeSize, name.GetUTF8());
 
         // Write the line.
         s_Current->WriteLine(line);
-        PAL_PerfJitDump_LogMethod((void*)pCode, codeSize, name.GetANSI(scratch), nullptr, nullptr);
+        PAL_PerfJitDump_LogMethod((void*)pCode, codeSize, name.GetUTF8(), nullptr, nullptr);
     }
     EX_CATCH{} EX_END_CATCH(SwallowAllExceptions);
 }

--- a/src/coreclr/vm/sigformat.cpp
+++ b/src/coreclr/vm/sigformat.cpp
@@ -561,11 +561,10 @@ void SigFormat::AddType(TypeHandle th)
     case ELEMENT_TYPE_VAR:
     case ELEMENT_TYPE_MVAR:
         {
-            StackScratchBuffer scratch;
             StackSString name;
             th.GetName(name);
 
-            AddString(name.GetANSI(scratch));
+            AddString(name.GetUTF8());
 
             break;
         }

--- a/src/coreclr/vm/typeparse.cpp
+++ b/src/coreclr/vm/typeparse.cpp
@@ -1143,8 +1143,7 @@ TypeHandle TypeName::GetTypeFromAsm()
                 for (COUNT_T i = 0; i < GetNames().GetCount(); i ++)
                     tnb.AddName(GetNames()[i]->GetUnicode());
 
-                StackScratchBuffer bufFullName;
-                DomainAssembly* pDomainAssembly = pDomain->RaiseTypeResolveEventThrowing(pRequestingAssembly?pRequestingAssembly->GetDomainAssembly():NULL,tnb.GetString()->GetANSI(bufFullName), pAsmRef);
+                DomainAssembly* pDomainAssembly = pDomain->RaiseTypeResolveEventThrowing(pRequestingAssembly?pRequestingAssembly->GetDomainAssembly():NULL,tnb.GetString()->GetUTF8(), pAsmRef);
                 if (pDomainAssembly)
                     th = GetTypeHaveAssembly(pDomainAssembly->GetAssembly(), bThrowIfNotFound, bIgnoreCase, pKeepAlive);
             }


### PR DESCRIPTION
99% of usages were just ASCII, so switch to using UTF8 as the underlying representation as it will have the same semantics for ASCII strings.

The main area of concern would be in the implementation of `SString::VPrintf(CHAR*, ...)`. I believe this will work correctly, but I'd like a second pair of eyes to verify.

Builds off of some of the ideas in #69748