### PR TITLE
Align System.Reflection.PortableExecutable.DllCharacteristics with PE spec

### DIFF
--- a/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -3247,12 +3247,14 @@ namespace System.Reflection.PortableExecutable
         ThreadTerm = (ushort)8,
         HighEntropyVirtualAddressSpace = (ushort)32,
         DynamicBase = (ushort)64,
+        ForceIntegrity = (ushort)128,
         NxCompatible = (ushort)256,
         NoIsolation = (ushort)512,
         NoSeh = (ushort)1024,
         NoBind = (ushort)2048,
         AppContainer = (ushort)4096,
         WdmDriver = (ushort)8192,
+        ControlFlowGuard = (ushort)16384,
         TerminalServerAware = (ushort)32768,
     }
     public enum Machine : ushort

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEFileFlags.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEFileFlags.cs
@@ -109,7 +109,7 @@ namespace System.Reflection.PortableExecutable
         /// Driver uses WDM model.
         /// </summary>
         WdmDriver = 0x2000,
-        
+
         /// <summary>
         /// Image supports Control Flow Guard.
         /// </summary>

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEFileFlags.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEFileFlags.cs
@@ -109,6 +109,11 @@ namespace System.Reflection.PortableExecutable
         /// Driver uses WDM model.
         /// </summary>
         WdmDriver = 0x2000,
+        
+        /// <summary>
+        /// Image supports Control Flow Guard.
+        /// </summary>
+        ControlFlowGuard = 0x4000,
 
         TerminalServerAware = 0x8000,
     }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEFileFlags.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEFileFlags.cs
@@ -81,6 +81,11 @@ namespace System.Reflection.PortableExecutable
         DynamicBase = 0x0040,
 
         /// <summary>
+        /// Code Integrity checks are enforced.
+        /// </summary>
+        ForceIntegrity = 0x0080,
+
+        /// <summary>
         /// Image is NX compatible.
         /// </summary>
         NxCompatible = 0x0100,


### PR DESCRIPTION
This PR adds the DLL characteristic flag for Control Flow Guard (0x4000) to `System.Reflection.PortableExecutable.DllCharacteristics` under the System.Reflection.Metadata assembly.

Not having this flag leads to difficulties parsing the value of this enum (stringification misbehaves) and it's already defined in the [PE specification](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#dll-characteristics), so there shouldn't be any reason not to add it here as well.

Fixes #71354.