### PR TITLE
Check layout compatibility before morphing `OBJ(ADDR(LCL_VAR))` into a list of promoted fields

### DIFF
--- a/src/tests/JIT/Directed/StructABI/TypeMismatchedArgs.cs
+++ b/src/tests/JIT/Directed/StructABI/TypeMismatchedArgs.cs
@@ -46,6 +46,16 @@ public unsafe class TypeMismatchedArgs
             return 106;
         }
 
+        if (ProblemWithPromotedStruct_Unix_x64(new StructWithFourLongs { LongOne = 1, LongTwo = 2, LongThree = 3, LongFour = 4 }))
+        {
+            return 107;
+        }
+
+        if (ProblemWithPromotedStruct_x86(new DblLngStruct { FirstLngValue = 1, SecondLngValue = 2 }))
+        {
+            return 108;
+        }
+
         return 100;
     }
 
@@ -107,6 +117,22 @@ public unsafe class TypeMismatchedArgs
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ProblemWithPromotedStruct_Unix_x64(StructWithFourLongs b)
+    {
+        var c = b;
+
+        return CallForDblStructs(default, default, default, default, *(DblLngStruct*)&c) != c.LongTwo;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ProblemWithPromotedStruct_x86(DblLngStruct a)
+    {
+        var b = a;
+
+        return CallForStructWithIndex(*(StructWithIndex*)&b) != (int)(b.FirstLngValue >> 32);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static float CallForVector4(Vector4 value) => value.X;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -123,6 +149,12 @@ public unsafe class TypeMismatchedArgs
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static float CallForFltStruct(FltStruct value) => value.Flt;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long CallForDblStructs(DblLngStruct arg0, DblLngStruct arg1, DblLngStruct arg2, DblLngStruct arg3, DblLngStruct stkArg) => stkArg.SecondLngValue;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int CallForStructWithIndex(StructWithIndex value) => value.Value;
 }
 
 [StructLayout(LayoutKind.Explicit)]
@@ -205,4 +237,10 @@ struct DblStruct
 struct FltStruct
 {
     public float Flt;
+}
+
+struct StructWithIndex
+{
+    public int Index;
+    public int Value;
 }


### PR DESCRIPTION
Fixes #65936.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1848148&view=ms.vss-build-web.run-extensions-tab) as expected.