### PR TITLE
Apply Auto layout to large internal structs in System.Text.Json

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -13,6 +13,7 @@ namespace System.Text.Json
             public int Year;
             public int Month;
             public int Day;
+            public bool IsCalendarDateOnly;
             public int Hour;
             public int Minute;
             public int Second;
@@ -20,7 +21,6 @@ namespace System.Text.Json
             public int OffsetHours;
             public int OffsetMinutes;
             public bool OffsetNegative => OffsetToken == JsonConstants.Hyphen;
-            public bool IsCalendarDateOnly;
             public byte OffsetToken;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -13,7 +13,6 @@ namespace System.Text.Json
             public int Year;
             public int Month;
             public int Day;
-            public bool IsCalendarDateOnly;
             public int Hour;
             public int Minute;
             public int Second;
@@ -21,6 +20,7 @@ namespace System.Text.Json
             public int OffsetHours;
             public int OffsetMinutes;
             public bool OffsetNegative => OffsetToken == JsonConstants.Hyphen;
+            public bool IsCalendarDateOnly;
             public byte OffsetToken;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -3,11 +3,13 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Text.Json
 {
     internal static partial class JsonHelpers
     {
+        [StructLayout(LayoutKind.Auto)]
         private struct DateTimeParseData
         {
             public int Year;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadBufferState.cs
@@ -4,11 +4,13 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.Text.Json.Serialization
 {
+    [StructLayout(LayoutKind.Auto)]
     internal struct ReadBufferState : IDisposable
     {
         private byte[] _buffer;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -5,11 +5,13 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json
 {
+    [StructLayout(LayoutKind.Auto)]
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal struct ReadStack
     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -3,11 +3,13 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json
 {
+    [StructLayout(LayoutKind.Auto)]
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal struct ReadStackFrame
     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
@@ -12,6 +13,7 @@ using System.Threading.Tasks;
 
 namespace System.Text.Json
 {
+    [StructLayout(LayoutKind.Auto)]
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal struct WriteStack
     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -3,11 +3,13 @@
 
 using System.Collections;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json
 {
+    [StructLayout(LayoutKind.Auto)]
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal struct WriteStackFrame
     {


### PR DESCRIPTION
Following feedback in https://github.com/dotnet/runtime/pull/69160#discussion_r905258287