### PR TITLE
Add test coverage for generic type substitution with byreflike generics

### DIFF
--- a/src/tests/Loader/classloader/generics/ByRefLike/GenericTypeSubstitution.cs
+++ b/src/tests/Loader/classloader/generics/ByRefLike/GenericTypeSubstitution.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using InvalidCSharp;
+
+using Xunit;
+
+class GenericTypeSubstitution
+{
+    [Fact]
+    [SkipOnMono("Mono does not support ByRefLike generics yet")]
+    public static void AllowByRefLike_Substituted_For_AllowByRefLike()
+    {
+        Console.WriteLine($"{nameof(AllowByRefLike_Substituted_For_AllowByRefLike)}...");
+        
+        Console.WriteLine($" -- Instantiate: {Exec.TypeSubstitutionInterfaceImplementationAllowByRefLike()}");
+        Console.WriteLine($" -- Instantiate: {Exec.TypeSubstitutionInheritanceAllowByRefLike()}");
+        Console.WriteLine($" -- Instantiate: {Exec.TypeSubstitutionFieldAllowByRefLike()}");
+    }
+
+    [Fact]
+    [SkipOnMono("Mono does not support ByRefLike generics yet")]
+    public static void NonByRefLike_Substituted_For_AllowByRefLike()
+    {
+        Console.WriteLine($" -- Instantiate: {Exec.TypeSubstitutionInterfaceImplementationNonByRefLike()}");
+        Console.WriteLine($" -- Instantiate: {Exec.TypeSubstitutionInheritanceNonByRefLike()}");
+        Console.WriteLine($" -- Instantiate: {Exec.TypeSubstitutionFieldNonByRefLike()}");
+    }
+
+    [Fact]
+    [ActiveIssue("To be created", TestRuntimes.CoreCLR)]
+    [SkipOnMono("Mono does not support ByRefLike generics yet")]
+    public static void AllowByRefLike_Substituted_For_NonByRefLike_Invalid()
+    {
+        Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionInterfaceImplementationAllowByRefLikeIntoNonByRefLike(); });
+        Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionInheritanceAllowByRefLikeIntoNonByRefLike(); });
+        Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionFieldAllowByRefLikeIntoNonByRefLike(); });
+    }
+}

--- a/src/tests/Loader/classloader/generics/ByRefLike/InvalidCSharp.il
+++ b/src/tests/Loader/classloader/generics/ByRefLike/InvalidCSharp.il
@@ -43,7 +43,7 @@
 // End invalid
 //
 
-.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericClass_Over`1<byreflike T>
+.class public sequential ansi beforefieldinit InvalidCSharp.GenericClass_Over`1<byreflike T>
     extends [System.Runtime]System.Object
 {
     .method public hidebysig specialname rtspecialname
@@ -355,6 +355,108 @@
     )
 }
 
+.class public sequential ansi sealed beforefieldinit RegularValueType
+    extends [System.Runtime]System.ValueType
+{
+}
+
+// Generic substitution of allow-byreflike with allow-byreflike
+.class interface public auto ansi abstract InvalidCSharp.GenericDerivedInterface_OverByRef`1<byreflike T>
+    implements class InvalidCSharp.GenericInterface_Over`1<!T>
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericDerivedClass_OverByRef`1<byreflike T>
+    extends class InvalidCSharp.GenericClass_Over`1<!T>
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericValueTypeWrapper_OverByRef`1<byreflike T>
+    extends [System.Runtime]System.ValueType
+{
+    .field public valuetype InvalidCSharp.GenericValueType_Over`1<!T> fld;
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericClassWithMethods_OverByRef`1<byreflike T>
+    extends [System.Runtime]System.Object
+{
+    .method public hidebysig static
+        string InstantiateWithTypeLevelTypeParameter() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericClass_Over`1<!T>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        string InstantiateWithMethodLevelTypeParameter<byreflike U>() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericClass_Over`1<!!U>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+}
+
+// Generic substitution of allow-byreflike with non-allow-byreflike
+.class interface public auto ansi abstract InvalidCSharp.GenericDerivedInterface_Over`1<T>
+    implements class InvalidCSharp.GenericInterface_Over`1<!T>
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericDerivedClass_Over`1<T>
+    extends class InvalidCSharp.GenericClass_Over`1<!T>
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericValueTypeWrapper_Over`1<T>
+    extends [System.Runtime]System.ValueType
+{
+    .field public valuetype InvalidCSharp.GenericValueType_Over`1<!T> fld;
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericClassWithMethods_Over`1< T>
+    extends [System.Runtime]System.Object
+{
+    .method public hidebysig static
+        string InstantiateWithTypeLevelTypeParameter() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericClass_Over`1<!T>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        string InstantiateWithMethodLevelTypeParameter<U>() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericClass_Over`1<!!U>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+}
+
+// Invalid generic substitution of non-allow-byreflike with allow-byreflike
+.class interface public auto ansi abstract InvalidCSharp.GenericDerivedInterface_Invalid`1<byreflike T>
+    implements class InvalidCSharp.GenericInterface_Invalid`1<!T>
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericDerivedClass_Invalid`1<byreflike T>
+    extends class InvalidCSharp.GenericClass_Invalid`1<!T>
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericValueTypeWrapper_Invalid`1<byreflike T>
+    extends [System.Runtime]System.ValueType
+{
+    .field public valuetype InvalidCSharp.GenericValueType_Invalid`1<!T> fld;
+}
+
+// Entry points
+
 .class public auto ansi abstract sealed beforefieldinit Exec
     extends [System.Runtime]System.Object
 {
@@ -627,5 +729,100 @@
         ceq
 
         DONE: ret
+    }
+
+    .method public hidebysig static
+        string TypeSubstitutionInterfaceImplementationAllowByRefLike() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericDerivedInterface_OverByRef`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        string TypeSubstitutionInheritanceAllowByRefLike() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericDerivedClass_OverByRef`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        string TypeSubstitutionFieldAllowByRefLike() cil managed
+    {
+        ldtoken valuetype InvalidCSharp.GenericValueTypeWrapper_OverByRef`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        string TypeSubstitutionTypeParameterInMethod() cil managed
+    {
+        call string class InvalidCSharp.GenericClassWithMethods_OverByRef`1<valuetype ByRefLikeType>::InstantiateWithTypeLevelTypeParameter()
+        ret
+    }
+
+    .method public hidebysig static
+        string TypeSubstitutionMethodTypeParameterInMethod() cil managed
+    {
+        call string class InvalidCSharp.GenericClassWithMethods_OverByRef`1<valuetype ByRefLikeType>::InstantiateWithMethodLevelTypeParameter<valuetype ByRefLikeType>()
+        ret
+    }
+
+    .method public hidebysig static
+        string TypeSubstitutionInterfaceImplementationNonByRefLike() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericDerivedInterface_Over`1<valuetype RegularValueType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        string TypeSubstitutionInheritanceNonByRefLike() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericDerivedClass_Over`1<valuetype RegularValueType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        string TypeSubstitutionFieldNonByRefLike() cil managed
+    {
+        ldtoken valuetype InvalidCSharp.GenericValueTypeWrapper_Over`1<valuetype RegularValueType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    
+    .method public hidebysig static
+        string TypeSubstitutionInterfaceImplementationAllowByRefLikeIntoNonByRefLike() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericDerivedInterface_Invalid`1<valuetype RegularValueType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        string TypeSubstitutionInheritanceAllowByRefLikeIntoNonByRefLike() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericDerivedClass_Invalid`1<valuetype RegularValueType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        string TypeSubstitutionFieldAllowByRefLikeIntoNonByRefLike() cil managed
+    {
+        ldtoken valuetype InvalidCSharp.GenericValueTypeWrapper_Invalid`1<valuetype RegularValueType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
     }
 }

--- a/src/tests/Loader/classloader/generics/ByRefLike/Validate.csproj
+++ b/src/tests/Loader/classloader/generics/ByRefLike/Validate.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Validate.cs" />
+    <Compile Include="GenericTypeSubstitution.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />


### PR DESCRIPTION
This test coverage also found some interesting behavior (issue TBD) in the following scenario:

Given a `<byreflike T>` (aka a `T` that can be a byreflike type), we allow passing this to a `<U>` generic parameter (where `U` does not allow byref-like types).

We do correctly throw when instantiating the generic with a byreflike type though, so we don't end up in a bad state.

I've marked this test with an ActiveIssue attribute pending feedback on whether or not this is a bug.