### PR TITLE
[Mono] Remove unused field in Exception.Mono

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Exception.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Exception.Mono.cs
@@ -49,8 +49,6 @@ namespace System
 
         private bool HasBeenThrown => _traceIPs != null;
 
-        private readonly object frameLock = new object();
-
         public MethodBase? TargetSite
         {
             [RequiresUnreferencedCode("Metadata for the method might be incomplete or removed")]


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/70970 was merged with a field that was unused.  This PR removes it.