### PR TITLE
Type loader support for static virtual methods

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
@@ -82,7 +82,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhResolveDispatchOnType")]
-        private static IntPtr RhResolveDispatchOnType(EETypePtr instanceType, EETypePtr interfaceType, ushort slot)
+        private static IntPtr RhResolveDispatchOnType(EETypePtr instanceType, EETypePtr interfaceType, ushort slot, EETypePtr* pGenericContext)
         {
             // Type of object we're dispatching on.
             MethodTable* pInstanceType = instanceType.ToPointer();
@@ -92,7 +92,8 @@ namespace System.Runtime
 
             return DispatchResolve.FindInterfaceMethodImplementationTarget(pInstanceType,
                                                                           pInterfaceType,
-                                                                          slot);
+                                                                          slot,
+                                                                          (MethodTable**)pGenericContext);
         }
 
         private static unsafe IntPtr RhResolveDispatchWorker(object pObject, void* cell, ref DispatchCellInfo cellInfo)
@@ -108,7 +109,8 @@ namespace System.Runtime
 
                 IntPtr pTargetCode = DispatchResolve.FindInterfaceMethodImplementationTarget(pResolvingInstanceType,
                                                                               cellInfo.InterfaceType.ToPointer(),
-                                                                              cellInfo.InterfaceSlot);
+                                                                              cellInfo.InterfaceSlot,
+                                                                              ppGenericContext: null);
                 if (pTargetCode == IntPtr.Zero && pInstanceType->IsIDynamicInterfaceCastable)
                 {
                     // Dispatch not resolved through normal dispatch map, try using the IDynamicInterfaceCastable

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/DispatchResolve.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/DispatchResolve.cs
@@ -12,7 +12,8 @@ namespace System.Runtime
     {
         public static IntPtr FindInterfaceMethodImplementationTarget(MethodTable* pTgtType,
                                                                  MethodTable* pItfType,
-                                                                 ushort itfSlotNumber)
+                                                                 ushort itfSlotNumber,
+                                                                 /* out */ MethodTable** ppGenericContext)
         {
             DynamicModule* dynamicModule = pTgtType->DynamicModule;
 
@@ -39,7 +40,7 @@ namespace System.Runtime
             {
                 ushort implSlotNumber;
                 if (FindImplSlotForCurrentType(
-                        pCur, pItfType, itfSlotNumber, fDoDefaultImplementationLookup, &implSlotNumber))
+                        pCur, pItfType, itfSlotNumber, fDoDefaultImplementationLookup, &implSlotNumber, ppGenericContext))
                 {
                     IntPtr targetMethod;
                     if (implSlotNumber < pCur->NumVtableSlots)
@@ -85,7 +86,8 @@ namespace System.Runtime
                                         MethodTable* pItfType,
                                         ushort itfSlotNumber,
                                         bool fDoDefaultImplementationLookup,
-                                        ushort* pImplSlotNumber)
+                                        ushort* pImplSlotNumber,
+                                        MethodTable** ppGenericContext)
         {
             bool fRes = false;
 
@@ -110,13 +112,13 @@ namespace System.Runtime
                 bool fDoVariantLookup = false; // do not check variance for first scan of dispatch map
 
                 fRes = FindImplSlotInSimpleMap(
-                    pTgtType, pItfType, itfSlotNumber, pImplSlotNumber, fDoVariantLookup, fDoDefaultImplementationLookup);
+                    pTgtType, pItfType, itfSlotNumber, pImplSlotNumber, ppGenericContext, fDoVariantLookup, fDoDefaultImplementationLookup);
 
                 if (!fRes)
                 {
                     fDoVariantLookup = true; // check variance for second scan of dispatch map
                     fRes = FindImplSlotInSimpleMap(
-                     pTgtType, pItfType, itfSlotNumber, pImplSlotNumber, fDoVariantLookup, fDoDefaultImplementationLookup);
+                     pTgtType, pItfType, itfSlotNumber, pImplSlotNumber, ppGenericContext, fDoVariantLookup, fDoDefaultImplementationLookup);
                 }
             }
 
@@ -127,6 +129,7 @@ namespace System.Runtime
                                      MethodTable* pItfType,
                                      uint itfSlotNumber,
                                      ushort* pImplSlotNumber,
+                                     MethodTable** ppGenericContext,
                                      bool actuallyCheckVariance,
                                      bool checkDefaultImplementations)
         {
@@ -176,10 +179,18 @@ namespace System.Runtime
                 }
             }
 
+            // It only makes sense to ask for generic context if we're asking about a static method
+            bool fStaticDispatch = ppGenericContext != null;
+
+            // We either scan the instance or static portion of the dispatch map. Depends on what the caller wants.
             DispatchMap* pMap = pTgtType->DispatchMap;
-            DispatchMap.DispatchMapEntry* i = (*pMap)[checkDefaultImplementations ? (int)pMap->NumStandardEntries : 0];
-            DispatchMap.DispatchMapEntry* iEnd = (*pMap)[checkDefaultImplementations ? (int)(pMap->NumStandardEntries + pMap->NumDefaultEntries) : (int)pMap->NumStandardEntries];
-            for (; i != iEnd; ++i)
+            DispatchMap.DispatchMapEntry* i = fStaticDispatch ?
+                pMap->GetStaticEntry(checkDefaultImplementations ? (int)pMap->NumStandardStaticEntries : 0) :
+                pMap->GetEntry(checkDefaultImplementations ? (int)pMap->NumStandardEntries : 0);
+            DispatchMap.DispatchMapEntry* iEnd = fStaticDispatch ?
+                pMap->GetStaticEntry(checkDefaultImplementations ? (int)(pMap->NumStandardStaticEntries + pMap->NumDefaultStaticEntries) : (int)pMap->NumStandardStaticEntries) :
+                pMap->GetEntry(checkDefaultImplementations ? (int)(pMap->NumStandardEntries + pMap->NumDefaultEntries) : (int)pMap->NumStandardEntries);
+            for (; i != iEnd; i = fStaticDispatch ? (DispatchMap.DispatchMapEntry*)(((DispatchMap.StaticDispatchMapEntry*)i) + 1) : i + 1)
             {
                 if (i->_usInterfaceMethodSlot == itfSlotNumber)
                 {
@@ -192,6 +203,12 @@ namespace System.Runtime
                     if (pCurEntryType == pItfType)
                     {
                         *pImplSlotNumber = i->_usImplMethodSlot;
+
+                        // If this is a static method, the entry point is not usable without generic context.
+                        // (Instance methods acquire the generic context from their `this`.)
+                        if (fStaticDispatch)
+                            *ppGenericContext = GetGenericContextSource(pTgtType, i);
+
                         return true;
                     }
                     else if (fCheckVariance && ((fArrayCovariance && pCurEntryType->IsGeneric) || pCurEntryType->HasGenericVariance))
@@ -227,6 +244,12 @@ namespace System.Runtime
                         if (TypeCast.TypeParametersAreCompatible(itfArity, pCurEntryInstantiation, pItfInstantiation, pItfVarianceInfo, fArrayCovariance, null))
                         {
                             *pImplSlotNumber = i->_usImplMethodSlot;
+
+                            // If this is a static method, the entry point is not usable without generic context.
+                            // (Instance methods acquire the generic context from their `this`.)
+                            if (fStaticDispatch)
+                                *ppGenericContext = GetGenericContextSource(pTgtType, i);
+
                             return true;
                         }
                     }
@@ -234,6 +257,17 @@ namespace System.Runtime
             }
 
             return false;
+        }
+
+        private static unsafe MethodTable* GetGenericContextSource(MethodTable* pTgtType, DispatchMap.DispatchMapEntry* pEntry)
+        {
+            ushort usEncodedValue = ((DispatchMap.StaticDispatchMapEntry*)pEntry)->_usContextMapSource;
+            return usEncodedValue switch
+            {
+                StaticVirtualMethodContextSource.None => null,
+                StaticVirtualMethodContextSource.ContextFromThisClass => pTgtType,
+                _ => pTgtType->InterfaceMap[usEncodedValue - StaticVirtualMethodContextSource.ContextFromFirstInterface].InterfaceType
+            };
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -641,6 +641,17 @@ namespace Internal.Runtime.Augments
             return RuntimeImports.RhResolveDispatchOnType(CreateEETypePtr(instanceType), CreateEETypePtr(interfaceType), checked((ushort)slot));
         }
 
+        public static unsafe IntPtr ResolveStaticDispatchOnType(RuntimeTypeHandle instanceType, RuntimeTypeHandle interfaceType, int slot, out RuntimeTypeHandle genericContext)
+        {
+            EETypePtr genericContextPtr = default;
+            IntPtr result = RuntimeImports.RhResolveDispatchOnType(CreateEETypePtr(instanceType), CreateEETypePtr(interfaceType), checked((ushort)slot), &genericContextPtr);
+            if (result != IntPtr.Zero)
+                genericContext = new RuntimeTypeHandle(genericContextPtr);
+            else
+                genericContext = default;
+            return result;
+        }
+
         public static IntPtr ResolveDispatch(object instance, RuntimeTypeHandle interfaceType, int slot)
         {
             return RuntimeImports.RhResolveDispatch(instance, CreateEETypePtr(interfaceType), checked((ushort)slot));

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -454,7 +454,14 @@ namespace System.Runtime
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhResolveDispatchOnType")]
-        internal static extern IntPtr RhResolveDispatchOnType(EETypePtr instanceType, EETypePtr interfaceType, ushort slot);
+        // For my life cannot figure out the ordering of modifiers this is expecting.
+#pragma warning disable IDE0036
+        internal static extern unsafe IntPtr RhResolveDispatchOnType(EETypePtr instanceType, EETypePtr interfaceType, ushort slot, EETypePtr* pGenericContext);
+
+        internal static unsafe IntPtr RhResolveDispatchOnType(EETypePtr instanceType, EETypePtr interfaceType, ushort slot)
+        {
+            return RhResolveDispatchOnType(instanceType, interfaceType, slot, null);
+        }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetRuntimeHelperForType")]

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -583,14 +583,25 @@ namespace Internal.Runtime.TypeLoader
                     DispatchMap* pDynamicDispatchMap = (DispatchMap*)dynamicDispatchMapPtr;
                     pDynamicDispatchMap->NumStandardEntries = pTemplateDispatchMap->NumStandardEntries;
                     pDynamicDispatchMap->NumDefaultEntries = pTemplateDispatchMap->NumDefaultEntries;
+                    pDynamicDispatchMap->NumStandardStaticEntries = pTemplateDispatchMap->NumStandardStaticEntries;
+                    pDynamicDispatchMap->NumDefaultStaticEntries = pTemplateDispatchMap->NumDefaultStaticEntries;
 
-                    for (int i = 0; i < pTemplateDispatchMap->NumStandardEntries + pTemplateDispatchMap->NumDefaultEntries; i++)
+                    uint numInstanceEntries = pTemplateDispatchMap->NumStandardEntries + pTemplateDispatchMap->NumDefaultEntries;
+                    for (uint i = 0; i < numInstanceEntries + pTemplateDispatchMap->NumStandardStaticEntries + pTemplateDispatchMap->NumDefaultStaticEntries; i++)
                     {
-                        DispatchMap.DispatchMapEntry* pTemplateEntry = (*pTemplateDispatchMap)[i];
-                        DispatchMap.DispatchMapEntry* pDynamicEntry = (*pDynamicDispatchMap)[i];
+                        DispatchMap.DispatchMapEntry* pTemplateEntry = i < numInstanceEntries ?
+                            pTemplateDispatchMap->GetEntry((int)i) :
+                            pTemplateDispatchMap->GetStaticEntry((int)(i - numInstanceEntries));
+                        DispatchMap.DispatchMapEntry* pDynamicEntry = i < numInstanceEntries ?
+                            pDynamicDispatchMap->GetEntry((int)i) :
+                            pDynamicDispatchMap->GetStaticEntry((int)(i - numInstanceEntries));
 
                         pDynamicEntry->_usInterfaceIndex = pTemplateEntry->_usInterfaceIndex;
                         pDynamicEntry->_usInterfaceMethodSlot = pTemplateEntry->_usInterfaceMethodSlot;
+                        if (i >= numInstanceEntries)
+                        {
+                            ((DispatchMap.StaticDispatchMapEntry*)pDynamicEntry)->_usContextMapSource = ((DispatchMap.StaticDispatchMapEntry*)pTemplateEntry)->_usContextMapSource;
+                        }
                         if (pTemplateEntry->_usImplMethodSlot < pTemplateEEType->NumVtableSlots)
                         {
                             pDynamicEntry->_usImplMethodSlot = (ushort)state.VTableSlotsMapping.GetVTableSlotInTargetType(pTemplateEntry->_usImplMethodSlot);

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -1152,8 +1152,10 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        private unsafe void FinishTypeDictionary(TypeDesc type, TypeBuilderState state)
+        private unsafe void FinishTypeDictionary(TypeDesc type)
         {
+            TypeBuilderState state = type.GetTypeBuilderState();
+
             if (state.Dictionary != null)
             {
                 // First, update the dictionary slot in the type's vtable to point to the created dictionary when applicable
@@ -1348,8 +1350,6 @@ namespace Internal.Runtime.TypeLoader
 
                 FinishInterfaces(type, state);
 
-                FinishTypeDictionary(type, state);
-
                 FinishClassConstructor(type, state);
 
 #if FEATURE_UNIVERSAL_GENERICS
@@ -1371,8 +1371,6 @@ namespace Internal.Runtime.TypeLoader
 
                     if (typeAsSzArrayType.IsSzArray && !typeAsSzArrayType.ElementType.IsPointer)
                     {
-                        FinishTypeDictionary(type, state);
-
 #if FEATURE_UNIVERSAL_GENERICS
                         // For types that were allocated from universal canonical templates, patch their vtables with
                         // pointers to calling convention conversion thunks
@@ -1520,6 +1518,11 @@ namespace Internal.Runtime.TypeLoader
             for (int i = 0; i < _typesThatNeedTypeHandles.Count; i++)
             {
                 FinishRuntimeType(_typesThatNeedTypeHandles[i]);
+            }
+
+            for (int i = 0; i < _typesThatNeedTypeHandles.Count; i++)
+            {
+                FinishTypeDictionary(_typesThatNeedTypeHandles[i]);
             }
 
             for (int i = 0; i < _methodsThatNeedDictionaries.Count; i++)

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormat.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormat.cs
@@ -100,6 +100,8 @@ namespace Internal.NativeFormat
         NonGenericDirectConstrainedMethod = 0x18,
         PointerToOtherSlot          = 0x19,
         IntValue                    = 0x20,
+        NonGenericStaticConstrainedMethod = 0x21,
+        GenericStaticConstrainedMethod = 0x22,
 
         NotYetSupported             = 0xee,
     }

--- a/src/coreclr/tools/Common/Internal/Runtime/RuntimeConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/RuntimeConstants.cs
@@ -64,6 +64,13 @@ namespace Internal.Runtime
         public const uint Reabstraction = 0xFFFFFFFE;
     }
 
+    internal static class StaticVirtualMethodContextSource
+    {
+        public const ushort None = 0;
+        public const ushort ContextFromThisClass = 1;
+        public const ushort ContextFromFirstInterface = 2;
+    }
+
     internal enum RuntimeHelperKind
     {
         AllocateObject,

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -371,14 +371,25 @@ namespace ILCompiler.DependencyAnalysis
                         if (interfaceMethod.HasInstantiation)
                             continue;
 
-                        // Static virtual methods are resolved at compile time
-                        if (interfaceMethod.Signature.IsStatic)
-                            continue;
+                        bool isStaticInterfaceMethod = interfaceMethod.Signature.IsStatic;
 
-                        MethodDesc implMethod = defType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod);
+                        MethodDesc implMethod = isStaticInterfaceMethod ?
+                            defType.ResolveInterfaceMethodToStaticVirtualMethodOnType(interfaceMethod) :
+                            defType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod);
                         if (implMethod != null)
                         {
-                            result.Add(new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.VirtualMethodUse(interfaceMethod), "Interface method"));
+                            if (isStaticInterfaceMethod)
+                            {
+                                Debug.Assert(!implMethod.IsVirtual);
+
+                                // If the interface method is used virtually, the implementation body is used
+                                result.Add(new CombinedDependencyListEntry(factory.CanonicalEntrypoint(implMethod), factory.VirtualMethodUse(interfaceMethod), "Interface method"));
+                            }
+                            else
+                            {
+                                // If the interface method is used virtually, the slot is used virtually
+                                result.Add(new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.VirtualMethodUse(interfaceMethod), "Interface method"));
+                            }
 
                             // If any of the implemented interfaces have variance, calls against compatible interface methods
                             // could result in interface methods of this type being used (e.g. IEnumerable<object>.GetEnumerator()
@@ -386,7 +397,11 @@ namespace ILCompiler.DependencyAnalysis
                             if (isVariantInterfaceImpl)
                             {
                                 MethodDesc typicalInterfaceMethod = interfaceMethod.GetTypicalMethodDefinition();
-                                result.Add(new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.VariantInterfaceMethodUse(typicalInterfaceMethod), "Interface method"));
+
+                                object implMethodUseNode = isStaticInterfaceMethod ?
+                                    factory.CanonicalEntrypoint(implMethod) : factory.VirtualMethodUse(implMethod);
+
+                                result.Add(new CombinedDependencyListEntry(implMethodUseNode, factory.VariantInterfaceMethodUse(typicalInterfaceMethod), "Interface method"));
                                 result.Add(new CombinedDependencyListEntry(factory.VirtualMethodUse(interfaceMethod), factory.VariantInterfaceMethodUse(typicalInterfaceMethod), "Interface method"));
                             }
 
@@ -411,8 +426,9 @@ namespace ILCompiler.DependencyAnalysis
                                 implMethod = implMethod.InstantiateSignature(defType.Instantiation, Instantiation.Empty);
 
                                 MethodDesc defaultIntfMethod = implMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                                if (defaultIntfMethod.IsCanonicalMethod(CanonicalFormKind.Any))
+                                if (!isStaticInterfaceMethod && defaultIntfMethod.IsCanonicalMethod(CanonicalFormKind.Any))
                                 {
+                                    // Canonical instance default methods need to go through a thunk that adds the right generic context
                                     defaultIntfMethod = factory.TypeSystemContext.GetDefaultInterfaceMethodImplementationThunk(defaultIntfMethod, _type.ConvertToCanonForm(CanonicalFormKind.Specific), providingInterfaceDefinitionType);
                                 }
                                 result.Add(new CombinedDependencyListEntry(factory.MethodEntrypoint(defaultIntfMethod), factory.VirtualMethodUse(interfaceMethod), "Interface method"));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -1432,7 +1432,8 @@ namespace ILCompiler.DependencyAnalysis
             MethodDesc canonMethod = _constrainedMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
 
             // If we're producing a full vtable for the type, we don't need to report virtual method use.
-            if (!factory.VTable(canonMethod.OwningType).HasFixedSlots)
+            // We also don't report virtual method use for generic virtual methods - tracking those is orthogonal.
+            if (!factory.VTable(canonMethod.OwningType).HasFixedSlots && !canonMethod.HasInstantiation)
             {
                 // Report the method as virtually used so that types that could be used here at runtime
                 // have the appropriate implementations generated.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -2013,8 +2013,29 @@ namespace ILCompiler.DependencyAnalysis
             + ","
             + factory.NameMangler.GetMangledTypeName(_constraintType);
 
-        protected sealed override FixupSignatureKind SignatureKind => _constrainedMethod.HasInstantiation ? FixupSignatureKind.GenericConstrainedMethod :
-            (_directCall ? FixupSignatureKind.NonGenericDirectConstrainedMethod : FixupSignatureKind.NonGenericConstrainedMethod);
+        protected sealed override FixupSignatureKind SignatureKind
+        {
+            get
+            {
+                if (_constrainedMethod.Signature.IsStatic)
+                {
+                    Debug.Assert(_directCall);
+                    if (_constrainedMethod.HasInstantiation)
+                        return FixupSignatureKind.GenericStaticConstrainedMethod;
+                    else
+                        return FixupSignatureKind.NonGenericStaticConstrainedMethod;
+                }
+                else
+                {
+                    if (_constrainedMethod.HasInstantiation)
+                        return FixupSignatureKind.GenericConstrainedMethod;
+                    else if (_directCall)
+                        return FixupSignatureKind.NonGenericDirectConstrainedMethod;
+                    else
+                        return FixupSignatureKind.NonGenericConstrainedMethod;
+                }
+            }
+        }
 
         public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
@@ -2052,14 +2073,14 @@ namespace ILCompiler.DependencyAnalysis
             Vertex constraintType = factory.NativeLayout.TypeSignatureVertex(_constraintType).WriteVertex(factory);
             if (_constrainedMethod.HasInstantiation)
             {
-                Debug.Assert(SignatureKind == FixupSignatureKind.GenericConstrainedMethod);
+                Debug.Assert(SignatureKind is FixupSignatureKind.GenericConstrainedMethod or FixupSignatureKind.GenericStaticConstrainedMethod);
                 Vertex constrainedMethodVertex = factory.NativeLayout.MethodLdTokenVertex(_constrainedMethod).WriteVertex(factory);
                 Vertex relativeOffsetVertex = GetNativeWriter(factory).GetRelativeOffsetSignature(constrainedMethodVertex);
                 return writer.GetTuple(constraintType, relativeOffsetVertex);
             }
             else
             {
-                Debug.Assert((SignatureKind == FixupSignatureKind.NonGenericConstrainedMethod) || (SignatureKind == FixupSignatureKind.NonGenericDirectConstrainedMethod));
+                Debug.Assert(SignatureKind is FixupSignatureKind.NonGenericConstrainedMethod or FixupSignatureKind.NonGenericDirectConstrainedMethod or FixupSignatureKind.NonGenericStaticConstrainedMethod);
                 Vertex methodType = factory.NativeLayout.TypeSignatureVertex(_constrainedMethod.OwningType).WriteVertex(factory);
                 var canonConstrainedMethod = _constrainedMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
                 int interfaceSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, canonConstrainedMethod, canonConstrainedMethod.OwningType);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -2019,7 +2019,6 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (_constrainedMethod.Signature.IsStatic)
                 {
-                    Debug.Assert(_directCall);
                     if (_constrainedMethod.HasInstantiation)
                         return FixupSignatureKind.GenericStaticConstrainedMethod;
                     else

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
@@ -248,14 +248,15 @@ namespace ILCompiler.DependencyAnalysis
 
             public IMethodNode GetTarget(NodeFactory factory, TypeDesc implementingClass)
             {
+                bool isStaticVirtualMethod = _method.Signature.IsStatic;
                 MethodDesc implMethod = _method.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                if (_interfaceDefinition != null && !_method.Signature.IsStatic && implMethod.IsCanonicalMethod(CanonicalFormKind.Any))
+                if (_interfaceDefinition != null && !isStaticVirtualMethod && implMethod.IsCanonicalMethod(CanonicalFormKind.Any))
                 {
                     // Canonical instance default interface methods need to go through a thunk that acquires the generic context from `this`.
                     // Static methods have their generic context passed explicitly.
                     implMethod = factory.TypeSystemContext.GetDefaultInterfaceMethodImplementationThunk(implMethod, implementingClass.ConvertToCanonForm(CanonicalFormKind.Specific), _interfaceDefinition);
                 }
-                return factory.MethodEntrypoint(implMethod, _method.OwningType.IsValueType);
+                return factory.MethodEntrypoint(implMethod, unboxingStub: !isStaticVirtualMethod && _method.OwningType.IsValueType);
             }
 
             public bool Matches(MethodDesc method)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
@@ -147,13 +147,16 @@ namespace ILCompiler.DependencyAnalysis
                     if  (!interfaceType.IsTypeDefinition)
                         declMethod = factory.TypeSystemContext.GetMethodForInstantiatedType(declMethod.GetTypicalMethodDefinition(), (InstantiatedType)interfaceDefinitionType);
 
-                    var implMethod = declTypeDefinition.ResolveInterfaceMethodToVirtualMethodOnType(declMethod);
+                    var implMethod = declMethod.Signature.IsStatic ?
+                        declTypeDefinition.ResolveInterfaceMethodToStaticVirtualMethodOnType(declMethod) :
+                        declTypeDefinition.ResolveInterfaceMethodToVirtualMethodOnType(declMethod);
 
                     // Interface methods first implemented by a base type in the hierarchy will return null for the implMethod (runtime interface
                     // dispatch will walk the inheritance chain).
                     if (implMethod != null)
                     {
-                        if (implMethod.CanMethodBeInSealedVTable() && !implMethod.OwningType.HasSameTypeDefinition(declType))
+                        if (implMethod.Signature.IsStatic ||
+                            (implMethod.CanMethodBeInSealedVTable() && !implMethod.OwningType.HasSameTypeDefinition(declType)))
                         {
                             TypeDesc implType = declType;
                             while (!implType.HasSameTypeDefinition(implMethod.OwningType))
@@ -246,8 +249,10 @@ namespace ILCompiler.DependencyAnalysis
             public IMethodNode GetTarget(NodeFactory factory, TypeDesc implementingClass)
             {
                 MethodDesc implMethod = _method.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                if (_interfaceDefinition != null && implMethod.IsCanonicalMethod(CanonicalFormKind.Any))
+                if (_interfaceDefinition != null && !_method.Signature.IsStatic && implMethod.IsCanonicalMethod(CanonicalFormKind.Any))
                 {
+                    // Canonical instance default interface methods need to go through a thunk that acquires the generic context from `this`.
+                    // Static methods have their generic context passed explicitly.
                     implMethod = factory.TypeSystemContext.GetDefaultInterfaceMethodImplementationThunk(implMethod, implementingClass.ConvertToCanonForm(CanonicalFormKind.Specific), _interfaceDefinition);
                 }
                 return factory.MethodEntrypoint(implMethod, _method.OwningType.IsValueType);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -114,10 +114,6 @@ namespace ILCompiler.DependencyAnalysis
 
             foreach (var method in allSlots)
             {
-                // Static virtual methods don't go in vtables
-                if (method.Signature.IsStatic)
-                    continue;
-
                 // GVMs are not emitted in the type's vtable.
                 if (method.HasInstantiation)
                     continue;
@@ -223,10 +219,6 @@ namespace ILCompiler.DependencyAnalysis
             {
                 // Generic virtual methods are tracked by an orthogonal mechanism.
                 if (method.HasInstantiation)
-                    continue;
-
-                // Static interface methods don't go into vtables
-                if (method.Signature.IsStatic)
                     continue;
 
                 // Current type doesn't define this slot. Another VTableSlice will take care of this.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -26,7 +26,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             Debug.Assert(!decl.IsRuntimeDeterminedExactMethod);
             Debug.Assert(decl.IsVirtual);
-            Debug.Assert(!decl.Signature.IsStatic);
 
             // Virtual method use always represents the slot defining method of the virtual.
             // Places that might see virtual methods being used through an override need to normalize

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1306,7 +1306,7 @@ namespace Internal.JitInterface
 
             if (directCall && resolvedConstraint && pResult->exactContextNeedsRuntimeLookup)
             {
-                // We want to do a direct call to a shared method on a valuetype. We need to provide
+                // We want to do a direct call to a shared method on a type. We need to provide
                 // a generic context, but the JitInterface doesn't provide a way for us to do it from here.
                 // So we do the next best thing and ask RyuJIT to look up a fat pointer.
 
@@ -1315,8 +1315,8 @@ namespace Internal.JitInterface
                 pResult->nullInstanceCheck = !targetMethod.Signature.IsStatic;
 
                 // We have the canonical version of the method - find the runtime determined version.
-                // This is simplified because we know the method is on a valuetype.
-                Debug.Assert(targetMethod.OwningType.IsValueType);
+                // For now simplify it by assuming the resolved method is on the same type as the constraint.
+                Debug.Assert(targetMethod.OwningType.GetTypeDefinition() == constrainedType.GetTypeDefinition());
                 TypeDesc runtimeDeterminedConstrainedType = (TypeDesc)GetRuntimeDeterminedObjectForToken(ref *pConstrainedResolvedToken);
 
                 if (forceUseRuntimeLookup)

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -44,6 +44,9 @@ public class Interfaces
         TestStaticInterfaceMethodsAnalysis.Run();
         TestStaticInterfaceMethods.Run();
         TestSimpleStaticDefaultInterfaceMethods.Run();
+        TestSimpleDynamicStaticVirtualMethods.Run();
+        TestGenericDynamicStaticVirtualMethods.Run();
+        TestVariantGenericDynamicStaticVirtualMethods.Run();
 
         return Pass;
     }
@@ -1094,4 +1097,195 @@ public class Interfaces
                 throw new Exception();
         }
     }
+
+    class TestSimpleDynamicStaticVirtualMethods
+    {
+        public interface IFoo
+        {
+            static abstract int CallMeDirect();
+            static abstract int CallMeIndirect();
+            static virtual int DefaultImplemented() => 42;
+        }
+
+        class Foo : IFoo
+        {
+            public static int CallMeDirect() => 2019;
+            public static int CallMeIndirect() => 2022;
+        }
+
+        class FrobCaller<T> where T : IFoo
+        {
+            public static int CallDirect() => T.CallMeDirect();
+            public static int CallIndirect()
+            {
+                Func<int> d = T.CallMeIndirect;
+                return d();
+            }
+            public static int CallDefault() => T.DefaultImplemented();
+        }
+
+        static Type s_fooType = typeof(Foo);
+
+        public static void Run()
+        {
+            Type t = typeof(FrobCaller<>).MakeGenericType(s_fooType);
+
+            {
+                var mi = t.GetMethod("CallDirect");
+                int result = (int)mi.Invoke(null, Array.Empty<object>());
+                if (result != 2019)
+                    throw new Exception();
+            }
+
+            {
+                var mi = t.GetMethod("CallIndirect");
+                int result = (int)mi.Invoke(null, Array.Empty<object>());
+                if (result != 2022)
+                    throw new Exception();
+            }
+
+            {
+                var mi = t.GetMethod("CallDefault");
+                int result = (int)mi.Invoke(null, Array.Empty<object>());
+                if (result != 42)
+                    throw new Exception();
+            }
+        }
+    }
+
+    class TestGenericDynamicStaticVirtualMethods
+    {
+        public interface IFoo<T>
+        {
+            static abstract (int, Type) CallMeDirect();
+            static abstract (int, Type) CallMeIndirect();
+            static virtual (int, Type) DefaultImplemented() => (42, typeof(T[]));
+        }
+
+        class Foo<T> : IFoo<T>
+        {
+            public static (int, Type) CallMeDirect() => (2019, typeof(T[,]));
+            public static (int, Type) CallMeIndirect() => (2022, typeof(T[,,]));
+        }
+
+        class FrobCaller<T, U> where T : IFoo<U>
+        {
+            public static (int, Type) CallDirect() => T.CallMeDirect();
+            public static (int, Type) CallIndirect()
+            {
+                Func<(int, Type)> d = T.CallMeIndirect;
+                return d();
+            }
+            public static (int, Type) CallDefault() => T.DefaultImplemented();
+        }
+
+        class Wrapper<T>
+        {
+            public static (int, Type) CallDirect() => FrobCaller<Foo<T>, T>.CallDirect();
+            public static (int, Type) CallIndirect() => FrobCaller<Foo<T>, T>.CallIndirect();
+            public static (int, Type) CallDefault() => FrobCaller<Foo<T>, T>.CallDefault();
+        }
+
+        class Atom { }
+
+        static Type s_atomType = typeof(Atom);
+
+        public static void Run()
+        {
+            Type t = typeof(Wrapper<>).MakeGenericType(s_atomType);
+
+            {
+                var mi = t.GetMethod("CallDirect");
+                var result = ((int, Type))mi.Invoke(null, Array.Empty<object>());
+                if (result.Item1 != 2019)
+                    throw new Exception();
+                if (result.Item2.GetArrayRank() != 2 || result.Item2.GetElementType() != s_atomType)
+                    throw new Exception();
+            }
+
+            {
+                var mi = t.GetMethod("CallIndirect");
+                var result = ((int, Type))mi.Invoke(null, Array.Empty<object>());
+                if (result.Item1 != 2022)
+                    throw new Exception();
+                if (result.Item2.GetArrayRank() != 3 || result.Item2.GetElementType() != s_atomType)
+                    throw new Exception();
+            }
+
+            {
+                var mi = t.GetMethod("CallDefault");
+                var result = ((int, Type))mi.Invoke(null, Array.Empty<object>());
+                if (result.Item1 != 42)
+                    throw new Exception();
+                if (result.Item2.GetArrayRank() != 1 || result.Item2.GetElementType() != s_atomType)
+                    throw new Exception();
+            }
+        }
+    }
+
+    class TestVariantGenericDynamicStaticVirtualMethods
+    {
+        public interface IFoo<in T>
+        {
+            static abstract (int, Type) CallMeDirect();
+            static abstract (int, Type) CallMeIndirect();
+            static virtual (int, Type) DefaultImplemented() => (42, typeof(T[]));
+        }
+
+        class AbjectFail<T> : IFoo<T>
+        {
+            public static (int, Type) CallMeDirect() => (2019, typeof(T[,]));
+            public static (int, Type) CallMeIndirect() => (2022, typeof(T[,,]));
+        }
+
+        class FrobCaller<T, U> where T : IFoo<U>
+        {
+            public static (int, Type) CallDirect() => T.CallMeDirect();
+            public static (int, Type) CallIndirect()
+            {
+                Func<(int, Type)> d = T.CallMeIndirect;
+                return d();
+            }
+            public static (int, Type) CallDefault() => T.DefaultImplemented();
+        }
+
+        class AtomBase { }
+        class Atom : AtomBase { }
+
+        static Type s_atomType = typeof(Atom);
+        static Type s_atomBaseType = typeof(AtomBase);
+
+        public static void Run()
+        {
+            Type t = typeof(FrobCaller<,>).MakeGenericType(typeof(AbjectFail<AtomBase>), s_atomType);
+
+            {
+                var mi = t.GetMethod("CallDirect");
+                var result = ((int, Type))mi.Invoke(null, Array.Empty<object>());
+                if (result.Item1 != 2019)
+                    throw new Exception();
+                if (result.Item2.GetArrayRank() != 2 || result.Item2.GetElementType() != s_atomBaseType)
+                    throw new Exception();
+            }
+
+            {
+                var mi = t.GetMethod("CallIndirect");
+                var result = ((int, Type))mi.Invoke(null, Array.Empty<object>());
+                if (result.Item1 != 2022)
+                    throw new Exception();
+                if (result.Item2.GetArrayRank() != 3 || result.Item2.GetElementType() != s_atomBaseType)
+                    throw new Exception();
+            }
+
+            {
+                var mi = t.GetMethod("CallDefault");
+                var result = ((int, Type))mi.Invoke(null, Array.Empty<object>());
+                if (result.Item1 != 42)
+                    throw new Exception();
+                if (result.Item2.GetArrayRank() != 1 || result.Item2.GetElementType() != s_atomBaseType)
+                    throw new Exception();
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #67745.

Support for static virtual methods that was added in #66084 was enough for compile-time resolution of static virtual methods, but didn't cover dynamic code. For example, given following code:

```csharp
interface IFoo { static virtual void Frob(); }
class SomeCaller<T> where T : IFoo { ... T.Frob(); }
class SomeClass : IFoo { ... }
```

If we do `typeof(SomeCaller<>).MakeGenericType(typeof(SomeClass)` at runtime, the runtime has to find what method implements `IFoo.Frob` on `SomeClass` and ensure proper data structures are generated for `SomeCaller<SomeClass>` so that the call lands in the right spot at runtime.

On a high level, what we need:
* Change to the compiler to generate extra data ("interface dispatch maps") that lets us find an implementation of interface method X on a given type Y.
* Change to the runtime to read the new data structure.
* Change to the compiler to generate extra method bodies for types that can potentially be used with MakeGeneric at runtime. This is an overapproximation since we don't know the set of types that will really be used.
* Change to type loader data structures to capture when shared generic code needs to do this mapping, and change the code in the compiler that emits it, and to the type loader that reads it.

I've made it so that the dispatch logic between instance and static methods is shared. It's not strictly necessary for both to go into the same data structure, but it prevents duplicating the code on the emission and reading side. The side effect of that is that static virtual methods now go into the sealed vtable. We have to put them somewhere. This spot is as good as any.

I've also had to make a small change to the ordering of data structure generation within the type loader. I've made is so that EEType/MethodTable structures are fully populated before we start filling out generic dictionaries. This prevents us from calling into the runtime dispatch logic with EETypes/MethodTables that are not actually built yet. I really didn't want to duplicate the dispatch logic into the type loader.

Cc @dotnet/ilc-contrib 