### PR TITLE
Cleanup CapiHelper.Unix

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CapiHelper.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CapiHelper.Unix.cs
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography
                 Oids.Sha384 => HashAlgorithmName.SHA384,
                 Oids.Sha512 => HashAlgorithmName.SHA512,
                 Oids.Md5 => HashAlgorithmName.MD5,
-                _ => throw new ArgumentException(SR.Argument_InvalidValue),
+                _ => throw new CryptographicException(SR.Cryptography_InvalidOID),
             };
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CapiHelper.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CapiHelper.Unix.cs
@@ -5,111 +5,63 @@ namespace System.Security.Cryptography
 {
     internal static partial class CapiHelper
     {
-        internal const string MD5 = "MD5";
-        internal const string SHA1 = "SHA1";
-        internal const string SHA256 = "SHA256";
-        internal const string SHA384 = "SHA384";
-        internal const string SHA512 = "SHA512";
-
-        private const string OID_MD5 = "1.2.840.113549.2.5";
-        private const string OID_SHA1 = "1.3.14.3.2.26";
-        private const string OID_SHA256 = "2.16.840.1.101.3.4.2.1";
-        private const string OID_SHA384 = "2.16.840.1.101.3.4.2.2";
-        private const string OID_SHA512 = "2.16.840.1.101.3.4.2.3";
-
         // For backwards compat with CapiHelper.ObjToHashAlgorithm, use "hashAlg" as name
         internal static HashAlgorithmName ObjToHashAlgorithmName(object hashAlg)
         {
             ArgumentNullException.ThrowIfNull(hashAlg);
 
-            HashAlgorithmName? name = null;
-
-            if (hashAlg is string)
+            return hashAlg switch
             {
-                name = NameOrOidToHashAlgorithmName((string)hashAlg);
-            }
-            else if (hashAlg is HashAlgorithm)
-            {
-                name = ((HashAlgorithm)hashAlg).ToHashAlgorithmName();
-            }
-            else if (hashAlg is Type)
-            {
-                name = HashAlgorithmTypeToHashAlgorithmName((Type)hashAlg);
-            }
-
-            if (name.HasValue)
-            {
-                return name.Value;
-            }
-
-            throw new ArgumentException(SR.Argument_InvalidValue);
+                string hashAlgString => NameOrOidToHashAlgorithmName(hashAlgString),
+                HashAlgorithm hashAlgorithm => AlgorithmToHashAlgorithmName(hashAlgorithm),
+                Type hashAlgType => HashAlgorithmTypeToHashAlgorithmName(hashAlgType),
+                _ => throw new ArgumentException(SR.Argument_InvalidValue),
+            };
         }
 
-        internal static HashAlgorithmName NameOrOidToHashAlgorithmName(string nameOrOid)
+        internal static HashAlgorithmName NameOrOidToHashAlgorithmName(string? nameOrOid)
         {
-            HashAlgorithmName? name;
-
-            if (nameOrOid == null)
+            if (nameOrOid is null)
             {
                 // Default Algorithm Id is CALG_SHA1
-                name = HashAlgorithmName.SHA1;
-            }
-            else
-            {
-                string? oidValue = CryptoConfig.MapNameToOID(nameOrOid);
-                if (oidValue == null)
-                    oidValue = nameOrOid; // we were probably passed an OID value directly
-
-                name = OidToHashAlgorithmName(oidValue);
+                return HashAlgorithmName.SHA1;
             }
 
-            if (!name.HasValue)
-            {
-                throw new CryptographicException(SR.Cryptography_InvalidOID);
-            }
-
-            return name.Value;
+            // Fall back to the input if MapNameToOID returns null; it is probably an OID value.
+            string oidValue = CryptoConfig.MapNameToOID(nameOrOid) ?? nameOrOid;
+            return OidToHashAlgorithmName(oidValue);
         }
 
         /// <summary>
-        /// Map HashAlgorithm type to HashAlgorithmName without using CryptoConfig. Returns null if not found.
+        /// Map HashAlgorithm type to HashAlgorithmName without using CryptoConfig. Throws if not found.
         /// </summary>
-        internal static HashAlgorithmName? ToHashAlgorithmName(this HashAlgorithm hashAlgorithm)
+        private static HashAlgorithmName AlgorithmToHashAlgorithmName(HashAlgorithm hashAlgorithm)
         {
-            if (hashAlgorithm is SHA1)
-                return HashAlgorithmName.SHA1;
-            if (hashAlgorithm is SHA256)
-                return HashAlgorithmName.SHA256;
-            if (hashAlgorithm is SHA384)
-                return HashAlgorithmName.SHA384;
-            if (hashAlgorithm is SHA512)
-                return HashAlgorithmName.SHA512;
-            if (hashAlgorithm is MD5)
-                return HashAlgorithmName.MD5;
-
-            return null;
-        }
-
-        internal static HashAlgorithmName? OidToHashAlgorithmName(string oid)
-        {
-            switch (oid)
+            return hashAlgorithm switch
             {
-                case OID_SHA1:
-                    return HashAlgorithmName.SHA1;
-                case OID_SHA256:
-                    return HashAlgorithmName.SHA256;
-                case OID_SHA384:
-                    return HashAlgorithmName.SHA384;
-                case OID_SHA512:
-                    return HashAlgorithmName.SHA512;
-                case OID_MD5:
-                    return HashAlgorithmName.MD5;
-                default:
-                    return null;
-            }
+                SHA256 => HashAlgorithmName.SHA256,
+                SHA1 => HashAlgorithmName.SHA1,
+                SHA384 => HashAlgorithmName.SHA384,
+                SHA512 => HashAlgorithmName.SHA512,
+                MD5 => HashAlgorithmName.MD5,
+                _ => throw new ArgumentException(SR.Argument_InvalidValue),
+            };
         }
 
-        internal static HashAlgorithmName? HashAlgorithmTypeToHashAlgorithmName(Type hashAlgType)
+        private static HashAlgorithmName OidToHashAlgorithmName(string oid)
+        {
+            return oid switch
+            {
+                Oids.Sha256 => HashAlgorithmName.SHA256,
+                Oids.Sha1 => HashAlgorithmName.SHA1,
+                Oids.Sha384 => HashAlgorithmName.SHA384,
+                Oids.Sha512 => HashAlgorithmName.SHA512,
+                Oids.Md5 => HashAlgorithmName.MD5,
+                _ => throw new ArgumentException(SR.Argument_InvalidValue),
+            };
+        }
+
+        private static HashAlgorithmName HashAlgorithmTypeToHashAlgorithmName(Type hashAlgType)
         {
             if (typeof(SHA1).IsAssignableFrom(hashAlgType))
                 return HashAlgorithmName.SHA1;
@@ -122,7 +74,7 @@ namespace System.Security.Cryptography
             if (typeof(MD5).IsAssignableFrom(hashAlgType))
                 return HashAlgorithmName.MD5;
 
-            return null;
+            throw new ArgumentException(SR.Argument_InvalidValue);
         }
 
         internal static CryptographicException GetBadDataException()


### PR DESCRIPTION
Some random cleanup:

1. Remove unused or duplicated constant members in favor of those already declared in `Oids.cs`.
2. Methods that were not used outside of the class were switched to `private`.
3. Changed a few of the methods to not return `null` and instead throw because we are going to throw later in the "if null, throw" check.
4. Some general formatting improvements.