### PR TITLE
JIT: fix double reporting of some GC frame slots

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4005,24 +4005,17 @@ inline bool Compiler::lvaIsFieldOfDependentlyPromotedStruct(const LclVarDsc* var
 //    This is because struct variables are never tracked as a whole for GC purposes.
 //    It is up to the caller to ensure that the fields of struct variables are
 //    correctly tracked.
-//    On Amd64/Arm64, we never GC-track fields of dependently promoted structs, even
+//
+//    We never GC-track fields of dependently promoted structs, even
 //    though they may be tracked for optimization purposes.
-//    It seems that on x86 and arm, we simply don't track these
-//    fields, though I have not verified that.  I attempted to make these GC-tracked,
-//    but there was too much logic that depends on these being untracked, so changing
-//    this would require non-trivial effort.
-
+//
 inline bool Compiler::lvaIsGCTracked(const LclVarDsc* varDsc)
 {
     if (varDsc->lvTracked && (varDsc->lvType == TYP_REF || varDsc->lvType == TYP_BYREF))
     {
         // Stack parameters are always untracked w.r.t. GC reportings
         const bool isStackParam = varDsc->lvIsParam && !varDsc->lvIsRegArg;
-#ifdef TARGET_AMD64
         return !isStackParam && !lvaIsFieldOfDependentlyPromotedStruct(varDsc);
-#else  // !TARGET_AMD64
-        return !isStackParam && !lvaIsFieldOfDependentlyPromotedStruct(varDsc);
-#endif // !TARGET_AMD64
     }
     else
     {

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4005,7 +4005,7 @@ inline bool Compiler::lvaIsFieldOfDependentlyPromotedStruct(const LclVarDsc* var
 //    This is because struct variables are never tracked as a whole for GC purposes.
 //    It is up to the caller to ensure that the fields of struct variables are
 //    correctly tracked.
-//    On Amd64, we never GC-track fields of dependently promoted structs, even
+//    On Amd64/Arm64, we never GC-track fields of dependently promoted structs, even
 //    though they may be tracked for optimization purposes.
 //    It seems that on x86 and arm, we simply don't track these
 //    fields, though I have not verified that.  I attempted to make these GC-tracked,
@@ -4021,7 +4021,7 @@ inline bool Compiler::lvaIsGCTracked(const LclVarDsc* varDsc)
 #ifdef TARGET_AMD64
         return !isStackParam && !lvaIsFieldOfDependentlyPromotedStruct(varDsc);
 #else  // !TARGET_AMD64
-        return !isStackParam;
+        return !isStackParam && !lvaIsFieldOfDependentlyPromotedStruct(varDsc);
 #endif // !TARGET_AMD64
     }
     else

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2368,6 +2368,11 @@ public:
     void emitSetFrameRangeLcls(int offsLo, int offsHi);
     void emitSetFrameRangeArgs(int offsLo, int offsHi);
 
+    bool emitIsWithinFrameRangeGCRs(int offs)
+    {
+        return (offs >= emitGCrFrameOffsMin) && (offs <= emitGCrFrameOffsMax);
+    }
+
     static instruction emitJumpKindToIns(emitJumpKind jumpKind);
     static emitJumpKind emitInsToJumpKind(instruction ins);
     static emitJumpKind emitReverseJumpKind(emitJumpKind jumpKind);

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2370,7 +2370,7 @@ public:
 
     bool emitIsWithinFrameRangeGCRs(int offs)
     {
-        return (offs >= emitGCrFrameOffsMin) && (offs <= emitGCrFrameOffsMax);
+        return (offs >= emitGCrFrameOffsMin) && (offs < emitGCrFrameOffsMax);
     }
 
     static instruction emitJumpKindToIns(emitJumpKind jumpKind);

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4229,6 +4229,7 @@ void GCInfo::gcMakeRegPtrTable(
                 unsigned const fieldOffset = i * TARGET_POINTER_SIZE;
                 int const      offset      = varDsc->GetStackOffset() + fieldOffset;
 
+#ifdef DEBUG
                 if (varDsc->lvPromoted)
                 {
                     assert(compiler->lvaGetPromotionType(varDsc) == Compiler::PROMOTION_TYPE_DEPENDENT);
@@ -4248,6 +4249,7 @@ void GCInfo::gcMakeRegPtrTable(
                                 varNum, fieldOffset, fieldLclNum, offset);
                     }
                 }
+#endif
 
 #if DOUBLE_ALIGN
                 // For genDoubleAlign(), locals are addressed relative to ESP and

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4242,10 +4242,9 @@ void GCInfo::gcMakeRegPtrTable(
                     assert(fieldLclNum != BAD_VAR_NUM);
                     LclVarDsc* const fieldVarDsc = compiler->lvaGetDesc(fieldLclNum);
 
-                    if (compiler->lvaIsGCTracked(fieldVarDsc) &&
+                    if (compiler->opts.IsOSR() && compiler->lvaIsGCTracked(fieldVarDsc) &&
                         compiler->GetEmitter()->emitIsWithinFrameRangeGCRs(offset))
                     {
-                        assert(compiler->opts.IsOSR());
                         JITDUMP("Untracked GC struct slot V%02u+%u (P-DEP promoted V%02u) is at frame offset %d within "
                                 "tracked ref range.\nWill report slot as tracked\n",
                                 varNum, fieldOffset, fieldLclNum, offset);


### PR DESCRIPTION
If there is a gc struct local that is dependently promoted, the struct
local may be untracked while the promoted gc fields of the struct are
tracked.

If so, the jit will double report the stack offset for the gc field,
first as an untracked slot, and then as a tracked slot.

Detect this case and report the slot as tracked only.

Closes #71005.