### PR TITLE
Adding AllBitsSet to IBinaryNumber Interface

### DIFF
--- a/src/libraries/Common/tests/System/GenericMathHelpers.cs
+++ b/src/libraries/Common/tests/System/GenericMathHelpers.cs
@@ -59,6 +59,8 @@ namespace System
     public static class BinaryNumberHelper<TSelf>
         where TSelf : IBinaryNumber<TSelf>
     {
+        public static TSelf AllBitsSet => TSelf.AllBitsSet;
+
         public static bool IsPow2(TSelf value) => TSelf.IsPow2(value);
 
         public static TSelf Log2(TSelf value) => TSelf.Log2(value);

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -379,7 +379,7 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
-        static byte IBinaryNumber<byte>.AllBitsSet => 0xFF;
+        static byte IBinaryNumber<byte>.AllBitsSet => MaxValue;
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(byte value) => BitOperations.IsPow2((uint)value);

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -378,6 +378,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static byte IBinaryNumber<byte>.AllBitsSet => 0xFF;
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(byte value) => BitOperations.IsPow2((uint)value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -1226,6 +1226,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static char IBinaryNumber<char>.AllBitsSet => (char)0xFFFF;
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         static bool IBinaryNumber<char>.IsPow2(char value) => ushort.IsPow2(value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -547,6 +547,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static double IBinaryNumber<double>.AllBitsSet => BitConverter.UInt64BitsToDouble(0xFFFFFFFFFFFFFFFF);
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(double value)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -548,7 +548,7 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
-        static double IBinaryNumber<double>.AllBitsSet => BitConverter.UInt64BitsToDouble(0xFFFFFFFFFFFFFFFF);
+        static double IBinaryNumber<double>.AllBitsSet => BitConverter.UInt64BitsToDouble(0xFFFF_FFFF_FFFF_FFFF);
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(double value)

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -1009,6 +1009,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static Half IBinaryNumber<Half>.AllBitsSet => BitConverter.UInt16BitsToHalf(0xFFFF);
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(Half value)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -867,6 +867,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static Int128 IBinaryNumber<Int128>.AllBitsSet => new Int128(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(Int128 value) => (PopCount(value) == 1U) && IsPositive(value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -868,7 +868,7 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
-        static Int128 IBinaryNumber<Int128>.AllBitsSet => new Int128(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
+        static Int128 IBinaryNumber<Int128>.AllBitsSet => new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF);
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(Int128 value) => (PopCount(value) == 1U) && IsPositive(value);

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -397,6 +397,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static short IBinaryNumber<short>.AllBitsSet => NegativeOne;
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(short value) => BitOperations.IsPow2(value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -389,6 +389,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static int IBinaryNumber<int>.AllBitsSet => NegativeOne;
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(int value) => BitOperations.IsPow2(value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -376,6 +376,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static long IBinaryNumber<long>.AllBitsSet => NegativeOne;
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(long value) => BitOperations.IsPow2(value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -359,6 +359,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static nint IBinaryNumber<nint>.AllBitsSet => -1;
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(nint value) => BitOperations.IsPow2(value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IBinaryNumber.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IBinaryNumber.cs
@@ -11,7 +11,7 @@ namespace System.Numerics
         where TSelf : IBinaryNumber<TSelf>
     {
         /// <summary>Gets an instance of the binary type in which all bits are set.</summary>
-        static virtual TSelf AllBitsSet => TSelf.One; // TODO: add the correct DIM when I am confident everything works
+        static abstract TSelf AllBitsSet { get; } // TODO: add the DIM once https://github.com/dotnet/linker/issues/2865 is fixed
 
         /// <summary>Determines if a value is a power of two.</summary>
         /// <param name="value">The value to be checked.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IBinaryNumber.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IBinaryNumber.cs
@@ -10,6 +10,9 @@ namespace System.Numerics
           INumber<TSelf>
         where TSelf : IBinaryNumber<TSelf>
     {
+        /// <summary>Gets an instance of the binary type in which all bits are set.</summary>
+        static virtual TSelf AllBitsSet => TSelf.One; // TODO: add the correct DIM when I am confident everything works
+
         /// <summary>Determines if a value is a power of two.</summary>
         /// <param name="value">The value to be checked.</param>
         /// <returns><c>true</c> if <paramref name="value" /> is a power of two; otherwise, <c>false</c>.</returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
@@ -871,6 +871,18 @@ namespace System.Runtime.InteropServices
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static NFloat IBinaryNumber<NFloat>.AllBitsSet
+        {
+#if TARGET_64BIT
+            [NonVersionable]
+            get => (NFloat)BitConverter.UInt64BitsToDouble(0xFFFFFFFFFFFFFFFF);
+#else
+            [NonVersionable]
+            get => BitConverter.UInt32BitsToSingle(0xFFFFFFFF);
+#endif
+        }
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(NFloat value) => NativeType.IsPow2(value._value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
@@ -876,10 +876,10 @@ namespace System.Runtime.InteropServices
         {
 #if TARGET_64BIT
             [NonVersionable]
-            get => (NFloat)BitConverter.UInt64BitsToDouble(0xFFFFFFFFFFFFFFFF);
+            get => (NFloat)BitConverter.UInt64BitsToDouble(0xFFFF_FFFF_FFFF_FFFF);
 #else
             [NonVersionable]
-            get => BitConverter.UInt32BitsToSingle(0xFFFFFFFF);
+            get => BitConverter.UInt32BitsToSingle(0xFFFF_FFFF);
 #endif
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -404,6 +404,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static sbyte IBinaryNumber<sbyte>.AllBitsSet => NegativeOne;
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(sbyte value) => BitOperations.IsPow2(value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -539,6 +539,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static float IBinaryNumber<float>.AllBitsSet => BitConverter.UInt32BitsToSingle(0xFFFFFFFF);
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(float value)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -540,7 +540,7 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
-        static float IBinaryNumber<float>.AllBitsSet => BitConverter.UInt32BitsToSingle(0xFFFFFFFF);
+        static float IBinaryNumber<float>.AllBitsSet => BitConverter.UInt32BitsToSingle(0xFFFF_FFFF);
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(float value)

--- a/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
@@ -907,7 +907,7 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
-        static UInt128 IBinaryNumber<UInt128>.AllBitsSet => new UInt128(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
+        static UInt128 IBinaryNumber<UInt128>.AllBitsSet => new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF);
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(UInt128 value) => PopCount(value) == 1U;

--- a/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
@@ -906,6 +906,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static UInt128 IBinaryNumber<UInt128>.AllBitsSet => new UInt128(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(UInt128 value) => PopCount(value) == 1U;
 

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -373,6 +373,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static ushort IBinaryNumber<ushort>.AllBitsSet => 0xFFFF;
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(ushort value) => BitOperations.IsPow2((uint)value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -374,7 +374,7 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
-        static ushort IBinaryNumber<ushort>.AllBitsSet => 0xFFFF;
+        static ushort IBinaryNumber<ushort>.AllBitsSet => ushort.MaxValue;
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(ushort value) => BitOperations.IsPow2((uint)value);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -374,7 +374,7 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
-        static ushort IBinaryNumber<ushort>.AllBitsSet => ushort.MaxValue;
+        static ushort IBinaryNumber<ushort>.AllBitsSet => MaxValue;
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(ushort value) => BitOperations.IsPow2((uint)value);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -360,7 +360,7 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
-        static uint IBinaryNumber<uint>.AllBitsSet => uint.MaxValue;
+        static uint IBinaryNumber<uint>.AllBitsSet => MaxValue;
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(uint value) => BitOperations.IsPow2(value);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -360,7 +360,7 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
-        static uint IBinaryNumber<uint>.AllBitsSet => 0xFFFFFFFF;
+        static uint IBinaryNumber<uint>.AllBitsSet => uint.MaxValue;
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(uint value) => BitOperations.IsPow2(value);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -359,6 +359,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static uint IBinaryNumber<uint>.AllBitsSet => 0xFFFFFFFF;
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(uint value) => BitOperations.IsPow2(value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -359,7 +359,7 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
-        static ulong IBinaryNumber<ulong>.AllBitsSet => 0xFFFFFFFFFFFFFFFF;
+        static ulong IBinaryNumber<ulong>.AllBitsSet => ulong.MaxValue;
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(ulong value) => BitOperations.IsPow2(value);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -359,7 +359,7 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
-        static ulong IBinaryNumber<ulong>.AllBitsSet => ulong.MaxValue;
+        static ulong IBinaryNumber<ulong>.AllBitsSet => MaxValue;
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(ulong value) => BitOperations.IsPow2(value);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -358,6 +358,9 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static ulong IBinaryNumber<ulong>.AllBitsSet => 0xFFFFFFFFFFFFFFFF;
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(ulong value) => BitOperations.IsPow2(value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -344,6 +344,18 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static nuint IBinaryNumber<nuint>.AllBitsSet
+        {
+#if TARGET_64BIT
+            [NonVersionable]
+            get => unchecked((nuint)0xFFFFFFFFFFFFFFFF);
+#else
+            [NonVersionable]
+            get => (nuint)0xFFFFFFFF;
+#endif
+        }
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(nuint value) => BitOperations.IsPow2(value);
 

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -349,10 +349,10 @@ namespace System
         {
 #if TARGET_64BIT
             [NonVersionable]
-            get => unchecked((nuint)0xFFFFFFFFFFFFFFFF);
+            get => unchecked((nuint)0xFFFF_FFFF_FFFF_FFFF);
 #else
             [NonVersionable]
-            get => (nuint)0xFFFFFFFF;
+            get => (nuint)0xFFFF_FFFF;
 #endif
         }
 

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -828,6 +828,7 @@ namespace System.Runtime.InteropServices
         public static System.Runtime.InteropServices.NFloat PositiveInfinity { get { throw null; } }
         public static int Size { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.IAdditiveIdentity<System.Runtime.InteropServices.NFloat,System.Runtime.InteropServices.NFloat>.AdditiveIdentity { get { throw null; } }
+        static System.Runtime.InteropServices.NFloat System.Numerics.IBinaryNumber<System.Runtime.InteropServices.NFloat>.AllBitsSet { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.IMultiplicativeIdentity<System.Runtime.InteropServices.NFloat,System.Runtime.InteropServices.NFloat>.MultiplicativeIdentity { get { throw null; } }
         static System.Runtime.InteropServices.NFloat System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>.One { get { throw null; } }
         static int System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>.Radix { get { throw null; } }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
@@ -223,12 +223,12 @@ namespace System.Runtime.InteropServices.Tests
             if (Environment.Is64BitProcess)
             {
                 Assert.Equal(0xFFFF_FFFF_FFFF_FFFF, BitConverter.DoubleToUInt64Bits((double)BinaryNumberHelper<NFloat>.AllBitsSet));
-                Assert.Equal((ulong)0, (ulong)(BitConverter.DoubleToUInt64Bits((double)BinaryNumberHelper<NFloat>.AllBitsSet) + 1));
+                Assert.Equal(0UL, ~BitConverter.DoubleToUInt64Bits((double)BinaryNumberHelper<NFloat>.AllBitsSet));
             }
             else
             {
                 Assert.Equal(0xFFFF_FFFF, BitConverter.SingleToUInt32Bits((float)BinaryNumberHelper<NFloat>.AllBitsSet));
-                Assert.Equal((uint)0, (uint)(BitConverter.SingleToUInt32Bits((float)BinaryNumberHelper<NFloat>.AllBitsSet) + 1));
+                Assert.Equal(0U, ~BitConverter.SingleToUInt32Bits((float)BinaryNumberHelper<NFloat>.AllBitsSet));
             }
         }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
@@ -218,6 +218,22 @@ namespace System.Runtime.InteropServices.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            if (NFloat.Size == sizeof(float))
+            {
+                Assert.Equal(0xFFFFFFFF, BitConverter.SingleToUInt32Bits((float)BinaryNumberHelper<NFloat>.AllBitsSet));
+                Assert.Equal((uint)0, (uint)(BitConverter.SingleToUInt32Bits((float)BinaryNumberHelper<NFloat>.AllBitsSet) + 1));
+            }
+            else
+            {
+                Assert.Equal(0xFFFFFFFFFFFFFFFF, BitConverter.DoubleToUInt64Bits((double)BinaryNumberHelper<NFloat>.AllBitsSet));
+                Assert.Equal((ulong)0, (ulong)(BitConverter.DoubleToUInt64Bits((double)BinaryNumberHelper<NFloat>.AllBitsSet) + 1));
+            }
+
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(NFloat.NegativeInfinity));

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
@@ -220,17 +220,16 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public static void AllBitsSetTest()
         {
-            if (NFloat.Size == sizeof(float))
+            if (Environment.Is64BitProcess)
             {
-                Assert.Equal(0xFFFFFFFF, BitConverter.SingleToUInt32Bits((float)BinaryNumberHelper<NFloat>.AllBitsSet));
-                Assert.Equal((uint)0, (uint)(BitConverter.SingleToUInt32Bits((float)BinaryNumberHelper<NFloat>.AllBitsSet) + 1));
+                Assert.Equal(0xFFFF_FFFF_FFFF_FFFF, BitConverter.DoubleToUInt64Bits((double)BinaryNumberHelper<NFloat>.AllBitsSet));
+                Assert.Equal((ulong)0, (ulong)(BitConverter.DoubleToUInt64Bits((double)BinaryNumberHelper<NFloat>.AllBitsSet) + 1));
             }
             else
             {
-                Assert.Equal(0xFFFFFFFFFFFFFFFF, BitConverter.DoubleToUInt64Bits((double)BinaryNumberHelper<NFloat>.AllBitsSet));
-                Assert.Equal((ulong)0, (ulong)(BitConverter.DoubleToUInt64Bits((double)BinaryNumberHelper<NFloat>.AllBitsSet) + 1));
+                Assert.Equal(0xFFFF_FFFF, BitConverter.SingleToUInt32Bits((float)BinaryNumberHelper<NFloat>.AllBitsSet));
+                Assert.Equal((uint)0, (uint)(BitConverter.SingleToUInt32Bits((float)BinaryNumberHelper<NFloat>.AllBitsSet) + 1));
             }
-
         }
 
         [Fact]

--- a/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
+++ b/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
@@ -30,6 +30,7 @@ namespace System.Numerics
         public static System.Numerics.BigInteger One { get { throw null; } }
         public int Sign { get { throw null; } }
         static System.Numerics.BigInteger System.Numerics.IAdditiveIdentity<System.Numerics.BigInteger,System.Numerics.BigInteger>.AdditiveIdentity { get { throw null; } }
+        static System.Numerics.BigInteger System.Numerics.IBinaryNumber<System.Numerics.BigInteger>.AllBitsSet { get { throw null; } }
         static System.Numerics.BigInteger System.Numerics.IMultiplicativeIdentity<System.Numerics.BigInteger,System.Numerics.BigInteger>.MultiplicativeIdentity { get { throw null; } }
         static int System.Numerics.INumberBase<System.Numerics.BigInteger>.Radix { get { throw null; } }
         static System.Numerics.BigInteger System.Numerics.ISignedNumber<System.Numerics.BigInteger>.NegativeOne { get { throw null; } }
@@ -60,7 +61,6 @@ namespace System.Numerics
         public static bool IsNegative(System.Numerics.BigInteger value) { throw null; }
         public static bool IsOddInteger(System.Numerics.BigInteger value) { throw null; }
         public static bool IsPositive(System.Numerics.BigInteger value) { throw null; }
-        static BigInteger System.Numerics.IBinaryNumber<BigInteger>.AllBitsSet { get { throw null; } }
         public static bool IsPow2(System.Numerics.BigInteger value) { throw null; }
         public static System.Numerics.BigInteger LeadingZeroCount(System.Numerics.BigInteger value) { throw null; }
         public static double Log(System.Numerics.BigInteger value) { throw null; }

--- a/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
+++ b/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
@@ -60,6 +60,7 @@ namespace System.Numerics
         public static bool IsNegative(System.Numerics.BigInteger value) { throw null; }
         public static bool IsOddInteger(System.Numerics.BigInteger value) { throw null; }
         public static bool IsPositive(System.Numerics.BigInteger value) { throw null; }
+        static BigInteger System.Numerics.IBinaryNumber<BigInteger>.AllBitsSet { get { throw null; } }
         public static bool IsPow2(System.Numerics.BigInteger value) { throw null; }
         public static System.Numerics.BigInteger LeadingZeroCount(System.Numerics.BigInteger value) { throw null; }
         public static double Log(System.Numerics.BigInteger value) { throw null; }

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -3821,6 +3821,9 @@ namespace System.Numerics
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.AllBitsSet" />
+        static BigInteger IBinaryNumber<BigInteger>.AllBitsSet => MinusOne;
+
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         public static bool IsPow2(BigInteger value) => value.IsPowerOfTwo;
 

--- a/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
@@ -551,6 +551,12 @@ namespace System.Numerics.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal(NegativeOne, BinaryNumberHelper<BigInteger>.AllBitsSet);
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<BigInteger>.IsPow2(Zero));

--- a/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
@@ -554,6 +554,7 @@ namespace System.Numerics.Tests
         public static void AllBitsSetTest()
         {
             Assert.Equal(NegativeOne, BinaryNumberHelper<BigInteger>.AllBitsSet);
+            Assert.Equal(BigInteger.Zero, ~BinaryNumberHelper<BigInteger>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -719,6 +719,7 @@ namespace System
         public const byte MaxValue = (byte)255;
         public const byte MinValue = (byte)0;
         static byte System.Numerics.IAdditiveIdentity<System.Byte,System.Byte>.AdditiveIdentity { get { throw null; } }
+        static byte System.Numerics.IBinaryNumber<System.Byte>.AllBitsSet { get { throw null; } }
         static byte System.Numerics.IMinMaxValue<System.Byte>.MaxValue { get { throw null; } }
         static byte System.Numerics.IMinMaxValue<System.Byte>.MinValue { get { throw null; } }
         static byte System.Numerics.IMultiplicativeIdentity<System.Byte,System.Byte>.MultiplicativeIdentity { get { throw null; } }
@@ -852,6 +853,7 @@ namespace System
         public const char MaxValue = '\uFFFF';
         public const char MinValue = '\0';
         static char System.Numerics.IAdditiveIdentity<System.Char,System.Char>.AdditiveIdentity { get { throw null; } }
+        static char System.Numerics.IBinaryNumber<System.Char>.AllBitsSet { get { throw null; } }
         static char System.Numerics.IMinMaxValue<System.Char>.MaxValue { get { throw null; } }
         static char System.Numerics.IMinMaxValue<System.Char>.MinValue { get { throw null; } }
         static char System.Numerics.IMultiplicativeIdentity<System.Char,System.Char>.MultiplicativeIdentity { get { throw null; } }
@@ -2097,6 +2099,7 @@ namespace System
         public const double PositiveInfinity = 1.0 / 0.0;
         public const double Tau = 6.283185307179586;
         static double System.Numerics.IAdditiveIdentity<System.Double,System.Double>.AdditiveIdentity { get { throw null; } }
+        static double System.Numerics.IBinaryNumber<System.Double>.AllBitsSet { get { throw null; } }
         static double System.Numerics.IFloatingPointIeee754<System.Double>.E { get { throw null; } }
         static double System.Numerics.IFloatingPointIeee754<System.Double>.Epsilon { get { throw null; } }
         static double System.Numerics.IFloatingPointIeee754<System.Double>.NaN { get { throw null; } }
@@ -2739,6 +2742,7 @@ namespace System
         public static System.Half Pi { get { throw null; } }
         public static System.Half PositiveInfinity { get { throw null; } }
         static System.Half System.Numerics.IAdditiveIdentity<System.Half,System.Half>.AdditiveIdentity { get { throw null; } }
+        static System.Half System.Numerics.IBinaryNumber<System.Half>.AllBitsSet { get { throw null; } }
         static int System.Numerics.INumberBase<System.Half>.Radix { get { throw null; } }
         public static System.Half Tau { get { throw null; } }
         public static System.Half Zero { get { throw null; } }
@@ -3077,6 +3081,7 @@ namespace System
         public static System.Int128 NegativeOne { get { throw null; } }
         public static System.Int128 One { get { throw null; } }
         static System.Int128 System.Numerics.IAdditiveIdentity<System.Int128,System.Int128>.AdditiveIdentity { get { throw null; } }
+        static System.Int128 System.Numerics.IBinaryNumber<System.Int128>.AllBitsSet { get { throw null; } }
         static System.Int128 System.Numerics.IMultiplicativeIdentity<System.Int128,System.Int128>.MultiplicativeIdentity { get { throw null; } }
         static int System.Numerics.INumberBase<System.Int128>.Radix { get { throw null; } }
         public static System.Int128 Zero { get { throw null; } }
@@ -3246,6 +3251,7 @@ namespace System
         public const short MaxValue = (short)32767;
         public const short MinValue = (short)-32768;
         static short System.Numerics.IAdditiveIdentity<System.Int16,System.Int16>.AdditiveIdentity { get { throw null; } }
+        static short System.Numerics.IBinaryNumber<System.Int16>.AllBitsSet { get { throw null; } }
         static short System.Numerics.IMinMaxValue<System.Int16>.MaxValue { get { throw null; } }
         static short System.Numerics.IMinMaxValue<System.Int16>.MinValue { get { throw null; } }
         static short System.Numerics.IMultiplicativeIdentity<System.Int16,System.Int16>.MultiplicativeIdentity { get { throw null; } }
@@ -3373,6 +3379,7 @@ namespace System
         public const int MaxValue = 2147483647;
         public const int MinValue = -2147483648;
         static int System.Numerics.IAdditiveIdentity<System.Int32,System.Int32>.AdditiveIdentity { get { throw null; } }
+        static int System.Numerics.IBinaryNumber<System.Int32>.AllBitsSet { get { throw null; } }
         static int System.Numerics.IMinMaxValue<System.Int32>.MaxValue { get { throw null; } }
         static int System.Numerics.IMinMaxValue<System.Int32>.MinValue { get { throw null; } }
         static int System.Numerics.IMultiplicativeIdentity<System.Int32,System.Int32>.MultiplicativeIdentity { get { throw null; } }
@@ -3500,6 +3507,7 @@ namespace System
         public const long MaxValue = (long)9223372036854775807;
         public const long MinValue = (long)-9223372036854775808;
         static long System.Numerics.IAdditiveIdentity<System.Int64,System.Int64>.AdditiveIdentity { get { throw null; } }
+        static long System.Numerics.IBinaryNumber<System.Int64>.AllBitsSet { get { throw null; } }
         static long System.Numerics.IMinMaxValue<System.Int64>.MaxValue { get { throw null; } }
         static long System.Numerics.IMinMaxValue<System.Int64>.MinValue { get { throw null; } }
         static long System.Numerics.IMultiplicativeIdentity<System.Int64,System.Int64>.MultiplicativeIdentity { get { throw null; } }
@@ -3633,6 +3641,7 @@ namespace System
         public static nint MinValue { get { throw null; } }
         public static int Size { get { throw null; } }
         static nint System.Numerics.IAdditiveIdentity<nint,nint>.AdditiveIdentity { get { throw null; } }
+        static nint System.Numerics.IBinaryNumber<nint>.AllBitsSet { get { throw null; } }
         static nint System.Numerics.IMinMaxValue<nint>.MaxValue { get { throw null; } }
         static nint System.Numerics.IMinMaxValue<nint>.MinValue { get { throw null; } }
         static nint System.Numerics.IMultiplicativeIdentity<nint,nint>.MultiplicativeIdentity { get { throw null; } }
@@ -4566,6 +4575,7 @@ namespace System
         public const sbyte MaxValue = (sbyte)127;
         public const sbyte MinValue = (sbyte)-128;
         static sbyte System.Numerics.IAdditiveIdentity<System.SByte,System.SByte>.AdditiveIdentity { get { throw null; } }
+        static sbyte System.Numerics.IBinaryNumber<System.SByte>.AllBitsSet { get { throw null; } }
         static sbyte System.Numerics.IMinMaxValue<System.SByte>.MaxValue { get { throw null; } }
         static sbyte System.Numerics.IMinMaxValue<System.SByte>.MinValue { get { throw null; } }
         static sbyte System.Numerics.IMultiplicativeIdentity<System.SByte,System.SByte>.MultiplicativeIdentity { get { throw null; } }
@@ -4706,6 +4716,7 @@ namespace System
         public const float PositiveInfinity = 1.0f / 0.0f;
         public const float Tau = 6.2831855f;
         static float System.Numerics.IAdditiveIdentity<System.Single,System.Single>.AdditiveIdentity { get { throw null; } }
+        static float System.Numerics.IBinaryNumber<System.Single>.AllBitsSet { get { throw null; } }
         static float System.Numerics.IFloatingPointIeee754<System.Single>.E { get { throw null; } }
         static float System.Numerics.IFloatingPointIeee754<System.Single>.Epsilon { get { throw null; } }
         static float System.Numerics.IFloatingPointIeee754<System.Single>.NaN { get { throw null; } }
@@ -6054,6 +6065,7 @@ namespace System
         public static System.UInt128 MinValue { get { throw null; } }
         public static System.UInt128 One { get { throw null; } }
         static System.UInt128 System.Numerics.IAdditiveIdentity<System.UInt128,System.UInt128>.AdditiveIdentity { get { throw null; } }
+        static System.UInt128 System.Numerics.IBinaryNumber<System.UInt128>.AllBitsSet { get { throw null; } }
         static System.UInt128 System.Numerics.IMultiplicativeIdentity<System.UInt128,System.UInt128>.MultiplicativeIdentity { get { throw null; } }
         static int System.Numerics.INumberBase<System.UInt128>.Radix { get { throw null; } }
         public static System.UInt128 Zero { get { throw null; } }
@@ -6230,6 +6242,7 @@ namespace System
         public const ushort MaxValue = (ushort)65535;
         public const ushort MinValue = (ushort)0;
         static ushort System.Numerics.IAdditiveIdentity<System.UInt16,System.UInt16>.AdditiveIdentity { get { throw null; } }
+        static ushort System.Numerics.IBinaryNumber<System.UInt16>.AllBitsSet { get { throw null; } }
         static ushort System.Numerics.IMinMaxValue<System.UInt16>.MaxValue { get { throw null; } }
         static ushort System.Numerics.IMinMaxValue<System.UInt16>.MinValue { get { throw null; } }
         static ushort System.Numerics.IMultiplicativeIdentity<System.UInt16,System.UInt16>.MultiplicativeIdentity { get { throw null; } }
@@ -6357,6 +6370,7 @@ namespace System
         public const uint MaxValue = (uint)4294967295;
         public const uint MinValue = (uint)0;
         static uint System.Numerics.IAdditiveIdentity<System.UInt32,System.UInt32>.AdditiveIdentity { get { throw null; } }
+        static uint System.Numerics.IBinaryNumber<System.UInt32>.AllBitsSet { get { throw null; } }
         static uint System.Numerics.IMinMaxValue<System.UInt32>.MaxValue { get { throw null; } }
         static uint System.Numerics.IMinMaxValue<System.UInt32>.MinValue { get { throw null; } }
         static uint System.Numerics.IMultiplicativeIdentity<System.UInt32,System.UInt32>.MultiplicativeIdentity { get { throw null; } }
@@ -6484,6 +6498,7 @@ namespace System
         public const ulong MaxValue = (ulong)18446744073709551615;
         public const ulong MinValue = (ulong)0;
         static ulong System.Numerics.IAdditiveIdentity<System.UInt64,System.UInt64>.AdditiveIdentity { get { throw null; } }
+        static ulong System.Numerics.IBinaryNumber<System.UInt64>.AllBitsSet { get { throw null; } }
         static ulong System.Numerics.IMinMaxValue<System.UInt64>.MaxValue { get { throw null; } }
         static ulong System.Numerics.IMinMaxValue<System.UInt64>.MinValue { get { throw null; } }
         static ulong System.Numerics.IMultiplicativeIdentity<System.UInt64,System.UInt64>.MultiplicativeIdentity { get { throw null; } }
@@ -6616,6 +6631,7 @@ namespace System
         public static nuint MinValue { get { throw null; } }
         public static int Size { get { throw null; } }
         static nuint System.Numerics.IAdditiveIdentity<nuint,nuint>.AdditiveIdentity { get { throw null; } }
+        static nuint System.Numerics.IBinaryNumber<nuint>.AllBitsSet { get { throw null; } }
         static nuint System.Numerics.IMinMaxValue<nuint>.MaxValue { get { throw null; } }
         static nuint System.Numerics.IMinMaxValue<nuint>.MinValue { get { throw null; } }
         static nuint System.Numerics.IMultiplicativeIdentity<nuint,nuint>.MultiplicativeIdentity { get { throw null; } }
@@ -10382,7 +10398,7 @@ namespace System.Numerics
     }
     public partial interface IBinaryNumber<TSelf> : System.IComparable, System.IComparable<TSelf>, System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IBitwiseOperators<TSelf, TSelf, TSelf>, System.Numerics.IComparisonOperators<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IModulusOperators<TSelf, TSelf, TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.INumber<TSelf>, System.Numerics.INumberBase<TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf> where TSelf : System.Numerics.IBinaryNumber<TSelf>
     {
-        static virtual TSelf AllBitsSet => throw null;
+        static abstract TSelf AllBitsSet { get; }
         static abstract bool IsPow2(TSelf value);
         static abstract TSelf Log2(TSelf value);
     }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10382,6 +10382,7 @@ namespace System.Numerics
     }
     public partial interface IBinaryNumber<TSelf> : System.IComparable, System.IComparable<TSelf>, System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IBitwiseOperators<TSelf, TSelf, TSelf>, System.Numerics.IComparisonOperators<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IModulusOperators<TSelf, TSelf, TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.INumber<TSelf>, System.Numerics.INumberBase<TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf> where TSelf : System.Numerics.IBinaryNumber<TSelf>
     {
+        static virtual TSelf AllBitsSet => throw null;
         static abstract bool IsPow2(TSelf value);
         static abstract TSelf Log2(TSelf value);
     }

--- a/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
@@ -198,7 +198,7 @@ namespace System.Tests
         public static void AllBitsSetTest()
         {
             Assert.Equal((byte)0xFF, BinaryNumberHelper<byte>.AllBitsSet);
-            Assert.Equal((byte)0, (byte)(BinaryNumberHelper<byte>.AllBitsSet + 1));
+            Assert.Equal((byte)0, (byte)~BinaryNumberHelper<byte>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
@@ -195,6 +195,13 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal((byte)0xFF, BinaryNumberHelper<byte>.AllBitsSet);
+            Assert.Equal((byte)0, (byte)(BinaryNumberHelper<byte>.AllBitsSet + 1));
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<byte>.IsPow2((byte)0x00));

--- a/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
@@ -194,6 +194,13 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal((char)0xFFFF, BinaryNumberHelper<char>.AllBitsSet);
+            Assert.Equal((char)0, (char)(BinaryNumberHelper<char>.AllBitsSet + 1));
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<char>.IsPow2((char)0x0000));

--- a/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
@@ -197,7 +197,7 @@ namespace System.Tests
         public static void AllBitsSetTest()
         {
             Assert.Equal((char)0xFFFF, BinaryNumberHelper<char>.AllBitsSet);
-            Assert.Equal((char)0, (char)(BinaryNumberHelper<char>.AllBitsSet + 1));
+            Assert.Equal((char)0, (char)~BinaryNumberHelper<char>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
@@ -92,8 +92,8 @@ namespace System.Tests
         [Fact]
         public static void AllBitsSetTest()
         {
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, BitConverter.DoubleToUInt64Bits(BinaryNumberHelper<double>.AllBitsSet));
-            Assert.Equal((ulong)0, (ulong)(BitConverter.DoubleToUInt64Bits(BinaryNumberHelper<double>.AllBitsSet) + 1));
+            Assert.Equal(0xFFFF_FFFF_FFFF_FFFF, BitConverter.DoubleToUInt64Bits(BinaryNumberHelper<double>.AllBitsSet));
+            Assert.Equal(0UL, ~BitConverter.DoubleToUInt64Bits(BinaryNumberHelper<double>.AllBitsSet));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
@@ -90,6 +90,13 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, BitConverter.DoubleToUInt64Bits(BinaryNumberHelper<double>.AllBitsSet));
+            Assert.Equal((ulong)0, (ulong)(BitConverter.DoubleToUInt64Bits(BinaryNumberHelper<double>.AllBitsSet) + 1));
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<double>.IsPow2(double.NegativeInfinity));

--- a/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
@@ -102,6 +102,13 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal((ushort)0xFFFF, BitConverter.HalfToUInt16Bits(BinaryNumberHelper<Half>.AllBitsSet));
+            Assert.Equal((ushort)0, (ushort)(BitConverter.HalfToUInt16Bits(BinaryNumberHelper<Half>.AllBitsSet) + 1));
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.NegativeInfinity));

--- a/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
@@ -105,7 +105,7 @@ namespace System.Tests
         public static void AllBitsSetTest()
         {
             Assert.Equal((ushort)0xFFFF, BitConverter.HalfToUInt16Bits(BinaryNumberHelper<Half>.AllBitsSet));
-            Assert.Equal((ushort)0, (ushort)(BitConverter.HalfToUInt16Bits(BinaryNumberHelper<Half>.AllBitsSet) + 1));
+            Assert.Equal((ushort)0, (ushort)~BitConverter.HalfToUInt16Bits(BinaryNumberHelper<Half>.AllBitsSet));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int128Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int128Tests.GenericMath.cs
@@ -247,9 +247,9 @@ namespace System.Tests
         [Fact]
         public static void AllBitsSetTest()
         {
-            Int128 compare = new Int128(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
+            Int128 compare = new Int128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF);
             Assert.Equal(compare, BinaryNumberHelper<Int128>.AllBitsSet);
-            Assert.Equal((Int128)0, (Int128)(BinaryNumberHelper<Int128>.AllBitsSet + 1));
+            Assert.Equal((Int128)0, ~BinaryNumberHelper<Int128>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int128Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int128Tests.GenericMath.cs
@@ -245,6 +245,14 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            Int128 compare = new Int128(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
+            Assert.Equal(compare, BinaryNumberHelper<Int128>.AllBitsSet);
+            Assert.Equal((Int128)0, (Int128)(BinaryNumberHelper<Int128>.AllBitsSet + 1));
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<Int128>.IsPow2(Zero));

--- a/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
@@ -195,6 +195,13 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal(unchecked((short)0xFFFF), BinaryNumberHelper<short>.AllBitsSet);
+            Assert.Equal(0, (short)(BinaryNumberHelper<short>.AllBitsSet + 1));
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<short>.IsPow2((short)0x0000));

--- a/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int16Tests.GenericMath.cs
@@ -198,7 +198,7 @@ namespace System.Tests
         public static void AllBitsSetTest()
         {
             Assert.Equal(unchecked((short)0xFFFF), BinaryNumberHelper<short>.AllBitsSet);
-            Assert.Equal(0, (short)(BinaryNumberHelper<short>.AllBitsSet + 1));
+            Assert.Equal((short)0, ~BinaryNumberHelper<short>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
@@ -195,6 +195,13 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal(unchecked((int)0xFFFFFFFF), BinaryNumberHelper<int>.AllBitsSet);
+            Assert.Equal((int)0, (int)(BinaryNumberHelper<int>.AllBitsSet + 1));
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<int>.IsPow2((int)0x00000000));

--- a/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int32Tests.GenericMath.cs
@@ -197,8 +197,8 @@ namespace System.Tests
         [Fact]
         public static void AllBitsSetTest()
         {
-            Assert.Equal(unchecked((int)0xFFFFFFFF), BinaryNumberHelper<int>.AllBitsSet);
-            Assert.Equal((int)0, (int)(BinaryNumberHelper<int>.AllBitsSet + 1));
+            Assert.Equal(unchecked((int)0xFFFF_FFFF), BinaryNumberHelper<int>.AllBitsSet);
+            Assert.Equal(0, ~BinaryNumberHelper<int>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
@@ -197,8 +197,8 @@ namespace System.Tests
         [Fact]
         public static void AllBitsSetTest()
         {
-            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), (long)BinaryNumberHelper <long>.AllBitsSet);
-            Assert.Equal((long)0, (long)(BinaryNumberHelper<long>.AllBitsSet + 1));
+            Assert.Equal(unchecked((long)0xFFFF_FFFF_FFFF_FFFF), BinaryNumberHelper<long>.AllBitsSet);
+            Assert.Equal(0L, ~BinaryNumberHelper<long>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
@@ -195,6 +195,13 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), (long)BinaryNumberHelper <long>.AllBitsSet);
+            Assert.Equal((long)0, (long)(BinaryNumberHelper<long>.AllBitsSet + 1));
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<long>.IsPow2((long)0x0000000000000000));

--- a/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
@@ -374,13 +374,13 @@ namespace System.Tests
         {
             if (nint.Size == sizeof(int))
             {
-                Assert.Equal(unchecked((int)0xFFFFFFFF), BinaryNumberHelper<nint>.AllBitsSet);
-                Assert.Equal((int)0, (int)(BinaryNumberHelper<nint>.AllBitsSet + 1));
+                Assert.Equal(unchecked((int)0xFFFF_FFFF), BinaryNumberHelper<nint>.AllBitsSet);
+                Assert.Equal(0, ~(int)BinaryNumberHelper<nint>.AllBitsSet);
             }
             else
             {
-                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), BinaryNumberHelper<nint>.AllBitsSet);
-                Assert.Equal((long)0, (long)(BinaryNumberHelper<nint>.AllBitsSet + 1));
+                Assert.Equal(unchecked((long)0xFFFF_FFFF_FFFF_FFFF), BinaryNumberHelper<nint>.AllBitsSet);
+                Assert.Equal(0L, ~(long)BinaryNumberHelper<nint>.AllBitsSet);
             }
 
         }

--- a/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
@@ -370,6 +370,22 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            if (nint.Size == sizeof(int))
+            {
+                Assert.Equal(unchecked((int)0xFFFFFFFF), BinaryNumberHelper<nint>.AllBitsSet);
+                Assert.Equal((int)0, (int)(BinaryNumberHelper<nint>.AllBitsSet + 1));
+            }
+            else
+            {
+                Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), BinaryNumberHelper<nint>.AllBitsSet);
+                Assert.Equal((long)0, (long)(BinaryNumberHelper<nint>.AllBitsSet + 1));
+            }
+
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             if (Environment.Is64BitProcess)

--- a/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
@@ -198,7 +198,7 @@ namespace System.Tests
         public static void AllBitsSetTest()
         {
             Assert.Equal(unchecked((sbyte)0xFF), BinaryNumberHelper<sbyte>.AllBitsSet);
-            Assert.Equal((sbyte)0, (sbyte)(BinaryNumberHelper<sbyte>.AllBitsSet + 1));
+            Assert.Equal((sbyte)0, ~BinaryNumberHelper<sbyte>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SByteTests.GenericMath.cs
@@ -195,6 +195,13 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal(unchecked((sbyte)0xFF), BinaryNumberHelper<sbyte>.AllBitsSet);
+            Assert.Equal((sbyte)0, (sbyte)(BinaryNumberHelper<sbyte>.AllBitsSet + 1));
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<sbyte>.IsPow2((sbyte)0x00));

--- a/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
@@ -90,6 +90,13 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal((uint)0xFFFFFFFF, BitConverter.SingleToUInt32Bits(BinaryNumberHelper<float>.AllBitsSet));
+            Assert.Equal((uint)0, (uint)(BitConverter.SingleToUInt32Bits(BinaryNumberHelper<float>.AllBitsSet) + 1));
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<float>.IsPow2(float.NegativeInfinity));

--- a/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
@@ -92,8 +92,8 @@ namespace System.Tests
         [Fact]
         public static void AllBitsSetTest()
         {
-            Assert.Equal((uint)0xFFFFFFFF, BitConverter.SingleToUInt32Bits(BinaryNumberHelper<float>.AllBitsSet));
-            Assert.Equal((uint)0, (uint)(BitConverter.SingleToUInt32Bits(BinaryNumberHelper<float>.AllBitsSet) + 1));
+            Assert.Equal(0xFFFF_FFFF, BitConverter.SingleToUInt32Bits(BinaryNumberHelper<float>.AllBitsSet));
+            Assert.Equal(0U, ~BitConverter.SingleToUInt32Bits(BinaryNumberHelper<float>.AllBitsSet));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt128Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt128Tests.GenericMath.cs
@@ -247,9 +247,9 @@ namespace System.Tests
         [Fact]
         public static void AllBitsSetTest()
         {
-            UInt128 compare = new UInt128(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
+            UInt128 compare = new UInt128(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF);
             Assert.Equal(compare, BinaryNumberHelper<UInt128>.AllBitsSet);
-            Assert.Equal((UInt128)0, (UInt128)(BinaryNumberHelper<UInt128>.AllBitsSet + 1));
+            Assert.Equal((UInt128)0, ~BinaryNumberHelper<UInt128>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt128Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt128Tests.GenericMath.cs
@@ -245,6 +245,14 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            UInt128 compare = new UInt128(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
+            Assert.Equal(compare, BinaryNumberHelper<UInt128>.AllBitsSet);
+            Assert.Equal((UInt128)0, (UInt128)(BinaryNumberHelper<UInt128>.AllBitsSet + 1));
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             Assert.False(BinaryNumberHelper<UInt128>.IsPow2(Zero));

--- a/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
@@ -199,7 +199,7 @@ namespace System.Tests
         public static void AllBitsSetTest()
         {
             Assert.Equal((ushort)0xFFFF, BinaryNumberHelper<ushort>.AllBitsSet);
-            Assert.Equal((ushort)0, (ushort)(BinaryNumberHelper<ushort>.AllBitsSet + 1));
+            Assert.Equal((ushort)0, (ushort)~BinaryNumberHelper<ushort>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
@@ -194,6 +194,14 @@ namespace System.Tests
         // IBinaryNumber
         //
 
+
+        [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal((ushort)0xFFFF, BinaryNumberHelper<ushort>.AllBitsSet);
+            Assert.Equal((ushort)0, (ushort)(BinaryNumberHelper<ushort>.AllBitsSet + 1));
+        }
+
         [Fact]
         public static void IsPow2Test()
         {

--- a/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
@@ -199,8 +199,8 @@ namespace System.Tests
         [Fact]
         public static void AllBitsSetTest()
         {
-            Assert.Equal((uint)0xFFFFFFFF, BinaryNumberHelper<uint>.AllBitsSet);
-            Assert.Equal((uint)0, (uint)(BinaryNumberHelper<uint>.AllBitsSet + 1));
+            Assert.Equal(0xFFFF_FFFF, BinaryNumberHelper<uint>.AllBitsSet);
+            Assert.Equal(0U, ~BinaryNumberHelper<uint>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
@@ -195,6 +195,14 @@ namespace System.Tests
         // IBinaryNumber
         //
 
+
+        [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal((uint)0xFFFFFFFF, BinaryNumberHelper<uint>.AllBitsSet);
+            Assert.Equal((uint)0, (uint)(BinaryNumberHelper<uint>.AllBitsSet + 1));
+        }
+
         [Fact]
         public static void IsPow2Test()
         {

--- a/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
@@ -42,8 +42,8 @@ namespace System.Tests
         [Fact]
         public static void AllBitsSetTest()
         {
-            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, BinaryNumberHelper<ulong>.AllBitsSet);
-            Assert.Equal((ulong)0, (ulong)(BinaryNumberHelper<ulong>.AllBitsSet + 1));
+            Assert.Equal(0xFFFF_FFFF_FFFF_FFFF, BinaryNumberHelper<ulong>.AllBitsSet);
+            Assert.Equal(0UL, ~BinaryNumberHelper<ulong>.AllBitsSet);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
@@ -38,6 +38,14 @@ namespace System.Tests
         // IAdditiveIdentity
         //
 
+
+        [Fact]
+        public static void AllBitsSetTest()
+        {
+            Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, BinaryNumberHelper<ulong>.AllBitsSet);
+            Assert.Equal((ulong)0, (ulong)(BinaryNumberHelper<ulong>.AllBitsSet + 1));
+        }
+
         [Fact]
         public static void AdditiveIdentityTest()
         {

--- a/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
@@ -374,13 +374,13 @@ namespace System.Tests
         {
             if (nint.Size == sizeof(uint))
             {
-                Assert.Equal((uint)0xFFFFFFFF, BinaryNumberHelper<nuint>.AllBitsSet);
-                Assert.Equal((uint)0, (uint)(BinaryNumberHelper<nuint>.AllBitsSet + 1));
+                Assert.Equal(0xFFFF_FFFF, BinaryNumberHelper<nuint>.AllBitsSet);
+                Assert.Equal(0U, ~(uint)BinaryNumberHelper<nuint>.AllBitsSet);
             }
             else
             {
-                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, BinaryNumberHelper<nuint>.AllBitsSet);
-                Assert.Equal((ulong)0, (ulong)(BinaryNumberHelper<nuint>.AllBitsSet + 1));
+                Assert.Equal(0xFFFF_FFFF_FFFF_FFFF, BinaryNumberHelper<nuint>.AllBitsSet);
+                Assert.Equal(0UL, ~(ulong)BinaryNumberHelper<nuint>.AllBitsSet);
             }
 
         }

--- a/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
@@ -370,6 +370,22 @@ namespace System.Tests
         //
 
         [Fact]
+        public static void AllBitsSetTest()
+        {
+            if (nint.Size == sizeof(uint))
+            {
+                Assert.Equal((uint)0xFFFFFFFF, BinaryNumberHelper<nuint>.AllBitsSet);
+                Assert.Equal((uint)0, (uint)(BinaryNumberHelper<nuint>.AllBitsSet + 1));
+            }
+            else
+            {
+                Assert.Equal((ulong)0xFFFFFFFFFFFFFFFF, BinaryNumberHelper<nuint>.AllBitsSet);
+                Assert.Equal((ulong)0, (ulong)(BinaryNumberHelper<nuint>.AllBitsSet + 1));
+            }
+
+        }
+
+        [Fact]
         public static void IsPow2Test()
         {
             if (Environment.Is64BitProcess)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/69676

Note: there is a trimmer bug that is preventing a DIM of AllBitsSet from being possible. This will be added later once the [bug](https://github.com/dotnet/linker/issues/2865) is fixed.

I tried to match the style of the files I was adding to, but feel free to nitpick any style choices. Specifically, there are quite a few ways to hard code in an AllBitsSet constant for each of these types, so happy to tweak as needed.