### PR TITLE
Re-enable automatic gc safe transitions in threaded wasm mode

### DIFF
--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -2288,7 +2288,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	int pos_leave, coop_gc_var = 0;
 	MonoExceptionClause *clause;
 	MonoType *object_type = mono_get_object_type ();
-#if defined (TARGET_WASM)
+#if defined (TARGET_WASM) && defined(DISABLE_THREADS)
 	const gboolean do_blocking_transition = FALSE;
 #else
 	const gboolean do_blocking_transition = TRUE;

--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -661,7 +661,7 @@ gc_safe_transition_builder_init (GCSafeTransitionBuilder *builder, MonoMethodBui
 #ifndef DISABLE_COM
 	builder->coop_cominterop_fnptr = -1;
 #endif
-#if defined (TARGET_WASM) && defined(DISABLE_THREADS)
+#if defined (TARGET_WASM)
 	/* if we're in the AOT compiler, obey the --wasm-gc-safepoints option even if the AOT compiler doesn't have threads enabled */
 	return mono_opt_wasm_gc_safepoints;
 #else
@@ -2289,7 +2289,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	int pos_leave, coop_gc_var = 0;
 	MonoExceptionClause *clause;
 	MonoType *object_type = mono_get_object_type ();
-#if defined (TARGET_WASM) && defined(DISABLE_THREADS)
+#if defined (TARGET_WASM)
 	/* in the AOT compiler emit blocking transitions if --wasm-gc-safepoints was used */
 	const gboolean do_blocking_transition = mono_opt_wasm_gc_safepoints;
 #else

--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -661,7 +661,7 @@ gc_safe_transition_builder_init (GCSafeTransitionBuilder *builder, MonoMethodBui
 #ifndef DISABLE_COM
 	builder->coop_cominterop_fnptr = -1;
 #endif
-#if defined (TARGET_WASM)
+#if defined (TARGET_WASM) && defined(DISABLE_THREADS)
 	return FALSE;
 #else
 	return TRUE;

--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -662,7 +662,8 @@ gc_safe_transition_builder_init (GCSafeTransitionBuilder *builder, MonoMethodBui
 	builder->coop_cominterop_fnptr = -1;
 #endif
 #if defined (TARGET_WASM) && defined(DISABLE_THREADS)
-	return FALSE;
+	/* if we're in the AOT compiler, obey the --wasm-gc-safepoints option even if the AOT compiler doesn't have threads enabled */
+	return mono_opt_wasm_gc_safepoints;
 #else
 	return TRUE;
 #endif

--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -663,8 +663,12 @@ gc_safe_transition_builder_init (GCSafeTransitionBuilder *builder, MonoMethodBui
 	builder->coop_cominterop_fnptr = -1;
 #endif
 #if defined (TARGET_WASM)
-	/* if we're in the AOT compiler, obey the --wasm-gc-safepoints option even if the AOT compiler doesn't have threads enabled */
-	return mono_opt_wasm_gc_safepoints;
+	#ifndef DISABLE_THREADS
+		return TRUE;
+	#else
+		/* if we're in the AOT compiler, obey the --wasm-gc-safepoints option even if the AOT compiler doesn't have threads enabled */
+		return mono_opt_wasm_gc_safepoints;
+	#endif
 #else
 	return TRUE;
 #endif
@@ -2292,7 +2296,11 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	MonoType *object_type = mono_get_object_type ();
 #if defined (TARGET_WASM)
 	/* in the AOT compiler emit blocking transitions if --wasm-gc-safepoints was used */
-	const gboolean do_blocking_transition = mono_opt_wasm_gc_safepoints;
+	#ifndef DISABLE_THREADS
+		const gboolean do_blocking_transition = TRUE;
+	#else
+		const gboolean do_blocking_transition = mono_opt_wasm_gc_safepoints;
+	#endif
 #else
 	const gboolean do_blocking_transition = TRUE;
 #endif

--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -45,6 +45,7 @@
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/mono-error-internals.h>
+#include <mono/utils/options.h>
 #include <string.h>
 #include <errno.h>
 #include "icall-decl.h"

--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -2290,7 +2290,8 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	MonoExceptionClause *clause;
 	MonoType *object_type = mono_get_object_type ();
 #if defined (TARGET_WASM) && defined(DISABLE_THREADS)
-	const gboolean do_blocking_transition = FALSE;
+	/* in the AOT compiler emit blocking transitions if --wasm-gc-safepoints was used */
+	const gboolean do_blocking_transition = mono_opt_wasm_gc_safepoints;
 #else
 	const gboolean do_blocking_transition = TRUE;
 #endif

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3724,9 +3724,7 @@ save_seq_points (TransformData *td, MonoJitInfo *jinfo)
 static void
 interp_emit_memory_barrier (TransformData *td, int kind)
 {
-#if defined(TARGET_WASM)
-	// mono_memory_barrier is dummy on wasm
-#elif defined(TARGET_X86) || defined(TARGET_AMD64)
+#if defined(TARGET_X86) || defined(TARGET_AMD64)
 	if (kind == MONO_MEMORY_BARRIER_SEQ)
 		interp_add_ins (td, MINT_MONO_MEMORY_BARRIER);
 #else

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2932,7 +2932,11 @@ static inline gboolean
 mini_safepoints_enabled (void)
 {
 #if defined (TARGET_WASM)
-	return mono_opt_wasm_gc_safepoints;
+	#ifndef DISABLE_THREADS
+		return TRUE;
+	#else
+		return mono_opt_wasm_gc_safepoints;
+	#endif
 #else
 	return TRUE;
 #endif

--- a/src/mono/mono/utils/mono-membar.h
+++ b/src/mono/mono/utils/mono-membar.h
@@ -21,23 +21,7 @@
  */
 //#define mono_compiler_barrier() asm volatile("": : :"memory")
 
-#ifdef HOST_WASM
-
-static inline void mono_memory_barrier (void)
-{
-}
-
-static inline void mono_memory_read_barrier (void)
-{
-}
-
-static inline void mono_memory_write_barrier (void)
-{
-}
-
-#define mono_compiler_barrier() asm volatile("": : :"memory")
-
-#elif _MSC_VER
+#if _MSC_VER
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -71,7 +55,7 @@ static inline void mono_memory_write_barrier (void)
 
 #define mono_compiler_barrier() _ReadWriteBarrier ()
 
-#elif defined(USE_GCC_ATOMIC_OPS)
+#elif defined(USE_GCC_ATOMIC_OPS) || defined(HOST_WASM)
 
 static inline void mono_memory_barrier (void)
 {


### PR DESCRIPTION
Right now GC safe transitions are always disabled in wasm, which can cause hangs if you try to GC when there are managed threads.