### PR TITLE
Utilize Kernel Samepage Merging

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -387,6 +387,10 @@ bool GCToOSInterface::Initialize()
         {
             return false;
         }
+#ifdef MADV_MERGEABLE
+        // Hint to Kernel Samepage Merging
+        madvise(g_helperPage, OS_PAGE_SIZE, MADV_MERGEABLE);
+#endif
 
         // Verify that the s_helperPage is really aligned to the g_SystemInfo.dwPageSize
         assert((((size_t)g_helperPage) & (OS_PAGE_SIZE - 1)) == 0);

--- a/src/coreclr/pal/src/map/virtual.cpp
+++ b/src/coreclr/pal/src/map/virtual.cpp
@@ -1038,6 +1038,11 @@ static LPVOID ReserveVirtualMemory(
     madvise(pRetVal, MemSize, MADV_DONTDUMP);
 #endif
 
+#ifdef MADV_MERGEABLE
+    // Hint to Kernel Samepage Merging
+    madvise(pRetVal, MemSize, MADV_MERGEABLE);
+#endif
+
     return pRetVal;
 }
 

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2705,6 +2705,10 @@ InitializeFlushProcessWriteBuffers()
     {
         return FALSE;
     }
+#ifdef MADV_MERGEABLE
+    // Hint to Kernel Samepage Merging
+    madvise(s_helperPage, GetVirtualPageSize(), MADV_MERGEABLE);
+#endif
 
     // Verify that the s_helperPage is really aligned to the GetVirtualPageSize()
     _ASSERTE((((SIZE_T)s_helperPage) & (GetVirtualPageSize() - 1)) == 0);

--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -944,6 +944,14 @@ void* SystemNative_MMap(void* address,
     }
 
     assert(ret != NULL);
+#ifdef MADV_MERGEABLE
+    bool isPrivateAnon = (flags & (MAP_ANON | MAP_PRIVATE)) == (MAP_ANON | MAP_PRIVATE);
+    // Hint to Kernel Samepage Merging if memory space is MAP_ANON | MAP_PRIVATE
+    if (isPrivateAnon)
+    {
+        madvise(ret, (size_t)length, MADV_MERGEABLE);
+    }
+#endif
     return ret;
 }
 


### PR DESCRIPTION
To take advantage of Kernel Samespace Merging, a process should notify the memory space for merging using `int madvise(addr, length, MADV_MERGEABLE)`.
https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html

With this patch, the number in `/sys/kernel/mm/ksm/pages_shared` is increased on linux-x64(Ubuntu20.04) and linux-aarch64(Tizen-RPI4).
Please take a look and share your opinion.
