### PR TITLE
Use in-tree ilasm to run test suite natively on s390x

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -115,7 +115,7 @@
     <MonoAOTCompilerTasksAssemblyPath>$([MSBuild]::NormalizePath('$(MonoAOTCompilerDir)', 'MonoAOTCompiler.dll'))</MonoAOTCompilerTasksAssemblyPath>
     <MonoTargetsTasksAssemblyPath>$([MSBuild]::NormalizePath('$(MonoTargetsTasksDir)', 'MonoTargetsTasks.dll'))</MonoTargetsTasksAssemblyPath>
     <TestExclusionListTasksAssemblyPath>$([MSBuild]::NormalizePath('$(TestExclusionListTasksDir)', 'TestExclusionListTasks.dll'))</TestExclusionListTasksAssemblyPath>
-    <ILAsmToolPath Condition="'$(DotNetBuildFromSource)' == 'true'">$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'coreclr', '$(TargetOS).$(TargetArchitecture).$(Configuration)'))</ILAsmToolPath>
+    <ILAsmToolPath Condition="'$(DotNetBuildFromSource)' == 'true' or '$(BuildArchitecture)' == 's390x'">$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'coreclr', '$(TargetOS).$(TargetArchitecture).$(Configuration)'))</ILAsmToolPath>
   </PropertyGroup>
 
   <PropertyGroup Label="CalculateConfiguration">


### PR DESCRIPTION
* There are no linux-s390x packages on nuget.org, so use in-tree
  built ilasm when running the test suite natively on s390x

In https://github.com/dotnet/runtime/pull/58952, @akoeplinger introduced code to allow building the test suite targeting linux-s390x, even through there are no linux-s390x packages currently available on nuget.org, by using the in-tree live-built versions of the host packages instead.

However, there is still one remaining obstacle to actually *running* the test suite natively on linux-s390x, and that is the availability of the ilasm package.  This PR sets the `ILAsmToolPath` property to use the in-tree live-built ilasm binary instead.

With this PR applied, I'm able to successfully build and run the runtime `libs.tests` test suite natively on linux-s390x without *any* changes applied to the upstream repository.