### PR TITLE
Custom marshallers v2 usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -154,6 +154,9 @@ csharp_space_between_square_brackets = false
 # License header
 file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
 
+# Marshaller type must have CustomTypeMarshallerAttribute attribute
+dotnet_diagnostic.SYSLIB1056.severity = silent
+
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true

--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -67,6 +67,11 @@
     <PropertyGroup>
         <LibraryImportGenerator_UseMarshalType>true</LibraryImportGenerator_UseMarshalType>
     </PropertyGroup>
+
+    <ItemGroup Condition="'$(NetCoreAppCurrentTargetFrameworkMoniker)' == '$(TargetFrameworkMoniker)' and '$(IncludeLibraryImportGeneratorSources)' != 'false'">
+      <Compile Include="$(LibrariesProjectRoot)System.Runtime.InteropServices/tests/Ancillary.Interop/CustomTypeMarshallersAttributeBase.cs" />
+      <Compile Include="$(LibrariesProjectRoot)System.Runtime.InteropServices/tests/Ancillary.Interop/ManagedToUnmanagedMarshallersAttribute.cs" />
+    </ItemGroup>
   </Target>
 
   <Import Project="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\LibraryImportGenerator\Microsoft.Interop.LibraryImportGenerator.props" />

--- a/src/libraries/Common/src/Interop/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Interop.Ldap.cs
@@ -31,7 +31,7 @@ namespace System.DirectoryServices.Protocols
     }
 
 #if NET7_0_OR_GREATER
-    [NativeMarshalling(typeof(Native))]
+    [NativeMarshalling(typeof(Marshaller))]
 #endif
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct SEC_WINNT_AUTH_IDENTITY_EX
@@ -49,8 +49,36 @@ namespace System.DirectoryServices.Protocols
         public int packageListLength;
 
 #if NET7_0_OR_GREATER
-        [CustomTypeMarshaller(typeof(SEC_WINNT_AUTH_IDENTITY_EX), Direction = CustomTypeMarshallerDirection.In, Features = CustomTypeMarshallerFeatures.UnmanagedResources)]
+        [ManagedToUnmanagedMarshallers(typeof(SEC_WINNT_AUTH_IDENTITY_EX), InMarshaller = typeof(Marshaller))]
+        internal static class Marshaller
+        {
+            public static Native ConvertToUnmanaged(SEC_WINNT_AUTH_IDENTITY_EX managed)
+            {
+                Native n = default;
+                n.version = managed.version;
+                n.length = managed.length;
+                n.user = Marshal.StringToCoTaskMemUni(managed.user);
+                n.userLength = managed.userLength;
+                n.domain = Marshal.StringToCoTaskMemUni(managed.domain);
+                n.domainLength = managed.domainLength;
+                n.password = Marshal.StringToCoTaskMemUni(managed.password);
+                n.passwordLength = managed.passwordLength;
+                n.flags = managed.flags;
+                n.packageList = Marshal.StringToCoTaskMemUni(managed.packageList);
+                n.packageListLength = managed.packageListLength;
+                return n;
+            }
+
+            public static void Free(Native native)
+            {
+                Marshal.FreeCoTaskMem(native.user);
+                Marshal.FreeCoTaskMem(native.domain);
+                Marshal.FreeCoTaskMem(native.password);
+                Marshal.FreeCoTaskMem(native.packageList);
+            }
+        }
 #endif
+
         [StructLayout(LayoutKind.Sequential)]
         internal struct Native
         {
@@ -65,29 +93,6 @@ namespace System.DirectoryServices.Protocols
             public int flags;
             public IntPtr packageList;
             public int packageListLength;
-
-            public Native(SEC_WINNT_AUTH_IDENTITY_EX managed)
-            {
-                version = managed.version;
-                length = managed.length;
-                user = Marshal.StringToCoTaskMemUni(managed.user);
-                userLength = managed.userLength;
-                domain = Marshal.StringToCoTaskMemUni(managed.domain);
-                domainLength = managed.domainLength;
-                password = Marshal.StringToCoTaskMemUni(managed.password);
-                passwordLength = managed.passwordLength;
-                flags = managed.flags;
-                packageList = Marshal.StringToCoTaskMemUni(managed.packageList);
-                packageListLength = managed.packageListLength;
-            }
-
-            public void FreeNative()
-            {
-                Marshal.FreeCoTaskMem(user);
-                Marshal.FreeCoTaskMem(domain);
-                Marshal.FreeCoTaskMem(password);
-                Marshal.FreeCoTaskMem(packageList);
-            }
         }
     }
 

--- a/src/libraries/Common/src/Interop/Windows/CryptUI/Interop.CryptUIDlgCertificate.cs
+++ b/src/libraries/Common/src/Interop/Windows/CryptUI/Interop.CryptUIDlgCertificate.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
     internal static partial class CryptUI
     {
 #if NET7_0_OR_GREATER
-        [NativeMarshalling(typeof(Native))]
+        [NativeMarshalling(typeof(Marshaller))]
 #else
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
 #endif
@@ -40,86 +40,95 @@ internal static partial class Interop
             internal uint nStartPage;
 
 #if NET7_0_OR_GREATER
-            [CustomTypeMarshaller(typeof(CRYPTUI_VIEWCERTIFICATE_STRUCTW), Features = CustomTypeMarshallerFeatures.UnmanagedResources)]
-            internal unsafe struct Native
+            [ManagedToUnmanagedMarshallers(typeof(CRYPTUI_VIEWCERTIFICATE_STRUCTW), InMarshaller = typeof(Marshaller), RefMarshaller = typeof(Marshaller), OutMarshaller = typeof(Marshaller))]
+            public static class Marshaller
             {
-                private uint dwSize;
-                private IntPtr hwndParent;
-                private uint dwFlags;
-                private IntPtr szTitle;
-                private IntPtr pCertContext;
-                private IntPtr rgszPurposes;
-                private uint cPurposes;
-                private IntPtr pCryptProviderData;
-                private bool fpCryptProviderDataTrustedUsage;
-                private uint idxSigner;
-                private uint idxCert;
-                private bool fCounterSigner;
-                private uint idxCounterSigner;
-                private uint cStores;
-                private IntPtr rghStores;
-                private uint cPropSheetPages;
-                private IntPtr rgPropSheetPages;
-                private uint nStartPage;
+                public static Native ConvertToUnmanaged(CRYPTUI_VIEWCERTIFICATE_STRUCTW managed) => new(managed);
 
-                public Native(CRYPTUI_VIEWCERTIFICATE_STRUCTW managed)
+                public static CRYPTUI_VIEWCERTIFICATE_STRUCTW ConvertToManaged(Native n) => n.ToManaged();
+
+                public static void Free(Native native) => native.FreeNative();
+
+                internal unsafe struct Native
                 {
-                    dwSize = managed.dwSize;
-                    hwndParent = managed.hwndParent;
-                    dwFlags = managed.dwFlags;
-                    szTitle = Marshal.StringToCoTaskMemUni(managed.szTitle);
-                    pCertContext = managed.pCertContext;
-                    rgszPurposes = managed.rgszPurposes;
-                    cPurposes = managed.cPurposes;
-                    pCryptProviderData = managed.pCryptProviderData;
-                    fpCryptProviderDataTrustedUsage = managed.fpCryptProviderDataTrustedUsage;
-                    idxSigner = managed.idxSigner;
-                    idxCert = managed.idxCert;
-                    fCounterSigner = managed.fCounterSigner;
-                    idxCounterSigner = managed.idxCounterSigner;
-                    cStores = managed.cStores;
-                    rghStores = managed.rghStores;
-                    cPropSheetPages = managed.cPropSheetPages;
-                    rgPropSheetPages = managed.rgPropSheetPages;
-                    nStartPage = managed.nStartPage;
+                    private uint dwSize;
+                    private IntPtr hwndParent;
+                    private uint dwFlags;
+                    private IntPtr szTitle;
+                    private IntPtr pCertContext;
+                    private IntPtr rgszPurposes;
+                    private uint cPurposes;
+                    private IntPtr pCryptProviderData;
+                    private bool fpCryptProviderDataTrustedUsage;
+                    private uint idxSigner;
+                    private uint idxCert;
+                    private bool fCounterSigner;
+                    private uint idxCounterSigner;
+                    private uint cStores;
+                    private IntPtr rghStores;
+                    private uint cPropSheetPages;
+                    private IntPtr rgPropSheetPages;
+                    private uint nStartPage;
 
-                }
-
-                public void FreeNative()
-                {
-                    Marshal.FreeCoTaskMem(szTitle);
-                }
-
-                public CRYPTUI_VIEWCERTIFICATE_STRUCTW ToManaged()
-                {
-                    return new()
+                    public Native(CRYPTUI_VIEWCERTIFICATE_STRUCTW managed)
                     {
-                        dwSize = dwSize,
-                        hwndParent = hwndParent,
-                        dwFlags = dwFlags,
-                        szTitle = Marshal.PtrToStringUni(szTitle),
-                        pCertContext = pCertContext,
-                        rgszPurposes = rgszPurposes,
-                        cPurposes = cPurposes,
-                        pCryptProviderData = pCryptProviderData,
-                        fpCryptProviderDataTrustedUsage = fpCryptProviderDataTrustedUsage,
-                        idxSigner = idxSigner,
-                        idxCert = idxCert,
-                        fCounterSigner = fCounterSigner,
-                        idxCounterSigner = idxCounterSigner,
-                        cStores = cStores,
-                        rghStores = rghStores,
-                        cPropSheetPages = cPropSheetPages,
-                        rgPropSheetPages = rgPropSheetPages,
-                        nStartPage = nStartPage
-                    };
+                        dwSize = managed.dwSize;
+                        hwndParent = managed.hwndParent;
+                        dwFlags = managed.dwFlags;
+                        szTitle = Marshal.StringToCoTaskMemUni(managed.szTitle);
+                        pCertContext = managed.pCertContext;
+                        rgszPurposes = managed.rgszPurposes;
+                        cPurposes = managed.cPurposes;
+                        pCryptProviderData = managed.pCryptProviderData;
+                        fpCryptProviderDataTrustedUsage = managed.fpCryptProviderDataTrustedUsage;
+                        idxSigner = managed.idxSigner;
+                        idxCert = managed.idxCert;
+                        fCounterSigner = managed.fCounterSigner;
+                        idxCounterSigner = managed.idxCounterSigner;
+                        cStores = managed.cStores;
+                        rghStores = managed.rghStores;
+                        cPropSheetPages = managed.cPropSheetPages;
+                        rgPropSheetPages = managed.rgPropSheetPages;
+                        nStartPage = managed.nStartPage;
+
+                    }
+
+                    public void FreeNative()
+                    {
+                        Marshal.FreeCoTaskMem(szTitle);
+                    }
+
+                    public CRYPTUI_VIEWCERTIFICATE_STRUCTW ToManaged()
+                    {
+                        return new()
+                        {
+                            dwSize = dwSize,
+                            hwndParent = hwndParent,
+                            dwFlags = dwFlags,
+                            szTitle = Marshal.PtrToStringUni(szTitle),
+                            pCertContext = pCertContext,
+                            rgszPurposes = rgszPurposes,
+                            cPurposes = cPurposes,
+                            pCryptProviderData = pCryptProviderData,
+                            fpCryptProviderDataTrustedUsage = fpCryptProviderDataTrustedUsage,
+                            idxSigner = idxSigner,
+                            idxCert = idxCert,
+                            fCounterSigner = fCounterSigner,
+                            idxCounterSigner = idxCounterSigner,
+                            cStores = cStores,
+                            rghStores = rghStores,
+                            cPropSheetPages = cPropSheetPages,
+                            rgPropSheetPages = rgPropSheetPages,
+                            nStartPage = nStartPage
+                        };
+                    }
                 }
             }
 #endif
         }
 
 #if NET7_0_OR_GREATER
-        [NativeMarshalling(typeof(Native))]
+        [NativeMarshalling(typeof(Marshaller))]
 #else
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
 #endif
@@ -143,73 +152,82 @@ internal static partial class Interop
             internal IntPtr hSelectedCertStore;
 
 #if NET7_0_OR_GREATER
-            [CustomTypeMarshaller(typeof(CRYPTUI_SELECTCERTIFICATE_STRUCTW), Features = CustomTypeMarshallerFeatures.UnmanagedResources)]
-            internal unsafe struct Native
+            [ManagedToUnmanagedMarshallers(typeof(CRYPTUI_SELECTCERTIFICATE_STRUCTW), InMarshaller = typeof(Marshaller), RefMarshaller = typeof(Marshaller), OutMarshaller = typeof(Marshaller))]
+            public static class Marshaller
             {
-                private uint dwSize;
-                private IntPtr hwndParent;
-                private uint dwFlags;
-                private IntPtr szTitle;
-                private uint dwDontUseColumn;
-                private IntPtr szDisplayString;
-                private IntPtr pFilterCallback;
-                private IntPtr pDisplayCallback;
-                private IntPtr pvCallbackData;
-                private uint cDisplayStores;
-                private IntPtr rghDisplayStores;
-                private uint cStores;
-                private IntPtr rghStores;
-                private uint cPropSheetPages;
-                private IntPtr rgPropSheetPages;
-                internal IntPtr hSelectedCertStore;
+                public static Native ConvertToUnmanaged(CRYPTUI_SELECTCERTIFICATE_STRUCTW managed) => new(managed);
 
-                public Native(CRYPTUI_SELECTCERTIFICATE_STRUCTW managed)
-                {
-                    dwSize = managed.dwSize;
-                    hwndParent = managed.hwndParent;
-                    dwFlags = managed.dwFlags;
-                    szTitle = Marshal.StringToCoTaskMemUni(managed.szTitle);
-                    dwDontUseColumn = managed.dwDontUseColumn;
-                    szDisplayString = Marshal.StringToCoTaskMemUni(managed.szDisplayString);
-                    pFilterCallback = managed.pFilterCallback;
-                    pDisplayCallback = managed.pDisplayCallback;
-                    pvCallbackData = managed.pvCallbackData;
-                    cDisplayStores = managed.cDisplayStores;
-                    rghDisplayStores = managed.rghDisplayStores;
-                    cStores = managed.cStores;
-                    rghStores = managed.rghStores;
-                    cPropSheetPages = managed.cPropSheetPages;
-                    rgPropSheetPages = managed.rgPropSheetPages;
-                    hSelectedCertStore = managed.hSelectedCertStore;
-                }
+                public static CRYPTUI_SELECTCERTIFICATE_STRUCTW ConvertToManaged(Native n) => n.ToManaged();
 
-                public void FreeNative()
-                {
-                    Marshal.FreeCoTaskMem(szTitle);
-                    Marshal.FreeCoTaskMem(szDisplayString);
-                }
+                public static void Free(Native native) => native.FreeNative();
 
-                public CRYPTUI_SELECTCERTIFICATE_STRUCTW ToManaged()
+                internal unsafe struct Native
                 {
-                    return new()
+                    private uint dwSize;
+                    private IntPtr hwndParent;
+                    private uint dwFlags;
+                    private IntPtr szTitle;
+                    private uint dwDontUseColumn;
+                    private IntPtr szDisplayString;
+                    private IntPtr pFilterCallback;
+                    private IntPtr pDisplayCallback;
+                    private IntPtr pvCallbackData;
+                    private uint cDisplayStores;
+                    private IntPtr rghDisplayStores;
+                    private uint cStores;
+                    private IntPtr rghStores;
+                    private uint cPropSheetPages;
+                    private IntPtr rgPropSheetPages;
+                    internal IntPtr hSelectedCertStore;
+
+                    public Native(CRYPTUI_SELECTCERTIFICATE_STRUCTW managed)
                     {
-                        dwSize = dwSize,
-                        hwndParent = hwndParent,
-                        dwFlags = dwFlags,
-                        szTitle = Marshal.PtrToStringUni(szTitle),
-                        dwDontUseColumn = dwDontUseColumn,
-                        szDisplayString = Marshal.PtrToStringUni(szDisplayString),
-                        pFilterCallback = pFilterCallback,
-                        pDisplayCallback = pDisplayCallback,
-                        pvCallbackData = pvCallbackData,
-                        cDisplayStores = cDisplayStores,
-                        rghDisplayStores = rghDisplayStores,
-                        cStores = cStores,
-                        rghStores = rghStores,
-                        cPropSheetPages = cPropSheetPages,
-                        rgPropSheetPages = rgPropSheetPages,
-                        hSelectedCertStore = hSelectedCertStore
-                    };
+                        dwSize = managed.dwSize;
+                        hwndParent = managed.hwndParent;
+                        dwFlags = managed.dwFlags;
+                        szTitle = Marshal.StringToCoTaskMemUni(managed.szTitle);
+                        dwDontUseColumn = managed.dwDontUseColumn;
+                        szDisplayString = Marshal.StringToCoTaskMemUni(managed.szDisplayString);
+                        pFilterCallback = managed.pFilterCallback;
+                        pDisplayCallback = managed.pDisplayCallback;
+                        pvCallbackData = managed.pvCallbackData;
+                        cDisplayStores = managed.cDisplayStores;
+                        rghDisplayStores = managed.rghDisplayStores;
+                        cStores = managed.cStores;
+                        rghStores = managed.rghStores;
+                        cPropSheetPages = managed.cPropSheetPages;
+                        rgPropSheetPages = managed.rgPropSheetPages;
+                        hSelectedCertStore = managed.hSelectedCertStore;
+                    }
+
+                    public void FreeNative()
+                    {
+                        Marshal.FreeCoTaskMem(szTitle);
+                        Marshal.FreeCoTaskMem(szDisplayString);
+                    }
+
+                    public CRYPTUI_SELECTCERTIFICATE_STRUCTW ToManaged()
+                    {
+                        return new()
+                        {
+                            dwSize = dwSize,
+                            hwndParent = hwndParent,
+                            dwFlags = dwFlags,
+                            szTitle = Marshal.PtrToStringUni(szTitle),
+                            dwDontUseColumn = dwDontUseColumn,
+                            szDisplayString = Marshal.PtrToStringUni(szDisplayString),
+                            pFilterCallback = pFilterCallback,
+                            pDisplayCallback = pDisplayCallback,
+                            pvCallbackData = pvCallbackData,
+                            cDisplayStores = cDisplayStores,
+                            rghDisplayStores = rghDisplayStores,
+                            cStores = cStores,
+                            rghStores = rghStores,
+                            cPropSheetPages = cPropSheetPages,
+                            rgPropSheetPages = rgPropSheetPages,
+                            hSelectedCertStore = hSelectedCertStore
+                        };
+                    }
                 }
             }
 #endif

--- a/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
@@ -248,7 +248,7 @@ internal static partial class Interop
             uint statusInformationLength);
 
 #if NET7_0_OR_GREATER
-        [NativeMarshalling(typeof(Native))]
+        [NativeMarshalling(typeof(Marshaller))]
 #endif
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public struct WINHTTP_AUTOPROXY_OPTIONS
@@ -262,42 +262,51 @@ internal static partial class Interop
             [MarshalAs(UnmanagedType.Bool)]
             public bool AutoLoginIfChallenged;
 #if NET7_0_OR_GREATER
-            [CustomTypeMarshaller(typeof(WINHTTP_AUTOPROXY_OPTIONS), Features = CustomTypeMarshallerFeatures.UnmanagedResources)]
-            public struct Native
+            [ManagedToUnmanagedMarshallers(typeof(WINHTTP_AUTOPROXY_OPTIONS), InMarshaller = typeof(Marshaller), RefMarshaller = typeof(Marshaller), OutMarshaller = typeof(Marshaller))]
+            public static class Marshaller
             {
-                private uint Flags;
-                private uint AutoDetectFlags;
-                private IntPtr AutoConfigUrl;
-                private IntPtr Reserved1;
-                private uint Reserved2;
-                private int AutoLoginIfChallenged;
+                public static Native ConvertToUnmanaged(WINHTTP_AUTOPROXY_OPTIONS managed) => new(managed);
 
-                public Native(WINHTTP_AUTOPROXY_OPTIONS managed)
-                {
-                    Flags = managed.Flags;
-                    AutoDetectFlags = managed.AutoDetectFlags;
-                    AutoConfigUrl = managed.AutoConfigUrl is not null ? Marshal.StringToCoTaskMemUni(managed.AutoConfigUrl) : IntPtr.Zero;
-                    Reserved1 = managed.Reserved1;
-                    Reserved2 = managed.Reserved2;
-                    AutoLoginIfChallenged = managed.AutoLoginIfChallenged ? 1 : 0;
-                }
+                public static WINHTTP_AUTOPROXY_OPTIONS ConvertToManaged(Native native) => native.ToManaged();
 
-                public WINHTTP_AUTOPROXY_OPTIONS ToManaged()
+                public static void Free(Native native) => native.FreeNative();
+
+                public struct Native
                 {
-                    return new WINHTTP_AUTOPROXY_OPTIONS
+                    private uint Flags;
+                    private uint AutoDetectFlags;
+                    private IntPtr AutoConfigUrl;
+                    private IntPtr Reserved1;
+                    private uint Reserved2;
+                    private int AutoLoginIfChallenged;
+
+                    public Native(WINHTTP_AUTOPROXY_OPTIONS managed)
                     {
-                        Flags = Flags,
-                        AutoDetectFlags = AutoDetectFlags,
-                        AutoConfigUrl = AutoConfigUrl != IntPtr.Zero ? Marshal.PtrToStringUni(AutoConfigUrl) : null,
-                        Reserved1 = Reserved1,
-                        Reserved2 = Reserved2,
-                        AutoLoginIfChallenged = AutoLoginIfChallenged != 0
-                    };
-                }
+                        Flags = managed.Flags;
+                        AutoDetectFlags = managed.AutoDetectFlags;
+                        AutoConfigUrl = managed.AutoConfigUrl is not null ? Marshal.StringToCoTaskMemUni(managed.AutoConfigUrl) : IntPtr.Zero;
+                        Reserved1 = managed.Reserved1;
+                        Reserved2 = managed.Reserved2;
+                        AutoLoginIfChallenged = managed.AutoLoginIfChallenged ? 1 : 0;
+                    }
 
-                public void FreeNative()
-                {
-                    Marshal.FreeCoTaskMem(AutoConfigUrl);
+                    public WINHTTP_AUTOPROXY_OPTIONS ToManaged()
+                    {
+                        return new WINHTTP_AUTOPROXY_OPTIONS
+                        {
+                            Flags = Flags,
+                            AutoDetectFlags = AutoDetectFlags,
+                            AutoConfigUrl = AutoConfigUrl != IntPtr.Zero ? Marshal.PtrToStringUni(AutoConfigUrl) : null,
+                            Reserved1 = Reserved1,
+                            Reserved2 = Reserved2,
+                            AutoLoginIfChallenged = AutoLoginIfChallenged != 0
+                        };
+                    }
+
+                    public void FreeNative()
+                    {
+                        Marshal.FreeCoTaskMem(AutoConfigUrl);
+                    }
                 }
             }
 #endif

--- a/src/libraries/Common/src/Interop/Windows/WinMm/Interop.waveOutGetDevCaps.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinMm/Interop.waveOutGetDevCaps.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
     {
 #pragma warning disable CA1823 // unused fields
 #if NET7_0_OR_GREATER
-        [NativeMarshalling(typeof(Native))]
+        [NativeMarshalling(typeof(Marshaller))]
 #endif
         internal struct WAVEOUTCAPS
         {
@@ -28,48 +28,54 @@ internal static partial class Interop
             private ushort wReserved1;
             private ushort dwSupport;
 #if NET7_0_OR_GREATER
-            [CustomTypeMarshaller(typeof(WAVEOUTCAPS))]
-            internal unsafe struct Native
+            [ManagedToUnmanagedMarshallers(typeof(WAVEOUTCAPS), InMarshaller = typeof(Marshaller), RefMarshaller = typeof(Marshaller), OutMarshaller = typeof(Marshaller))]
+            public static class Marshaller
             {
-                private ushort wMid;
-                private ushort wPid;
-                private uint vDriverVersion;
-                internal fixed char szPname[szPnameLength];
-                private uint dwFormats;
-                private ushort wChannels;
-                private ushort wReserved1;
-                private ushort dwSupport;
+                public static Native ConvertToUnmanaged(WAVEOUTCAPS managed) => new(managed);
+                public static WAVEOUTCAPS ConvertToManaged(Native native) => native.ToManaged();
 
-                public Native(WAVEOUTCAPS managed)
+                internal unsafe struct Native
                 {
-                    wMid = managed.wMid;
-                    wPid = managed.wPid;
-                    vDriverVersion = managed.vDriverVersion;
-                    fixed (char* pszPname = szPname)
-                    {
-                        managed.szPname.AsSpan().CopyTo(new Span<char>(pszPname, szPnameLength));
-                    }
-                    dwFormats = managed.dwFormats;
-                    wChannels = managed.wChannels;
-                    wReserved1 = managed.wReserved1;
-                    dwSupport = managed.dwSupport;
-                }
+                    private ushort wMid;
+                    private ushort wPid;
+                    private uint vDriverVersion;
+                    internal fixed char szPname[szPnameLength];
+                    private uint dwFormats;
+                    private ushort wChannels;
+                    private ushort wReserved1;
+                    private ushort dwSupport;
 
-                public WAVEOUTCAPS ToManaged()
-                {
-                    fixed (char* pszPname = szPname)
+                    public Native(WAVEOUTCAPS managed)
                     {
-                        return new WAVEOUTCAPS
+                        wMid = managed.wMid;
+                        wPid = managed.wPid;
+                        vDriverVersion = managed.vDriverVersion;
+                        fixed (char* pszPname = szPname)
                         {
-                            wMid = wMid,
-                            wPid = wPid,
-                            vDriverVersion = vDriverVersion,
-                            szPname = new Span<char>(pszPname, szPnameLength).ToString(),
-                            dwFormats = dwFormats,
-                            wChannels = wChannels,
-                            wReserved1 = wReserved1,
-                            dwSupport = dwSupport,
-                        };
+                            managed.szPname.AsSpan().CopyTo(new Span<char>(pszPname, szPnameLength));
+                        }
+                        dwFormats = managed.dwFormats;
+                        wChannels = managed.wChannels;
+                        wReserved1 = managed.wReserved1;
+                        dwSupport = managed.dwSupport;
+                    }
+
+                    public WAVEOUTCAPS ToManaged()
+                    {
+                        fixed (char* pszPname = szPname)
+                        {
+                            return new WAVEOUTCAPS
+                            {
+                                wMid = wMid,
+                                wPid = wPid,
+                                vDriverVersion = vDriverVersion,
+                                szPname = new Span<char>(pszPname, szPnameLength).ToString(),
+                                dwFormats = dwFormats,
+                                wChannels = wChannels,
+                                wReserved1 = wReserved1,
+                                dwSupport = dwSupport,
+                            };
+                        }
                     }
                 }
             }

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WinsockBSD.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WinsockBSD.cs
@@ -69,45 +69,50 @@ internal static partial class Interop
         }
 
         // Argument structure for IPV6_ADD_MEMBERSHIP and IPV6_DROP_MEMBERSHIP.
-        [NativeMarshalling(typeof(Native))]
+        [NativeMarshalling(typeof(Marshaller))]
         internal struct IPv6MulticastRequest
         {
             internal byte[] MulticastAddress; // IP address of group.
             internal int InterfaceIndex; // Local interface index.
-
-            [CustomTypeMarshaller(typeof(IPv6MulticastRequest))]
-            public unsafe struct Native
+            [ManagedToUnmanagedMarshallers(typeof(IPv6MulticastRequest), InMarshaller = typeof(Marshaller), RefMarshaller = typeof(Marshaller), OutMarshaller = typeof(Marshaller))]
+            public static class Marshaller
             {
-                private const int MulticastAddressLength = 16;
-                private fixed byte _multicastAddress[MulticastAddressLength];
-                private int _interfaceIndex;
+                public static Native ConvertToUnmanaged(IPv6MulticastRequest managed) => new(managed);
+                public static IPv6MulticastRequest ConvertToManaged(Native native) => native.ToManaged();
 
-                public Native(IPv6MulticastRequest managed)
+                public unsafe struct Native
                 {
-                    Debug.Assert(managed.MulticastAddress.Length == MulticastAddressLength);
-                    fixed (void* dest = _multicastAddress)
-                    {
-                        managed.MulticastAddress.CopyTo(new Span<byte>(dest, MulticastAddressLength));
-                    }
-                    _interfaceIndex = managed.InterfaceIndex;
-                }
+                    private const int MulticastAddressLength = 16;
+                    private fixed byte _multicastAddress[MulticastAddressLength];
+                    private int _interfaceIndex;
 
-                public IPv6MulticastRequest ToManaged()
-                {
-                    IPv6MulticastRequest managed = new()
+                    public Native(IPv6MulticastRequest managed)
                     {
-                        MulticastAddress = new byte[MulticastAddressLength],
-                        InterfaceIndex = _interfaceIndex
-                    };
-                    fixed (void* src = _multicastAddress)
-                    {
-                        new Span<byte>(src, 16).CopyTo(managed.MulticastAddress);
+                        Debug.Assert(managed.MulticastAddress.Length == MulticastAddressLength);
+                        fixed (void* dest = _multicastAddress)
+                        {
+                            managed.MulticastAddress.CopyTo(new Span<byte>(dest, MulticastAddressLength));
+                        }
+                        _interfaceIndex = managed.InterfaceIndex;
                     }
-                    return managed;
+
+                    public IPv6MulticastRequest ToManaged()
+                    {
+                        IPv6MulticastRequest managed = new()
+                        {
+                            MulticastAddress = new byte[MulticastAddressLength],
+                            InterfaceIndex = _interfaceIndex
+                        };
+                        fixed (void* src = _multicastAddress)
+                        {
+                            new Span<byte>(src, 16).CopyTo(managed.MulticastAddress);
+                        }
+                        return managed;
+                    }
                 }
             }
 
-            internal static readonly unsafe int Size = sizeof(Native);
+            internal static readonly unsafe int Size = sizeof(Marshaller.Native);
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Gdi32.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Gdi32.cs
@@ -176,7 +176,7 @@ internal static partial class Interop
         }
 
 #if NET7_0_OR_GREATER
-        [NativeMarshalling(typeof(Native))]
+        [NativeMarshalling(typeof(Marshaller))]
 #endif
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         internal sealed class DOCINFO
@@ -188,29 +188,35 @@ internal static partial class Interop
             internal int fwType;
 
 #if NET7_0_OR_GREATER
-            [CustomTypeMarshaller(typeof(DOCINFO), Direction = CustomTypeMarshallerDirection.In, Features = CustomTypeMarshallerFeatures.UnmanagedResources)]
-            internal struct Native
+            [ManagedToUnmanagedMarshallers(typeof(DOCINFO), InMarshaller = typeof(Marshaller))]
+            public static class Marshaller
             {
-                internal int cbSize;
-                internal IntPtr lpszDocName;
-                internal IntPtr lpszOutput;
-                internal IntPtr lpszDatatype;
-                internal int fwType;
+                public static Native ConvertToUnmanaged(DOCINFO managed) => new(managed);
+                public static void Free(Native native) => native.FreeNative();
 
-                public Native(DOCINFO docInfo)
+                internal struct Native
                 {
-                    cbSize = docInfo.cbSize;
-                    lpszDocName = Marshal.StringToCoTaskMemAuto(docInfo.lpszDocName);
-                    lpszOutput = Marshal.StringToCoTaskMemAuto(docInfo.lpszOutput);
-                    lpszDatatype = Marshal.StringToCoTaskMemAuto(docInfo.lpszDatatype);
-                    fwType = docInfo.fwType;
-                }
+                    internal int cbSize;
+                    internal IntPtr lpszDocName;
+                    internal IntPtr lpszOutput;
+                    internal IntPtr lpszDatatype;
+                    internal int fwType;
 
-                public void FreeNative()
-                {
-                    Marshal.FreeCoTaskMem(lpszDocName);
-                    Marshal.FreeCoTaskMem(lpszOutput);
-                    Marshal.FreeCoTaskMem(lpszDatatype);
+                    public Native(DOCINFO docInfo)
+                    {
+                        cbSize = docInfo.cbSize;
+                        lpszDocName = Marshal.StringToCoTaskMemAuto(docInfo.lpszDocName);
+                        lpszOutput = Marshal.StringToCoTaskMemAuto(docInfo.lpszOutput);
+                        lpszDatatype = Marshal.StringToCoTaskMemAuto(docInfo.lpszDatatype);
+                        fwType = docInfo.fwType;
+                    }
+
+                    public void FreeNative()
+                    {
+                        Marshal.FreeCoTaskMem(lpszDocName);
+                        Marshal.FreeCoTaskMem(lpszOutput);
+                        Marshal.FreeCoTaskMem(lpszDatatype);
+                    }
                 }
             }
 #endif

--- a/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/CustomTypeMarshallersAttributeBase.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/CustomTypeMarshallersAttributeBase.cs
@@ -11,7 +11,12 @@ namespace System.Runtime.InteropServices.Marshalling
     /// For the following attribute types, any marshaller types that are provided will be validated by an analyzer to have the correct members to prevent
     /// developers from accidentally typoing a member like Free() and causing memory leaks.
     /// </remarks>
-    public abstract class CustomUnmanagedTypeMarshallersAttributeBase : Attribute
+#if LIBRARYIMPORT_GENERATOR_TEST
+    public
+#else
+    internal
+#endif
+    abstract class CustomUnmanagedTypeMarshallersAttributeBase : Attribute
     {
         /// <summary>
         /// Placeholder type for generic parameter

--- a/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/ManagedToUnmanagedMarshallersAttribute.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/ManagedToUnmanagedMarshallersAttribute.cs
@@ -1,12 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+#nullable enable
 
 namespace System.Runtime.InteropServices.Marshalling
 {
     /// <summary>
     /// Specify marshallers used in the managed to unmanaged direction (that is, P/Invoke)
     /// </summary>
-    public sealed class ManagedToUnmanagedMarshallersAttribute : CustomUnmanagedTypeMarshallersAttributeBase
+#if LIBRARYIMPORT_GENERATOR_TEST
+    public
+#else
+    internal
+#endif
+    sealed class ManagedToUnmanagedMarshallersAttribute : CustomUnmanagedTypeMarshallersAttributeBase
     {
         /// <summary>
         /// Create instance of <see cref="ManagedToUnmanagedMarshallersAttribute"/>.

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/LibraryImportGenerator.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/LibraryImportGenerator.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
+    <InculdeLibraryImportGeneratorSources>false</InculdeLibraryImportGeneratorSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/LibraryImportGenerator.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/LibraryImportGenerator.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
-    <InculdeLibraryImportGeneratorSources>false</InculdeLibraryImportGeneratorSources>
+    <IncludeLibraryImportGeneratorSources>false</IncludeLibraryImportGeneratorSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Windows.Extensions/src/System/Security/Cryptography/X509Certificates/X509Certificate2UI.cs
+++ b/src/libraries/System.Windows.Extensions/src/System/Security/Cryptography/X509Certificates/X509Certificate2UI.cs
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography.X509Certificates
                 // Initialize view structure.
                 Interop.CryptUI.CRYPTUI_VIEWCERTIFICATE_STRUCTW ViewInfo = default;
 #if NET7_0_OR_GREATER
-                ViewInfo.dwSize = (uint)sizeof(Interop.CryptUI.CRYPTUI_VIEWCERTIFICATE_STRUCTW.Native);
+                ViewInfo.dwSize = (uint)sizeof(Interop.CryptUI.CRYPTUI_VIEWCERTIFICATE_STRUCTW.Marshaller.Native);
 #else
                 ViewInfo.dwSize = (uint)Marshal.SizeOf<Interop.CryptUI.CRYPTUI_VIEWCERTIFICATE_STRUCTW>();
 #endif
@@ -121,9 +121,9 @@ namespace System.Security.Cryptography.X509Certificates
 #if NET7_0_OR_GREATER
             // Declare a local for Native to enable us to get the managed byte offset
             // without having a null check cause a failure.
-            Interop.CryptUI.CRYPTUI_SELECTCERTIFICATE_STRUCTW.Native native;
+            Interop.CryptUI.CRYPTUI_SELECTCERTIFICATE_STRUCTW.Marshaller.Native native;
             Unsafe.SkipInit(out native);
-            csc.dwSize = (uint)Unsafe.ByteOffset(ref Unsafe.As<Interop.CryptUI.CRYPTUI_SELECTCERTIFICATE_STRUCTW.Native, byte>(ref native), ref Unsafe.As<IntPtr, byte>(ref native.hSelectedCertStore));
+            csc.dwSize = (uint)Unsafe.ByteOffset(ref Unsafe.As<Interop.CryptUI.CRYPTUI_SELECTCERTIFICATE_STRUCTW.Marshaller.Native, byte>(ref native), ref Unsafe.As<IntPtr, byte>(ref native.hSelectedCertStore));
 #else
             csc.dwSize = (uint)Marshal.OffsetOf(typeof(Interop.CryptUI.CRYPTUI_SELECTCERTIFICATE_STRUCTW), "hSelectedCertStore");
 #endif


### PR DESCRIPTION
Convert some custom type marshallers to the v2 design.

Convert as many of the marshallers as possible to their correct representation with the currently implemented feature set.

This PR does not convert marshallers that can be represented with the new design but need more features to be accurately represented.

Viewing this PR with no whitespace diffs is highly recommended, as the changes are very mechanical but the whitespace changes make them look much worse.