### PR TITLE
Enable `TYP_STRUCT` `LCL_VAR/LCL_FLD` call args on LA

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1068,7 +1068,7 @@ private:
         // | Partial    | LCL_FLD | LCL_FLD | LCL_FLD |
         // |------------|---------|---------|---------|
         //
-        // * - On XArch/Arm64 only.
+        // * - On XArch/Arm64/LA only.
         //
         // |------------|------|------|--------|----------|
         // | SIMD       | CALL | ASG  | RETURN | HWI/SIMD |
@@ -1086,9 +1086,9 @@ private:
 
         if (user->IsCall())
         {
-#if !defined(TARGET_XARCH) && !defined(TARGET_ARM64)
+#ifdef TARGET_ARM
             return IndirTransform::None;
-#endif // !defined(TARGET_XARCH) && !defined(TARGET_ARM64)
+#endif // TARGET_ARM
         }
 
         if (match == StructMatch::Compatible)

--- a/src/coreclr/jit/lowerloongarch64.cpp
+++ b/src/coreclr/jit/lowerloongarch64.cpp
@@ -432,7 +432,7 @@ void Lowering::LowerPutArgStkOrSplit(GenTreePutArgStk* putArgNode)
         MakeSrcContained(putArgNode, src);
 
         // Currently, codegen does not support LCL_VAR/LCL_FLD sources, so we morph them to OBJs.
-        // TODO-LOONGARCH64: support the local nodes in codegen and remove this code.
+        // TODO-ADDR: support the local nodes in codegen and remove this code.
         if (src->OperIsLocalRead())
         {
             unsigned     lclNum  = src->AsLclVarCommon()->GetLclNum();


### PR DESCRIPTION
For now, lower the local nodes into `OBJ`s, as full codegen support would require changes I deem too extensive for the level of validation that we have for LA currently.

For context, the changes to port to LA to would be:

#69905
#70256
#69905
#70861

I plan to do this eventually; as part of the final push to delete `ADDR`.