### PR TITLE
Add stateless shape support for caller-allocated buffer and guaranteed unmarshal

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
@@ -321,7 +321,7 @@ namespace Microsoft.Interop
                 }
             }
 
-            // Bidirectional requires ToManaged without the caller-allocated buffer
+            // Bidirectional requires ToUnmanaged without the caller-allocated buffer
             if (direction.HasFlag(MarshallingDirection.Bidirectional) && !shape.HasFlag(MarshallerShape.ToUnmanaged))
                 return null;
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
@@ -10,10 +10,22 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Interop
 {
+    [Flags]
+    public enum MarshallerShape
+    {
+        None = 0x0,
+        ToUnmanaged = 0x1,
+        CallerAllocatedBuffer = 0x2,
+        PinnableReference = 0x4,
+        ToManaged = 0x8,
+        GuaranteedUnmarshal = 0x10,
+        Free = 0x20,
+    }
+
     public readonly record struct CustomTypeMarshallerData(
         ManagedTypeInfo MarshallerType,
         ManagedTypeInfo NativeType,
-        CustomTypeMarshallerFeatures Features,
+        MarshallerShape Shape,
         bool IsStrictlyBlittable,
         ManagedTypeInfo? BufferElementType,
         int? BufferSize);
@@ -29,6 +41,7 @@ namespace Microsoft.Interop
             public abstract class Stateless
             {
                 public const string ConvertToManaged = nameof(ConvertToManaged);
+                public const string ConvertToManagedGuaranteed = nameof(ConvertToManagedGuaranteed);
                 public const string ConvertToUnmanaged = nameof(ConvertToUnmanaged);
                 public const string Free = nameof(Free);
             }
@@ -82,7 +95,7 @@ namespace Microsoft.Interop
             return false;
         }
 
-        public static bool TryGetMarshallers(ITypeSymbol entryPointType, ITypeSymbol managedType, bool isLinearCollectionMarshalling, out CustomTypeMarshallers? marshallers)
+        public static bool TryGetMarshallers(ITypeSymbol entryPointType, ITypeSymbol managedType, bool isLinearCollectionMarshalling, Compilation compilation, out CustomTypeMarshallers? marshallers)
         {
             marshallers = null;
             var attr = entryPointType.GetAttributes().FirstOrDefault(attr => attr.AttributeClass.ToDisplayString() == TypeNames.ManagedToUnmanagedMarshallersAttribute);
@@ -90,19 +103,22 @@ namespace Microsoft.Interop
                 return false;
 
             ITypeSymbol? managedTypeOnAttr = attr.ConstructorArguments[0].Value as ITypeSymbol;
+            if (!SymbolEqualityComparer.Default.Equals(managedType, managedTypeOnAttr)
+                && !compilation.HasImplicitConversion(managedType, managedTypeOnAttr))
+                return false;
 
             var namedArguments = attr.NamedArguments.ToImmutableDictionary();
-            CustomTypeMarshallerData? inMarshaller = GetNamedArgumentAsMarshallerData(namedArguments, MarshallersProperties.InMarshaller, MarshallingDirection.ManagedToUnmanaged);
+            CustomTypeMarshallerData? inMarshaller = GetNamedArgumentAsMarshallerData(namedArguments, MarshallersProperties.InMarshaller, MarshallingDirection.ManagedToUnmanaged, managedTypeOnAttr, compilation);
             if (inMarshaller is null)
-                inMarshaller = GetMarshallerDataForType(entryPointType, MarshallingDirection.ManagedToUnmanaged);
+                inMarshaller = GetMarshallerDataForType(entryPointType, MarshallingDirection.ManagedToUnmanaged, managedTypeOnAttr, compilation);
 
-            CustomTypeMarshallerData? refMarshaller = GetNamedArgumentAsMarshallerData(namedArguments, MarshallersProperties.RefMarshaller, MarshallingDirection.Bidirectional);
+            CustomTypeMarshallerData? refMarshaller = GetNamedArgumentAsMarshallerData(namedArguments, MarshallersProperties.RefMarshaller, MarshallingDirection.Bidirectional, managedTypeOnAttr, compilation);
             if (refMarshaller is null)
-                refMarshaller = GetMarshallerDataForType(entryPointType, MarshallingDirection.Bidirectional);
+                refMarshaller = GetMarshallerDataForType(entryPointType, MarshallingDirection.Bidirectional, managedTypeOnAttr, compilation);
 
-            CustomTypeMarshallerData? outMarshaller = GetNamedArgumentAsMarshallerData(namedArguments, MarshallersProperties.OutMarshaller, MarshallingDirection.UnmanagedToManaged);
+            CustomTypeMarshallerData? outMarshaller = GetNamedArgumentAsMarshallerData(namedArguments, MarshallersProperties.OutMarshaller, MarshallingDirection.UnmanagedToManaged, managedTypeOnAttr, compilation);
             if (outMarshaller is null)
-                outMarshaller = GetMarshallerDataForType(entryPointType, MarshallingDirection.UnmanagedToManaged);
+                outMarshaller = GetMarshallerDataForType(entryPointType, MarshallingDirection.UnmanagedToManaged, managedTypeOnAttr, compilation);
 
             if (inMarshaller is null && refMarshaller is null && outMarshaller is null)
                 return false;
@@ -115,13 +131,6 @@ namespace Microsoft.Interop
             };
 
             return true;
-        }
-
-        public static bool HasStatelessFree(ITypeSymbol type)
-        {
-            return type.GetMembers(ShapeMemberNames.Value.Stateless.Free)
-                .OfType<IMethodSymbol>()
-                .Any(m => m is { IsStatic: true, Parameters.Length: 1, ReturnsVoid: true });
         }
 
         /// <summary>
@@ -226,68 +235,183 @@ namespace Microsoft.Interop
                     ({ ReturnsByRef: true } or { ReturnsByRefReadonly: true }));
         }
 
-        private static CustomTypeMarshallerData? GetNamedArgumentAsMarshallerData(ImmutableDictionary<string, TypedConstant> namedArguments, string name, MarshallingDirection direction)
+        private static CustomTypeMarshallerData? GetNamedArgumentAsMarshallerData(ImmutableDictionary<string, TypedConstant> namedArguments, string name, MarshallingDirection direction, ITypeSymbol managedType, Compilation compilation)
         {
             ITypeSymbol? marshallerType = namedArguments.TryGetValue(name, out TypedConstant typeMaybe) ? typeMaybe.Value as ITypeSymbol : null;
             if (marshallerType is null)
                 return null;
 
             // TODO: Report invalid shape
-            return GetMarshallerDataForType(marshallerType, direction);
+            return GetMarshallerDataForType(marshallerType, direction, managedType, compilation);
         }
 
-        private static CustomTypeMarshallerData? GetMarshallerDataForType(ITypeSymbol marshallerType, MarshallingDirection direction)
+        private static (MarshallerShape, Dictionary<MarshallerShape, IMethodSymbol>) GetShapeForType(ITypeSymbol marshallerType, ITypeSymbol managedType, Compilation compilation)
         {
+            MarshallerShape shape = MarshallerShape.None;
+            var methodsByShape = new Dictionary<MarshallerShape, IMethodSymbol>();
+
+            IMethodSymbol? method = GetConvertToUnmanagedMethod(marshallerType, managedType);
+            if (method is not null)
+                AddMethod(MarshallerShape.ToUnmanaged, method);
+
+            INamedTypeSymbol spanOfT = compilation.GetTypeByMetadataName(TypeNames.System_Span_Metadata)!;
+            method = GetConvertToUnmanagedWithCallerAllocatedBufferMethod(marshallerType, managedType, spanOfT, out _);
+            if (method is not null)
+                AddMethod(MarshallerShape.CallerAllocatedBuffer, method);
+
+            method = GetConvertToManagedMethod(marshallerType, managedType);
+            if (method is not null)
+                AddMethod(MarshallerShape.ToManaged, method);
+
+            method = GetConvertToManagedGuaranteedMethod(marshallerType, managedType);
+            if (method is not null)
+                AddMethod(MarshallerShape.GuaranteedUnmarshal, method);
+
+            method = GetStatelessGetPinnableReference(marshallerType);
+            if (method is not null)
+                AddMethod(MarshallerShape.PinnableReference, method);
+
+            method = GetStatelessFree(marshallerType);
+            if (method is not null)
+                AddMethod(MarshallerShape.Free, method);
+
+            return (shape, methodsByShape);
+
+            void AddMethod(MarshallerShape shapeToAdd, IMethodSymbol methodToAdd)
+            {
+                methodsByShape.Add(shapeToAdd, methodToAdd);
+                shape |= shapeToAdd;
+            }
+        }
+
+        private static CustomTypeMarshallerData? GetMarshallerDataForType(ITypeSymbol marshallerType, MarshallingDirection direction, ITypeSymbol managedType, Compilation compilation)
+        {
+            (MarshallerShape shape, Dictionary<MarshallerShape, IMethodSymbol> methodsByShape) = GetShapeForType(marshallerType, managedType, compilation);
+
             ITypeSymbol? nativeType = null;
             if (direction.HasFlag(MarshallingDirection.ManagedToUnmanaged))
             {
-                // Make sure required method exists
-                IMethodSymbol? method = GetConvertToUnmanagedMethod(marshallerType);
-                if (method is null)
+                if (!shape.HasFlag(MarshallerShape.CallerAllocatedBuffer) && !shape.HasFlag(MarshallerShape.ToUnmanaged))
                     return null;
 
-                nativeType = method.ReturnType;
+                IMethodSymbol method;
+                if (methodsByShape.TryGetValue(MarshallerShape.CallerAllocatedBuffer, out method))
+                {
+                    nativeType = method.ReturnType;
+                }
+                else if (methodsByShape.TryGetValue(MarshallerShape.ToUnmanaged, out method))
+                {
+                    nativeType = method.ReturnType;
+                }
             }
 
             if (direction.HasFlag(MarshallingDirection.UnmanagedToManaged))
             {
-                // Make sure required method exists
-                IMethodSymbol? method = GetConvertToManagedMethod(marshallerType);
-                if (method is null)
+                if (!shape.HasFlag(MarshallerShape.GuaranteedUnmarshal) && !shape.HasFlag(MarshallerShape.ToManaged))
                     return null;
 
-                nativeType = method.Parameters[0].Type;
+                IMethodSymbol method;
+                if (methodsByShape.TryGetValue(MarshallerShape.GuaranteedUnmarshal, out method))
+                {
+                    nativeType = method.Parameters[0].Type;
+                }
+                else if (methodsByShape.TryGetValue(MarshallerShape.ToManaged, out method))
+                {
+                    nativeType = method.Parameters[0].Type;
+                }
             }
+
+            // Bidirectional requires ToManaged without the caller-allocated buffer
+            if (direction.HasFlag(MarshallingDirection.Bidirectional) && !shape.HasFlag(MarshallerShape.ToUnmanaged))
+                return null;
 
             if (nativeType is null)
                 return null;
 
-            var features = CustomTypeMarshallerFeatures.None;
-            if (HasStatelessFree(marshallerType))
-                features |= CustomTypeMarshallerFeatures.UnmanagedResources;
-
-            // TODO: Determine optional support - caller-allocated buffer, pinning, free
             return new CustomTypeMarshallerData(
                 ManagedTypeInfo.CreateTypeInfoForTypeSymbol(marshallerType),
                 ManagedTypeInfo.CreateTypeInfoForTypeSymbol(nativeType),
-                features,
+                shape,
                 nativeType.IsStrictlyBlittable(),
                 BufferElementType: null,
                 BufferSize: null);
         }
 
-        private static IMethodSymbol? GetConvertToUnmanagedMethod(ITypeSymbol type)
+        private static IMethodSymbol? GetStatelessFree(ITypeSymbol type)
+        {
+            return type.GetMembers(ShapeMemberNames.Value.Stateless.Free)
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(m => m is { IsStatic: true, Parameters.Length: 1, ReturnsVoid: true });
+        }
+
+        private static IMethodSymbol? GetStatelessGetPinnableReference(ITypeSymbol type)
+        {
+            return type.GetMembers(ShapeMemberNames.GetPinnableReference)
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(m => m is { IsStatic: true, Parameters.Length: 1 } and
+                    ({ ReturnsByRef: true } or { ReturnsByRefReadonly: true }));
+        }
+
+        private static IMethodSymbol? GetConvertToUnmanagedMethod(ITypeSymbol type, ITypeSymbol managedType)
         {
             return type.GetMembers(ShapeMemberNames.Value.Stateless.ConvertToUnmanaged)
                 .OfType<IMethodSymbol>()
-                .FirstOrDefault(m => m is { IsStatic: true, Parameters.Length: 1, ReturnsVoid: false });
+                .FirstOrDefault(m => m is { IsStatic: true, Parameters.Length: 1, ReturnsVoid: false }
+                    && SymbolEqualityComparer.Default.Equals(managedType, m.Parameters[0].Type));
         }
 
-        private static IMethodSymbol? GetConvertToManagedMethod(ITypeSymbol type)
+        private static IMethodSymbol? GetConvertToUnmanagedWithCallerAllocatedBufferMethod(
+            ITypeSymbol type,
+            ITypeSymbol managedType,
+            ITypeSymbol spanOfT,
+            out ITypeSymbol? spanElementType)
+        {
+            spanElementType = null;
+            IEnumerable<IMethodSymbol> methods = type.GetMembers(ShapeMemberNames.Value.Stateless.ConvertToUnmanaged)
+                .OfType<IMethodSymbol>()
+                .Where(m => m is { IsStatic: true, Parameters.Length: 2, ReturnsVoid: false }
+                    && SymbolEqualityComparer.Default.Equals(managedType, m.Parameters[0].Type));
+
+            foreach (IMethodSymbol method in methods)
+            {
+                if (IsSpanOfUnmanagedType(method.Parameters[1].Type, spanOfT, out spanElementType))
+                {
+                    return method;
+                }
+            }
+
+            return null;
+
+            static bool IsSpanOfUnmanagedType(ITypeSymbol typeToCheck, ITypeSymbol spanOfT, out ITypeSymbol? typeArgument)
+            {
+                typeArgument = null;
+                if (typeToCheck is INamedTypeSymbol namedType
+                    && SymbolEqualityComparer.Default.Equals(spanOfT, namedType.ConstructedFrom)
+                    && namedType.TypeArguments.Length == 1
+                    && namedType.TypeArguments[0].IsUnmanagedType)
+                {
+                    typeArgument = namedType.TypeArguments[0];
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        private static IMethodSymbol? GetConvertToManagedMethod(ITypeSymbol type, ITypeSymbol managedType)
         {
             return type.GetMembers(ShapeMemberNames.Value.Stateless.ConvertToManaged)
                 .OfType<IMethodSymbol>()
-                .FirstOrDefault(m => m is { IsStatic: true, Parameters.Length: 1, ReturnsVoid: false });
+                .FirstOrDefault(m => m is { IsStatic: true, Parameters.Length: 1, ReturnsVoid: false }
+                    && SymbolEqualityComparer.Default.Equals(managedType, m.ReturnType));
+        }
+
+        private static IMethodSymbol? GetConvertToManagedGuaranteedMethod(ITypeSymbol type, ITypeSymbol managedType)
+        {
+            return type.GetMembers(ShapeMemberNames.Value.Stateless.ConvertToManagedGuaranteed)
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(m => m is { IsStatic: true, Parameters.Length: 1, ReturnsVoid: false }
+                    && SymbolEqualityComparer.Default.Equals(managedType, m.ReturnType));
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Interop
                 };
             }
 
-            ICustomTypeMarshallingStrategy marshallingStrategy = new StatelessValueMarshalling(marshallerData.MarshallerType.Syntax, marshallerData.NativeType.Syntax, marshallerData.Features);
+            ICustomTypeMarshallingStrategy marshallingStrategy = new StatelessValueMarshalling(marshallerData.MarshallerType.Syntax, marshallerData.NativeType.Syntax, marshallerData.Shape);
 
             IMarshallingGenerator marshallingGenerator = new CustomNativeTypeMarshallingGenerator(marshallingStrategy, enableByValueContentsMarshalling: false);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
@@ -236,6 +236,8 @@ namespace Microsoft.Interop
             }
 
             ICustomTypeMarshallingStrategy marshallingStrategy = new StatelessValueMarshalling(marshallerData.MarshallerType.Syntax, marshallerData.NativeType.Syntax, marshallerData.Shape);
+            if (marshallerData.Shape.HasFlag(MarshallerShape.CallerAllocatedBuffer))
+                marshallingStrategy = new CallerAllocatedBufferMarshalling(marshallingStrategy, marshallerData.MarshallerType.Syntax, marshallerData.BufferElementType.Syntax);
 
             IMarshallingGenerator marshallingGenerator = new CustomNativeTypeMarshallingGenerator(marshallingStrategy, enableByValueContentsMarshalling: false);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
@@ -14,10 +14,10 @@ namespace Microsoft.Interop
     /// </summary>
     internal sealed class CustomNativeTypeMarshallingGenerator : IMarshallingGenerator
     {
-        private readonly ICustomTypeMarshallingStrategy _nativeTypeMarshaller;
+        private readonly ICustomTypeMarshallingStrategyBase _nativeTypeMarshaller;
         private readonly bool _enableByValueContentsMarshalling;
 
-        public CustomNativeTypeMarshallingGenerator(ICustomTypeMarshallingStrategy nativeTypeMarshaller, bool enableByValueContentsMarshalling)
+        public CustomNativeTypeMarshallingGenerator(ICustomTypeMarshallingStrategyBase nativeTypeMarshaller, bool enableByValueContentsMarshalling)
         {
             _nativeTypeMarshaller = nativeTypeMarshaller;
             _enableByValueContentsMarshalling = enableByValueContentsMarshalling;
@@ -80,6 +80,16 @@ namespace Microsoft.Interop
                         || (_enableByValueContentsMarshalling && !info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out)))
                     {
                         return _nativeTypeMarshaller.GenerateUnmarshalStatements(info, context);
+                    }
+                    break;
+                case StubCodeContext.Stage.GuaranteedUnmarshal:
+                    if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In)
+                        || (_enableByValueContentsMarshalling && !info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out)))
+                    {
+                        if (_nativeTypeMarshaller is ICustomTypeMarshallingStrategy strategyWithGuaranteedUnmarshal)
+                        {
+                            return strategyWithGuaranteedUnmarshal.GenerateGuaranteedUnmarshalStatements(info, context);
+                        }
                     }
                     break;
                 case StubCodeContext.Stage.Cleanup:

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
@@ -83,7 +83,8 @@ namespace Microsoft.Interop
                     }
                     break;
                 case StubCodeContext.Stage.GuaranteedUnmarshal:
-                    if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In)
+                    if (info.IsManagedReturnPosition
+                        || (info.IsByRef && info.RefKind != RefKind.In)
                         || (_enableByValueContentsMarshalling && !info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out)))
                     {
                         if (_nativeTypeMarshaller is ICustomTypeMarshallingStrategy strategyWithGuaranteedUnmarshal)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -11,7 +11,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Interop
 {
-    internal interface ICustomNativeTypeMarshallingStrategy : ICustomTypeMarshallingStrategy { }
+    internal interface ICustomNativeTypeMarshallingStrategy : ICustomTypeMarshallingStrategyBase { }
 
     /// <summary>
     /// Marshalling support for a type that has a custom native type.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomTypeMarshallingStrategy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -161,6 +162,91 @@ namespace Microsoft.Interop
         public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context)
         {
             return Array.Empty<StatementSyntax>();
+        }
+    }
+
+    /// <summary>
+    /// Marshaller that enables support for a stackalloc constructor variant on a native type.
+    /// </summary>
+    internal sealed class CallerAllocatedBufferMarshalling : ICustomTypeMarshallingStrategy
+    {
+        private readonly ICustomTypeMarshallingStrategy _innerMarshaller;
+        private readonly TypeSyntax _marshallerType;
+        private readonly TypeSyntax _bufferElementType;
+
+        public CallerAllocatedBufferMarshalling(ICustomTypeMarshallingStrategy innerMarshaller, TypeSyntax marshallerType, TypeSyntax bufferElementType)
+        {
+            _innerMarshaller = innerMarshaller;
+            _marshallerType = marshallerType;
+            _bufferElementType = bufferElementType;
+        }
+
+        public TypeSyntax AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
+        public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateCleanupStatements(info, context);
+        public IEnumerable<StatementSyntax> GenerateGuaranteedUnmarshalStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateGuaranteedUnmarshalStatements(info, context);
+
+        public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context, IEnumerable<ArgumentSyntax> nativeTypeConstructorArguments)
+        {
+            if (CanUseCallerAllocatedBuffer(info, context))
+            {
+                string bufferIdentifier = context.GetAdditionalIdentifier(info, "buffer");
+
+                // Span<bufferElementType> <bufferIdentifier> = stackalloc <bufferElementType>[<marshallerType>.BufferSize];
+                yield return LocalDeclarationStatement(
+                    VariableDeclaration(
+                        GenericName(
+                            Identifier(TypeNames.System_Span),
+                            TypeArgumentList(
+                                SingletonSeparatedList(_bufferElementType))),
+                        SingletonSeparatedList(
+                            VariableDeclarator(bufferIdentifier)
+                                .WithInitializer(EqualsValueClause(
+                                    StackAllocArrayCreationExpression(
+                                        ArrayType(
+                                            _bufferElementType,
+                                            SingletonList(ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(
+                                                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                                    _marshallerType,
+                                                    IdentifierName(ShapeMemberNames.BufferSize))
+                                            ))))))))));
+
+                (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);
+
+                // <nativeIdentifier> = <marshallerType>.ConvertToUnmanaged(<managedIdentifier>, <nativeIdentifier>__buffer);
+                yield return ExpressionStatement(
+                    AssignmentExpression(
+                        SyntaxKind.SimpleAssignmentExpression,
+                        IdentifierName(nativeIdentifier),
+                        InvocationExpression(
+                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                _marshallerType,
+                                IdentifierName(ShapeMemberNames.Value.Stateless.ConvertToUnmanaged)),
+                            ArgumentList(SeparatedList(new ArgumentSyntax[]
+                            {
+                                Argument(IdentifierName(managedIdentifier)),
+                                Argument(IdentifierName(bufferIdentifier))
+                            })))));
+            }
+            else
+            {
+                foreach (StatementSyntax statement in _innerMarshaller.GenerateMarshalStatements(info, context, nativeTypeConstructorArguments))
+                {
+                    yield return statement;
+                }
+            }
+        }
+
+        public IEnumerable<StatementSyntax> GeneratePinnedMarshalStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GeneratePinnedMarshalStatements(info, context);
+        public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GeneratePinStatements(info, context);
+        public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateSetupStatements(info, context);
+        public IEnumerable<StatementSyntax> GenerateUnmarshalCaptureStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateUnmarshalCaptureStatements(info, context);
+        public IEnumerable<StatementSyntax> GenerateUnmarshalStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateUnmarshalStatements(info, context);
+        public IEnumerable<ArgumentSyntax> GetNativeTypeConstructorArguments(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GetNativeTypeConstructorArguments(info, context);
+        public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.UsesNativeIdentifier(info, context);
+
+        private static bool CanUseCallerAllocatedBuffer(TypePositionInfo info, StubCodeContext context)
+        {
+            return context.SingleFrameSpansNativeContext && (!info.IsByRef || info.RefKind == RefKind.In);
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
@@ -584,7 +584,7 @@ namespace Microsoft.Interop
             ref int maxIndirectionDepthUsed)
         {
             bool isLinearCollectionMarshalling = ManualTypeMarshallingHelper.IsLinearCollectionEntryPoint(entryPointType);
-            if (ManualTypeMarshallingHelper.TryGetMarshallers(entryPointType, type, isLinearCollectionMarshalling, out CustomTypeMarshallers? marshallers))
+            if (ManualTypeMarshallingHelper.TryGetMarshallers(entryPointType, type, isLinearCollectionMarshalling, _compilation, out CustomTypeMarshallers? marshallers))
             {
                 if (!entryPointType.IsStatic)
                 {

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
@@ -707,6 +707,16 @@ public static class Marshaller
     public static Native ConvertToUnmanaged(S s) => default;
 }
 ";
+            private static string StatelessInBuffer = @"
+[ManagedToUnmanagedMarshallers(typeof(S))]
+public static class Marshaller
+{
+    public struct Native { }
+
+    public const int BufferSize = 0x100;
+    public static Native ConvertToUnmanaged(S s, System.Span<byte> buffer) => default;
+}
+";
             private static string StatelessOut = @"
 [ManagedToUnmanagedMarshallers(typeof(S))]
 public static class Marshaller
@@ -714,6 +724,15 @@ public static class Marshaller
     public struct Native { }
 
     public static S ConvertToManaged(Native n) => default;
+}
+";
+            private static string StatelessOutGuaranteed = @"
+[ManagedToUnmanagedMarshallers(typeof(S))]
+public static class Marshaller
+{
+    public struct Native { }
+
+    public static S ConvertToManagedGuaranteed(Native n) => default;
 }
 ";
             public static string StatelessRef = @"
@@ -726,6 +745,30 @@ public static class Marshaller
     public static S ConvertToManaged(Native n) => default;
 }
 ";
+            public static string StatelessRefBuffer = @"
+[ManagedToUnmanagedMarshallers(typeof(S))]
+public static class Marshaller
+{
+    public struct Native { }
+
+    public const int BufferSize = 0x100;
+    public static Native ConvertToUnmanaged(S s, System.Span<byte> buffer) => default;
+    public static S ConvertToManaged(Native n) => default;
+}
+";
+            public static string StatelessRefOptionalBuffer = @"
+[ManagedToUnmanagedMarshallers(typeof(S))]
+public static class Marshaller
+{
+    public struct Native { }
+
+    public const int BufferSize = 0x100;
+    public static Native ConvertToUnmanaged(S s) => default;
+    public static Native ConvertToUnmanaged(S s, System.Span<byte> buffer) => default;
+    public static S ConvertToManaged(Native n) => default;
+}
+";
+
             public static string ManagedToNativeOnlyOutParameter => BasicParameterWithByRefModifier("out", "S")
                 + NonBlittableUserDefinedType()
                 + StatelessIn;
@@ -734,11 +777,19 @@ public static class Marshaller
                 + NonBlittableUserDefinedType()
                 + StatelessOut;
 
+            public static string NativeToManagedGuaranteedOnlyOutParameter => BasicParameterWithByRefModifier("out", "S")
+                + NonBlittableUserDefinedType()
+                + StatelessOutGuaranteed;
+
             public static string ManagedToNativeOnlyReturnValue => BasicReturnType("S")
                 + NonBlittableUserDefinedType()
                 + StatelessIn;
 
             public static string NativeToManagedOnlyReturnValue => BasicReturnType("S")
+                + NonBlittableUserDefinedType()
+                + StatelessOut;
+
+            public static string NativeToManagedGuaranteedOnlyReturnValue => BasicReturnType("S")
                 + NonBlittableUserDefinedType()
                 + StatelessOut;
 
@@ -757,6 +808,22 @@ public static class Marshaller
             public static string NonStaticMarshallerEntryPoint => BasicParameterByValue("S")
                 + NonBlittableUserDefinedType()
                 + NonStatic;
+
+            public static string StackallocByValueInParameter => BasicParameterByValue("S")
+                + NonBlittableUserDefinedType()
+                + StatelessInBuffer;
+
+            public static string StackallocParametersAndModifiersNoRef = BasicParametersAndModifiersNoRef("S")
+                + NonBlittableUserDefinedType()
+                + StatelessRefBuffer;
+
+            public static string StackallocOnlyRefParameter = BasicParameterWithByRefModifier("ref", "S")
+                + NonBlittableUserDefinedType()
+                + StatelessRefBuffer;
+
+            public static string OptionalStackallocParametersAndModifiers = BasicParametersAndModifiers("S", UsingSystemRuntimeInteropServicesMarshalling)
+                + NonBlittableUserDefinedType()
+                + StatelessRefOptionalBuffer;
         }
 
         public static class CustomStructMarshalling_V1

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
@@ -96,6 +96,7 @@ namespace LibraryImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.CustomStructMarshalling.ManagedToNativeOnlyReturnValue, 1, 0 };
             yield return new object[] { CodeSnippets.CustomStructMarshalling.NativeToManagedOnlyInParameter, 1, 0 };
             yield return new object[] { CodeSnippets.CustomStructMarshalling.NonStaticMarshallerEntryPoint, 2, 0 };
+            yield return new object[] { CodeSnippets.CustomStructMarshalling.StackallocOnlyRefParameter, 1, 0 };
             yield return new object[] { CodeSnippets.CustomStructMarshalling_V1.TwoStageRefReturn, 3, 0 };
             yield return new object[] { CodeSnippets.CustomStructMarshalling_V1.ManagedToNativeOnlyOutParameter, 1, 0 };
             yield return new object[] { CodeSnippets.CustomStructMarshalling_V1.ManagedToNativeOnlyReturnValue, 1, 0 };

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -173,7 +173,12 @@ namespace LibraryImportGenerator.UnitTests
             yield return new[] { CodeSnippets.CustomStructMarshalling.ParametersAndModifiers };
             yield return new[] { CodeSnippets.CustomStructMarshalling.MarshalUsingParametersAndModifiers };
             yield return new[] { CodeSnippets.CustomStructMarshalling.NativeToManagedOnlyOutParameter };
+            yield return new[] { CodeSnippets.CustomStructMarshalling.NativeToManagedGuaranteedOnlyOutParameter };
             yield return new[] { CodeSnippets.CustomStructMarshalling.NativeToManagedOnlyReturnValue };
+            yield return new[] { CodeSnippets.CustomStructMarshalling.NativeToManagedGuaranteedOnlyReturnValue };
+            yield return new[] { CodeSnippets.CustomStructMarshalling.StackallocByValueInParameter };
+            yield return new[] { CodeSnippets.CustomStructMarshalling.StackallocParametersAndModifiersNoRef };
+            yield return new[] { CodeSnippets.CustomStructMarshalling.OptionalStackallocParametersAndModifiers };
             yield return new[] { CodeSnippets.CustomStructMarshalling_V1.ParametersAndModifiers };
             yield return new[] { CodeSnippets.CustomStructMarshalling_V1.StackallocParametersAndModifiersNoRef };
             yield return new[] { CodeSnippets.CustomStructMarshalling_V1.StackallocTwoStageParametersAndModifiersNoRef };

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/CustomMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/CustomMarshalling.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using SharedTypes;
 
@@ -31,6 +32,19 @@ namespace NativeExports
         public static double GetLongBytesAsDouble(long l)
         {
             return *(double*)&l;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "get_bytes_as_double_big_endian")]
+        public static double GetBytesAsDoubleBigEndian(byte* b)
+        {
+            return BinaryPrimitives.ReadDoubleBigEndian(new ReadOnlySpan<byte>(b, 8));
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "return_zero")]
+        public static int ReturnZero(int* ret)
+        {
+            *ret = 0;
+            return 0;
         }
 
         [UnmanagedCallersOnly(EntryPoint = "negate_bools")]

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/NonBlittable.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/NonBlittable.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -73,6 +74,18 @@ namespace SharedTypes
 
             public static void Free(StringContainerNative unmanaged)
                 => Ref.Free(unmanaged);
+        }
+    }
+
+    [ManagedToUnmanagedMarshallers(typeof(double))]
+    public static unsafe class DoubleToBytesBigEndianMarshaller
+    {
+        public const int BufferSize = 8;
+
+        public static byte* ConvertToUnmanaged(double managed, Span<byte> buffer)
+        {
+            BinaryPrimitives.WriteDoubleBigEndian(buffer, managed);
+            return (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(buffer));
         }
     }
 


### PR DESCRIPTION
- Look for optional members on stateless marshaller shape
  - Made this a helper that returns the shape methods - hoping that will be useful for the analyzer as well.
- Handle caller-allocated buffer and guaranteed unmarshal

Not handled:
- GetPinnableReference (checks for the method, but doesn't use it)
- linear collection marshalling