### PR TITLE
Fixing Int128/UInt128 field order for s390x, ppc64be, and other big endian platforms

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -21,11 +21,13 @@ namespace System
     {
         internal const int Size = 16;
 
-        // Unix System V ABI actually requires this to be little endian
-        // order and not `upper, lower` on big endian systems.
-
+#if BIGENDIAN
+		private readonly ulong _upper;
+		private readonly ulong _lower;
+#else
         private readonly ulong _lower;
         private readonly ulong _upper;
+#endif
 
         /// <summary>Initializes a new instance of the <see cref="Int128" /> struct.</summary>
         /// <param name="upper">The upper 64-bits of the 128-bit value.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -22,8 +22,8 @@ namespace System
         internal const int Size = 16;
 
 #if BIGENDIAN
-		private readonly ulong _upper;
-		private readonly ulong _lower;
+        private readonly ulong _upper;
+        private readonly ulong _lower;
 #else
         private readonly ulong _lower;
         private readonly ulong _upper;

--- a/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
@@ -23,8 +23,8 @@ namespace System
         internal const int Size = 16;
 
 #if BIGENDIAN
-		private readonly ulong _upper;
-		private readonly ulong _lower;
+        private readonly ulong _upper;
+        private readonly ulong _lower;
 #else
         private readonly ulong _lower;
         private readonly ulong _upper;

--- a/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
@@ -22,11 +22,13 @@ namespace System
     {
         internal const int Size = 16;
 
-        // Unix System V ABI actually requires this to be little endian
-        // order and not `upper, lower` on big endian systems.
-
+#if BIGENDIAN
+		private readonly ulong _upper;
+		private readonly ulong _lower;
+#else
         private readonly ulong _lower;
         private readonly ulong _upper;
+#endif
 
         /// <summary>Initializes a new instance of the <see cref="UInt128" /> struct.</summary>
         /// <param name="upper">The upper 64-bits of the 128-bit value.</param>


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/71212

All of the System V ABI docs that had been looked at explicitly described the order as little-endian. However the docs looked at were also all for little-endian platforms.

Normally this would have been caught by the interop tests but they are all disabled on Mono: https://github.com/dotnet/runtime/issues/69531

The following godbolt link shows the ordering difference for s390x: https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGIM9KuADJ4DJgAcj4ARpjEEhqkAA6oCoRODB7evv7SyamOAiFhkSwxcVwJdpgO6UIETMQEmT5%2BAbaY9gUMdQ0ERRHRsfG29Y3N2W0Ko32hA6VDFQCUtqhexMjsHOYAzKHI3lgA1CbbblP4ggB0CCfYJhoAgvcPXqEEAGySAPoEhwCyXAgXgYqWAYXQhy%2BXzeXDMAA4AFSHVSLZ4mADsVkehxxh2ImAIawYhyBb0%2BP0WEARKJOWKe6IAImjHq9BOTfn8zECQXgwZgIVCYfCkTTHhi6bi8QSiSTWR9vgRKdTjts7qrDp9Uds6RiGRxlrROABWXh%2BDhaUioThuazWQ4KVbrTDHMzbHikAiafXLADWIG220uAeDIdD730nEkpq9ls4vAUIASnvN%2BtIcFgSDQLESdFi5EoWZz9DiwGQyAU2wAnBpVFxYQkaLQCLEExAojGoqEGgBPTjurNsQQAeQYtF7KdIWBYhmA4gn%2BHxNQAbpgExPMKpql5m33eG8OjHaHgosQex4sDGCMQ8Cxd8sqAZgAoAGp4TAAdyHiUYu5kghEYjsFIf7yEoagxroXD6DOKC2pY%2BjHgmkDLKgiRdGuAC0Q7bPGHTVF0LgMO4ngtHowSzCUZR6HkaQCOMfhQTRXT9JRCztJ0tTTPRehVDUAg9I0LGDOUIy9NxUFTL0QnzOUywOmsGx6FemCbDwBrGtGE5WhwFbVqohylsghx1pcZiXBoJI2pY1ikIcuCECQLpurZHjZrmxBOVwiy8MmWiLL6/qBqGwXBuGhocFGpBmha2nxomHpess6aICgqBucW%2BYQIW7kgMAdZmHwdDNsQrbthOnbMMQ479mlg4ECOY4xlOM5zhaC74XgK5rhaG5bju3B7oIB4TkeJ5nhgmwWleN53nwj4vm%2Bn7fma7r8P%2BojiMBa2gSo6gTroBUGEYsHWfBo1IRAKFoekmHYbhHHOBArjiaQ5HFMJ1EpLRGQkdkjFfcxFEfRJeF8d0XG/Qx7Edfx0zSVREkQ1kUOSYJQMyRIcmOopUHKapqbhSaUUxtpqhwu8GGfAZZbGVwpmWXBNh2fgRAeTsUGHK5RaxE5ZjeQlKb%2BaQfoBkGIXBRGEWaTFca2PFvnepLZjS7wsUC35ywriV6QgJIQA%3D%3D

Changing to the PowerPC BE compiler shows similar (with lower being at offset 8).