### PR TITLE
Add `System.Drawing.Imaging.ImageFormat.Heif` and `Webp`.

### DIFF
--- a/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.netcoreapp.cs
+++ b/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.netcoreapp.cs
@@ -35,3 +35,13 @@ namespace System.Drawing.Drawing2D
         public System.Numerics.Matrix3x2 MatrixElements { get { throw null; } set { } }
     }
 }
+namespace System.Drawing.Imaging
+{
+    public sealed partial class ImageFormat
+    {
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.17763.0")]
+        public static ImageFormat Heif { get { throw null; } }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.17763.0")]
+        public static ImageFormat Webp { get { throw null; } }
+    }
+}

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/ImageFormatConverter.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/ImageFormatConverter.cs
@@ -10,6 +10,8 @@ using System.Reflection;
 
 namespace System.Drawing
 {
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Heif and Webp are referenced here for " +
+        "design-time support, the user is responsible to ensure that they are used on a supported version of Windows.")]
     public class ImageFormatConverter : TypeConverter
     {
         public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
@@ -63,6 +65,10 @@ namespace System.Drawing
                 return ImageFormat.Tiff;
             else if (strFormat.Equals("Wmf", StringComparison.OrdinalIgnoreCase))
                 return ImageFormat.Wmf;
+            else if (strFormat.Equals("Heif", StringComparison.OrdinalIgnoreCase))
+                return ImageFormat.Heif;
+            else if (strFormat.Equals("Webp", StringComparison.OrdinalIgnoreCase))
+                return ImageFormat.Webp;
 
             throw new FormatException(SR.Format(SR.ConvertInvalidPrimitive, strFormat, nameof(ImageFormat)));
         }
@@ -128,7 +134,9 @@ namespace System.Drawing
                 ImageFormat.Png,
                 ImageFormat.Tiff,
                 ImageFormat.Exif,
-                ImageFormat.Icon
+                ImageFormat.Icon,
+                ImageFormat.Heif,
+                ImageFormat.Webp
             });
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Versioning;
 
 namespace System.Drawing.Imaging
 {
@@ -24,6 +25,8 @@ namespace System.Drawing.Imaging
         private static readonly ImageFormat s_tiff = new ImageFormat(new Guid("{b96b3cb1-0728-11d3-9d7b-0000f81ef32e}"));
         private static readonly ImageFormat s_exif = new ImageFormat(new Guid("{b96b3cb2-0728-11d3-9d7b-0000f81ef32e}"));
         private static readonly ImageFormat s_icon = new ImageFormat(new Guid("{b96b3cb5-0728-11d3-9d7b-0000f81ef32e}"));
+        private static readonly ImageFormat s_heif = new ImageFormat(new Guid("{b96b3cb6-0728-11d3-9d7b-0000f81ef32e}"));
+        private static readonly ImageFormat s_webp = new ImageFormat(new Guid("{b96b3cb7-0728-11d3-9d7b-0000f81ef32e}"));
 
         private Guid _guid;
 
@@ -124,6 +127,30 @@ namespace System.Drawing.Imaging
         }
 
         /// <summary>
+        /// Specifies the High Efficiency Image Format (HEIF).
+        /// </summary>
+        /// <remarks>
+        /// This format is supported since Windows 10 1809.
+        /// </remarks>
+        [SupportedOSPlatform("windows10.0.17763.0")]
+        public static ImageFormat Heif
+        {
+            get { return s_heif; }
+        }
+
+        /// <summary>
+        /// Specifies the WebP image format.
+        /// </summary>
+        /// <remarks>
+        /// This format is supported since Windows 10 1809.
+        /// </remarks>
+        [SupportedOSPlatform("windows10.0.17763.0")]
+        public static ImageFormat Webp
+        {
+            get { return s_webp; }
+        }
+
+        /// <summary>
         /// Returns a value indicating whether the specified object is an <see cref='ImageFormat'/> equivalent to this
         /// <see cref='ImageFormat'/>.
         /// </summary>
@@ -170,6 +197,8 @@ namespace System.Drawing.Imaging
             if (this.Guid == s_tiff.Guid) return "Tiff";
             if (this.Guid == s_exif.Guid) return "Exif";
             if (this.Guid == s_icon.Guid) return "Icon";
+            if (this.Guid == s_heif.Guid) return "Heif";
+            if (this.Guid == s_webp.Guid) return "Webp";
             return $"[ImageFormat: {_guid}]";
         }
     }

--- a/src/libraries/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
@@ -19,6 +19,8 @@ namespace System.Drawing.Imaging.Tests
         private static ImageFormat IconImageFormat = new ImageFormat(new Guid("b96b3cb5-0728-11d3-9d7b-0000f81ef32e"));
         private static ImageFormat JpegImageFormat = new ImageFormat(new Guid("b96b3cae-0728-11d3-9d7b-0000f81ef32e"));
         private static ImageFormat WmfImageFormat = new ImageFormat(new Guid("b96b3cad-0728-11d3-9d7b-0000f81ef32e"));
+        private static ImageFormat HeifImageFormat = new ImageFormat(new Guid("{b96b3cb6-0728-11d3-9d7b-0000f81ef32e}"));
+        private static ImageFormat WebpImageFormat = new ImageFormat(new Guid("{b96b3cb7-0728-11d3-9d7b-0000f81ef32e}"));
         private static ImageFormat CustomImageFormat = new ImageFormat(new Guid("48749428-316f-496a-ab30-c819a92b3137"));
 
         public static IEnumerable<object[]> ImageFormatGuidTestData
@@ -35,6 +37,10 @@ namespace System.Drawing.Imaging.Tests
                 yield return new object[] { IconImageFormat.Guid, ImageFormat.Icon };
                 yield return new object[] { JpegImageFormat.Guid, ImageFormat.Jpeg };
                 yield return new object[] { WmfImageFormat.Guid, ImageFormat.Wmf };
+#if NET
+                yield return new object[] { HeifImageFormat.Guid, ImageFormat.Heif };
+                yield return new object[] { WebpImageFormat.Guid, ImageFormat.Webp };
+#endif
                 yield return new object[] { new Guid("48749428-316f-496a-ab30-c819a92b3137"), CustomImageFormat };
             }
         }
@@ -53,6 +59,10 @@ namespace System.Drawing.Imaging.Tests
                 yield return new object[] { "Icon", ImageFormat.Icon };
                 yield return new object[] { "Jpeg", ImageFormat.Jpeg };
                 yield return new object[] { "Wmf", ImageFormat.Wmf };
+#if NET
+                yield return new object[] { "Heif", ImageFormat.Heif };
+                yield return new object[] { "Webp", ImageFormat.Webp };
+#endif
                 yield return new object[] { "[ImageFormat: 48749428-316f-496a-ab30-c819a92b3137]", CustomImageFormat };
             }
         }

--- a/src/libraries/System.Drawing.Common/tests/System/Drawing/ImageFormatConverterTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/System/Drawing/ImageFormatConverterTests.cs
@@ -101,6 +101,10 @@ namespace System.ComponentModel.TypeConverterTests
             Assert.Equal(ImageFormat.Icon, ConvertFromName("Icon"));
             Assert.Equal(ImageFormat.Jpeg, ConvertFromName("Jpeg"));
             Assert.Equal(ImageFormat.Wmf, ConvertFromName("Wmf"));
+#if NET
+            Assert.Equal(ImageFormat.Heif, ConvertFromName("Heif"));
+            Assert.Equal(ImageFormat.Webp, ConvertFromName("Webp"));
+#endif
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -174,6 +178,10 @@ namespace System.ComponentModel.TypeConverterTests
             bool tiff = false;
             bool exif = false;
             bool icon = false;
+#if NET
+            bool heif = false;
+            bool webp = false;
+#endif
 
             foreach (ImageFormat iformat in values)
             {
@@ -209,6 +217,14 @@ namespace System.ComponentModel.TypeConverterTests
                     case "b96b3cb5-0728-11d3-9d7b-0000f81ef32e":
                         icon = true;
                         break;
+#if NET
+                    case "b96b3cb6-0728-11d3-9d7b-0000f81ef32e":
+                        heif = true;
+                        break;
+                    case "b96b3cb7-0728-11d3-9d7b-0000f81ef32e":
+                        webp = true;
+                        break;
+#endif
                     default:
                         throw new InvalidOperationException($"Unknown GUID {iformat.Guid}.");
                 }
@@ -223,6 +239,10 @@ namespace System.ComponentModel.TypeConverterTests
             Assert.True(tiff, "Tiff");
             Assert.True(exif, "Exif");
             Assert.True(icon, "Icon");
+#if NET
+            Assert.True(heif, "Heif");
+            Assert.True(webp, "Webp");
+#endif
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]


### PR DESCRIPTION
Fixes #70422.

This PR is a mostly straightforward addition of two new image file formats GDI+ supports since Windows 10 1809. The GUIDs are taken from `gdiplusimaging.h` in the Windows SDK. There are two things to notice:

* I added support for these formats in the `ImageFormatTypeConverter`, which I guess is used for designer support in things like Windows Forms. Platform compatibility warnings were suppressed because we are not actually using these formats, moving the burden of checking for compatibility to the developer. I don't think this is a major issue, apart from the dying Windows 7 and 8.1, all supported consumer versions of Windows support these formats.
* I did not add tests that read or write to these formats, not all formats have tests, and [there are concerns that GDI+'s support for them is incomplete](https://github.com/dotnet/runtime/issues/70422#issuecomment-1164734034).