### PR TITLE
Argument tests for CreateJsonTypeInfo and CreateJsonPropertyInfo

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -642,7 +642,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal static bool IsInvalidForSerialization(Type type)
         {
-            return type.IsPointer || type.IsByRef || IsByRefLike(type) || type.ContainsGenericParameters;
+            return type == typeof(void) || type.IsPointer || type.IsByRef || IsByRefLike(type) || type.ContainsGenericParameters;
         }
 
         private static bool IsByRefLike(Type type)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -412,6 +412,11 @@ namespace System.Text.Json.Serialization.Metadata
         [RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
         public static JsonTypeInfo<T> CreateJsonTypeInfo<T>(JsonSerializerOptions options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             return new CustomJsonTypeInfo<T>(options);
         }
 
@@ -427,6 +432,21 @@ namespace System.Text.Json.Serialization.Metadata
         [RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use generic overload or System.Text.Json source generation for native AOT applications.")]
         public static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options)
         {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (IsInvalidForSerialization(type))
+            {
+                ThrowHelper.ThrowArgumentException_CannotSerializeInvalidType(nameof(type), type, null, null);
+            }
+
             s_createJsonTypeInfo ??= typeof(JsonTypeInfo).GetMethod(nameof(CreateJsonTypeInfo), new Type[] { typeof(JsonSerializerOptions) })!;
             return (JsonTypeInfo)s_createJsonTypeInfo.MakeGenericMethod(type)
                 .Invoke(null, new object[] { options })!;
@@ -440,7 +460,20 @@ namespace System.Text.Json.Serialization.Metadata
         /// <returns>JsonPropertyInfo instance</returns>
         public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name)
         {
-            ValidateType(propertyType, Type, null, Options);
+            if (propertyType == null)
+            {
+                throw new ArgumentNullException(nameof(propertyType));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (IsInvalidForSerialization(propertyType))
+            {
+                ThrowHelper.ThrowArgumentException_CannotSerializeInvalidType(nameof(propertyType), propertyType, Type, name);
+            }
 
             JsonConverter converter = GetConverter(propertyType,
                 parentClassType: null,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -86,6 +86,19 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowArgumentException_CannotSerializeInvalidType(string paramName, Type type, Type? parentClassType, string? propertyName)
+        {
+            if (parentClassType == null)
+            {
+                Debug.Assert(propertyName == null);
+                throw new ArgumentException(SR.Format(SR.CannotSerializeInvalidType, type), paramName);
+            }
+
+            Debug.Assert(propertyName != null);
+            throw new ArgumentException(SR.Format(SR.CannotSerializeInvalidMember, type, propertyName, parentClassType), paramName);
+        }
+
+        [DoesNotReturn]
         public static void ThrowInvalidOperationException_CannotSerializeInvalidType(Type type, Type? parentClassType, MemberInfo? memberInfo)
         {
             if (parentClassType == null)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
@@ -580,6 +580,54 @@ namespace System.Text.Json.Serialization.Tests
             Assert.NotNull(typeInfo.Properties[0]);
         }
 
+        [Fact]
+        public static void CreateJsonTypeInfoWithNullArgumentsThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => JsonTypeInfo.CreateJsonTypeInfo(null, new JsonSerializerOptions()));
+            Assert.Throws<ArgumentNullException>(() => JsonTypeInfo.CreateJsonTypeInfo(typeof(string), null));
+            Assert.Throws<ArgumentNullException>(() => JsonTypeInfo.CreateJsonTypeInfo(null, null));
+            Assert.Throws<ArgumentNullException>(() => JsonTypeInfo.CreateJsonTypeInfo<string>(null));
+        }
+
+        [Theory]
+        [InlineData(typeof(void))]
+        [InlineData(typeof(Dictionary<,>))]
+        [InlineData(typeof(List<>))]
+        [InlineData(typeof(Nullable<>))]
+        [InlineData(typeof(int*))]
+        [InlineData(typeof(RefStruct))]
+        public static void CreateJsonTypeInfoWithInappropriateTypeThrows(Type type)
+        {
+            Assert.Throws<ArgumentException>(() => JsonTypeInfo.CreateJsonTypeInfo(type, new JsonSerializerOptions()));
+        }
+
+        ref struct RefStruct
+        {
+            public int Foo { get; set; }
+        }
+
+        [Fact]
+        public static void CreateJsonPropertyInfoWithNullArgumentsThrows()
+        {
+            JsonTypeInfo ti = JsonTypeInfo.CreateJsonTypeInfo<MyClass>(new JsonSerializerOptions());
+            Assert.Throws<ArgumentNullException>(() => ti.CreateJsonPropertyInfo(null, "test"));
+            Assert.Throws<ArgumentNullException>(() => ti.CreateJsonPropertyInfo(typeof(string), null));
+            Assert.Throws<ArgumentNullException>(() => ti.CreateJsonPropertyInfo(null, null));
+        }
+
+        [Theory]
+        [InlineData(typeof(void))]
+        [InlineData(typeof(Dictionary<,>))]
+        [InlineData(typeof(List<>))]
+        [InlineData(typeof(Nullable<>))]
+        [InlineData(typeof(int*))]
+        [InlineData(typeof(RefStruct))]
+        public static void CreateJsonPropertyInfoWithInappropriateTypeThrows(Type type)
+        {
+            JsonTypeInfo ti = JsonTypeInfo.CreateJsonTypeInfo<MyClass>(new JsonSerializerOptions());
+            Assert.Throws<ArgumentException>(() => ti.CreateJsonPropertyInfo(type, "test"));
+        }
+
         [Theory]
         [InlineData(typeof(object))]
         [InlineData(typeof(string))]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.cs
@@ -178,6 +178,14 @@ namespace System.Text.Json.Serialization.Tests
             Assert.True(secondModifierCalled);
         }
 
+        [Fact]
+        public static void AddingNullModifierThrows()
+        {
+            DefaultJsonTypeInfoResolver r = new();
+            Assert.Throws<ArgumentNullException>(() => r.Modifiers.Add(null));
+            Assert.Throws<ArgumentNullException>(() => r.Modifiers.Insert(0, null));
+        }
+
         private static void InvokeGeneric(Type type, string methodName, params object[] args)
         {
             typeof(DefaultJsonTypeInfoResolverTests)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/71296

I went through all APIs and seems only CreateJsonTypeInfo and CreatePropertyInfo were missing checks. I also added some test gaps for null modifier but that was checking args already