### PR TITLE
Bump Helix workitem timeout for iOS Device perf scenarios

### DIFF
--- a/eng/testing/performance/ios_scenarios.proj
+++ b/eng/testing/performance/ios_scenarios.proj
@@ -42,7 +42,7 @@
     </HelixWorkItem>
     <XHarnessAppBundleToTest Include="Device Startup - iOS Mono HelloWorld $(LlvmPath)">
       <AppBundlePath>$(WorkItemDirectory).zip</AppBundlePath>
-      <WorkItemTimeout>00:05:00</WorkItemTimeout>
+      <WorkItemTimeout>00:15:00</WorkItemTimeout>
       <TestTarget>ios-device</TestTarget>
       <CustomCommands>
         <![CDATA[
@@ -98,7 +98,7 @@
     </HelixWorkItem>
 	<XHarnessAppBundleToTest Include="Device Startup - iOS Maui Default" Condition="'$(iOSLlvmBuild)' == 'False'">
     <AppBundlePath>$(WorkItemDirectory).zip</AppBundlePath>
-    <WorkItemTimeout>00:05:00</WorkItemTimeout>
+    <WorkItemTimeout>00:15:00</WorkItemTimeout>
 	  <TestTarget>ios-device</TestTarget>
 	  <CustomCommands>
 	   	<![CDATA[
@@ -124,7 +124,7 @@
 	</XHarnessAppBundleToTest>
     <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Podcast" Condition="'$(iOSLlvmBuild)' == 'False'">
     <AppBundlePath>$(WorkItemDirectory).zip</AppBundlePath>
-    <WorkItemTimeout>00:05:00</WorkItemTimeout>
+    <WorkItemTimeout>00:15:00</WorkItemTimeout>
 	  <TestTarget>ios-device</TestTarget>
 	  <CustomCommands>
 	   	<![CDATA[


### PR DESCRIPTION
iOS requires more waiting between app runs and sometimes the 5mins timeout is not enough.

/cc @LoopedBard3 