### PR TITLE
Fix manual delegate interop in System.Drawing.Common to handle nulls correctly.

### DIFF
--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -120,7 +120,7 @@ namespace System.Drawing
             public EnumerateMetafileProcMarshaller(EnumerateMetafileProc? managed)
             {
                 _managed = managed is null ? null : (recordType, flags, dataSize, data, callbackData) =>
-                    managed(recordType, flags, dataSize, data, Marshal.GetDelegateForFunctionPointer<PlayRecordCallback>(callbackData)) ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;
+                    managed(recordType, flags, dataSize, data, callbackData == IntPtr.Zero ? null! : Marshal.GetDelegateForFunctionPointer<PlayRecordCallback>(callbackData)) ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;
                 _nativeFunction = _managed is null ? null : (delegate* unmanaged<IntPtr, Interop.BOOL>)Marshal.GetFunctionPointerForDelegate(_managed);
             }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -48,12 +48,20 @@ namespace System.Drawing
         internal unsafe struct GetThumbnailImageAbortMarshaller
         {
             private delegate Interop.BOOL GetThumbnailImageAbortNative(IntPtr callbackdata);
-            private GetThumbnailImageAbortNative _managed;
+            private GetThumbnailImageAbortNative? _managed;
             private delegate* unmanaged<IntPtr, Interop.BOOL> _nativeFunction;
             public GetThumbnailImageAbortMarshaller(GetThumbnailImageAbort managed)
             {
-                _managed = data => managed() ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;
-                _nativeFunction = (delegate* unmanaged<IntPtr, Interop.BOOL>)Marshal.GetFunctionPointerForDelegate(_managed);
+                if (managed is null)
+                {
+                    _managed = null;
+                    _nativeFunction = null;
+                }
+                else
+                {
+                    _managed = data => managed() ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;
+                    _nativeFunction = (delegate* unmanaged<IntPtr, Interop.BOOL>)Marshal.GetFunctionPointerForDelegate(_managed);
+                }
             }
 
             public delegate* unmanaged<IntPtr, Interop.BOOL> ToNativeValue()


### PR DESCRIPTION
Fixes #69348