### PR TITLE
NonBacktracking locking fixes and cleanup

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -76,6 +76,7 @@
     <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicRegexNode.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicRegexKind.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicRegexInfo.cs" />
+    <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicRegexMatcher.Automata.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicRegexMatcher.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicRegexMatcher.Dgml.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicRegexMatcher.Explore.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -64,7 +64,7 @@
     <Compile Include="System\Text\RegularExpressions\Symbolic\CharKind.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\CharSetSolver.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\DerivativeEffect.cs" />
-    <Compile Include="System\Text\RegularExpressions\Symbolic\DfaMatchingState.cs" />
+    <Compile Include="System\Text\RegularExpressions\Symbolic\MatchingState.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\DoublyLinkedList.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\ISolver.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\MintermClassifier.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/CharKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/CharKind.cs
@@ -43,5 +43,8 @@ namespace System.Text.RegularExpressions.Symbolic
             WordLetter => @"\w",
             _ => string.Empty,
         };
+
+        /// <summary>Returns whether the given value is in the range of valid character kinds.</summary>
+        internal static bool IsValidCharKind(uint charKind) => 0 <= charKind && charKind < CharKindCount;
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/CharKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/CharKind.cs
@@ -45,6 +45,6 @@ namespace System.Text.RegularExpressions.Symbolic
         };
 
         /// <summary>Returns whether the given value is in the range of valid character kinds.</summary>
-        internal static bool IsValidCharKind(uint charKind) => 0 <= charKind && charKind < CharKindCount;
+        internal static bool IsValidCharKind(uint charKind) => charKind < CharKindCount;
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeConverter.cs
@@ -240,12 +240,12 @@ namespace System.Text.RegularExpressions.Symbolic
                                     SymbolicRegexNode<BDD> elem = childResult.Count == 1 ?
                                         childResult.FirstElement :
                                         _builder.CreateConcatAlreadyReversed(childResult);
-                                    if (elem.IsNothing)
+                                    if (elem.IsNothing(_builder._solver))
                                     {
                                         continue;
                                     }
 
-                                    or = elem.IsAnyStar ?
+                                    or = elem.IsAnyStar(_builder._solver) ?
                                         elem : // .* is the absorbing element
                                         SymbolicRegexNode<BDD>.CreateAlternate(_builder, elem, or);
                                 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -30,28 +30,28 @@ namespace System.Text.RegularExpressions.Symbolic
         internal SymbolicRegexNode<TSet> Epsilon => _epsilon ??= SymbolicRegexNode<TSet>.CreateEpsilon(this);
 
         private SymbolicRegexNode<TSet>? _beginningAnchor;
-        internal SymbolicRegexNode<TSet> BeginningAnchor => _beginningAnchor ??= SymbolicRegexNode<TSet>.CreateBeginEndAnchor(this, SymbolicRegexNodeKind.BeginningAnchor);
+        internal SymbolicRegexNode<TSet> BeginningAnchor => _beginningAnchor ??= SymbolicRegexNode<TSet>.CreateAnchor(this, SymbolicRegexNodeKind.BeginningAnchor);
 
         private SymbolicRegexNode<TSet>? _endAnchor;
-        internal SymbolicRegexNode<TSet> EndAnchor => _endAnchor ??= SymbolicRegexNode<TSet>.CreateBeginEndAnchor(this, SymbolicRegexNodeKind.EndAnchor);
+        internal SymbolicRegexNode<TSet> EndAnchor => _endAnchor ??= SymbolicRegexNode<TSet>.CreateAnchor(this, SymbolicRegexNodeKind.EndAnchor);
 
         private SymbolicRegexNode<TSet>? _endAnchorZ;
-        internal SymbolicRegexNode<TSet> EndAnchorZ => _endAnchorZ ??= SymbolicRegexNode<TSet>.CreateBeginEndAnchor(this, SymbolicRegexNodeKind.EndAnchorZ);
+        internal SymbolicRegexNode<TSet> EndAnchorZ => _endAnchorZ ??= SymbolicRegexNode<TSet>.CreateAnchor(this, SymbolicRegexNodeKind.EndAnchorZ);
 
         private SymbolicRegexNode<TSet>? _endAnchorZReverse;
-        internal SymbolicRegexNode<TSet> EndAnchorZReverse => _endAnchorZReverse ??= SymbolicRegexNode<TSet>.CreateBeginEndAnchor(this, SymbolicRegexNodeKind.EndAnchorZReverse);
+        internal SymbolicRegexNode<TSet> EndAnchorZReverse => _endAnchorZReverse ??= SymbolicRegexNode<TSet>.CreateAnchor(this, SymbolicRegexNodeKind.EndAnchorZReverse);
 
         private SymbolicRegexNode<TSet>? _bolAnchor;
-        internal SymbolicRegexNode<TSet> BolAnchor => _bolAnchor ??= SymbolicRegexNode<TSet>.CreateBeginEndAnchor(this, SymbolicRegexNodeKind.BOLAnchor);
+        internal SymbolicRegexNode<TSet> BolAnchor => _bolAnchor ??= SymbolicRegexNode<TSet>.CreateAnchor(this, SymbolicRegexNodeKind.BOLAnchor);
 
         private SymbolicRegexNode<TSet>? _eolAnchor;
-        internal SymbolicRegexNode<TSet> EolAnchor => _eolAnchor ??= SymbolicRegexNode<TSet>.CreateBeginEndAnchor(this, SymbolicRegexNodeKind.EOLAnchor);
+        internal SymbolicRegexNode<TSet> EolAnchor => _eolAnchor ??= SymbolicRegexNode<TSet>.CreateAnchor(this, SymbolicRegexNodeKind.EOLAnchor);
 
         private SymbolicRegexNode<TSet>? _wbAnchor;
-        internal SymbolicRegexNode<TSet> BoundaryAnchor => _wbAnchor ??= SymbolicRegexNode<TSet>.CreateBoundaryAnchor(this, SymbolicRegexNodeKind.BoundaryAnchor);
+        internal SymbolicRegexNode<TSet> BoundaryAnchor => _wbAnchor ??= SymbolicRegexNode<TSet>.CreateAnchor(this, SymbolicRegexNodeKind.BoundaryAnchor);
 
         private SymbolicRegexNode<TSet>? _nwbAnchor;
-        internal SymbolicRegexNode<TSet> NonBoundaryAnchor => _nwbAnchor ??= SymbolicRegexNode<TSet>.CreateBoundaryAnchor(this, SymbolicRegexNodeKind.NonBoundaryAnchor);
+        internal SymbolicRegexNode<TSet> NonBoundaryAnchor => _nwbAnchor ??= SymbolicRegexNode<TSet>.CreateAnchor(this, SymbolicRegexNodeKind.NonBoundaryAnchor);
 
         internal TSet _wordLetterForBoundariesSet;
         internal TSet _newLineSet;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexInfo.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexInfo.cs
@@ -14,6 +14,7 @@ namespace System.Text.RegularExpressions.Symbolic
         private const uint StartsWithSomeAnchorMask = 32;
         private const uint IsHighPriorityNullableMask = 64;
         private const uint ContainsEffectMask = 128;
+        private const uint ContainsLineAnchorMask = 256;
 
         private readonly uint _info;
 
@@ -21,7 +22,8 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal static SymbolicRegexInfo Create(
             bool isAlwaysNullable = false, bool canBeNullable = false,
-            bool startsWithLineAnchor = false, bool startsWithSomeAnchor = false, bool containsSomeAnchor = false,
+            bool startsWithLineAnchor = false, bool containsLineAnchor = false,
+            bool startsWithSomeAnchor = false, bool containsSomeAnchor = false,
             bool isHighPriorityNullable = false, bool containsEffect = false)
         {
             uint i = 0;
@@ -36,13 +38,18 @@ namespace System.Text.RegularExpressions.Symbolic
                 }
             }
 
-            if (containsSomeAnchor || startsWithLineAnchor || startsWithSomeAnchor)
+            if (containsLineAnchor || containsSomeAnchor || startsWithLineAnchor || startsWithSomeAnchor)
             {
                 i |= ContainsSomeAnchorMask;
 
-                if (startsWithLineAnchor)
+                if (containsLineAnchor || startsWithLineAnchor)
                 {
-                    i |= StartsWithLineAnchorMask;
+                    i |= ContainsLineAnchorMask;
+
+                    if (startsWithLineAnchor)
+                    {
+                        i |= StartsWithLineAnchorMask;
+                    }
                 }
 
                 if (startsWithLineAnchor || startsWithSomeAnchor)
@@ -70,6 +77,8 @@ namespace System.Text.RegularExpressions.Symbolic
 
         public bool StartsWithLineAnchor => (_info & StartsWithLineAnchorMask) != 0;
 
+        public bool ContainsLineAnchor => (_info & ContainsLineAnchorMask) != 0;
+
         public bool StartsWithSomeAnchor => (_info & StartsWithSomeAnchorMask) != 0;
 
         public bool ContainsSomeAnchor => (_info & ContainsSomeAnchorMask) != 0;
@@ -90,6 +99,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 isAlwaysNullable: left_info.IsNullable || right_info.IsNullable,
                 canBeNullable: left_info.CanBeNullable || right_info.CanBeNullable,
                 startsWithLineAnchor: left_info.StartsWithLineAnchor || right_info.StartsWithLineAnchor,
+                containsLineAnchor: left_info.ContainsLineAnchor || right_info.ContainsLineAnchor,
                 startsWithSomeAnchor: left_info.StartsWithSomeAnchor || right_info.StartsWithSomeAnchor,
                 containsSomeAnchor: left_info.ContainsSomeAnchor || right_info.ContainsSomeAnchor,
                 isHighPriorityNullable: left_info.IsHighPriorityNullable,
@@ -105,6 +115,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 isAlwaysNullable: left_info.IsNullable && right_info.IsNullable,
                 canBeNullable: left_info.CanBeNullable && right_info.CanBeNullable,
                 startsWithLineAnchor: left_info.StartsWithLineAnchor || (left_info.CanBeNullable && right_info.StartsWithLineAnchor),
+                containsLineAnchor: left_info.ContainsLineAnchor || right_info.ContainsLineAnchor,
                 startsWithSomeAnchor: left_info.StartsWithSomeAnchor || (left_info.CanBeNullable && right_info.StartsWithSomeAnchor),
                 containsSomeAnchor: left_info.ContainsSomeAnchor || right_info.ContainsSomeAnchor,
                 isHighPriorityNullable: left_info.IsHighPriorityNullable && right_info.IsHighPriorityNullable,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexInfo.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace System.Text.RegularExpressions.Symbolic
 {
     /// <summary>Misc information of structural properties of a <see cref="SymbolicRegexNode{S}"/> that is computed bottom up.</summary>
@@ -20,55 +22,28 @@ namespace System.Text.RegularExpressions.Symbolic
 
         private SymbolicRegexInfo(uint i) => _info = i;
 
-        internal static SymbolicRegexInfo Create(
+        private static SymbolicRegexInfo Create(
             bool isAlwaysNullable = false, bool canBeNullable = false,
             bool startsWithLineAnchor = false, bool containsLineAnchor = false,
             bool startsWithSomeAnchor = false, bool containsSomeAnchor = false,
             bool isHighPriorityNullable = false, bool containsEffect = false)
         {
-            uint i = 0;
-
-            if (canBeNullable || isAlwaysNullable)
-            {
-                i |= CanBeNullableMask;
-
-                if (isAlwaysNullable)
-                {
-                    i |= IsAlwaysNullableMask;
-                }
-            }
-
-            if (containsLineAnchor || containsSomeAnchor || startsWithLineAnchor || startsWithSomeAnchor)
-            {
-                i |= ContainsSomeAnchorMask;
-
-                if (containsLineAnchor || startsWithLineAnchor)
-                {
-                    i |= ContainsLineAnchorMask;
-
-                    if (startsWithLineAnchor)
-                    {
-                        i |= StartsWithLineAnchorMask;
-                    }
-                }
-
-                if (startsWithLineAnchor || startsWithSomeAnchor)
-                {
-                    i |= StartsWithSomeAnchorMask;
-                }
-            }
-
-            if (isHighPriorityNullable)
-            {
-                i |= IsHighPriorityNullableMask;
-            }
-
-            if (containsEffect)
-            {
-                i |= ContainsEffectMask;
-            }
-
-            return new SymbolicRegexInfo(i);
+            // Assert that the expected implications hold. For example, every node that contains a line anchor
+            // must also be marked as containing some anchor.
+            Debug.Assert(!isAlwaysNullable || canBeNullable);
+            Debug.Assert(!startsWithLineAnchor || containsLineAnchor);
+            Debug.Assert(!startsWithLineAnchor || startsWithSomeAnchor);
+            Debug.Assert(!containsLineAnchor || containsSomeAnchor);
+            Debug.Assert(!startsWithSomeAnchor || containsSomeAnchor);
+            return new SymbolicRegexInfo(
+                (isAlwaysNullable ? IsAlwaysNullableMask : 0) |
+                (canBeNullable ? CanBeNullableMask : 0) |
+                (startsWithLineAnchor ? StartsWithLineAnchorMask : 0) |
+                (containsLineAnchor ? ContainsLineAnchorMask : 0) |
+                (startsWithSomeAnchor ? StartsWithSomeAnchorMask : 0) |
+                (containsSomeAnchor ? ContainsSomeAnchorMask : 0) |
+                (isHighPriorityNullable ? IsHighPriorityNullableMask : 0) |
+                (containsEffect ? ContainsEffectMask : 0));
         }
 
         public bool IsNullable => (_info & IsAlwaysNullableMask) != 0;
@@ -88,6 +63,27 @@ namespace System.Text.RegularExpressions.Symbolic
         public bool IsHighPriorityNullable => (_info & IsHighPriorityNullableMask) != 0;
 
         public bool ContainsEffect => (_info & ContainsEffectMask) != 0;
+
+        /// <summary>
+        /// Used for any node that acts as an epsilon, i.e., something that always matches the empty string.
+        /// </summary>
+        public static SymbolicRegexInfo Epsilon() =>
+            Create(
+                isAlwaysNullable: true,
+                canBeNullable: true,
+                isHighPriorityNullable: true);
+
+        /// <summary>
+        /// Used for all anchors.
+        /// </summary>
+        /// <param name="isLineAnchor">whether this anchor is a line anchor</param>
+        public static SymbolicRegexInfo Anchor(bool isLineAnchor) =>
+            Create(
+                canBeNullable: true,
+                startsWithLineAnchor: isLineAnchor,
+                containsLineAnchor: isLineAnchor,
+                startsWithSomeAnchor: true,
+                containsSomeAnchor: true);
 
         /// <summary>
         /// The alternation remains high priority nullable if the left alternative is so.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexKind.cs
@@ -48,7 +48,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Effects to be applied when taking a transition.</summary>
         /// <remarks>
         /// Left child is the pattern itself and the right child is a concatenation of nodes whose effects should be applied.
-        /// Effect nodes are created in the rule for concatenation in <see cref="SymbolicRegexNode{TSet}.CreateDerivative(TSet, uint)"/>,
+        /// Effect nodes are created in the rule for concatenation in <see cref="SymbolicRegexNode{TSet}.CreateDerivative(SymbolicRegexBuilder{TSet}, TSet, uint)"/>,
         /// where they are used to represent additional operations that should be performed in the current position if
         /// the pattern in the left child is used to match the input. Since these Effect nodes are relative to the current
         /// position in the input, the effects from the right child must be applied in the transition that the derivative is

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Automata.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Automata.cs
@@ -1,0 +1,429 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace System.Text.RegularExpressions.Symbolic
+{
+    internal sealed partial class SymbolicRegexMatcher<TSet>
+    {
+        /// <summary>
+        /// Initial capacity for DFA related arrays.
+        /// </summary>
+        private const int InitialDfaStateCapacity = 1024;
+
+        /// <summary>
+        /// Minimum capacity for NFA related arrays when the matcher first enters NFA mode. The arrays start out empty,
+        /// but are resized to this capacity upon first use.
+        /// </summary>
+        private const int InitialNfaStateCapacity = 64;
+
+        /// <summary>
+        /// Cache for the states that have been created. Each state is uniquely identified by its associated
+        /// <see cref="SymbolicRegexNode{TSet}"/> and the kind of the previous character.
+        /// </summary>
+        private Dictionary<(SymbolicRegexNode<TSet> Node, uint PrevCharKind), DfaMatchingState<TSet>> _stateCache = new();
+
+        /// <summary>
+        /// Maps state ids to states, initial capacity is given by <see cref="InitialDfaStateCapacity"/>.
+        /// Each time more states are needed the length is doubled.
+        /// The first valid state is at index 1.
+        /// </summary>
+        private DfaMatchingState<TSet>?[] _stateArray;
+
+        /// <summary>
+        /// Maps state IDs to context-independent information for all states in <see cref="_stateArray"/>.
+        /// The first valid entry is at index 1.
+        /// </summary>
+        private ContextIndependentState[] _stateInfo;
+
+        /// <summary>Context-independent information available for every state.</summary>
+        [Flags]
+        private enum ContextIndependentState : byte
+        {
+            IsInitial = 1,
+            IsDeadend = 2,
+            IsNullable = 4,
+            CanBeNullable = 8,
+        }
+
+        /// <summary>
+        /// The transition function for DFA mode.
+        /// Each state has a range of consecutive entries for each minterm ID. A range of size 2^L, where L is
+        /// the number of bits required to represent the largest minterm ID <see cref="_mintermsLog"/>, is reserved
+        /// for each state. This makes indexing into this array not require a multiplication
+        /// <see cref="DeltaOffset(int, int)"/>, but does mean some unused space may be present.
+        /// The first valid state ID is 1.
+        /// </summary>
+        /// <remarks>
+        /// For these "delta" arrays, technically Volatile.Read should be used to read out an element,
+        /// but in practice that's not needed on the runtimes in use (though that needs to be documented
+        /// via https://github.com/dotnet/runtime/issues/63474), and use of Volatile.Read is
+        /// contributing non-trivial overhead (https://github.com/dotnet/runtime/issues/65789).
+        /// </remarks>
+        private int[] _delta;
+
+        /// <summary>
+        /// Maps each NFA state id to the state id of the DfaMatchingState stored in _stateArray.
+        /// This map is used to compactly represent NFA state ids in NFA mode in order to utilize
+        /// the property that all NFA states are small integers in one interval.
+        /// The valid entries are 0 to <see cref="NfaStateCount"/>-1.
+        /// </summary>
+        private int[] _nfaStateArray = Array.Empty<int>();
+
+        /// <summary>
+        /// Maps the id of a DfaMatchingState to the NFA state id that it is being identifed with in the NFA.
+        /// It is the inverse of used entries in _nfaStateArray.
+        /// The range of this map is 0 to <see cref="NfaStateCount"/>-1.
+        /// </summary>
+        private readonly Dictionary<int, int> _nfaStateArrayInverse = new();
+
+        /// <summary>Gets <see cref="_nfaStateArrayInverse"/>.Count</summary>
+        private int NfaStateCount => _nfaStateArrayInverse.Count;
+
+        /// <summary>
+        /// Transition function for NFA transitions in NFA mode.
+        /// Each NFA entry maps to a list of NFA target states.
+        /// Each list of target states is without repetitions.
+        /// If the entry is null then the targets states have not been computed yet.
+        /// </summary>
+        private int[]?[] _nfaDelta = Array.Empty<int[]>();
+
+        /// <summary>
+        /// The transition function for <see cref="FindSubcaptures(ReadOnlySpan{char}, int, int, PerThreadData)"/>,
+        /// which is an NFA mode with additional state to track capture start and end positions.
+        /// Each entry is an array of pairs of target state and effects to be applied when taking the transition.
+        /// If the entry is null then the transition has not been computed yet.
+        /// </summary>
+        private (int, DerivativeEffect[])[]?[] _capturingNfaDelta = Array.Empty<(int, DerivativeEffect[])[]?>();
+
+        /// <summary>
+        /// Implements a version of <see cref="Array.Resize"/> that is guaranteed to not publish an array before values
+        /// have been copied over.
+        /// </summary>
+        /// <remarks>
+        /// This may not be strictly necessary for arrays of primitive or reference types (which have atomic
+        /// reads/writes), as when, e.g., <see cref="_delta"/> is found to not have an entry the array is checked again
+        /// after a lock on the matcher has been acquired. However, in a highly threaded use case it still seems better
+        /// to avoid unnecessarily causing other threads to acquire the lock.
+        /// </remarks>
+        private static void ConcurrentArrayResize<T>(ref T[] array, int newSize)
+        {
+            Debug.Assert(newSize >= array.Length);
+            T[] newArray = new T[newSize];
+            Array.Copy(array, newArray, array.Length);
+            Volatile.Write(ref array, newArray);
+        }
+
+        private int DeltaOffset(int stateId, int mintermId) => (stateId << _mintermsLog) | mintermId;
+
+        /// <summary>Returns the span from <see cref="_delta"/> that may contain transitions for the given state</summary>
+        private Span<int> GetDeltasFor(DfaMatchingState<TSet> state)
+        {
+            int numMinterms = _minterms.Length;
+            if (state.StartsWithLineAnchor)
+            {
+                numMinterms++;
+            }
+
+            return _delta.AsSpan(state.Id << _mintermsLog, numMinterms);
+        }
+
+        /// <summary>Returns the span from <see cref="_nfaDelta"/> that may contain transitions for the given state</summary>
+        private Span<int[]?> GetNfaDeltasFor(DfaMatchingState<TSet> state)
+        {
+            Debug.Assert(Monitor.IsEntered(this));
+
+            if (!_nfaStateArrayInverse.TryGetValue(state.Id, out int nfaState))
+            {
+                return default;
+            }
+
+            int numMinterms = _minterms.Length;
+            if (state.StartsWithLineAnchor)
+            {
+                numMinterms++;
+            }
+
+            return _nfaDelta.AsSpan(nfaState << _mintermsLog, numMinterms);
+        }
+
+        /// <summary>Get context-independent information for the given state.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private (bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable) GetStateInfo(int stateId)
+        {
+            Debug.Assert(stateId > 0);
+
+            ContextIndependentState info = _stateInfo[stateId];
+            return ((info & ContextIndependentState.IsInitial) != 0,
+                    (info & ContextIndependentState.IsDeadend) != 0,
+                    (info & ContextIndependentState.IsNullable) != 0,
+                    (info & ContextIndependentState.CanBeNullable) != 0);
+        }
+
+        /// <summary>
+        /// Create a state with given node and previous character context.
+        /// </summary>
+        /// <param name="node">the pattern that this state will represent</param>
+        /// <param name="prevCharKind">the kind of the character that led to this state</param>
+        /// <returns></returns>
+        private DfaMatchingState<TSet> GetOrCreateState(SymbolicRegexNode<TSet> node, uint prevCharKind)
+        {
+            Debug.Assert(Monitor.IsEntered(this));
+            return GetOrCreateStateUnsafe(node, prevCharKind);
+        }
+
+        /// <summary>
+        /// Create a state with given node and previous character context.
+        /// </summary>
+        /// <param name="node">the pattern that this state will represent</param>
+        /// <param name="prevCharKind">the kind of the character that led to this state</param>
+        /// <param name="isInitialState">whether to mark the state as an initial state or not</param>
+        /// <returns></returns>
+        private DfaMatchingState<TSet> GetOrCreateStateUnsafe(SymbolicRegexNode<TSet> node, uint prevCharKind, bool isInitialState = false)
+        {
+            SymbolicRegexNode<TSet> prunedNode = node.PruneAnchors(_builder, prevCharKind);
+            (SymbolicRegexNode<TSet> Node, uint PrevCharKind) key = (prunedNode, prevCharKind);
+            if (!_stateCache.TryGetValue(key, out DfaMatchingState<TSet>? state))
+            {
+                state = new DfaMatchingState<TSet>(key.Node, key.PrevCharKind);
+                _stateCache.Add(key, state); // Add to cache first to make 1 the first state ID
+                state.Id = _stateCache.Count;
+
+                Debug.Assert(_stateArray is not null);
+
+                if (state.Id == _stateArray.Length)
+                {
+                    // The growth factor 2 matches that of List<T>
+                    int newsize = _stateArray.Length * 2;
+                    ConcurrentArrayResize(ref _stateArray, newsize);
+                    ConcurrentArrayResize(ref _delta, newsize << _mintermsLog);
+                    ConcurrentArrayResize(ref _stateInfo, newsize);
+                }
+                _stateArray[state.Id] = state;
+                _stateInfo[state.Id] = BuildStateInfo(state.Id, isInitialState, state.IsDeadend(Solver), state.Node.IsNullable, state.Node.CanBeNullable);
+            }
+
+            return state;
+
+            // Assign the context-independent information for the given state
+            static ContextIndependentState BuildStateInfo(int stateId, bool isInitial, bool isDeadend, bool isNullable, bool canBeNullable)
+            {
+                Debug.Assert(stateId > 0);
+                Debug.Assert(!isNullable || canBeNullable);
+
+                ContextIndependentState info = 0;
+
+                if (isInitial)
+                {
+                    info |= ContextIndependentState.IsInitial;
+                }
+
+                if (isDeadend)
+                {
+                    info |= ContextIndependentState.IsDeadend;
+                }
+
+                if (canBeNullable)
+                {
+                    info |= ContextIndependentState.CanBeNullable;
+                    if (isNullable)
+                    {
+                        info |= ContextIndependentState.IsNullable;
+                    }
+                }
+
+                return info;
+            }
+        }
+
+        /// <summary>
+        /// Make an NFA state for the given node and previous character kind.
+        /// </summary>
+        /// <returns>the NFA ID of the new state, or null if the state is a dead end</returns>
+        private int? CreateNfaState(SymbolicRegexNode<TSet> node, uint prevCharKind)
+        {
+            Debug.Assert(Monitor.IsEntered(this));
+            Debug.Assert(node.Kind != SymbolicRegexNodeKind.Alternate);
+
+            // First make the underlying core state
+            DfaMatchingState<TSet> coreState = GetOrCreateState(node, prevCharKind);
+
+            // If the state is a dead end then don't create an NFA state, as dead ends in NFA mode are represented
+            // as empty lists of states.
+            if (coreState.IsDeadend(Solver))
+            {
+                return null;
+            }
+
+            if (!_nfaStateArrayInverse.TryGetValue(coreState.Id, out int nfaStateId))
+            {
+                nfaStateId = MakeNewNfaState(coreState.Id);
+            }
+
+            return nfaStateId;
+        }
+
+        /// <summary>Creates a new NFA state for the underlying core state</summary>
+        private int MakeNewNfaState(int coreStateId)
+        {
+            Debug.Assert(Monitor.IsEntered(this));
+
+            if (NfaStateCount == _nfaStateArray.Length)
+            {
+                // The growth factor 2 matches that of List<T>
+                int newsize = Math.Max(_nfaStateArray.Length * 2, InitialNfaStateCapacity);
+                ConcurrentArrayResize(ref _nfaStateArray, newsize);
+                ConcurrentArrayResize(ref _nfaDelta, newsize << _mintermsLog);
+                ConcurrentArrayResize(ref _capturingNfaDelta, newsize << _mintermsLog);
+            }
+
+            int nfaStateId = NfaStateCount;
+            _nfaStateArray[nfaStateId] = coreStateId;
+            _nfaStateArrayInverse[coreStateId] = nfaStateId;
+            return nfaStateId;
+        }
+
+        /// <summary>Gets the <see cref="DfaMatchingState{TSet}"/> corresponding to the given state ID.</summary>
+        private DfaMatchingState<TSet> GetState(int stateId)
+        {
+            Debug.Assert(stateId > 0);
+            DfaMatchingState<TSet>? state = _stateArray[stateId];
+            Debug.Assert(state is not null);
+            return state;
+        }
+
+        /// <summary>Gets the core state Id corresponding to the NFA state</summary>
+        private int GetCoreStateId(int nfaStateId)
+        {
+            Debug.Assert(nfaStateId < _nfaStateArray.Length);
+            Debug.Assert(_nfaStateArray[nfaStateId] < _stateArray.Length);
+            return _nfaStateArray[nfaStateId];
+        }
+
+        /// <summary>Gets or creates a new DFA transition.</summary>
+        /// <remarks>This function locks the matcher for safe concurrent use of the <see cref="_builder"/></remarks>
+        private bool TryCreateNewTransition(
+            DfaMatchingState<TSet> sourceState, int mintermId, int offset, bool checkThreshold, [NotNullWhen(true)] out DfaMatchingState<TSet>? nextState)
+        {
+            Debug.Assert(offset < _delta.Length);
+
+            lock (this)
+            {
+                // check if meanwhile delta[offset] has become defined possibly by another thread
+                DfaMatchingState<TSet>? targetState = _stateArray[_delta[offset]];
+                if (targetState is null)
+                {
+                    if (checkThreshold && _stateCache.Count >= SymbolicRegexThresholds.NfaThreshold)
+                    {
+                        nextState = null;
+                        return false;
+                    }
+
+                    TSet minterm = GetMintermFromId(mintermId);
+                    uint nextCharKind = GetPositionKind(mintermId);
+                    targetState = GetOrCreateState(sourceState.Next(_builder, minterm, nextCharKind), nextCharKind);
+                    Volatile.Write(ref _delta[offset], targetState.Id);
+                }
+
+                nextState = targetState;
+                return true;
+            }
+        }
+
+        /// <summary>Gets or creates a new NFA transition.</summary>
+        /// <remarks>This function locks the matcher for safe concurrent use of the <see cref="_builder"/></remarks>
+        private int[] CreateNewNfaTransition(int nfaStateId, int mintermId, int nfaOffset)
+        {
+            Debug.Assert(nfaOffset < _nfaDelta.Length);
+
+            lock (this)
+            {
+                // check if meanwhile the nfaoffset has become defined possibly by another thread
+                int[]? targets = _nfaDelta[nfaOffset];
+                if (targets is null)
+                {
+                    // Create the underlying transition from the core state corresponding to the nfa state
+                    int coreId = GetCoreStateId(nfaStateId);
+                    int coreOffset = (coreId << _mintermsLog) | mintermId;
+                    int coreTargetId = _delta[coreOffset];
+                    DfaMatchingState<TSet> coreState = GetState(coreId);
+                    TSet minterm = GetMintermFromId(mintermId);
+                    uint nextCharKind = GetPositionKind(mintermId);
+                    SymbolicRegexNode<TSet>? targetNode = coreTargetId > 0 ?
+                        GetState(coreTargetId).Node : coreState.Next(_builder, minterm, nextCharKind);
+
+                    List<int> targetsList = new();
+                    ForEachNfaState(targetNode, nextCharKind, targetsList, static (int nfaId, List<int> targetsList) =>
+                        targetsList.Add(nfaId));
+
+                    targets = targetsList.ToArray();
+                    Volatile.Write(ref _nfaDelta[nfaOffset], targets);
+                }
+
+                return targets;
+            }
+        }
+
+        /// <summary>Gets or creates a new capturing NFA transition.</summary>
+        /// <remarks>This function locks the matcher for safe concurrent use of the <see cref="_builder"/></remarks>
+        private (int, DerivativeEffect[])[] CreateNewCapturingTransition(int nfaStateId, int mintermId, int offset)
+        {
+            lock (this)
+            {
+                // Get the next state if it exists.  The caller should have already tried and found it null (not yet created),
+                // but in the interim another thread could have created it.
+                (int, DerivativeEffect[])[]? targets = _capturingNfaDelta[offset];
+                if (targets is null)
+                {
+                    DfaMatchingState<TSet> coreState = GetState(GetCoreStateId(nfaStateId));
+                    TSet minterm = GetMintermFromId(mintermId);
+                    uint nextCharKind = GetPositionKind(mintermId);
+                    List<(SymbolicRegexNode<TSet> Node, DerivativeEffect[] Effects)>? transition = coreState.NfaNextWithEffects(_builder, minterm, nextCharKind);
+                    // Build the new state and store it into the array.
+                    List<(int, DerivativeEffect[])> targetsList = new();
+                    foreach ((SymbolicRegexNode<TSet> Node, DerivativeEffect[] Effects) entry in transition)
+                    {
+                        ForEachNfaState(entry.Node, nextCharKind, (targetsList, entry.Effects),
+                            static (int nfaId, (List<(int, DerivativeEffect[])> Targets, DerivativeEffect[] Effects) args) =>
+                                args.Targets.Add((nfaId, args.Effects)));
+                    }
+                    targets = targetsList.ToArray();
+                    Volatile.Write(ref _capturingNfaDelta[offset], targets);
+                }
+
+                return targets;
+            }
+        }
+
+        /// <summary>
+        /// Iterates through the alternation branches <see cref="SymbolicRegexNode{TSet}.EnumerateAlternationBranches(SymbolicRegexBuilder{TSet})"/>
+        /// and tries to create NFA states for each. The supplied action is called for each created NFA state. These never
+        /// include dead ends as <see cref="CreateNfaState(SymbolicRegexNode{TSet}, uint)"/> will filter those out.
+        /// </summary>
+        /// <remarks>This function locks the matcher for safe concurrent use of the <see cref="_builder"/></remarks>
+        /// <typeparam name="T">the type of the additional argument passed through to the action</typeparam>
+        /// <param name="node">the node to break up into NFA states</param>
+        /// <param name="prevCharKind">the previous character kind for each created NFA state</param>
+        /// <param name="arg">an additional argument passed through to each call to the action</param>
+        /// <param name="action">action to call for each NFA state</param>
+        private void ForEachNfaState<T>(SymbolicRegexNode<TSet> node, uint prevCharKind, T arg, Action<int, T> action)
+        {
+            lock (this)
+            {
+                foreach (SymbolicRegexNode<TSet> nfaNode in node.EnumerateAlternationBranches(_builder))
+                {
+                    if (CreateNfaState(nfaNode, prevCharKind) is int nfaId)
+                    {
+                        action(nfaId, arg);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Automata.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Automata.cs
@@ -242,8 +242,18 @@ namespace System.Text.RegularExpressions.Symbolic
         }
 
         /// <summary>
-        /// Make an NFA state for the given node and previous character kind.
+        /// Make an NFA state for the given node and previous character kind. NFA states include a "core state" of a
+        /// <see cref="MatchingState{TSet}"/> allocated with <see cref="GetOrCreateState(SymbolicRegexNode{TSet}, uint)"/>,
+        /// which stores the pattern and previous character kind and can be used for creating further NFA transitions.
+        /// In addition to the ID of the core state, NFA states are allocated a new NFA mode specific ID, which is
+        /// used to index into NFA mode transition arrays (e.g. <see cref="_nfaDelta"/>).
         /// </summary>
+        /// <remarks>
+        /// Using an ID numbering for NFA mode that is separate from DFA mode allows the IDs to be smaller, which saves
+        /// space both in the NFA mode arrays and in the <see cref="SparseIntMap{T}"/> instances used during matching for
+        /// sets of NFA states.
+        /// The core state ID can be looked up by the NFA ID with <see cref="GetCoreStateId(int)"/>.
+        /// </remarks>
         /// <returns>the NFA ID of the new state, or null if the state is a dead end</returns>
         private int? CreateNfaState(SymbolicRegexNode<TSet> node, uint prevCharKind)
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Dgml.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Dgml.cs
@@ -28,7 +28,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 writer.WriteLine("    <Nodes>");
                 writer.WriteLine("        <Node Id=\"dfa\" Label=\" \" Group=\"Collapsed\" Category=\"DFA\" DFAInfo=\"{0}\" />", FormatInfo(this, transitions.Count));
                 writer.WriteLine("        <Node Id=\"dfainfo\" Category=\"DFAInfo\" Label=\"{0}\"/>", FormatInfo(this, transitions.Count));
-                foreach (DfaMatchingState<TSet> state in _stateCache.Values)
+                foreach (MatchingState<TSet> state in _stateCache.Values)
                 {
                     string info = CharKind.DescribePrev(state.PrevCharKind);
                     string deriv = WebUtility.HtmlEncode(state.Node.ToString());
@@ -48,7 +48,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 }
                 writer.WriteLine("    </Nodes>");
                 writer.WriteLine("    <Links>");
-                foreach (DfaMatchingState<TSet> initialState in GetInitialStates(this))
+                foreach (MatchingState<TSet> initialState in GetInitialStates(this))
                 {
                     writer.WriteLine("        <Link Source=\"dfa\" Target=\"{0}\" Label=\"\" Category=\"StartTransition\" />", initialState.Id);
                 }
@@ -73,7 +73,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     }
                 }
 
-                foreach (DfaMatchingState<TSet> state in _stateCache.Values)
+                foreach (MatchingState<TSet> state in _stateCache.Values)
                 {
                     writer.WriteLine("        <Link Source=\"{0}\" Target=\"{0}info\" Category=\"Contains\" />", state.Id);
                 }
@@ -144,7 +144,7 @@ namespace System.Text.RegularExpressions.Symbolic
             static Dictionary<(int Source, int Target), (TSet Rule, List<int> NfaTargets)> GatherTransitions(SymbolicRegexMatcher<TSet> matcher)
             {
                 Dictionary<(int Source, int Target), (TSet Rule, List<int> NfaTargets)> result = new();
-                foreach (DfaMatchingState<TSet> source in matcher._stateCache.Values)
+                foreach (MatchingState<TSet> source in matcher._stateCache.Values)
                 {
                     // Get the span of entries in delta that gives the transitions for the different minterms
                     Span<int> deltas = matcher.GetDeltasFor(source);
@@ -168,7 +168,7 @@ namespace System.Text.RegularExpressions.Symbolic
                             {
                                 foreach (int nfaTarget in nfaTargets)
                                 {
-                                    entry.NfaTargets.Add(matcher._nfaStateArray[nfaTarget]);
+                                    entry.NfaTargets.Add(matcher._nfaCoreIdArray[nfaTarget]);
                                 }
                             }
                             // Expand the rule for this minterm
@@ -200,13 +200,13 @@ namespace System.Text.RegularExpressions.Symbolic
             static string DescribeLabel(TSet label, SymbolicRegexBuilder<TSet> builder) =>
                 WebUtility.HtmlEncode(builder._solver.PrettyPrint(label, builder._charSetSolver));
 
-            static IEnumerable<DfaMatchingState<TSet>> GetInitialStates(SymbolicRegexMatcher<TSet> matcher)
+            static IEnumerable<MatchingState<TSet>> GetInitialStates(SymbolicRegexMatcher<TSet> matcher)
             {
-                foreach (DfaMatchingState<TSet> state in matcher._dotstarredInitialStates)
+                foreach (MatchingState<TSet> state in matcher._dotstarredInitialStates)
                     yield return state;
-                foreach (DfaMatchingState<TSet> state in matcher._initialStates)
+                foreach (MatchingState<TSet> state in matcher._initialStates)
                     yield return state;
-                foreach (DfaMatchingState<TSet> state in matcher._reverseInitialStates)
+                foreach (MatchingState<TSet> state in matcher._reverseInitialStates)
                     yield return state;
             }
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
@@ -30,132 +30,133 @@ namespace System.Text.RegularExpressions.Symbolic
         [ExcludeFromCodeCoverage(Justification = "Currently only used for testing")]
         public override IEnumerable<string> SampleMatches(int k, int randomseed)
         {
-            // Zero is treated as no seed, instead using a system provided one
-            Random random = randomseed != 0 ? new Random(randomseed) : new Random();
+            lock (this)
+            {
+                // Zero is treated as no seed, instead using a system provided one
+                Random random = randomseed != 0 ? new Random(randomseed) : new Random();
+                CharSetSolver charSetSolver = _builder._charSetSolver;
 
-            ISolver<TSet> solver = _builder._solver;
-            CharSetSolver charSetSolver = _builder._charSetSolver;
-
-            // Create helper BDDs for handling anchors and preferentially generating ASCII inputs
-            BDD asciiWordCharacters = charSetSolver.Or(new BDD[] {
+                // Create helper BDDs for handling anchors and preferentially generating ASCII inputs
+                BDD asciiWordCharacters = charSetSolver.Or(new BDD[] {
                 charSetSolver.CreateBDDFromRange('A', 'Z'),
                 charSetSolver.CreateBDDFromRange('a', 'z'),
                 charSetSolver.CreateBDDFromChar('_'),
                 charSetSolver.CreateBDDFromRange('0', '9')});
-            // Visible ASCII range for input character generation
-            BDD ascii = charSetSolver.CreateBDDFromRange('\x20', '\x7E');
-            BDD asciiNonWordCharacters = charSetSolver.And(ascii, charSetSolver.Not(asciiWordCharacters));
+                // Visible ASCII range for input character generation
+                BDD ascii = charSetSolver.CreateBDDFromRange('\x20', '\x7E');
+                BDD asciiNonWordCharacters = charSetSolver.And(ascii, charSetSolver.Not(asciiWordCharacters));
 
-            // Set up two sets of minterms, one with the additional special minterm for the last end-of-line
-            Debug.Assert(_builder._minterms is not null);
-            int[] mintermIdsWithoutZ = new int[_builder._minterms.Length];
-            int[] mintermIdsWithZ = new int[_builder._minterms.Length + 1];
-            for (int i = 0; i < _builder._minterms.Length; ++i)
-            {
-                mintermIdsWithoutZ[i] = i;
-                mintermIdsWithZ[i] = i;
-            }
-            mintermIdsWithZ[_builder._minterms.Length] = _builder._minterms.Length;
-
-            for (int i = 0; i < k; i++)
-            {
-                // Holds the generated input so far
-                StringBuilder inputSoFar = new();
-                StringBuilder? latestCandidate = null;
-
-                // Current set of states reached initially contains just the root
-                NfaMatchingState states = new(_builder);
-                // Here one could also consider previous characters for example for \b, \B, and ^ anchors
-                // and initialize inputSoFar accordingly
-                states.InitializeFrom(_initialStates[GetCharKind(ReadOnlySpan<char>.Empty, -1)]);
-                CurrentState statesWrapper = new(states);
-
-                // Used for end suffixes
-                List<string> possibleEndings = new();
-
-                while (true)
+                // Set up two sets of minterms, one with the additional special minterm for the last end-of-line
+                Debug.Assert(_minterms is not null);
+                int[] mintermIdsWithoutZ = new int[_minterms.Length];
+                int[] mintermIdsWithZ = new int[_minterms.Length + 1];
+                for (int i = 0; i < _minterms.Length; ++i)
                 {
-                    Debug.Assert(states.NfaStateSet.Count > 0);
+                    mintermIdsWithoutZ[i] = i;
+                    mintermIdsWithZ[i] = i;
+                }
+                mintermIdsWithZ[_minterms.Length] = _minterms.Length;
 
-                    // Gather the possible endings for satisfying nullability
-                    possibleEndings.Clear();
-                    if (NfaStateHandler.CanBeNullable(ref statesWrapper))
+                for (int i = 0; i < k; i++)
+                {
+                    // Holds the generated input so far
+                    StringBuilder inputSoFar = new();
+                    StringBuilder? latestCandidate = null;
+
+                    // Current set of states reached initially contains just the root
+                    NfaMatchingState states = new();
+                    // Here one could also consider previous characters for example for \b, \B, and ^ anchors
+                    // and initialize inputSoFar accordingly
+                    states.InitializeFrom(this, _initialStates[GetCharKind<FullInputReader>(ReadOnlySpan<char>.Empty, -1)]);
+                    CurrentState statesWrapper = new(states);
+
+                    // Used for end suffixes
+                    List<string> possibleEndings = new();
+
+                    while (true)
                     {
-                        // Unconditionally final state or end of the input due to \Z anchor for example
-                        if (NfaStateHandler.IsNullable(ref statesWrapper) ||
-                            NfaStateHandler.IsNullableFor(_builder, ref statesWrapper, CharKind.BeginningEnd))
+                        Debug.Assert(states.NfaStateSet.Count > 0);
+
+                        // Gather the possible endings for satisfying nullability
+                        possibleEndings.Clear();
+                        if (SymbolicRegexMatcher<TSet>.NfaStateHandler.CanBeNullable(this, in statesWrapper))
                         {
-                            possibleEndings.Add("");
+                            // Unconditionally final state or end of the input due to \Z anchor for example
+                            if (SymbolicRegexMatcher<TSet>.NfaStateHandler.IsNullable(this, in statesWrapper) ||
+                                SymbolicRegexMatcher<TSet>.NfaStateHandler.IsNullableFor(this, in statesWrapper, CharKind.BeginningEnd))
+                            {
+                                possibleEndings.Add("");
+                            }
+
+                            // End of line due to end-of-line anchor
+                            if (SymbolicRegexMatcher<TSet>.NfaStateHandler.IsNullableFor(this, in statesWrapper, CharKind.Newline))
+                            {
+                                possibleEndings.Add("\n");
+                            }
+
+                            // Related to wordborder due to \b or \B
+                            if (SymbolicRegexMatcher<TSet>.NfaStateHandler.IsNullableFor(this, in statesWrapper, CharKind.WordLetter))
+                            {
+                                possibleEndings.Add(ChooseChar(random, asciiWordCharacters, ascii, charSetSolver).ToString());
+                            }
+
+                            // Related to wordborder due to \b or \B
+                            if (SymbolicRegexMatcher<TSet>.NfaStateHandler.IsNullableFor(this, in statesWrapper, CharKind.General))
+                            {
+                                possibleEndings.Add(ChooseChar(random, asciiNonWordCharacters, ascii, charSetSolver).ToString());
+                            }
                         }
 
-                        // End of line due to end-of-line anchor
-                        if (NfaStateHandler.IsNullableFor(_builder, ref statesWrapper, CharKind.Newline))
+                        // If we have a possible ending, then store a candidate input
+                        if (possibleEndings.Count > 0)
                         {
-                            possibleEndings.Add("\n");
+                            latestCandidate ??= new();
+                            latestCandidate.Clear();
+                            latestCandidate.Append(inputSoFar);
+                            //Choose some suffix that allows some anchor (if any) to be nullable
+                            latestCandidate.Append(Choose(random, possibleEndings));
+
+                            // Choose to stop here based on a coin-toss
+                            if (FlipBiasedCoin(random, SampleMatchesStoppingProbability))
+                            {
+                                yield return latestCandidate.ToString();
+                                break;
+                            }
                         }
 
-                        // Related to wordborder due to \b or \B
-                        if (NfaStateHandler.IsNullableFor(_builder, ref statesWrapper, CharKind.WordLetter))
+                        // Shuffle the minterms, including the last end-of-line marker if appropriate
+                        int[] mintermIds = SymbolicRegexMatcher<TSet>.NfaStateHandler.StartsWithLineAnchor(this, in statesWrapper) ?
+                            Shuffle(random, mintermIdsWithZ) :
+                            Shuffle(random, mintermIdsWithoutZ);
+                        foreach (int mintermId in mintermIds)
                         {
-                            possibleEndings.Add(ChooseChar(random, asciiWordCharacters, ascii, charSetSolver).ToString());
+                            bool success = SymbolicRegexMatcher<TSet>.NfaStateHandler.TryTakeTransition(this, ref statesWrapper, mintermId);
+                            Debug.Assert(success);
+                            if (states.NfaStateSet.Count > 0)
+                            {
+                                TSet minterm = GetMintermFromId(mintermId);
+                                // Append a random member of the minterm
+                                inputSoFar.Append(ChooseChar(random, ToBDD(minterm, Solver, charSetSolver), ascii, charSetSolver));
+                                break;
+                            }
+                            else
+                            {
+                                // The transition was a dead end, undo and continue to try another minterm
+                                NfaStateHandler.UndoTransition(ref statesWrapper);
+                            }
                         }
 
-                        // Related to wordborder due to \b or \B
-                        if (NfaStateHandler.IsNullableFor(_builder, ref statesWrapper, CharKind.General))
+                        // In the case that there are no next states or input has become too large: stop here
+                        if (states.NfaStateSet.Count == 0 || inputSoFar.Length > SampleMatchesMaxInputLength)
                         {
-                            possibleEndings.Add(ChooseChar(random, asciiNonWordCharacters, ascii, charSetSolver).ToString());
-                        }
-                    }
-
-                    // If we have a possible ending, then store a candidate input
-                    if (possibleEndings.Count > 0)
-                    {
-                        latestCandidate ??= new();
-                        latestCandidate.Clear();
-                        latestCandidate.Append(inputSoFar);
-                        //Choose some suffix that allows some anchor (if any) to be nullable
-                        latestCandidate.Append(Choose(random, possibleEndings));
-
-                        // Choose to stop here based on a coin-toss
-                        if (FlipBiasedCoin(random, SampleMatchesStoppingProbability))
-                        {
-                            yield return latestCandidate.ToString();
+                            // Ending up here without an ending is unlikely but possible for example for infeasible patterns
+                            // such as @"no\bway" or due to poor choice of c -- no anchor is enabled -- so this is a deadend.
+                            if (latestCandidate != null)
+                            {
+                                yield return latestCandidate.ToString();
+                            }
                             break;
                         }
-                    }
-
-                    // Shuffle the minterms, including the last end-of-line marker if appropriate
-                    int[] mintermIds = NfaStateHandler.StartsWithLineAnchor(_builder, ref statesWrapper) ?
-                        Shuffle(random, mintermIdsWithZ) :
-                        Shuffle(random, mintermIdsWithoutZ);
-                    foreach (int mintermId in mintermIds)
-                    {
-                        bool success = NfaStateHandler.TakeTransition(_builder, ref statesWrapper, mintermId);
-                        Debug.Assert(success);
-                        if (states.NfaStateSet.Count > 0)
-                        {
-                            TSet minterm = _builder.GetMinterm(mintermId);
-                            // Append a random member of the minterm
-                            inputSoFar.Append(ChooseChar(random, ToBDD(minterm, solver, charSetSolver), ascii, charSetSolver));
-                            break;
-                        }
-                        else
-                        {
-                            // The transition was a dead end, undo and continue to try another minterm
-                            NfaStateHandler.UndoTransition(ref statesWrapper);
-                        }
-                    }
-
-                    // In the case that there are no next states or input has become too large: stop here
-                    if (states.NfaStateSet.Count == 0 || inputSoFar.Length > SampleMatchesMaxInputLength)
-                    {
-                        // Ending up here without an ending is unlikely but possible for example for infeasible patterns
-                        // such as @"no\bway" or due to poor choice of c -- no anchor is enabled -- so this is a deadend.
-                        if (latestCandidate != null)
-                        {
-                            yield return latestCandidate.ToString();
-                        }
-                        break;
                     }
                 }
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -94,9 +95,21 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <remarks>If the pattern doesn't contain any anchors, there will only be a single initial state.</remarks>
         private readonly DfaMatchingState<TSet>[] _reverseInitialStates;
 
-        /// <summary>Lookup table to quickly determine the character kind for ASCII characters.</summary>
-        /// <remarks>Non-null iff the pattern contains anchors; otherwise, it's unused.</remarks>
-        private readonly uint[]? _asciiCharKinds;
+        /// <summary>Partition of the input space of sets.</summary>
+        private readonly TSet[] _minterms;
+
+        /// <summary>
+        /// Character kinds <see cref="CharKind"/> for all minterms in <see cref="_minterms"/> as well as two special
+        /// cases: character positions outside the input bounds and an end-of-line as the last input character.
+        /// </summary>
+        private readonly uint[] _positionKinds;
+
+        /// <summary>
+        /// The smallest k s.t. 2^k >= minterms.Length + 1. The "delta arrays", e.g., <see cref="_delta"/> allocate 2^k
+        /// consecutive slots for each state ID to represent the transitions for each minterm. The extra slot at index
+        /// _minterms.Length is used to represent an \n occurring at the very end of input, for supporting the \Z anchor.
+        /// </summary>
+        private readonly int _mintermsLog;
 
         /// <summary>Number of capture groups.</summary>
         private readonly int _capsize;
@@ -105,14 +118,10 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <remarks>This determines whether the matcher uses the special capturing NFA simulation mode.</remarks>
         internal bool HasSubcaptures => _capsize > 1;
 
-        /// <summary>Get the minterm of <paramref name="c"/>.</summary>
-        /// <param name="c">character code</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private TSet GetMinterm(int c)
-        {
-            Debug.Assert(_builder._minterms is not null);
-            return _builder._minterms[_mintermClassifier.GetMintermID(c)];
-        }
+        /// <remarks>
+        /// Both solvers supported here, <see cref="UInt64Solver"/> and <see cref="BitVectorSolver"/> are thread safe.
+        /// </remarks>
+        private ISolver<TSet> Solver => _builder._solver;
 
         /// <summary>Creates a new <see cref="SymbolicRegexMatcher{TSetType}"/>.</summary>
         /// <param name="captureCount">The number of captures in the regular expression.</param>
@@ -136,24 +145,45 @@ namespace System.Text.RegularExpressions.Symbolic
                 _newLineSet = solver.ConvertFromBDD(bddBuilder._newLineSet, charSetSolver)
             };
 
-            // Convert the BDD-based AST to TSetType-based AST
+            // Convert the BDD-based AST to TSet-based AST
             SymbolicRegexNode<TSet> rootNode = bddBuilder.Transform(rootBddNode, builder, (builder, bdd) => builder._solver.ConvertFromBDD(bdd, charSetSolver));
-            return new SymbolicRegexMatcher<TSet>(rootNode, captureCount, findOptimizations, matchTimeout);
+            return new SymbolicRegexMatcher<TSet>(builder, rootNode, captureCount, findOptimizations, matchTimeout);
         }
 
         /// <summary>Constructs matcher for given symbolic regex.</summary>
-        private SymbolicRegexMatcher(SymbolicRegexNode<TSet> rootNode, int captureCount, RegexFindOptimizations findOptimizations, TimeSpan matchTimeout)
+        private SymbolicRegexMatcher(SymbolicRegexBuilder<TSet> builder, SymbolicRegexNode<TSet> rootNode, int captureCount, RegexFindOptimizations findOptimizations, TimeSpan matchTimeout)
         {
-            Debug.Assert(rootNode._builder._solver is UInt64Solver or BitVectorSolver, $"Unsupported solver: {rootNode._builder._solver}");
+            Debug.Assert(builder._solver is UInt64Solver or BitVectorSolver, $"Unsupported solver: {builder._solver}");
 
             _pattern = rootNode;
-            _builder = rootNode._builder;
+            _builder = builder;
             _checkTimeout = Regex.InfiniteMatchTimeout != matchTimeout;
             _timeout = (int)(matchTimeout.TotalMilliseconds + 0.5); // Round up, so it will be at least 1ms
-            _mintermClassifier = _builder._solver is UInt64Solver bv64 ?
+            TSet[]? solverMinterms = builder._solver.GetMinterms();
+            Debug.Assert(solverMinterms is not null);
+            _minterms = solverMinterms;
+            // BitOperations.Log2 gives the integer floor of the log, so the +1 below either rounds up with non-power-of-two
+            // minterms or adds an extra bit with power-of-two minterms. The extra slot at index _minterms.Length is used to
+            // represent an \n occurring at the very end of input, for supporting the \Z anchor.
+            _mintermsLog = BitOperations.Log2((uint)_minterms.Length) + 1;
+            _mintermClassifier = builder._solver is UInt64Solver bv64 ?
                 bv64._classifier :
-                ((BitVectorSolver)(object)_builder._solver)._classifier;
+                ((BitVectorSolver)(object)builder._solver)._classifier;
             _capsize = captureCount;
+
+            // Initialization for fields in SymbolicRegexMatcher.Automata.cs
+            _stateArray = new DfaMatchingState<TSet>[InitialDfaStateCapacity];
+            _stateInfo = new ContextIndependentState[InitialDfaStateCapacity];
+            _delta = new int[InitialDfaStateCapacity << _mintermsLog];
+
+            // Initialize a lookup array for the character kinds of each minterm ID. This includes one "special" minterm
+            // ID _minterms.Length, which is used to represent a \n at the very end of input, and another ID -1,
+            // which is used to represent any position outside the bounds of the input.
+            _positionKinds = new uint[_minterms.Length + 2];
+            for (int mintermId = -1; mintermId < _positionKinds.Length - 1; mintermId++)
+            {
+                _positionKinds[mintermId + 1] = CalculateMintermIdKind(mintermId);
+            }
 
             // Store the find optimizations that can be used to jump ahead to the next possible starting location.
             // If there's a leading beginning anchor, the find optimizations are unnecessary on top of the DFA's
@@ -170,24 +200,23 @@ namespace System.Text.RegularExpressions.Symbolic
 
             // Create the initial states for the original pattern.
             var initialStates = new DfaMatchingState<TSet>[statesCount];
-            for (uint i = 0; i < initialStates.Length; i++)
+            for (uint charKind = 0; charKind < initialStates.Length; charKind++)
             {
-                initialStates[i] = _builder.CreateState(_pattern, i, capturing: HasSubcaptures);
+                initialStates[charKind] = GetOrCreateStateUnsafe(_pattern, charKind);
             }
             _initialStates = initialStates;
 
             // Create the dot-star pattern (a concatenation of any* with the original pattern)
             // and all of its initial states.
-            _dotStarredPattern = _builder.CreateConcat(_builder._anyStarLazy, _pattern);
+            _dotStarredPattern = builder.CreateConcat(builder._anyStarLazy, _pattern);
             var dotstarredInitialStates = new DfaMatchingState<TSet>[statesCount];
-            for (uint i = 0; i < dotstarredInitialStates.Length; i++)
+            for (uint charKind = 0; charKind < dotstarredInitialStates.Length; charKind++)
             {
                 // Used to detect if initial state was reentered,
                 // but observe that the behavior from the state may ultimately depend on the previous
                 // input char e.g. possibly causing nullability of \b or \B or of a start-of-line anchor,
                 // in that sense there can be several "versions" (not more than StateCount) of the initial state.
-                DfaMatchingState<TSet> state = _builder.CreateState(_dotStarredPattern, i, capturing: false, isInitialState: true);
-                dotstarredInitialStates[i] = state;
+                dotstarredInitialStates[charKind] = GetOrCreateStateUnsafe(_dotStarredPattern, charKind, isInitialState: true);
             }
             _dotstarredInitialStates = dotstarredInitialStates;
 
@@ -195,84 +224,94 @@ namespace System.Text.RegularExpressions.Symbolic
             // initial states. Also disable backtracking simulation to ensure the reverse path from
             // the final state that was found is followed. Not doing so might cause the earliest
             // starting point to not be found.
-            _reversePattern = _builder.CreateDisableBacktrackingSimulation(_pattern.Reverse());
+            _reversePattern = builder.CreateDisableBacktrackingSimulation(_pattern.Reverse(builder));
             var reverseInitialStates = new DfaMatchingState<TSet>[statesCount];
-            for (uint i = 0; i < reverseInitialStates.Length; i++)
+            for (uint charKind = 0; charKind < reverseInitialStates.Length; charKind++)
             {
-                reverseInitialStates[i] = _builder.CreateState(_reversePattern, i, capturing: false);
+                reverseInitialStates[charKind] = GetOrCreateStateUnsafe(_reversePattern, charKind);
             }
             _reverseInitialStates = reverseInitialStates;
 
-            // Initialize our fast-lookup for determining the character kind of ASCII characters.
-            // This is only required when the pattern contains anchors, as otherwise there's only
-            // ever a single kind used.
-            if (_pattern._info.ContainsSomeAnchor)
+            // Maps a minterm ID to a character kind
+            uint CalculateMintermIdKind(int mintermId)
             {
-                var asciiCharKinds = new uint[128];
-                for (int i = 0; i < asciiCharKinds.Length; i++)
+                if (!_pattern._info.ContainsSomeAnchor)
                 {
-                    TSet set;
-                    uint charKind;
-
-                    if (i == '\n')
-                    {
-                        set = _builder._newLineSet;
-                        charKind = CharKind.Newline;
-                    }
-                    else
-                    {
-                        set = _builder._wordLetterForBoundariesSet;
-                        charKind = CharKind.WordLetter;
-                    }
-
-                    asciiCharKinds[i] = _builder._solver.And(GetMinterm(i), set).Equals(_builder._solver.Empty) ? 0 : charKind;
+                    return CharKind.General;
                 }
-                _asciiCharKinds = asciiCharKinds;
+
+                // A minterm ID of -1 represents the positions before the first and after the last character
+                // in the input.
+                if (mintermId == -1)
+                {
+                    return CharKind.BeginningEnd;
+                }
+
+                // A minterm ID of minterms.Length represents a \n at the very end of input, which is matched
+                // by the \Z anchor.
+                if ((uint)mintermId == (uint)_minterms.Length)
+                {
+                    return CharKind.NewLineS;
+                }
+
+                TSet minterm = _minterms[mintermId];
+
+                // Examine the minterm to figure out its character kind
+                if (_builder._newLineSet.Equals(minterm))
+                {
+                    // The minterm is a new line character
+                    return CharKind.Newline;
+                }
+                else if (!Solver.IsEmpty(Solver.And(_builder._wordLetterForBoundariesSet, minterm)))
+                {
+                    Debug.Assert(Solver.IsEmpty(Solver.And(Solver.Not(_builder._wordLetterForBoundariesSet), minterm)));
+                    // The minterm is a subset of word letters as considered by \b and \B
+                    return CharKind.WordLetter;
+                }
+                else
+                {
+                    // All other minterms belong to the general kind
+                    return CharKind.General;
+                }
             }
         }
 
         /// <summary>
         /// Create a PerThreadData with the appropriate parts initialized for this matcher's pattern.
         /// </summary>
-        internal PerThreadData CreatePerThreadData() => new PerThreadData(_builder, _capsize);
+        internal PerThreadData CreatePerThreadData() => new PerThreadData(_capsize);
 
-        /// <summary>Compute the target state for the source state and input[i] character and transition to it.</summary>
-        /// <param name="builder">The associated builder.</param>
-        /// <param name="input">The input text.</param>
-        /// <param name="i">The index into <paramref name="input"/> at which the target character lives.</param>
-        /// <param name="state">The current state being transitioned from. Upon return it's the new state if the transition succeeded.</param>
+        /// <summary>Look up what is the character kind given a position ID</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool TryTakeTransition<TStateHandler>(SymbolicRegexBuilder<TSet> builder, ReadOnlySpan<char> input, int i, ref CurrentState state)
-            where TStateHandler : struct, IStateHandler
+        private uint GetPositionKind(int positionId) => _positionKinds[positionId + 1];
+
+        /// <summary>
+        /// Lookup the actual minterm based on its ID. Also get its character kind, which is a general categorization of
+        /// characters used for cheaply deciding the nullability of anchors.
+        /// </summary>
+        internal TSet GetMintermFromId(int mintermId)
         {
-            int c = input[i];
+            TSet[] minterms = _minterms;
 
-            // Find the minterm, handling the special case for the last \n for states that start with a relevant anchor
-            int mintermId = c == '\n' && i == input.Length - 1 && TStateHandler.StartsWithLineAnchor(builder, ref state) ?
-                builder._minterms!.Length : // mintermId = minterms.Length represents an \n at the very end of input
-                _mintermClassifier.GetMintermID(c);
-
-            return TStateHandler.TakeTransition(builder, ref state, mintermId);
-        }
-
-        private List<(DfaMatchingState<TSet>, DerivativeEffect[])> CreateNewCapturingTransitions(DfaMatchingState<TSet> state, TSet minterm, int offset)
-        {
-            Debug.Assert(_builder._capturingDelta is not null);
-            lock (this)
+            // A minterm ID of minterms.Length represents a \n at the very end of input, which is matched
+            // by the \Z anchor.
+            if ((uint)mintermId == (uint)minterms.Length)
             {
-                // Get the next state if it exists.  The caller should have already tried and found it null (not yet created),
-                // but in the interim another thread could have created it.
-                List<(DfaMatchingState<TSet>, DerivativeEffect[])>? p = _builder._capturingDelta[offset];
-                if (p is null)
-                {
-                    // Build the new state and store it into the array.
-                    p = state.NfaNextWithEffects(minterm);
-                    Volatile.Write(ref _builder._capturingDelta[offset], p);
-                }
-
-                return p;
+                return _builder._newLineSet;
             }
+
+            // Otherwise look up the minterm from the array
+            return minterms[mintermId];
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private uint GetCharKind<TInputReader>(ReadOnlySpan<char> input, int i)
+            where TInputReader : struct, IInputReader => !_pattern._info.ContainsSomeAnchor ?
+                CharKind.General : // The previous character kind is irrelevant when anchors are not used.
+                GetPositionKind(TInputReader.GetPositionId(this, input, i));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsMintermId(int positionId) => positionId >= 0;
 
         private void CheckTimeout(long timeoutOccursAt)
         {
@@ -309,12 +348,16 @@ namespace System.Text.RegularExpressions.Symbolic
             // the position of the last b: aacaaaabbbc.  It additionally records the position of the first a after
             // the c as the low boundary for the starting position.
             int matchStartLowBoundary, matchStartLengthMarker;
-            int matchEnd = (_findOpts is not null, _pattern._info.ContainsSomeAnchor) switch
+            int matchEnd = (_pattern._info.ContainsLineAnchor, _findOpts is not null, _pattern._info.ContainsSomeAnchor) switch
             {
-                (true, true) => FindEndPosition<InitialStateFindOptimizationsHandler, FullNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
-                (true, false) => FindEndPosition<InitialStateFindOptimizationsHandler, NoAnchorsNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
-                (false, true) => FindEndPosition<NoOptimizationsInitialStateHandler, FullNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
-                (false, false) => FindEndPosition<NoOptimizationsInitialStateHandler, NoAnchorsNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
+                (true, true, true) => FindEndPosition<FullInputReader, InitialStateFindOptimizationsHandler, FullNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
+                (true, true, false) => FindEndPosition<FullInputReader, InitialStateFindOptimizationsHandler, NoAnchorsNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
+                (true, false, true) => FindEndPosition<FullInputReader, NoOptimizationsInitialStateHandler, FullNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
+                (true, false, false) => FindEndPosition<FullInputReader, NoOptimizationsInitialStateHandler, NoAnchorsNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
+                (false, true, true) => FindEndPosition<NoZAnchorInputReader, InitialStateFindOptimizationsHandler, FullNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
+                (false, true, false) => FindEndPosition<NoZAnchorInputReader, InitialStateFindOptimizationsHandler, NoAnchorsNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
+                (false, false, true) => FindEndPosition<NoZAnchorInputReader, NoOptimizationsInitialStateHandler, FullNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
+                (false, false, false) => FindEndPosition<NoZAnchorInputReader, NoOptimizationsInitialStateHandler, NoAnchorsNullabilityHandler>(input, startat, timeoutOccursAt, mode, out matchStartLowBoundary, out matchStartLengthMarker, perThreadData),
             };
 
             // If there wasn't a match, we're done.
@@ -345,9 +388,13 @@ namespace System.Text.RegularExpressions.Symbolic
             {
                 Debug.Assert(matchEnd >= startat - 1);
                 matchStart = matchEnd < startat ?
-                    startat : _pattern._info.ContainsSomeAnchor ?
-                        FindStartPosition<FullNullabilityHandler>(input, matchEnd, matchStartLowBoundary, perThreadData) :
-                        FindStartPosition<NoAnchorsNullabilityHandler>(input, matchEnd, matchStartLowBoundary, perThreadData);
+                    startat : (_pattern._info.ContainsLineAnchor, _pattern._info.ContainsSomeAnchor) switch
+                    {
+                        (true, true) => FindStartPosition<FullInputReader, FullNullabilityHandler>(input, matchEnd, matchStartLowBoundary, perThreadData),
+                        (true, false) => FindStartPosition<FullInputReader, NoAnchorsNullabilityHandler>(input, matchEnd, matchStartLowBoundary, perThreadData),
+                        (false, true) => FindStartPosition<NoZAnchorInputReader, FullNullabilityHandler>(input, matchEnd, matchStartLowBoundary, perThreadData),
+                        (false, false) => FindStartPosition<NoZAnchorInputReader, NoAnchorsNullabilityHandler>(input, matchEnd, matchStartLowBoundary, perThreadData),
+                    };
             }
 
             // Phase 3:
@@ -361,7 +408,9 @@ namespace System.Text.RegularExpressions.Symbolic
             }
             else
             {
-                Registers endRegisters = FindSubcaptures(input, matchStart, matchEnd, perThreadData);
+                Registers endRegisters = _pattern._info.ContainsLineAnchor ?
+                    FindSubcaptures<FullInputReader>(input, matchStart, matchEnd, perThreadData) :
+                    FindSubcaptures<NoZAnchorInputReader>(input, matchStart, matchEnd, perThreadData);
                 return new SymbolicMatch(matchStart, matchEnd - matchStart, endRegisters.CaptureStarts, endRegisters.CaptureEnds);
             }
         }
@@ -377,15 +426,15 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <returns>
         /// A one-past-the-end index into input for the preferred match, or first final state position if isMatch is true, or NoMatchExists if no match exists.
         /// </returns>
-        private int FindEndPosition<TFindOptimizationsHandler, TNullabilityHandler>(ReadOnlySpan<char> input, int pos, long timeoutOccursAt, RegexRunnerMode mode, out int initialStatePos, out int matchLength, PerThreadData perThreadData)
+        private int FindEndPosition<TInputReader, TFindOptimizationsHandler, TNullabilityHandler>(ReadOnlySpan<char> input, int pos, long timeoutOccursAt, RegexRunnerMode mode, out int initialStatePos, out int matchLength, PerThreadData perThreadData)
+            where TInputReader : struct, IInputReader
             where TFindOptimizationsHandler : struct, IInitialStateHandler
             where TNullabilityHandler : struct, INullabilityHandler
         {
             initialStatePos = pos;
             int initialStatePosCandidate = pos;
 
-            var currentState = new CurrentState(_dotstarredInitialStates[GetCharKind(input, pos - 1)]);
-            SymbolicRegexBuilder<TSet> builder = _builder;
+            var currentState = new CurrentState(_dotstarredInitialStates[GetCharKind<TInputReader>(input, pos - 1)]);
 
             int endPos = NoMatchExists;
             int endStateId = -1;
@@ -404,8 +453,8 @@ namespace System.Text.RegularExpressions.Symbolic
                     input;
 
                 bool done = currentState.NfaState is not null ?
-                    FindEndPositionDeltas<NfaStateHandler, TFindOptimizationsHandler, TNullabilityHandler>(builder, input, mode, ref pos, ref currentState, ref endPos, ref endStateId, ref initialStatePos, ref initialStatePosCandidate) :
-                    FindEndPositionDeltas<DfaStateHandler, TFindOptimizationsHandler, TNullabilityHandler>(builder, input, mode, ref pos, ref currentState, ref endPos, ref endStateId, ref initialStatePos, ref initialStatePosCandidate);
+                    FindEndPositionDeltas<NfaStateHandler, TInputReader, TFindOptimizationsHandler, TNullabilityHandler>(input, mode, ref pos, ref currentState, ref endPos, ref endStateId, ref initialStatePos, ref initialStatePosCandidate) :
+                    FindEndPositionDeltas<DfaStateHandler, TInputReader, TFindOptimizationsHandler, TNullabilityHandler>(input, mode, ref pos, ref currentState, ref endPos, ref endStateId, ref initialStatePos, ref initialStatePosCandidate);
 
                 // If the inner loop indicates that the search finished (for example due to reaching a deadend state) or
                 // there is no more input available, then the whole search is done.
@@ -421,10 +470,8 @@ namespace System.Text.RegularExpressions.Symbolic
                 {
                     // Because there was still more input available, a failure to transition in DFA mode must be the cause
                     // of the early exit. Upgrade to NFA mode.
-                    DfaMatchingState<TSet>? dfaState = currentState.DfaState(_builder);
-                    Debug.Assert(dfaState is not null);
                     NfaMatchingState nfaState = perThreadData.NfaState;
-                    nfaState.InitializeFrom(dfaState);
+                    nfaState.InitializeFrom(this, GetState(currentState.DfaStateId));
                     currentState = new CurrentState(nfaState);
                 }
 
@@ -437,7 +484,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
             // Check whether there's a fixed-length marker for the current state.  If there is, we can
             // use that length to optimize subsequent matching phases.
-            matchLength = endStateId > 0 ? _builder._stateArray![endStateId].FixedLength(GetCharKind(input, endPos)) : -1;
+            matchLength = endStateId > 0 ? GetState(endStateId).FixedLength(GetCharKind<TInputReader>(input, endPos)) : -1;
             return endPos;
         }
 
@@ -458,9 +505,10 @@ namespace System.Text.RegularExpressions.Symbolic
         /// 0 if iteration completed because we reached an initial state.
         /// A negative value if iteration completed because we ran out of input or we failed to transition.
         /// </returns>
-        private bool FindEndPositionDeltas<TStateHandler, TFindOptimizationsHandler, TNullabilityHandler>(SymbolicRegexBuilder<TSet> builder, ReadOnlySpan<char> input, RegexRunnerMode mode,
+        private bool FindEndPositionDeltas<TStateHandler, TInputReader, TFindOptimizationsHandler, TNullabilityHandler>(ReadOnlySpan<char> input, RegexRunnerMode mode,
                 ref int posRef, ref CurrentState stateRef, ref int endPosRef, ref int endStateIdRef, ref int initialStatePosRef, ref int initialStatePosCandidateRef)
             where TStateHandler : struct, IStateHandler
+            where TInputReader : struct, IInputReader
             where TFindOptimizationsHandler : struct, IInitialStateHandler
             where TNullabilityHandler : struct, INullabilityHandler
         {
@@ -476,13 +524,13 @@ namespace System.Text.RegularExpressions.Symbolic
                 // Loop through each character in the input, transitioning from state to state for each.
                 while (true)
                 {
-                    (bool isInitial, bool isDeadend, bool isNullable, bool canBeNullable) = TStateHandler.GetStateInfo(builder, ref state);
+                    (bool isInitial, bool isDeadend, bool isNullable, bool canBeNullable) = TStateHandler.GetStateInfo(this, in state);
 
                     // Check if currentState represents an initial state. If it does, call into any possible find optimizations
                     // to hopefully more quickly find the next possible starting location.
                     if (isInitial)
                     {
-                        if (!TFindOptimizationsHandler.TryFindNextStartingPosition(this, input, ref state, ref pos))
+                        if (!TFindOptimizationsHandler.TryFindNextStartingPosition<TInputReader>(this, input, ref state, ref pos))
                         {
                             return true;
                         }
@@ -496,12 +544,14 @@ namespace System.Text.RegularExpressions.Symbolic
                         return true;
                     }
 
+                    int positionId = TInputReader.GetPositionId(this, input, pos);
+
                     // If the state is nullable for the next character, meaning it accepts the empty string,
                     // we found a potential end state.
-                    if (TNullabilityHandler.IsNullableAt<TStateHandler>(this, ref state, input, pos, isNullable, canBeNullable))
+                    if (TNullabilityHandler.IsNullableAt<TStateHandler>(this, in state, positionId, isNullable, canBeNullable))
                     {
                         endPos = pos;
-                        endStateId = TStateHandler.ExtractNullableCoreStateId(this, ref state, input, pos);
+                        endStateId = TStateHandler.ExtractNullableCoreStateId(this, in state, input, pos);
                         initialStatePos = initialStatePosCandidate;
 
                         // A match is known to exist.  If that's all we need to know, we're done.
@@ -512,7 +562,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     }
 
                     // If there is more input available try to transition with the next character.
-                    if ((uint)pos >= (uint)input.Length || !TryTakeTransition<TStateHandler>(builder, input, pos, ref state))
+                    if (!IsMintermId(positionId) || !TStateHandler.TryTakeTransition(this, ref state, positionId))
                     {
                         return false;
                     }
@@ -546,7 +596,8 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="matchStartBoundary">The initial starting location discovered in phase 1, a point we must not walk earlier than.</param>
         /// <param name="perThreadData">Per thread data reused between calls.</param>
         /// <returns>The found starting position for the match.</returns>
-        private int FindStartPosition<TNullabilityHandler>(ReadOnlySpan<char> input, int i, int matchStartBoundary, PerThreadData perThreadData)
+        private int FindStartPosition<TInputReader, TNullabilityHandler>(ReadOnlySpan<char> input, int i, int matchStartBoundary, PerThreadData perThreadData)
+            where TInputReader : struct, IInputReader
             where TNullabilityHandler : struct, INullabilityHandler
         {
             Debug.Assert(i >= 0, $"{nameof(i)} == {i}");
@@ -555,18 +606,17 @@ namespace System.Text.RegularExpressions.Symbolic
 
             // Get the starting state for the reverse pattern. This depends on previous character (which, because we're
             // going backwards, is character number i).
-            var currentState = new CurrentState(_reverseInitialStates[GetCharKind(input, i)]);
+            var currentState = new CurrentState(_reverseInitialStates[GetCharKind<TInputReader>(input, i)]);
 
             int lastStart = -1; // invalid sentinel value
 
             // Walk backwards to the furthest accepting state of the reverse pattern but no earlier than matchStartBoundary.
-            SymbolicRegexBuilder<TSet> builder = _builder;
             while (true)
             {
                 // Run the DFA or NFA traversal backwards from the current point using the current state.
                 bool done = currentState.NfaState is not null ?
-                    FindStartPositionDeltas<NfaStateHandler, TNullabilityHandler>(builder, input, ref i, matchStartBoundary, ref currentState, ref lastStart) :
-                    FindStartPositionDeltas<DfaStateHandler, TNullabilityHandler>(builder, input, ref i, matchStartBoundary, ref currentState, ref lastStart);
+                    FindStartPositionDeltas<NfaStateHandler, TInputReader, TNullabilityHandler>(input, ref i, matchStartBoundary, ref currentState, ref lastStart) :
+                    FindStartPositionDeltas<DfaStateHandler, TInputReader, TNullabilityHandler>(input, ref i, matchStartBoundary, ref currentState, ref lastStart);
 
                 // If we found the starting position, we're done.
                 if (done)
@@ -578,10 +628,8 @@ namespace System.Text.RegularExpressions.Symbolic
                 // if we were unable to transition, which should only happen if we were in DFA mode and exceeded our graph size.
                 // Upgrade to NFA mode and continue.
                 Debug.Assert(i >= matchStartBoundary);
-                DfaMatchingState<TSet>? dfaState = currentState.DfaState(_builder);
-                Debug.Assert(dfaState is not null);
                 NfaMatchingState nfaState = perThreadData.NfaState;
-                nfaState.InitializeFrom(dfaState);
+                nfaState.InitializeFrom(this, GetState(currentState.DfaStateId));
                 currentState = new CurrentState(nfaState);
             }
 
@@ -594,8 +642,9 @@ namespace System.Text.RegularExpressions.Symbolic
         /// starting at <paramref name="i"/>, for each character transitioning from one state in the DFA or NFA graph to the next state,
         /// lazily building out the graph as needed.
         /// </summary>
-        private bool FindStartPositionDeltas<TStateHandler, TNullabilityHandler>(SymbolicRegexBuilder<TSet> builder, ReadOnlySpan<char> input, ref int i, int startThreshold, ref CurrentState currentState, ref int lastStart)
+        private bool FindStartPositionDeltas<TStateHandler, TInputReader, TNullabilityHandler>(ReadOnlySpan<char> input, ref int i, int startThreshold, ref CurrentState currentState, ref int lastStart)
             where TStateHandler : struct, IStateHandler
+            where TInputReader : struct, IInputReader
             where TNullabilityHandler : struct, INullabilityHandler
         {
             // To avoid frequent reads/writes to ref values, make and operate on local copies, which we then copy back once before returning.
@@ -606,11 +655,13 @@ namespace System.Text.RegularExpressions.Symbolic
                 // Loop backwards through each character in the input, transitioning from state to state for each.
                 while (true)
                 {
-                    (bool isInitial, bool isDeadend, bool isNullable, bool canBeNullable) = TStateHandler.GetStateInfo(builder, ref state);
+                    (bool isInitial, bool isDeadend, bool isNullable, bool canBeNullable) = TStateHandler.GetStateInfo(this, in state);
+
+                    int positionId = TInputReader.GetPositionId(this, input, pos - 1);
 
                     // If the state accepts the empty string, we found a valid starting position.  Record it and keep going,
                     // since we're looking for the earliest one to occur within bounds.
-                    if (TNullabilityHandler.IsNullableAt<TStateHandler>(this, ref state, input, pos - 1, isNullable, canBeNullable))
+                    if (TNullabilityHandler.IsNullableAt<TStateHandler>(this, in state, positionId, isNullable, canBeNullable))
                     {
                         lastStart = pos;
                     }
@@ -624,7 +675,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     }
 
                     // Try to transition with the next character, the one before the current position.
-                    if (!TryTakeTransition<TStateHandler>(builder, input, pos - 1, ref state))
+                    if (!TStateHandler.TryTakeTransition(this, ref state, positionId))
                     {
                         // Return false to indicate the search didn't finish.
                         return false;
@@ -649,10 +700,11 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="iEnd">exclusive end position</param>
         /// <param name="perThreadData">Per thread data reused between calls.</param>
         /// <returns>the final register values, which indicate capture starts and ends</returns>
-        private Registers FindSubcaptures(ReadOnlySpan<char> input, int i, int iEnd, PerThreadData perThreadData)
+        private Registers FindSubcaptures<TInputReader>(ReadOnlySpan<char> input, int i, int iEnd, PerThreadData perThreadData)
+            where TInputReader : struct, IInputReader
         {
             // Pick the correct start state based on previous character kind.
-            DfaMatchingState<TSet> initialState = _initialStates[GetCharKind(input, i - 1)];
+            DfaMatchingState<TSet> initialState = _initialStates[GetCharKind<TInputReader>(input, i - 1)];
 
             Registers initialRegisters = perThreadData.InitialRegisters;
 
@@ -667,52 +719,45 @@ namespace System.Text.RegularExpressions.Symbolic
             SparseIntMap<Registers> current = perThreadData.Current, next = perThreadData.Next;
             current.Clear();
             next.Clear();
-            current.Add(initialState.Id, initialRegisters);
 
-            SymbolicRegexBuilder<TSet> builder = _builder;
+            ForEachNfaState(initialState.Node, initialState.PrevCharKind, (current, initialRegisters),
+                static (int nfaId, (SparseIntMap<Registers> Current, Registers InitialRegisters) args) =>
+                    args.Current.Add(nfaId, args.InitialRegisters.Clone()));
 
             while ((uint)i < (uint)iEnd)
             {
                 Debug.Assert(next.Count == 0);
 
-                // Read the next character and find its minterm
-                int c = input[i];
-                int normalMintermId = _mintermClassifier.GetMintermID(c);
+                // i is guaranteed to be within bounds, so the position ID is a minterm ID
+                int mintermId = TInputReader.GetPositionId(this, input, i);
 
                 foreach ((int sourceId, Registers sourceRegisters) in current.Values)
                 {
-                    Debug.Assert(builder._capturingStateArray is not null);
-                    DfaMatchingState<TSet> sourceState = builder._capturingStateArray[sourceId];
-
-                    // Handle the special case for the last \n for states that start with a relevant anchor
-                    int mintermId = c == '\n' && i == input.Length - 1 && sourceState.StartsWithLineAnchor ?
-                        builder._minterms!.Length : // mintermId = minterms.Length represents an \n at the very end of input
-                        normalMintermId;
-                    TSet minterm = builder.GetMinterm(mintermId);
-
                     // Get or create the transitions
-                    int offset = (sourceId << builder._mintermsLog) | mintermId;
-                    Debug.Assert(builder._capturingDelta is not null);
-                    List<(DfaMatchingState<TSet>, DerivativeEffect[])>? transitions =
-                        builder._capturingDelta[offset] ??
-                        CreateNewCapturingTransitions(sourceState, minterm, offset);
+                    int offset = DeltaOffset(sourceId, mintermId);
+                    (int, DerivativeEffect[])[] transitions = _capturingNfaDelta[offset] ??
+                        CreateNewCapturingTransition(sourceId, mintermId, offset);
 
                     // Take the transitions in their prioritized order
-                    for (int j = 0; j < transitions.Count; ++j)
+                    for (int j = 0; j < transitions.Length; ++j)
                     {
-                        (DfaMatchingState<TSet> targetState, DerivativeEffect[] effects) = transitions[j];
-                        Debug.Assert(!targetState.IsDeadend, "Transitions should not include dead ends.");
+                        (int targetStateId, DerivativeEffect[] effects) = transitions[j];
 
                         // Try to add the state and handle the case where it didn't exist before. If the state already
                         // exists, then the transition can be safely ignored, as the existing state was generated by a
                         // higher priority transition.
-                        if (next.Add(targetState.Id, out int index))
+                        if (next.Add(targetStateId, out int index))
                         {
                             // Avoid copying the registers on the last transition from this state, reusing the registers instead
-                            Registers newRegisters = j != transitions.Count - 1 ? sourceRegisters.Clone() : sourceRegisters;
+                            Registers newRegisters = j != transitions.Length - 1 ? sourceRegisters.Clone() : sourceRegisters;
                             newRegisters.ApplyEffects(effects, i);
-                            next.Update(index, targetState.Id, newRegisters);
-                            if (targetState.IsNullableFor(GetCharKind(input, i + 1)))
+                            next.Update(index, targetStateId, newRegisters);
+
+                            int coreStateId = GetCoreStateId(targetStateId);
+                            (bool isInitial, bool isDeadend, bool isNullable, bool canBeNullable) = GetStateInfo(coreStateId);
+                            Debug.Assert(!isDeadend);
+
+                            if (isNullable || (canBeNullable && GetState(coreStateId).IsNullableFor(GetCharKind<TInputReader>(input, i + 1))))
                             {
                                 // No lower priority transitions from this or other source states are taken because the
                                 // backtracking engines would return the match ending here.
@@ -732,54 +777,20 @@ namespace System.Text.RegularExpressions.Symbolic
             }
 
             Debug.Assert(current.Count > 0);
-            Debug.Assert(_builder._capturingStateArray is not null);
             foreach (var (endStateId, endRegisters) in current.Values)
             {
-                DfaMatchingState<TSet> endState = _builder._capturingStateArray[endStateId];
-                if (endState.IsNullableFor(GetCharKind(input, iEnd)))
+                DfaMatchingState<TSet> endState = GetState(GetCoreStateId(endStateId));
+                if (endState.IsNullableFor(GetCharKind<TInputReader>(input, iEnd)))
                 {
                     // Apply effects for finishing at the stored end state
                     endState.Node.ApplyEffects((effect, args) => args.Registers.ApplyEffect(effect, args.Pos),
-                        CharKind.Context(endState.PrevCharKind, GetCharKind(input, iEnd)), (Registers: endRegisters, Pos: iEnd));
+                        CharKind.Context(endState.PrevCharKind, GetCharKind<TInputReader>(input, iEnd)), (Registers: endRegisters, Pos: iEnd));
                     return endRegisters;
                 }
             }
 
             Debug.Fail("No nullable state found in the set of end states");
             return default;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private uint GetCharKind(ReadOnlySpan<char> input, int i)
-        {
-            return !_pattern._info.ContainsSomeAnchor ?
-                CharKind.General : // The previous character kind is irrelevant when anchors are not used.
-                GetCharKindWithAnchor(input, i);
-
-            uint GetCharKindWithAnchor(ReadOnlySpan<char> input, int i)
-            {
-                Debug.Assert(_asciiCharKinds is not null);
-
-                if ((uint)i >= (uint)input.Length)
-                {
-                    return CharKind.BeginningEnd;
-                }
-
-                char nextChar = input[i];
-                if (nextChar == '\n')
-                {
-                    return
-                        _builder._newLineSet.Equals(_builder._solver.Empty) ? 0 : // ignore \n
-                        i == 0 || i == input.Length - 1 ? CharKind.NewLineS : // very first or very last \n. Detection of very first \n is needed for rev(\Z).
-                        CharKind.Newline;
-                }
-
-                uint[] asciiCharKinds = _asciiCharKinds;
-                return
-                    nextChar < (uint)asciiCharKinds.Length ? asciiCharKinds[nextChar] :
-                    _builder._solver.And(GetMinterm(nextChar), _builder._wordLetterForBoundariesSet).Equals(_builder._solver.Empty) ? 0 : // intersect with the wordletter set to compute the kind of the next character
-                    CharKind.WordLetter;
-            }
         }
 
         /// <summary>Stores additional data for tracking capture start and end positions.</summary>
@@ -867,9 +878,9 @@ namespace System.Text.RegularExpressions.Symbolic
             /// <summary>Registers used for the capturing third phase.</summary>
             public readonly Registers InitialRegisters;
 
-            public PerThreadData(SymbolicRegexBuilder<TSet> builder, int capsize)
+            public PerThreadData(int capsize)
             {
-                NfaState = new NfaMatchingState(builder);
+                NfaState = new NfaMatchingState();
 
                 // Only create data used for capturing mode if there are subcaptures
                 if (capsize > 1)
@@ -883,11 +894,9 @@ namespace System.Text.RegularExpressions.Symbolic
 
         /// <summary>Stores the state that represents a current state in NFA mode.</summary>
         /// <remarks>The entire state is composed of a list of individual states.</remarks>
+        /// <remarks>New instances should only be created once per runner.</remarks>
         internal sealed class NfaMatchingState
         {
-            /// <summary>The associated builder used to lazily add new DFA or NFA nodes to the graph.</summary>
-            public readonly SymbolicRegexBuilder<TSet> Builder;
-
             /// <summary>Ordered set used to store the current NFA states.</summary>
             /// <remarks>The value is unused.  The type is used purely for its keys.</remarks>
             public SparseIntMap<int> NfaStateSet = new();
@@ -899,24 +908,17 @@ namespace System.Text.RegularExpressions.Symbolic
             /// </remarks>
             public SparseIntMap<int> NfaStateSetScratch = new();
 
-            /// <summary>Create the instance.</summary>
-            /// <remarks>New instances should only be created once per runner.</remarks>
-            public NfaMatchingState(SymbolicRegexBuilder<TSet> builder) => Builder = builder;
-
             /// <summary>Resets this NFA state to represent the supplied DFA state.</summary>
+            /// <param name="matcher"></param>
             /// <param name="dfaMatchingState">The DFA state to use to initialize the NFA state.</param>
-            public void InitializeFrom(DfaMatchingState<TSet> dfaMatchingState)
+            public void InitializeFrom(SymbolicRegexMatcher<TSet> matcher, DfaMatchingState<TSet> dfaMatchingState)
             {
                 NfaStateSet.Clear();
 
                 // If the DFA state is a union of multiple DFA states, loop through all of them
                 // adding an NFA state for each.
-                foreach (SymbolicRegexNode<TSet> element in dfaMatchingState.Node.EnumerateAlternationBranches())
-                {
-                    // Create (possibly new) NFA states for all the members.
-                    // Add their IDs to the current set of NFA states and into the list.
-                    NfaStateSet.Add(Builder.CreateNfaState(element, dfaMatchingState.PrevCharKind), out _);
-                }
+                matcher.ForEachNfaState(dfaMatchingState.Node, dfaMatchingState.PrevCharKind, NfaStateSet,
+                    static (int nfaId, SparseIntMap<int> nfaStateSet) => nfaStateSet.Add(nfaId, out _));
             }
         }
 
@@ -942,51 +944,48 @@ namespace System.Text.RegularExpressions.Symbolic
             public int DfaStateId;
             /// <summary>The NFA state.</summary>
             public NfaMatchingState? NfaState;
-
-            public DfaMatchingState<TSet>? DfaState(SymbolicRegexBuilder<TSet> builder) => DfaStateId > 0 ? builder._stateArray![DfaStateId] : null;
         }
 
         /// <summary>Represents a set of routines for operating over a <see cref="CurrentState"/>.</summary>
         private interface IStateHandler
         {
-            public static abstract bool StartsWithLineAnchor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state);
-            public static abstract bool IsNullableFor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind);
-            public static abstract int ExtractNullableCoreStateId(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, ReadOnlySpan<char> input, int pos);
-            public static abstract int FixedLength(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind);
-            public static abstract bool TakeTransition(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, int mintermId);
-            public static abstract (bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable) GetStateInfo(SymbolicRegexBuilder<TSet> builder, ref CurrentState state);
+            public static abstract bool StartsWithLineAnchor(SymbolicRegexMatcher<TSet> matcher, in CurrentState state);
+            public static abstract bool IsNullableFor(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, uint nextCharKind);
+            public static abstract int ExtractNullableCoreStateId(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, ReadOnlySpan<char> input, int pos);
+            public static abstract int FixedLength(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, uint nextCharKind);
+            public static abstract bool TryTakeTransition(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, int mintermId);
+            public static abstract (bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable) GetStateInfo(SymbolicRegexMatcher<TSet> matcher, in CurrentState state);
         }
 
         /// <summary>An <see cref="IStateHandler"/> for operating over <see cref="CurrentState"/> instances configured as DFA states.</summary>
         private readonly struct DfaStateHandler : IStateHandler
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool StartsWithLineAnchor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state) => state.DfaState(builder)!.StartsWithLineAnchor;
+            public static bool StartsWithLineAnchor(SymbolicRegexMatcher<TSet> matcher, in CurrentState state) => matcher.GetState(state.DfaStateId).StartsWithLineAnchor;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool IsNullableFor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind) => state.DfaState(builder)!.IsNullableFor(nextCharKind);
+            public static bool IsNullableFor(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, uint nextCharKind) => matcher.GetState(state.DfaStateId).IsNullableFor(nextCharKind);
 
             /// <summary>Gets the preferred DFA state for nullability. In DFA mode this is just the state itself.</summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static int ExtractNullableCoreStateId(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, ReadOnlySpan<char> input, int pos) => state.DfaStateId;
+            public static int ExtractNullableCoreStateId(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, ReadOnlySpan<char> input, int pos) => state.DfaStateId;
 
             /// <summary>Gets the length of any fixed-length marker that exists for this state, or -1 if there is none.</summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static int FixedLength(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind) => state.DfaState(builder)!.FixedLength(nextCharKind);
+            public static int FixedLength(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, uint nextCharKind) => matcher.GetState(state.DfaStateId).FixedLength(nextCharKind);
 
             /// <summary>Take the transition to the next DFA state.</summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool TakeTransition(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, int mintermId)
+            public static bool TryTakeTransition(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, int mintermId)
             {
                 Debug.Assert(state.DfaStateId > 0, $"Expected non-zero {nameof(state.DfaStateId)}.");
                 Debug.Assert(state.NfaState is null, $"Expected null {nameof(state.NfaState)}.");
-                Debug.Assert(builder._delta is not null);
 
                 // Use the mintermId for the character being read to look up which state to transition to.
                 // If that state has already been materialized, move to it, and we're done. If that state
                 // hasn't been materialized, try to create it; if we can, move to it, and we're done.
-                int dfaOffset = (state.DfaStateId << builder._mintermsLog) | mintermId;
-                int nextStateId = builder._delta[dfaOffset];
+                int dfaOffset = matcher.DeltaOffset(state.DfaStateId, mintermId);
+                int nextStateId = matcher._delta[dfaOffset];
                 if (nextStateId > 0)
                 {
                     // There was an existing DFA transition to some state. Move to it and
@@ -995,7 +994,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     return true;
                 }
 
-                if (builder.TryCreateNewTransition(state.DfaState(builder)!, mintermId, dfaOffset, checkThreshold: true, out DfaMatchingState<TSet>? nextState))
+                if (matcher.TryCreateNewTransition(matcher.GetState(state.DfaStateId), mintermId, dfaOffset, checkThreshold: true, out DfaMatchingState<TSet>? nextState))
                 {
                     // We were able to create a new DFA transition to some state. Move to it and
                     // return that we're still operating as a DFA and can keep going.
@@ -1014,22 +1013,19 @@ namespace System.Text.RegularExpressions.Symbolic
             /// - whether this state may be contextually nullable
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static (bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable) GetStateInfo(SymbolicRegexBuilder<TSet> builder, ref CurrentState state)
-            {
-                Debug.Assert(state.DfaStateId > 0);
-                return builder.GetStateInfo(state.DfaStateId);
-            }
+            public static (bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable) GetStateInfo(SymbolicRegexMatcher<TSet> matcher, in CurrentState state)
+                => matcher.GetStateInfo(state.DfaStateId);
         }
 
         /// <summary>An <see cref="IStateHandler"/> for operating over <see cref="CurrentState"/> instances configured as NFA states.</summary>
         private readonly struct NfaStateHandler : IStateHandler
         {
             /// <summary>Check if any underlying core state starts with a line anchor.</summary>
-            public static bool StartsWithLineAnchor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state)
+            public static bool StartsWithLineAnchor(SymbolicRegexMatcher<TSet> matcher, in CurrentState state)
             {
                 foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
                 {
-                    if (builder.GetCoreState(nfaState.Key).StartsWithLineAnchor)
+                    if (matcher.GetState(matcher.GetCoreStateId(nfaState.Key)).StartsWithLineAnchor)
                     {
                         return true;
                     }
@@ -1039,11 +1035,11 @@ namespace System.Text.RegularExpressions.Symbolic
             }
 
             /// <summary>Check if any underlying core state is nullable in the context of the next character kind.</summary>
-            public static bool IsNullableFor(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind)
+            public static bool IsNullableFor(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, uint nextCharKind)
             {
                 foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
                 {
-                    if (builder.GetCoreState(nfaState.Key).IsNullableFor(nextCharKind))
+                    if (matcher.GetState(matcher.GetCoreStateId(nfaState.Key)).IsNullableFor(nextCharKind))
                     {
                         return true;
                     }
@@ -1053,12 +1049,12 @@ namespace System.Text.RegularExpressions.Symbolic
             }
 
             /// <summary>Gets the preferred DFA state for nullability. In DFA mode this is just the state itself.</summary>
-            public static int ExtractNullableCoreStateId(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, ReadOnlySpan<char> input, int pos)
+            public static int ExtractNullableCoreStateId(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, ReadOnlySpan<char> input, int pos)
             {
-                uint nextCharKind = matcher.GetCharKind(input, pos);
+                uint nextCharKind = matcher.GetCharKind<FullInputReader>(input, pos);
                 foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
                 {
-                    DfaMatchingState<TSet> coreState = matcher._builder.GetCoreState(nfaState.Key);
+                    DfaMatchingState<TSet> coreState = matcher.GetState(matcher.GetCoreStateId(nfaState.Key));
                     if (coreState.IsNullableFor(nextCharKind))
                     {
                         return coreState.Id;
@@ -1070,11 +1066,11 @@ namespace System.Text.RegularExpressions.Symbolic
             }
 
             /// <summary>Gets the length of any fixed-length marker that exists for this state, or -1 if there is none.</summary>
-            public static int FixedLength(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, uint nextCharKind)
+            public static int FixedLength(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, uint nextCharKind)
             {
                 foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
                 {
-                    DfaMatchingState<TSet> coreState = builder.GetCoreState(nfaState.Key);
+                    DfaMatchingState<TSet> coreState = matcher.GetState(matcher.GetCoreStateId(nfaState.Key));
                     if (coreState.IsNullableFor(nextCharKind))
                     {
                         return coreState.FixedLength(nextCharKind);
@@ -1086,7 +1082,7 @@ namespace System.Text.RegularExpressions.Symbolic
             }
 
             /// <summary>Take the transition to the next NFA state.</summary>
-            public static bool TakeTransition(SymbolicRegexBuilder<TSet> builder, ref CurrentState state, int mintermId)
+            public static bool TryTakeTransition(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, int mintermId)
             {
                 Debug.Assert(state.DfaStateId < 0, $"Expected negative {nameof(state.DfaStateId)}.");
                 Debug.Assert(state.NfaState is not null, $"Expected non-null {nameof(state.NfaState)}.");
@@ -1105,7 +1101,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 {
                     // We have a single source state.  We know its next states are already deduped,
                     // so we can just add them directly to the destination states list.
-                    foreach (int nextState in GetNextStates(sourceStates.Values[0].Key, mintermId, builder))
+                    foreach (int nextState in GetNextStates(sourceStates.Values[0].Key, mintermId, matcher))
                     {
                         nextStates.Add(nextState, out _);
                     }
@@ -1118,7 +1114,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     // to the set, then add the known-unique state to the destination list.
                     foreach (ref KeyValuePair<int, int> sourceState in CollectionsMarshal.AsSpan(sourceStates.Values))
                     {
-                        foreach (int nextState in GetNextStates(sourceState.Key, mintermId, builder))
+                        foreach (int nextState in GetNextStates(sourceState.Key, mintermId, matcher))
                         {
                             nextStates.Add(nextState, out _);
                         }
@@ -1128,13 +1124,13 @@ namespace System.Text.RegularExpressions.Symbolic
                 return true;
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                static int[] GetNextStates(int sourceState, int mintermId, SymbolicRegexBuilder<TSet> builder)
+                static int[] GetNextStates(int sourceState, int mintermId, SymbolicRegexMatcher<TSet> matcher)
                 {
                     // Calculate the offset into the NFA transition table.
-                    int nfaOffset = (sourceState << builder._mintermsLog) | mintermId;
+                    int nfaOffset = matcher.DeltaOffset(sourceState, mintermId);
 
                     // Get the next NFA state.
-                    return builder._nfaDelta[nfaOffset] ?? builder.CreateNewNfaTransition(sourceState, mintermId, nfaOffset);
+                    return matcher._nfaDelta[nfaOffset] ?? matcher.CreateNewNfaTransition(sourceState, mintermId, nfaOffset);
                 }
             }
 
@@ -1153,15 +1149,15 @@ namespace System.Text.RegularExpressions.Symbolic
             ///   can transition back to a DFA state.
             /// </remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static (bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable) GetStateInfo(SymbolicRegexBuilder<TSet> builder, ref CurrentState state) =>
-                (false, state.NfaState!.NfaStateSet.Count == 0, IsNullable(builder, ref state), CanBeNullable(builder, ref state));
+            public static (bool IsInitial, bool IsDeadend, bool IsNullable, bool CanBeNullable) GetStateInfo(SymbolicRegexMatcher<TSet> matcher, in CurrentState state) =>
+                (false, state.NfaState!.NfaStateSet.Count == 0, IsNullable(matcher, in state), CanBeNullable(matcher, in state));
 
             /// <summary>Check if any underlying core state is unconditionally nullable.</summary>
-            private static bool IsNullable(SymbolicRegexBuilder<TSet> builder, ref CurrentState state)
+            public static bool IsNullable(SymbolicRegexMatcher<TSet> matcher, in CurrentState state)
             {
                 foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
                 {
-                    if (builder.GetStateInfo(builder.GetCoreStateId(nfaState.Key)).IsNullable)
+                    if (matcher.GetStateInfo(matcher.GetCoreStateId(nfaState.Key)).IsNullable)
                     {
                         return true;
                     }
@@ -1171,11 +1167,11 @@ namespace System.Text.RegularExpressions.Symbolic
             }
 
             /// <summary>Check if any underlying core state can be nullable in some context.</summary>
-            private static bool CanBeNullable(SymbolicRegexBuilder<TSet> builder, ref CurrentState state)
+            public static bool CanBeNullable(SymbolicRegexMatcher<TSet> matcher, in CurrentState state)
             {
                 foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
                 {
-                    if (builder.GetStateInfo(builder.GetCoreStateId(nfaState.Key)).CanBeNullable)
+                    if (matcher.GetStateInfo(matcher.GetCoreStateId(nfaState.Key)).CanBeNullable)
                     {
                         return true;
                     }
@@ -1185,10 +1181,10 @@ namespace System.Text.RegularExpressions.Symbolic
             }
 
 #if DEBUG
-            /// <summary>Undo a previous call to <see cref="TakeTransition"/>.</summary>
+            /// <summary>Undo a previous call to <see cref="TryTakeTransition"/>.</summary>
             public static void UndoTransition(ref CurrentState state)
             {
-                Debug.Assert(state.DfaStateId < 0, $"Expected negative {nameof(state.DfaState)}.");
+                Debug.Assert(state.DfaStateId < 0, $"Expected negative {nameof(state.DfaStateId)}.");
                 Debug.Assert(state.NfaState is not null, $"Expected non-null {nameof(state.NfaState)}.");
 
                 NfaMatchingState nfaState = state.NfaState!;
@@ -1202,37 +1198,43 @@ namespace System.Text.RegularExpressions.Symbolic
                 // Sanity check: if there are any next states, then there must have been some source states.
                 Debug.Assert(nextStates.Count == 0 || sourceStates.Count > 0);
             }
-
-            /// <summary>Check if any underlying core state is unconditionally nullable.</summary>
-            public static bool IsNullable(ref CurrentState state)
-            {
-                SymbolicRegexBuilder<TSet> builder = state.NfaState!.Builder;
-                foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
-                {
-                    if (builder.GetCoreState(nfaState.Key).Node.IsNullable)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            /// <summary>Check if any underlying core state can be nullable.</summary>
-            public static bool CanBeNullable(ref CurrentState state)
-            {
-                SymbolicRegexBuilder<TSet> builder = state.NfaState!.Builder;
-                foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
-                {
-                    if (builder.GetCoreState(nfaState.Key).Node.CanBeNullable)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
 #endif
+        }
+
+        /// <summary>
+        /// Interface for mapping positions in the input to position IDs, which capture all the information necessary to
+        /// both take transitions and decide nullability. For positions of valid characters that are handled normally,
+        /// these IDs coincide with minterm IDs (i.e. indices to <see cref="_minterms"/>). Positions outside the bounds
+        /// of the input are mapped to -1. Optionally, an end-of-line as the very last character in the input may be
+        /// mapped to _minterms.Length for supporting the \Z anchor.
+        /// </summary>
+        private interface IInputReader
+        {
+            public static abstract int GetPositionId(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, int pos);
+        }
+
+        /// <summary>This reader omits the special handling of \n for the \Z anchor.</summary>
+        private readonly struct NoZAnchorInputReader : IInputReader
+        {
+            public static int GetPositionId(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, int pos) =>
+                (uint)pos >= (uint)input.Length ? -1 : matcher._mintermClassifier.GetMintermID(input[pos]);
+        }
+
+        /// <summary>This reader includes full handling of an \n as the last character of input for the \Z anchor.</summary>
+        private readonly struct FullInputReader : IInputReader
+        {
+            public static int GetPositionId(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, int pos)
+            {
+                if ((uint)pos >= (uint)input.Length)
+                    return -1;
+
+                int c = input[pos];
+
+                // Find the minterm, handling the special case for the last \n for states that start with a relevant anchor
+                return c == '\n' && pos == input.Length - 1 ?
+                    matcher._minterms.Length : // mintermId = minterms.Length represents an \n at the very end of input
+                    matcher._mintermClassifier.GetMintermID(c);
+            }
         }
 
         /// <summary>
@@ -1240,7 +1242,8 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         private interface IInitialStateHandler
         {
-            public static abstract bool TryFindNextStartingPosition(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, ref CurrentState state, ref int pos);
+            public static abstract bool TryFindNextStartingPosition<TInputReader>(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, ref CurrentState state, ref int pos)
+                where TInputReader : struct, IInputReader;
         }
 
         /// <summary>
@@ -1249,7 +1252,8 @@ namespace System.Text.RegularExpressions.Symbolic
         private readonly struct NoOptimizationsInitialStateHandler : IInitialStateHandler
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool TryFindNextStartingPosition(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, ref CurrentState state, ref int pos)
+            public static bool TryFindNextStartingPosition<TInputReader>(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, ref CurrentState state, ref int pos)
+                where TInputReader : struct, IInputReader
             {
                 // return true to indicate that the current position is a possible starting position
                 return true;
@@ -1262,7 +1266,8 @@ namespace System.Text.RegularExpressions.Symbolic
         private readonly struct InitialStateFindOptimizationsHandler : IInitialStateHandler
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool TryFindNextStartingPosition(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, ref CurrentState state, ref int pos)
+            public static bool TryFindNextStartingPosition<TInputReader>(SymbolicRegexMatcher<TSet> matcher, ReadOnlySpan<char> input, ref CurrentState state, ref int pos)
+                where TInputReader : struct, IInputReader
             {
                 // Find the first position that matches with some likely character.
                 if (!matcher._findOpts!.TryFindNextStartingPosition(input, ref pos, 0))
@@ -1273,7 +1278,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
                 // Update the starting state based on where TryFindNextStartingPosition moved us to.
                 // As with the initial starting state, if it's a dead end, no match exists.
-                state = new CurrentState(matcher._dotstarredInitialStates[matcher.GetCharKind(input, pos - 1)]);
+                state = new CurrentState(matcher._dotstarredInitialStates[matcher.GetCharKind<TInputReader>(input, pos - 1)]);
                 return true;
             }
         }
@@ -1283,7 +1288,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         private interface INullabilityHandler
         {
-            public static abstract bool IsNullableAt<TStateHandler>(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, ReadOnlySpan<char> input, int pos, bool isNullable, bool canBeNullable)
+            public static abstract bool IsNullableAt<TStateHandler>(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, int positionId, bool isNullable, bool canBeNullable)
                     where TStateHandler : struct, IStateHandler;
         }
 
@@ -1293,7 +1298,7 @@ namespace System.Text.RegularExpressions.Symbolic
         private readonly struct NoAnchorsNullabilityHandler : INullabilityHandler
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool IsNullableAt<TStateHandler>(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, ReadOnlySpan<char> input, int pos, bool isNullable, bool canBeNullable)
+            public static bool IsNullableAt<TStateHandler>(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, int positionId, bool isNullable, bool canBeNullable)
                 where TStateHandler : struct, IStateHandler
             {
                 Debug.Assert(!matcher._pattern._info.ContainsSomeAnchor);
@@ -1307,10 +1312,10 @@ namespace System.Text.RegularExpressions.Symbolic
         private readonly struct FullNullabilityHandler : INullabilityHandler
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool IsNullableAt<TStateHandler>(SymbolicRegexMatcher<TSet> matcher, ref CurrentState state, ReadOnlySpan<char> input, int pos, bool isNullable, bool canBeNullable)
+            public static bool IsNullableAt<TStateHandler>(SymbolicRegexMatcher<TSet> matcher, in CurrentState state, int positionId, bool isNullable, bool canBeNullable)
                 where TStateHandler : struct, IStateHandler
             {
-                return isNullable || (canBeNullable && TStateHandler.IsNullableFor(matcher._builder, ref state, matcher.GetCharKind(input, pos)));
+                return isNullable || (canBeNullable && TStateHandler.IsNullableFor(matcher, in state, matcher.GetPositionKind(positionId)));
             }
         }
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
@@ -37,8 +37,8 @@ namespace System.Text.RegularExpressions.Symbolic
                 }
             }
 
-            rootNode = rootNode.AddFixedLengthMarkers();
-            BDD[] minterms = rootNode.ComputeMinterms();
+            rootNode = rootNode.AddFixedLengthMarkers(bddBuilder);
+            BDD[] minterms = rootNode.ComputeMinterms(bddBuilder);
 
             _matcher = minterms.Length > 64 ?
                 SymbolicRegexMatcher<BitVector>.Create(regexTree.CaptureCount, regexTree.FindOptimizations, bddBuilder, rootNode, new BitVectorSolver(minterms, charSetSolver), matchTimeout) :

--- a/src/libraries/System.Text.RegularExpressions/src/System/Threading/StackHelper.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Threading/StackHelper.cs
@@ -69,6 +69,38 @@ namespace System.Threading
         /// <typeparam name="TArg2">The type of the second argument to pass to the function.</typeparam>
         /// <typeparam name="TArg3">The type of the third argument to pass to the function.</typeparam>
         /// <typeparam name="TArg4">The type of the fourth argument to pass to the function.</typeparam>
+        /// <param name="action">The action to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the action.</param>
+        /// <param name="arg2">The second argument to pass to the action.</param>
+        /// <param name="arg3">The third argument to pass to the action.</param>
+        /// <param name="arg4">The fourth argument to pass to the action.</param>
+        public static void CallOnEmptyStack<TArg1, TArg2, TArg3, TArg4>(Action<TArg1, TArg2, TArg3, TArg4> action, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4) =>
+            Task.Run(() => action(arg1, arg2, arg3, arg4))
+                .ContinueWith(t => t.GetAwaiter().GetResult(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
+                .GetAwaiter().GetResult();
+
+        /// <summary>Calls the provided function on the stack of a different thread pool thread.</summary>
+        /// <typeparam name="TArg1">The type of the first argument to pass to the function.</typeparam>
+        /// <typeparam name="TArg2">The type of the second argument to pass to the function.</typeparam>
+        /// <typeparam name="TArg3">The type of the third argument to pass to the function.</typeparam>
+        /// <typeparam name="TArg4">The type of the fourth argument to pass to the function.</typeparam>
+        /// <typeparam name="TArg5">The type of the fifth argument to pass to the function.</typeparam>
+        /// <param name="action">The action to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the action.</param>
+        /// <param name="arg2">The second argument to pass to the action.</param>
+        /// <param name="arg3">The third argument to pass to the action.</param>
+        /// <param name="arg4">The fourth argument to pass to the action.</param>
+        /// <param name="arg5">The fifth argument to pass to the action.</param>
+        public static void CallOnEmptyStack<TArg1, TArg2, TArg3, TArg4, TArg5>(Action<TArg1, TArg2, TArg3, TArg4, TArg5> action, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5) =>
+            Task.Run(() => action(arg1, arg2, arg3, arg4, arg5))
+                .ContinueWith(t => t.GetAwaiter().GetResult(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
+                .GetAwaiter().GetResult();
+
+        /// <summary>Calls the provided function on the stack of a different thread pool thread.</summary>
+        /// <typeparam name="TArg1">The type of the first argument to pass to the function.</typeparam>
+        /// <typeparam name="TArg2">The type of the second argument to pass to the function.</typeparam>
+        /// <typeparam name="TArg3">The type of the third argument to pass to the function.</typeparam>
+        /// <typeparam name="TArg4">The type of the fourth argument to pass to the function.</typeparam>
         /// <typeparam name="TArg5">The type of the fifth argument to pass to the function.</typeparam>
         /// <typeparam name="TArg6">The type of the sixth argument to pass to the function.</typeparam>
         /// <param name="action">The action to invoke.</param>
@@ -124,6 +156,22 @@ namespace System.Threading
         /// <param name="arg3">The third argument to pass to the function.</param>
         public static TResult CallOnEmptyStack<TArg1, TArg2, TArg3, TResult>(Func<TArg1, TArg2, TArg3, TResult> func, TArg1 arg1, TArg2 arg2, TArg3 arg3) =>
             Task.Run(() => func(arg1, arg2, arg3))
+                .ContinueWith(t => t.GetAwaiter().GetResult(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
+                .GetAwaiter().GetResult();
+
+        /// <summary>Calls the provided function on the stack of a different thread pool thread.</summary>
+        /// <typeparam name="TArg1">The type of the first argument to pass to the function.</typeparam>
+        /// <typeparam name="TArg2">The type of the second argument to pass to the function.</typeparam>
+        /// <typeparam name="TArg3">The type of the third argument to pass to the function.</typeparam>
+        /// <typeparam name="TArg4">The type of the fourth argument to pass to the function.</typeparam>
+        /// <typeparam name="TResult">The return type of the function.</typeparam>
+        /// <param name="func">The function to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the function.</param>
+        /// <param name="arg2">The second argument to pass to the function.</param>
+        /// <param name="arg3">The third argument to pass to the function.</param>
+        /// <param name="arg4">The fourth argument to pass to the function.</param>
+        public static TResult CallOnEmptyStack<TArg1, TArg2, TArg3, TArg4, TResult>(Func<TArg1, TArg2, TArg3, TArg4, TResult> func, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4) =>
+            Task.Run(() => func(arg1, arg2, arg3, arg4))
                 .ContinueWith(t => t.GetAwaiter().GetResult(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
                 .GetAwaiter().GetResult();
     }

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/SymbolicRegexTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/SymbolicRegexTests.cs
@@ -86,7 +86,7 @@ namespace System.Text.RegularExpressions.Tests
             {
                 RegexNode tree = RegexParser.Parse(Pattern, options | RegexOptions.ExplicitCapture, CultureInfo.CurrentCulture).Root;
                 SymbolicRegexNode<BDD> rootNode = converter.ConvertToSymbolicRegexNode(tree);
-                yield return new object[] { rootNode, ExpectedSafeSize };
+                yield return new object[] { bddBuilder, rootNode, ExpectedSafeSize };
             }
 
             // add .*? in front of the pattern, this adds 1 more NFA state
@@ -94,7 +94,7 @@ namespace System.Text.RegularExpressions.Tests
             {
                 RegexNode tree = RegexParser.Parse(".*?" + Pattern, options | RegexOptions.ExplicitCapture, CultureInfo.CurrentCulture).Root;
                 SymbolicRegexNode<BDD> rootNode = converter.ConvertToSymbolicRegexNode(tree);
-                yield return new object[] { rootNode, 1 + ExpectedSafeSize};
+                yield return new object[] { bddBuilder, rootNode, 1 + ExpectedSafeSize};
             }
 
             // use of anchors increases the estimate by 5x in general but in reality much less, at most 3x
@@ -102,7 +102,7 @@ namespace System.Text.RegularExpressions.Tests
             {
                 RegexNode tree = RegexParser.Parse(Pattern + "$", options | RegexOptions.ExplicitCapture, CultureInfo.CurrentCulture).Root;
                 SymbolicRegexNode<BDD> rootNode = converter.ConvertToSymbolicRegexNode(tree);
-                yield return new object[] { rootNode, 5 * ExpectedSafeSize };
+                yield return new object[] { bddBuilder, rootNode, 5 * ExpectedSafeSize };
             }
 
             // use of captures has no effect on the estimations
@@ -110,31 +110,32 @@ namespace System.Text.RegularExpressions.Tests
             {
                 RegexNode tree = RegexParser.Parse(Pattern, options, CultureInfo.CurrentCulture).Root;
                 SymbolicRegexNode<BDD> rootNode = converter.ConvertToSymbolicRegexNode(tree);
-                yield return new object[] { rootNode, ExpectedSafeSize };
+                yield return new object[] { bddBuilder, rootNode, ExpectedSafeSize };
             }
         }
 
         [Theory]
         [MemberData(nameof(SafeThresholdTests_MemberData))]
-        public void SafeThresholdTests(object obj, int expectedSafeSize)
+        public void SafeThresholdTests(object builderObj, object nodeObj, int expectedSafeSize)
         {
-            SymbolicRegexNode<BDD> node = (SymbolicRegexNode<BDD>)obj;
+            SymbolicRegexBuilder<BDD> builder = (SymbolicRegexBuilder<BDD>)builderObj;
+            SymbolicRegexNode<BDD> node = (SymbolicRegexNode<BDD>)nodeObj;
             int safeSize = node.EstimateNfaSize();
             Assert.Equal(expectedSafeSize, safeSize);
-            int nfaStateCount = CalculateNfaStateCount(node);
+            int nfaStateCount = CalculateNfaStateCount(builder, node);
             Assert.True(nfaStateCount <= expectedSafeSize);
         }
 
         /// <summary>
         /// Compute the closure of all NFA states from root and return the size of the resulting state space.
         /// </summary>
-        private static int CalculateNfaStateCount(SymbolicRegexNode<BDD> root)
+        private static int CalculateNfaStateCount(SymbolicRegexBuilder<BDD> builder, SymbolicRegexNode<BDD> root)
         {
             // Here we are actually using the original BDD algebra (not converting to the BV or Uint64 algebra)
             // because it does not matter which algebra we use here (this matters only for performance)
             HashSet<(uint, SymbolicRegexNode<BDD>)> states = new();
             Stack<(uint, SymbolicRegexNode<BDD>)> frontier = new();
-            List<BDD> minterms = MintermGenerator<BDD>.GenerateMinterms(root._builder._solver, root.GetSets());
+            List<BDD> minterms = MintermGenerator<BDD>.GenerateMinterms(builder._solver, root.GetSets(builder));
 
             // Start from the initial state that has kind 'General' when no anchors are being used, else kind 'BeginningEnd'
             (uint, SymbolicRegexNode<BDD>) initialState = (root._info.ContainsSomeAnchor ? CharKind.BeginningEnd : CharKind.General, root);
@@ -150,7 +151,7 @@ namespace System.Text.RegularExpressions.Tests
                 foreach (BDD minterm in minterms)
                 {
                     uint kind = GetCharKind(minterm);
-                    SymbolicRegexNode<BDD> target = source.Node.CreateDerivativeWithoutEffects(minterm, source.Kind);
+                    SymbolicRegexNode<BDD> target = source.Node.CreateDerivativeWithoutEffects(builder, minterm, source.Kind);
 
                     //In the case of an NFA all the different alternatives in the DFA state become individual states themselves
                     foreach (SymbolicRegexNode<BDD> node in GetAlternatives(target))
@@ -169,7 +170,7 @@ namespace System.Text.RegularExpressions.Tests
             return states.Count;
 
             // Enumerates the alternatives from a node, for eaxmple (ab|(bc|cd)) has three alternatives
-            static IEnumerable<SymbolicRegexNode<BDD>> GetAlternatives(SymbolicRegexNode<BDD> node)
+            IEnumerable<SymbolicRegexNode<BDD>> GetAlternatives(SymbolicRegexNode<BDD> node)
             {
                 if (node._kind == SymbolicRegexNodeKind.Alternate)
                 {
@@ -178,7 +179,7 @@ namespace System.Text.RegularExpressions.Tests
                     foreach (SymbolicRegexNode<BDD> elem in GetAlternatives(node._right!))
                         yield return elem;
                 }
-                else if (!node.IsNothing) // omit deadend states
+                else if (!node.IsNothing(builder._solver)) // omit deadend states
                 {
                     yield return node;
                 }
@@ -187,8 +188,8 @@ namespace System.Text.RegularExpressions.Tests
             // Simplified character kind calculation that omits the special case that minterm can be the very last \n
             // This omission has practically no effect of the size of the state space, but would complicate the logic
             uint GetCharKind(BDD minterm) =>
-                minterm.Equals(root._builder._newLineSet) ? CharKind.Newline :  // is \n
-                (!root._builder._solver.IsEmpty(root._builder._solver.And(root._builder._wordLetterForBoundariesSet, minterm)) ?
+                minterm.Equals(builder._newLineSet) ? CharKind.Newline :  // is \n
+                (!builder._solver.IsEmpty(builder._solver.And(builder._wordLetterForBoundariesSet, minterm)) ?
                 CharKind.WordLetter : // in \w
                 CharKind.General);    // anything else, thus in particular in \W
         }

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/System.Text.RegularExpressions.Unit.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/System.Text.RegularExpressions.Unit.Tests.csproj
@@ -51,7 +51,7 @@
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\CharKind.cs" Link="Production\CharKind.cs" />
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\CharSetSolver.cs" Link="Production\CharSetSolver.cs" />
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\DerivativeEffect.cs" Link="Production\DerivativeEffect.cs" />
-    <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\DfaMatchingState.cs" Link="Production\DfaMatchingState.cs" />
+    <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\MatchingState.cs" Link="Production\MatchingState.cs" />
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\DoublyLinkedList.cs" Link="Production\DoublyLinkedList.cs" />
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\ISolver.cs" Link="Production\ISolver.cs" />
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\MintermGenerator.cs" Link="Production\MintermGenerator.cs" />


### PR DESCRIPTION
This PR addresses https://github.com/dotnet/runtime/issues/70753. `SymbolicRegexBuilder` has mutable state that has to be protected by locks when used concurrently from `SymbolicRegexMatcher`. The builder has some locking, but a bug had crept in. This PR introduces the following to make the code more clearly correct:

- Move matching-specific state such as arrays of DFA/NFA states and transitions from the builder to the matcher. This allows removing conditional initialization of these in uses of the builder outside the matcher. The state left in the builder is now caches for `SymbolicRegexNode` instances and memoization caches for functions in `SymbolicRegexNode`.
- Remove the `_builder` variable from `SymbolicRegexNode` to avoid accidental concurrent use through concurrent calls to functions in the nodes. The builder now has to be passed into all functions that need it, which makes it obvious which functions are thread safe.
- Move all synchronization from the builder to the matcher. Locking is used now to protect all concurrent usage of `_builder` in the matcher as well as state caches and transition arrays (as necessary: transition arrays are still read without locking or `Volatile.Read` for performance, see https://github.com/dotnet/runtime/issues/63474 and https://github.com/dotnet/runtime/issues/65789).
- Create a `ConcurrentArrayResize` function to replace `Array.Resize` usage with the difference that the array is copied to a larger one first and then published with `Volatile.Write`. This addresses a concern that other threads might see an inconsistent copy when reading from the arrays being resized without holding a lock. I think the code was correct without this as 1. all of these arrays were ones with atomic reads/writes and 2. any read that saw a zero value would acquire the lock and re-read the array after. However, the code could easily break if any of the arrays change, e.g., to a struct element type and generally it seems better to not cause other threads to spuriously have to acquire a lock.

Then the actual issue in https://github.com/dotnet/runtime/issues/70753 is addressed by asserting that the lock is held in `GetOrCreateState` and calling a `GetOrCreateStateUnsafe` variant in the constructor, where locking is not required yet.

In addition to these changes, the following cleanup is done (mostly because I just happened to be looking at the code again):

- Simplify logic related to figuring out character kinds. There is now much less duplication of logic for 1. mapping characters/minterms to character kinds, 2. handling an `\n` at the very end of input for the \Z anchor, and 3. giving the `BeginningEnd` kind to indices outside the `input` span. All of the logic is in the main `SymbolicRegexMatcher` code file. The logic for mapping minterms back to character kinds in `DfaMatchingState` is now gone.
- Make state and transition arrays grow by factor of 2 instead of a fixed 1024 elements (this had a todo on it). This mirrors what `List<T>` does. The reason we're not using `List<T>` itself is concerns with concurrent usage and ability to resize cheaply.

One potentially performance-impactful change (among a few others) is that the "ascii characters to character kinds" array is now gone, in favor of a "minterm IDs to character kinds" array. I'll be evaluating/debugging any performance regressions before merging.