### PR TITLE
Remove unnecessary DynamicDependency in CoreLib

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.CoreCLR.cs
@@ -20,7 +20,6 @@ namespace System.Collections.Generic
 
         public static IArraySortHelper<T> Default => s_defaultArraySortHelper;
 
-        [DynamicDependency("#ctor", typeof(GenericArraySortHelper<>))]
         private static IArraySortHelper<T> CreateArraySortHelper()
         {
             IArraySortHelper<T> defaultArraySortHelper;
@@ -55,7 +54,6 @@ namespace System.Collections.Generic
 
         public static IArraySortHelper<TKey, TValue> Default => s_defaultArraySortHelper;
 
-        [DynamicDependency("#ctor", typeof(GenericArraySortHelper<,>))]
         private static IArraySortHelper<TKey, TValue> CreateArraySortHelper()
         {
             IArraySortHelper<TKey, TValue> defaultArraySortHelper;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
@@ -167,17 +167,14 @@ namespace System.Reflection
         private static class Methods
         {
             private static MethodInfo? s_ByReferenceOfByte_Value;
-            [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(ByReference<>))]
             public static MethodInfo ByReferenceOfByte_Value() =>
                 s_ByReferenceOfByte_Value ??= typeof(ByReference<byte>).GetMethod("get_Value")!;
 
             private static MethodInfo? s_ThrowHelper_Throw_NullReference_InvokeNullRefReturned;
-            [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(ThrowHelper))]
             public static MethodInfo ThrowHelper_Throw_NullReference_InvokeNullRefReturned() =>
                 s_ThrowHelper_Throw_NullReference_InvokeNullRefReturned ??= typeof(ThrowHelper).GetMethod(nameof(ThrowHelper.Throw_NullReference_InvokeNullRefReturned))!;
 
             private static MethodInfo? s_Pointer_Box;
-            [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(Pointer))]
             public static MethodInfo Pointer_Box() =>
                 s_Pointer_Box ??= typeof(Pointer).GetMethod(nameof(Pointer.Box), new[] { typeof(void*), typeof(Type) })!;
 


### PR DESCRIPTION
* The ones on `CreateArraySortHelper` were introduced before we introduced dataflow annotations on `CreateInstanceForAnotherGenericParameter`. This should now just fall out naturally.
* The ones on `InvokerEmitUtil` were added recently in #67917. I'm going to assume it's just a cargo cult because the reflection within the methods is fully analyzable. We would need warning suppressions if it wasn't.