### PR TITLE
don't start new processes on iOS and tvOS (it's not supported)

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -92,6 +92,7 @@ namespace System
         public static bool IsThreadingSupported => !IsBrowser;
         public static bool IsBinaryFormatterSupported => IsNotMobile && !IsNativeAot;
         public static bool IsSymLinkSupported => !IsiOS && !IstvOS;
+        public static bool IsStartingProcessesSupported => !IsiOS && !IstvOS;
 
         public static bool IsSpeedOptimized => !IsSizeOptimized;
         public static bool IsSizeOptimized => IsBrowser || IsAndroid || IsAppleMobile;

--- a/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetUnixFileMode.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetUnixFileMode.cs
@@ -91,7 +91,7 @@ namespace System.IO.Tests
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
-        [Theory]
+        [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         [MemberData(nameof(TestUnixFileModes))]
         public void SetThenGet_SymbolicLink(UnixFileMode mode)
         {
@@ -134,7 +134,7 @@ namespace System.IO.Tests
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [Fact]
+        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         public void FileDoesntExist_SymbolicLink()
         {
             string path = GetTestFilePath();

--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory_UnixFileMode.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory_UnixFileMode.Unix.cs
@@ -14,7 +14,7 @@ namespace System.IO.Tests
             return Directory.CreateDirectory(path, AllAccess);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsStartingProcessesSupported))]
         [MemberData(nameof(TestUnixFileModes))]
         public void CreateWithUnixFileMode(UnixFileMode mode)
         {

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_options.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_options.Unix.cs
@@ -9,7 +9,7 @@ namespace System.IO.Tests
 {
     public partial class FileStream_ctor_options
     {
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsStartingProcessesSupported))]
         [MemberData(nameof(TestUnixFileModes))]
         public void CreateWithUnixFileMode(UnixFileMode mode)
         {

--- a/src/libraries/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
+++ b/src/libraries/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
@@ -102,6 +102,12 @@ internal class IOServices
 
     public static string GetPath(string rootPath, int characterCount)
     {
+        if (rootPath.Length > characterCount)
+        {
+            // don't return immediately as the path might be ending with directory separator now
+            rootPath = rootPath.Substring(0, characterCount);
+        }
+
         rootPath = rootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
         StringBuilder path = new StringBuilder(characterCount);

--- a/src/libraries/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
+++ b/src/libraries/System.IO.FileSystem/tests/PortedCommon/IOServices.cs
@@ -137,7 +137,7 @@ internal class IOServices
             }
         }
 
-        Assert.Equal(path.Length, characterCount);
+        Assert.Equal(characterCount, path.Length);
 
         return path.ToString();
     }


### PR DESCRIPTION
These two tests use `Process.Start `to launch `umask`:

https://github.com/dotnet/runtime/blob/ddc4f95432facf2deebfa85bad7143469dca0129/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs#L148-L153

And starting new processes is not supported on `iOS` and `tvOS`:

![image](https://user-images.githubusercontent.com/6011991/175532806-f92b6ccb-a920-4401-bfe3-c3b2dbfc63b3.png)


fixes #71253