### PR TITLE
[mono] Avoid transformation from multiplication to left shift in case of 64 bit value

### DIFF
--- a/src/coreclr/pal/src/misc/perfjitdump.cpp
+++ b/src/coreclr/pal/src/misc/perfjitdump.cpp
@@ -50,7 +50,7 @@ namespace
         ELF_MACHINE = EM_LOONGARCH,
 #elif defined(HOST_S390X)
         ELF_MACHINE = EM_S390,
-#elif defined(HOST_POWERPC)
+#elif defined(HOST_POWERPC64)
 	ELF_MACHINE = EM_PPC64,
 #else
 #error ELF_MACHINE unsupported for target

--- a/src/mono/mono/mini/local-propagation.c
+++ b/src/mono/mono/mini/local-propagation.c
@@ -350,7 +350,7 @@ mono_strength_reduction_ins (MonoCompile *cfg, MonoInst *ins, const char **spec)
 			ins->opcode = OP_INEG;
 		} else if ((ins->opcode == OP_LMUL_IMM) && (ins->inst_imm == -1)) {
 			ins->opcode = OP_LNEG;
-		} else if (ins->inst_imm > 0) {
+		} else if (ins->inst_imm > 0 && ins->inst_imm <= UINT32_MAX) {
 			int power2 = mono_is_power_of_two (GTMREG_TO_UINT32 (ins->inst_imm));
 			if (power2 >= 0) {
 				ins->opcode = (ins->opcode == OP_MUL_IMM) ? OP_SHL_IMM : ((ins->opcode == OP_LMUL_IMM) ? OP_LSHL_IMM : OP_ISHL_IMM);


### PR DESCRIPTION
This has fixed following issues:
1. Build failure for ppc64le
2. Avoid transformation from multiplication to left shift in case of 64 bit value. This has fixed several test failures which invokes Double.TryFormat function including Microsoft.CSharp.Tests in debug build (observed and tested on ppc64le).