### PR TITLE
Make sure we emit diagnostics for "unsupported" marshalling for downlevel platforms

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -341,6 +341,8 @@ namespace Microsoft.Interop
                     generatorFactory = new UnsupportedMarshallingFactory();
                 }
 
+                generatorFactory = new NoMarshallingInfoErrorMarshallingFactory(generatorFactory);
+
                 // The presence of System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute is tied to TFM,
                 // so we use TFM in the generator factory key instead of the Compilation as the compilation changes on every keystroke.
                 IAssemblySymbol coreLibraryAssembly = env.Compilation.GetSpecialType(SpecialType.System_Object).ContainingAssembly;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/NoMarshallingInfoErrorMarshallingFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/NoMarshallingInfoErrorMarshallingFactory.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Interop
+{
+    public sealed class NoMarshallingInfoErrorMarshallingFactory : IMarshallingGeneratorFactory
+    {
+        private readonly IMarshallingGeneratorFactory _inner;
+
+        public IMarshallingGenerator Create(
+            TypePositionInfo info,
+            StubCodeContext context)
+        {
+            if (info.MarshallingAttributeInfo is NoMarshallingInfo && CustomTypeToErrorMessageMap.TryGetValue(info.ManagedType, out string errorMessage))
+            {
+                throw new MarshallingNotSupportedException(info, context)
+                {
+                    NotSupportedDetails = errorMessage
+                };
+            }
+            return _inner.Create(info, context);
+        }
+
+        public NoMarshallingInfoErrorMarshallingFactory(IMarshallingGeneratorFactory inner)
+            : this(inner, DefaultTypeToErrorMessageMap)
+        {
+        }
+
+        private NoMarshallingInfoErrorMarshallingFactory(IMarshallingGeneratorFactory inner, ImmutableDictionary<ManagedTypeInfo, string> customTypeToErrorMessageMap)
+        {
+            _inner = inner;
+            CustomTypeToErrorMessageMap = customTypeToErrorMessageMap;
+        }
+
+        public ImmutableDictionary<ManagedTypeInfo, string> CustomTypeToErrorMessageMap { get; }
+
+        private static ImmutableDictionary<ManagedTypeInfo, string> DefaultTypeToErrorMessageMap { get; } =
+            ImmutableDictionary.CreateRange(new Dictionary<ManagedTypeInfo, string>
+            {
+                { SpecialTypeInfo.String, SR.MarshallingStringOrCharAsUndefinedNotSupported },
+                { SpecialTypeInfo.Boolean, SR.MarshallingBoolAsUndefinedNotSupported },
+            });
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/UnsupportedMarshallingFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/UnsupportedMarshallingFactory.cs
@@ -11,38 +11,7 @@ namespace Microsoft.Interop
 {
     public sealed class UnsupportedMarshallingFactory : IMarshallingGeneratorFactory
     {
-        public IMarshallingGenerator Create(
-            TypePositionInfo info,
-            StubCodeContext context)
-        {
-            if (info.MarshallingAttributeInfo is NoMarshallingInfo && CustomTypeToErrorMessageMap.TryGetValue(info.ManagedType, out string errorMessage))
-            {
-                throw new MarshallingNotSupportedException(info, context)
-                {
-                    NotSupportedDetails = errorMessage
-                };
-            }
+        public IMarshallingGenerator Create(TypePositionInfo info, StubCodeContext context) =>
             throw new MarshallingNotSupportedException(info, context);
-        }
-
-        public UnsupportedMarshallingFactory()
-            : this(DefaultTypeToErrorMessageMap)
-        {
-
-        }
-
-        private UnsupportedMarshallingFactory(ImmutableDictionary<ManagedTypeInfo, string> customTypeToErrorMessageMap)
-        {
-            CustomTypeToErrorMessageMap = customTypeToErrorMessageMap;
-        }
-
-        public ImmutableDictionary<ManagedTypeInfo, string> CustomTypeToErrorMessageMap { get; }
-
-        private static ImmutableDictionary<ManagedTypeInfo, string> DefaultTypeToErrorMessageMap { get; } =
-            ImmutableDictionary.CreateRange(new Dictionary<ManagedTypeInfo, string>
-            {
-                { SpecialTypeInfo.String, SR.MarshallingStringOrCharAsUndefinedNotSupported },
-                { SpecialTypeInfo.Boolean, SR.MarshallingBoolAsUndefinedNotSupported },
-            });
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
@@ -295,7 +295,7 @@ partial class Test
         }
 
         [Fact]
-        //[OuterLoop("Uses the network for downlevel ref packs")]
+        [OuterLoop("Uses the network for downlevel ref packs")]
         public async Task StringMarshallingForwardingNotSupported_ReportsDiagnostic()
         {
             string source = @"

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
@@ -295,7 +295,7 @@ partial class Test
         }
 
         [Fact]
-        [OuterLoop("Uses the network for downlevel ref packs")]
+        //[OuterLoop("Uses the network for downlevel ref packs")]
         public async Task StringMarshallingForwardingNotSupported_ReportsDiagnostic()
         {
             string source = @"


### PR DESCRIPTION
Separate out the "no marshalling info" error factory from the "unsupported" marshalling factory so we still get the same diagnostics on downlevel platforms where we use the forwarder as our fallback.

Fixes #71315