### PR TITLE
[wasm][debugger] Fixing entrypoint breakpoint on release mode.

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -1297,12 +1297,12 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var argsNew = JObject.FromObject(new
                 {
                     callFrameId = args?["callFrames"]?[0]?["callFrameId"]?.Value<string>(),
-                    expression = "assembly_name_str + '|' + entrypoint_method_token",
+                    expression = "_assembly_name_str + '|' + _entrypoint_method_token",
                 });
                 Result assemblyAndMethodToken = await SendCommand(sessionId, "Debugger.evaluateOnCallFrame", argsNew, token);
                 if (!assemblyAndMethodToken.IsOk)
                 {
-                    logger.LogDebug("Failure evaluating assembly_name_str + '|' + entrypoint_method_token");
+                    logger.LogDebug("Failure evaluating _assembly_name_str + '|' + _entrypoint_method_token");
                     return;
                 }
                 logger.LogDebug($"Entrypoint assembly and method token {assemblyAndMethodToken.Value["result"]["value"].Value<string>()}");

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -169,7 +169,7 @@ export function mono_wasm_set_entrypoint_breakpoint(assembly_name: CharPtr, entr
     _assembly_name_str = Module.UTF8ToString(assembly_name).concat(".dll");
     _entrypoint_method_token = entrypoint_method_token;
     //keep this console.trace, otherwise optimization will remove the assigments
-    console.trace(`Adding an entrypoint breakpoint ${_assembly_name_str} at method token  ${_entrypoint_method_token}`);
+    console.assert(true, `Adding an entrypoint breakpoint ${_assembly_name_str} at method token  ${_entrypoint_method_token}`);
     // eslint-disable-next-line no-debugger
     debugger;
 }

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -168,8 +168,8 @@ export function mono_wasm_set_entrypoint_breakpoint(assembly_name: CharPtr, entr
     //keep these assignments, these values are used by BrowserDebugProxy
     _assembly_name_str = Module.UTF8ToString(assembly_name).concat(".dll");
     _entrypoint_method_token = entrypoint_method_token;
-    console.log(`Adding an entrypoint breakpoint ${_assembly_name_str} at method token  ${_entrypoint_method_token}`);
-    // eslint-disable-next-line no-debugger    
+    console.trace(`Adding an entrypoint breakpoint ${_assembly_name_str} at method token  ${_entrypoint_method_token}`);
+    // eslint-disable-next-line no-debugger
     debugger;
 }
 

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -12,8 +12,8 @@ let _call_function_res_cache: any = {};
 let _next_call_function_res_id = 0;
 let _debugger_buffer_len = -1;
 let _debugger_buffer: VoidPtr;
-let _assembly_name_str: string;
-let _entrypoint_method_token: number;
+let _assembly_name_str: string; //keep this variable, it's used by BrowserDebugProxy
+let _entrypoint_method_token: number; //keep this variable, it's used by BrowserDebugProxy
 
 const regexes:any[] = [];
 
@@ -168,6 +168,7 @@ export function mono_wasm_set_entrypoint_breakpoint(assembly_name: CharPtr, entr
     //keep these assignments, these values are used by BrowserDebugProxy
     _assembly_name_str = Module.UTF8ToString(assembly_name).concat(".dll");
     _entrypoint_method_token = entrypoint_method_token;
+    //keep this console.trace, otherwise optimization will remove the assigments
     console.trace(`Adding an entrypoint breakpoint ${_assembly_name_str} at method token  ${_entrypoint_method_token}`);
     // eslint-disable-next-line no-debugger
     debugger;

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -168,7 +168,7 @@ export function mono_wasm_set_entrypoint_breakpoint(assembly_name: CharPtr, entr
     //keep these assignments, these values are used by BrowserDebugProxy
     _assembly_name_str = Module.UTF8ToString(assembly_name).concat(".dll");
     _entrypoint_method_token = entrypoint_method_token;
-    //keep this console.trace, otherwise optimization will remove the assigments
+    //keep this console.assert, otherwise optimization will remove the assigments
     console.assert(true, `Adding an entrypoint breakpoint ${_assembly_name_str} at method token  ${_entrypoint_method_token}`);
     // eslint-disable-next-line no-debugger
     debugger;

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -164,11 +164,9 @@ export function mono_wasm_debugger_attached(): void {
     cwraps.mono_wasm_set_is_debugger_attached(true);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function mono_wasm_set_entrypoint_breakpoint(assembly_name: CharPtr, entrypoint_method_token: number): void {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    //keep these assignments, these values are used by BrowserDebugProxy
     _assembly_name_str = Module.UTF8ToString(assembly_name).concat(".dll");
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _entrypoint_method_token = entrypoint_method_token;
     console.log(`Adding an entrypoint breakpoint ${_assembly_name_str} at method token  ${_entrypoint_method_token}`);
     // eslint-disable-next-line no-debugger    

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -12,6 +12,8 @@ let _call_function_res_cache: any = {};
 let _next_call_function_res_id = 0;
 let _debugger_buffer_len = -1;
 let _debugger_buffer: VoidPtr;
+let _assembly_name_str: string;
+let _entrypoint_method_token: number;
 
 const regexes:any[] = [];
 
@@ -165,8 +167,11 @@ export function mono_wasm_debugger_attached(): void {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function mono_wasm_set_entrypoint_breakpoint(assembly_name: CharPtr, entrypoint_method_token: number): void {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const assembly_name_str = Module.UTF8ToString(assembly_name).concat(".dll");
-    // eslint-disable-next-line no-debugger
+    _assembly_name_str = Module.UTF8ToString(assembly_name).concat(".dll");
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _entrypoint_method_token = entrypoint_method_token;
+    console.log(`Adding an entrypoint breakpoint ${_assembly_name_str} at method token  ${_entrypoint_method_token}`);
+    // eslint-disable-next-line no-debugger    
     debugger;
 }
 


### PR DESCRIPTION
The way we get entrypoint details is by calling `mono_wasm_set_entrypoint_breakpoint` with the assembly name, and the method token. And this function breaks into the debugger. Then the debug proxy simply reads the function arguments.

But as @pavel alerted me, this wasn't working in release mode because the function's arguments, and local variables would get minimized in Release mode (like `assembly_name` -> `n`), and removed.

This PR changes that
- so we have variables defined in `debug.ts`, and set these from `mono_wasm_set_entrypoint_breakpoint`. And the proxy is updated to use these instead of the locals, thus avoiding the renaming issue.
- And the locals are retained by using them in a `console.trace`

Thanks a lot @pavelsavara !
