### PR TITLE
Fix 32-bit process module enumeration on 64-bit Windows (#70370)

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Constants.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Constants.cs
@@ -14,7 +14,5 @@ internal static partial class Interop
         internal const int MUTEX_MODIFY_STATE = 0x00000001;
         internal const int SEMAPHORE_MODIFY_STATE = 0x00000002;
         internal const int EVENT_MODIFY_STATE = 0x00000002;
-
-        internal const int LIST_MODULES_ALL = 0x00000003;
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Constants.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Constants.cs
@@ -14,5 +14,7 @@ internal static partial class Interop
         internal const int MUTEX_MODIFY_STATE = 0x00000001;
         internal const int SEMAPHORE_MODIFY_STATE = 0x00000002;
         internal const int EVENT_MODIFY_STATE = 0x00000002;
+
+        internal const int LIST_MODULES_ALL = 0x00000003;
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModulesEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModulesEx.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [LibraryImport(Libraries.Kernel32, EntryPoint = "K32EnumProcessModules",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [LibraryImport(Libraries.Kernel32, EntryPoint = "K32EnumProcessModulesEx",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static partial bool EnumProcessModules(SafeProcessHandle handle, IntPtr[]? modules, int size, out int needed);
+        internal static partial bool EnumProcessModulesEx(SafeProcessHandle handle, IntPtr[]? modules, int size, out int needed, int filterFlag);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModulesEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModulesEx.cs
@@ -9,6 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
+        internal const int LIST_MODULES_ALL = 0x00000003;
+
         [LibraryImport(Libraries.Kernel32, EntryPoint = "K32EnumProcessModulesEx",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EnumProcessModulesEx(SafeProcessHandle handle, IntPtr[]? modules, int size, out int needed, int filterFlag);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModulesEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModulesEx.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     {
         internal const int LIST_MODULES_ALL = 0x00000003;
 
-        [LibraryImport(Libraries.Kernel32, EntryPoint = "K32EnumProcessModulesEx",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [LibraryImport(Libraries.Kernel32, EntryPoint = "K32EnumProcessModulesEx",  SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EnumProcessModulesEx(SafeProcessHandle handle, IntPtr[]? modules, int size, out int needed, int filterFlag);
     }

--- a/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -45,8 +45,8 @@
              Link="Common\System\Collections\Generic\ArrayBuilder.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.EnumProcessModules.cs"
-             Link="Common\Interop\Windows\Kernel32\Interop.EnumProcessModules.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.EnumProcessModulesEx.cs"
+             Link="Common\Interop\Windows\Kernel32\Interop.EnumProcessModulesEx.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FormatMessage.cs"
              Link="Common\Interop\Windows\Kernel32\Interop.FormatMessage.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtQueryInformationProcess.cs"

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -78,7 +78,7 @@ namespace System.Diagnostics
             {
                 processHandle = ProcessManager.OpenProcess(processId, Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION | Interop.Advapi32.ProcessOptions.PROCESS_VM_READ, true);
 
-                bool succeeded = Interop.Kernel32.EnumProcessModules(processHandle, null, 0, out int needed);
+                bool succeeded = Interop.Kernel32.EnumProcessModulesEx(processHandle, null, 0, out int needed, Interop.Kernel32.LIST_MODULES_ALL);
 
                 // The API we need to use to enumerate process modules differs on two factors:
                 //   1) If our process is running in WOW64.
@@ -229,7 +229,7 @@ namespace System.Diagnostics
             int i = 0;
             while (true)
             {
-                if (Interop.Kernel32.EnumProcessModules(processHandle, modules, size, out needed))
+                if (Interop.Kernel32.EnumProcessModulesEx(processHandle, modules, size, out needed, Interop.Kernel32.LIST_MODULES_ALL))
                 {
                     return;
                 }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -108,7 +108,7 @@ namespace System.Diagnostics
                         throw new Win32Exception(Interop.Errors.ERROR_PARTIAL_COPY, SR.EnumProcessModuleFailedDueToWow);
                     }
 
-                    EnumProcessModulesUntilSuccess(processHandle, null, 0, out needed);
+                    EnumProcessModulesUntilSuccess(processHandle, null, 0, out needed, Interop.Kernel32.LIST_MODULES_ALL);
                 }
 
                 int modulesCount = needed / IntPtr.Size;
@@ -116,7 +116,7 @@ namespace System.Diagnostics
                 while (true)
                 {
                     int size = needed;
-                    EnumProcessModulesUntilSuccess(processHandle, moduleHandles, size, out needed);
+                    EnumProcessModulesUntilSuccess(processHandle, moduleHandles, size, out needed, Interop.Kernel32.LIST_MODULES_ALL);
                     if (size == needed)
                     {
                         break;
@@ -221,7 +221,7 @@ namespace System.Diagnostics
             }
         }
 
-        private static void EnumProcessModulesUntilSuccess(SafeProcessHandle processHandle, IntPtr[]? modules, int size, out int needed)
+        private static void EnumProcessModulesUntilSuccess(SafeProcessHandle processHandle, IntPtr[]? modules, int size, out int needed, int filterFlag)
         {
             // When called on a running process, EnumProcessModules may fail with ERROR_PARTIAL_COPY
             // if the target process is not yet initialized or if the module list changes during the function call.
@@ -229,7 +229,7 @@ namespace System.Diagnostics
             int i = 0;
             while (true)
             {
-                if (Interop.Kernel32.EnumProcessModulesEx(processHandle, modules, size, out needed, Interop.Kernel32.LIST_MODULES_ALL))
+                if (Interop.Kernel32.EnumProcessModulesEx(processHandle, modules, size, out needed, filterFlag))
                 {
                     return;
                 }


### PR DESCRIPTION
Fixes the faulty `Process.Modules` behavior described in #70370.

* Deleted `~\Kernel32\Interop.EnumProcessModules.cs` and created `~\Kernel32\Interop.EnumProcessModulesEx.cs` in its stead
* Created `Kernel32.Interop.LIST_MODULES_ALL` in `~\Kernel32\Interop.Constants.cs`
* Changed `NtProcessManager.GetModules` and `NtProcessManager.EnumProcessModulesUntilSuccess` to use `Interop.Kernel32.EnumProcessModulesEx` instead of the previous `Interop.Kernel32.EnumProcessModules`