### PR TITLE
Disable HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -3247,20 +3247,6 @@ void Compiler::fgFindBasicBlocks()
             BADCODE("Handler Clause is invalid");
         }
 
-#if HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION
-        // This will change the block weight from 0 to 1
-        // and clear the rarely run flag
-        hndBegBB->makeBlockHot();
-#else
-        // Handler entry points are rarely executed,
-        // but don't assume finally clause is cold
-        // (we want to enable fgCloneFinally() optimization).
-        if (hndBegBB->bbJumpKind != BBJ_EHFINALLYRET)
-        {
-            hndBegBB->bbSetRunRarely();
-        }
-#endif
-
         if (hndEndOff < info.compILCodeSize)
         {
             hndEndBB = fgLookupBB(hndEndOff);
@@ -3271,14 +3257,6 @@ void Compiler::fgFindBasicBlocks()
             filtBB = HBtab->ebdFilter = fgLookupBB(clause.FilterOffset);
             filtBB->bbCatchTyp        = BBCT_FILTER;
             hndBegBB->bbCatchTyp      = BBCT_FILTER_HANDLER;
-
-#if HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION
-            // This will change the block weight from 0 to 1
-            // and clear the rarely run flag
-            filtBB->makeBlockHot();
-#else
-            filtBB->bbSetRunRarely(); // filter entry points are rarely executed
-#endif
 
             // Mark all BBs that belong to the filter with the XTnum of the corresponding handler
             for (block = filtBB; /**/; block = block->bbNext)

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -3252,7 +3252,13 @@ void Compiler::fgFindBasicBlocks()
         // and clear the rarely run flag
         hndBegBB->makeBlockHot();
 #else
-        hndBegBB->bbSetRunRarely();   // handler entry points are rarely executed
+        // Handler entry points are rarely executed,
+        // but don't assume finally clause is cold
+        // (we want to enable fgCloneFinally() optimization).
+        if (hndBegBB->bbJumpKind != BBJ_EHFINALLYRET)
+        {
+            hndBegBB->bbSetRunRarely();
+        }
 #endif
 
         if (hndEndOff < info.compILCodeSize)

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3590,13 +3590,18 @@ weight_t Compiler::fgComputeMissingBlockWeights()
                 if (bbIsHandlerBeg(bDst))
                 {
                     bSrc = bDst->bbPreds->getBlock();
-                    if (bSrc->bbJumpKind == BBJ_CALLFINALLY)
+
+                    // To minimize asmdiffs for now, modify weights only if splitting.
+                    if (fgFirstColdBlock != nullptr)
                     {
-                        newWeight = bSrc->bbWeight;
-                    }
-                    else
-                    {
-                        newWeight = BB_ZERO_WEIGHT;
+                        if (bSrc->bbJumpKind == BBJ_CALLFINALLY)
+                        {
+                            newWeight = bSrc->bbWeight;
+                        }
+                        else
+                        {
+                            newWeight = BB_ZERO_WEIGHT;
+                        }
                     }
                 }
 
@@ -3620,9 +3625,14 @@ weight_t Compiler::fgComputeMissingBlockWeights()
                 // Assume handler/filter entries are rarely executed.
                 // To avoid unnecessary loop iterations, set weight
                 // only if bDst->bbWeight is not already zero.
-                changed  = true;
-                modified = true;
-                bDst->bbSetRunRarely();
+
+                // To minimize asmdiffs for now, modify weights only if splitting.
+                if (fgFirstColdBlock != nullptr)
+                {
+                    changed  = true;
+                    modified = true;
+                    bDst->bbSetRunRarely();
+                }
             }
 
             // Sum up the weights of all of the return blocks and throw blocks

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3584,6 +3584,22 @@ weight_t Compiler::fgComputeMissingBlockWeights()
                     }
                 }
 
+                // Handler entries are assumed to run rarely, except for
+                // finally blocks: These are executed regardless of if
+                // an exception is thrown, and thus should inherit weight.
+                if (bbIsHandlerBeg(bDst))
+                {
+                    bSrc = bDst->bbPreds->getBlock();
+                    if (bSrc->bbJumpKind == BBJ_CALLFINALLY)
+                    {
+                        newWeight = bSrc->bbWeight;
+                    }
+                    else
+                    {
+                        newWeight = BB_ZERO_WEIGHT;
+                    }
+                }
+
                 if ((newWeight != BB_MAX_WEIGHT) && (bDst->bbWeight != newWeight))
                 {
                     changed        = true;
@@ -3598,6 +3614,15 @@ weight_t Compiler::fgComputeMissingBlockWeights()
                         bDst->bbFlags &= ~BBF_RUN_RARELY;
                     }
                 }
+            }
+            else if (!bDst->hasProfileWeight() && bbIsHandlerBeg(bDst) && !bDst->isRunRarely())
+            {
+                // Assume handler/filter entries are rarely executed.
+                // To avoid unnecessary loop iterations, set weight
+                // only if bDst->bbWeight is not already zero.
+                changed  = true;
+                modified = true;
+                bDst->bbSetRunRarely();
             }
 
             // Sum up the weights of all of the return blocks and throw blocks

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -400,7 +400,7 @@ public:
 
 #define CSE_INTO_HANDLERS 0
 #define DUMP_FLOWGRAPHS DEBUG                  // Support for creating Xml Flowgraph reports in *.fgx files
-#define HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION 1 // if 1 we must have all handler entry points in the Hot code section
+#define HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION 0 // if 1 we must have all handler entry points in the Hot code section
 
 /*****************************************************************************/
 


### PR DESCRIPTION
Follow-up to #71236. `HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION` is currently hard-coded to `1`, but the EE currently handles cold handler entrypoints [correctly](https://github.com/dotnet/runtime/pull/71236#discussion_r906314550). This PR experiments with disabling `HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION`. If successful, this could simplify code logic and enable hot/cold splitting in more scenarios.