### PR TITLE
Improve interoperability of NTLM encryption/decryption and authentication

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
@@ -204,7 +204,7 @@ internal static partial class Interop
         private static unsafe partial Status Wrap(
             out Status minorStatus,
             SafeGssContextHandle? contextHandle,
-            [MarshalAs(UnmanagedType.Bool)] bool isEncrypt,
+            [MarshalAs(UnmanagedType.Bool)] ref bool isEncrypt,
             byte* inputBytes,
             int count,
             ref GssBuffer outBuffer);
@@ -213,8 +213,8 @@ internal static partial class Interop
         private static unsafe partial Status Unwrap(
             out Status minorStatus,
             SafeGssContextHandle? contextHandle,
+            [MarshalAs(UnmanagedType.Bool)] out bool isEncrypt,
             byte* inputBytes,
-            int offset,
             int count,
             ref GssBuffer outBuffer);
 
@@ -238,25 +238,26 @@ internal static partial class Interop
         internal static unsafe Status WrapBuffer(
             out Status minorStatus,
             SafeGssContextHandle? contextHandle,
-            bool isEncrypt,
+            ref bool isEncrypt,
             ReadOnlySpan<byte> inputBytes,
             ref GssBuffer outBuffer)
         {
             fixed (byte* inputBytesPtr = inputBytes)
             {
-                return Wrap(out minorStatus, contextHandle, isEncrypt, inputBytesPtr, inputBytes.Length, ref outBuffer);
+                return Wrap(out minorStatus, contextHandle, ref isEncrypt, inputBytesPtr, inputBytes.Length, ref outBuffer);
             }
         }
 
         internal static unsafe Status UnwrapBuffer(
             out Status minorStatus,
             SafeGssContextHandle? contextHandle,
+            out bool isEncrypt,
             ReadOnlySpan<byte> inputBytes,
             ref GssBuffer outBuffer)
         {
             fixed (byte* inputBytesPtr = inputBytes)
             {
-                return Unwrap(out minorStatus, contextHandle, inputBytesPtr, 0, inputBytes.Length, ref outBuffer);
+                return Unwrap(out minorStatus, contextHandle, out isEncrypt, inputBytesPtr, inputBytes.Length, ref outBuffer);
             }
         }
 

--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
@@ -218,6 +218,23 @@ internal static partial class Interop
             int count,
             ref GssBuffer outBuffer);
 
+        [LibraryImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_GetMic")]
+        private static unsafe partial Status GetMic(
+            out Status minorStatus,
+            SafeGssContextHandle? contextHandle,
+            byte* inputBytes,
+            int inputLength,
+            ref GssBuffer outBuffer);
+
+        [LibraryImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_VerifyMic")]
+        private static unsafe partial Status VerifyMic(
+            out Status minorStatus,
+            SafeGssContextHandle? contextHandle,
+            byte* inputBytes,
+            int inputLength,
+            byte* tokenBytes,
+            int tokenLength);
+
         internal static unsafe Status WrapBuffer(
             out Status minorStatus,
             SafeGssContextHandle? contextHandle,
@@ -240,6 +257,31 @@ internal static partial class Interop
             fixed (byte* inputBytesPtr = inputBytes)
             {
                 return Unwrap(out minorStatus, contextHandle, inputBytesPtr, 0, inputBytes.Length, ref outBuffer);
+            }
+        }
+
+        internal static unsafe Status GetMic(
+            out Status minorStatus,
+            SafeGssContextHandle? contextHandle,
+            ReadOnlySpan<byte> inputBytes,
+            ref GssBuffer outBuffer)
+        {
+            fixed (byte* inputBytesPtr = inputBytes)
+            {
+                return GetMic(out minorStatus, contextHandle, inputBytesPtr, inputBytes.Length, ref outBuffer);
+            }
+        }
+
+        internal static unsafe Status VerifyMic(
+            out Status minorStatus,
+            SafeGssContextHandle? contextHandle,
+            ReadOnlySpan<byte> inputBytes,
+            ReadOnlySpan<byte> tokenBytes)
+        {
+            fixed (byte* inputBytesPtr = inputBytes)
+            fixed (byte* tokenBytesPtr = tokenBytes)
+            {
+                return VerifyMic(out minorStatus, contextHandle, inputBytesPtr, inputBytes.Length, tokenBytesPtr, tokenBytes.Length);
             }
         }
     }

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/ISSPIInterface.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/ISSPIInterface.cs
@@ -17,10 +17,8 @@ namespace System.Net
         int AcquireDefaultCredential(string moduleName, Interop.SspiCli.CredentialUse usage, out SafeFreeCredentials outCredential);
         int AcceptSecurityContext(SafeFreeCredentials? credential, ref SafeDeleteSslContext? context, InputSecurityBuffers inputBuffers, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags);
         int InitializeSecurityContext(ref SafeFreeCredentials? credential, ref SafeDeleteSslContext? context, string? targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, InputSecurityBuffers inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags);
-        int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
-        int DecryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
-        int MakeSignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
-        int VerifySignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
+        int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint qop);
+        int DecryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, out uint qop);
 
         int QueryContextChannelBinding(SafeDeleteContext phContext, Interop.SspiCli.ContextAttribute attribute, out SafeFreeContextBufferChannelBinding refHandle);
         int QueryContextAttributes(SafeDeleteContext phContext, Interop.SspiCli.ContextAttribute attribute, Span<byte> buffer, Type? handleType, out SafeHandle? refHandle);

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIAuthType.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIAuthType.cs
@@ -60,14 +60,14 @@ namespace System.Net
             return SafeDeleteContext.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, endianness, inputBuffers, ref outputBuffer, ref outFlags);
         }
 
-        public int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
+        public int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint qop)
         {
             try
             {
                 bool ignore = false;
 
                 context.DangerousAddRef(ref ignore);
-                return Interop.SspiCli.EncryptMessage(ref context._handle, 0, ref inputOutput, sequenceNumber);
+                return Interop.SspiCli.EncryptMessage(ref context._handle, qop, ref inputOutput, 0);
             }
             finally
             {
@@ -75,61 +75,24 @@ namespace System.Net
             }
         }
 
-        public unsafe int DecryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
+        public unsafe int DecryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, out uint qop)
         {
             int status = (int)Interop.SECURITY_STATUS.InvalidHandle;
-            uint qop = 0;
+            uint qopTemp = 0;
 
             try
             {
                 bool ignore = false;
                 context.DangerousAddRef(ref ignore);
-                status = Interop.SspiCli.DecryptMessage(ref context._handle, ref inputOutput, sequenceNumber, &qop);
+                status = Interop.SspiCli.DecryptMessage(ref context._handle, ref inputOutput, 0, &qopTemp);
             }
             finally
             {
                 context.DangerousRelease();
             }
 
-            if (status == 0 && qop == Interop.SspiCli.SECQOP_WRAP_NO_ENCRYPT)
-            {
-                Debug.Fail($"Expected qop = 0, returned value = {qop}");
-                throw new InvalidOperationException(SR.net_auth_message_not_encrypted);
-            }
-
+            qop = qopTemp;
             return status;
-        }
-
-        public int MakeSignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
-        {
-            try
-            {
-                bool ignore = false;
-
-                context.DangerousAddRef(ref ignore);
-
-                return Interop.SspiCli.EncryptMessage(ref context._handle, Interop.SspiCli.SECQOP_WRAP_NO_ENCRYPT, ref inputOutput, sequenceNumber);
-            }
-            finally
-            {
-                context.DangerousRelease();
-            }
-        }
-
-        public unsafe int VerifySignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
-        {
-            try
-            {
-                bool ignore = false;
-                uint qop = 0;
-
-                context.DangerousAddRef(ref ignore);
-                return Interop.SspiCli.DecryptMessage(ref context._handle, ref inputOutput, sequenceNumber, &qop);
-            }
-            finally
-            {
-                context.DangerousRelease();
-            }
         }
 
         public int QueryContextChannelBinding(SafeDeleteContext context, Interop.SspiCli.ContextAttribute attribute, out SafeFreeContextBufferChannelBinding binding)

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPISecureChannelType.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPISecureChannelType.cs
@@ -59,13 +59,13 @@ namespace System.Net
             return SafeDeleteContext.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, endianness, inputBuffers, ref outputBuffer, ref outFlags);
         }
 
-        public int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
+        public int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint qop)
         {
             try
             {
                 bool ignore = false;
                 context.DangerousAddRef(ref ignore);
-                return Interop.SspiCli.EncryptMessage(ref context._handle, 0, ref inputOutput, sequenceNumber);
+                return Interop.SspiCli.EncryptMessage(ref context._handle, qop, ref inputOutput, 0);
             }
             finally
             {
@@ -73,29 +73,24 @@ namespace System.Net
             }
         }
 
-        public unsafe int DecryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput,
-            uint sequenceNumber)
+        public unsafe int DecryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, out uint qop)
         {
+            int status = (int)Interop.SECURITY_STATUS.InvalidHandle;
+            uint qopTemp = 0;
+
             try
             {
                 bool ignore = false;
                 context.DangerousAddRef(ref ignore);
-                return Interop.SspiCli.DecryptMessage(ref context._handle, ref inputOutput, sequenceNumber, null);
+                status = Interop.SspiCli.DecryptMessage(ref context._handle, ref inputOutput, 0, &qopTemp);
             }
             finally
             {
                 context.DangerousRelease();
             }
-        }
 
-        public int MakeSignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
-        {
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
-        }
-
-        public int VerifySignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber)
-        {
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+            qop = qopTemp;
+            return status;
         }
 
         public unsafe int QueryContextChannelBinding(SafeDeleteContext phContext, Interop.SspiCli.ContextAttribute attribute, out SafeFreeContextBufferChannelBinding refHandle)

--- a/src/libraries/Common/src/System/Net/NTAuthentication.Common.cs
+++ b/src/libraries/Common/src/System/Net/NTAuthentication.Common.cs
@@ -324,26 +324,24 @@ namespace System.Net
             return spn;
         }
 
-        internal int Encrypt(ReadOnlySpan<byte> buffer, [NotNull] ref byte[]? output, uint sequenceNumber)
+        internal int Encrypt(ReadOnlySpan<byte> buffer, [NotNull] ref byte[]? output)
         {
             return NegotiateStreamPal.Encrypt(
                 _securityContext!,
                 buffer,
                 (_contextFlags & ContextFlagsPal.Confidentiality) != 0,
                 IsNTLM,
-                ref output,
-                sequenceNumber);
+                ref output);
         }
 
-        internal int Decrypt(Span<byte> payload, out int newOffset, uint expectedSeqNumber)
+        internal int Decrypt(Span<byte> payload, out int newOffset)
         {
             return NegotiateStreamPal.Decrypt(
                 _securityContext!,
                 payload,
                 (_contextFlags & ContextFlagsPal.Confidentiality) != 0,
                 IsNTLM,
-                out newOffset,
-                expectedSeqNumber);
+                out newOffset);
         }
     }
 }

--- a/src/libraries/Common/src/System/Net/NTAuthentication.Common.cs
+++ b/src/libraries/Common/src/System/Net/NTAuthentication.Common.cs
@@ -148,14 +148,14 @@ namespace System.Net
             _isCompleted = false;
         }
 
-        internal int VerifySignature(ReadOnlySpan<byte> buffer)
+        internal int Wrap(ReadOnlySpan<byte> buffer, [NotNull] ref byte[]? output, bool isConfidential)
         {
-            return NegotiateStreamPal.VerifySignature(_securityContext!, buffer);
+            return NegotiateStreamPal.Wrap(_securityContext!, buffer, ref output, isConfidential);
         }
 
-        internal int MakeSignature(ReadOnlySpan<byte> buffer, [AllowNull] ref byte[] output)
+        internal int Unwrap(Span<byte> buffer, out int newOffset, out bool wasConfidential)
         {
-            return NegotiateStreamPal.MakeSignature(_securityContext!, buffer, ref output);
+            return NegotiateStreamPal.Unwrap(_securityContext!, buffer, out newOffset, out wasConfidential);
         }
 
         internal string? GetOutgoingBlob(string? incomingBlob)

--- a/src/libraries/Common/src/System/Net/NTAuthentication.Managed.cs
+++ b/src/libraries/Common/src/System/Net/NTAuthentication.Managed.cs
@@ -1000,12 +1000,12 @@ namespace System.Net
         }
 
 #pragma warning disable CA1822
-        internal int Encrypt(ReadOnlySpan<byte> buffer, [NotNull] ref byte[]? output, uint sequenceNumber)
+        internal int Encrypt(ReadOnlySpan<byte> buffer, [NotNull] ref byte[]? output)
         {
             throw new PlatformNotSupportedException();
         }
 
-        internal int Decrypt(Span<byte> payload, out int newOffset, uint expectedSeqNumber)
+        internal int Decrypt(Span<byte> payload, out int newOffset)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/libraries/Common/src/System/Net/NTAuthentication.Managed.cs
+++ b/src/libraries/Common/src/System/Net/NTAuthentication.Managed.cs
@@ -33,6 +33,8 @@ namespace System.Net
         private byte[]? _negotiateMessage;
         private byte[]? _clientSigningKey;
         private byte[]? _serverSigningKey;
+        private byte[]? _clientSealingKey;
+        private byte[]? _serverSealingKey;
         private RC4? _clientSeal;
         private RC4? _serverSeal;
         private uint _clientSequenceNumber;
@@ -291,6 +293,8 @@ namespace System.Net
             _negotiateMessage = null;
             _clientSigningKey = null;
             _serverSigningKey = null;
+            _clientSealingKey = null;
+            _serverSealingKey = null;
             _clientSeal?.Dispose();
             _serverSeal?.Dispose();
             _clientSeal = null;
@@ -753,8 +757,9 @@ namespace System.Net
             // Derive signing keys
             _clientSigningKey = DeriveKey(exportedSessionKey, ClientSigningKeyMagic);
             _serverSigningKey = DeriveKey(exportedSessionKey, ServerSigningKeyMagic);
-            _clientSeal = new RC4(DeriveKey(exportedSessionKey, ClientSealingKeyMagic));
-            _serverSeal = new RC4(DeriveKey(exportedSessionKey, ServerSealingKeyMagic));
+            _clientSealingKey = DeriveKey(exportedSessionKey, ClientSealingKeyMagic);
+            _serverSealingKey = DeriveKey(exportedSessionKey, ServerSealingKeyMagic);
+            ResetKeys();
             _clientSequenceNumber = 0;
             _serverSequenceNumber = 0;
             CryptographicOperations.ZeroMemory(exportedSessionKey);
@@ -763,6 +768,12 @@ namespace System.Net
 
             statusCode = SecurityStatusPalOk;
             return responseBytes;
+        }
+
+        private void ResetKeys()
+        {
+            _clientSeal = new RC4(_clientSealingKey);
+            _serverSeal = new RC4(_serverSealingKey);
         }
 
         private void CalculateSignature(
@@ -986,6 +997,8 @@ namespace System.Net
                     statusCode = SecurityStatusPalMessageAltered;
                     return null;
                 }
+
+                ResetKeys();
             }
 
             IsCompleted = state == NegState.AcceptCompleted || state == NegState.Reject;

--- a/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -545,8 +545,7 @@ namespace System.Net.Security
             ReadOnlySpan<byte> buffer,
             bool isConfidential,
             bool isNtlm,
-            [NotNull] ref byte[]? output,
-            uint sequenceNumber)
+            [NotNull] ref byte[]? output)
         {
             SafeGssContextHandle gssContext = ((SafeDeleteNegoContext)securityContext).GssContext!;
             int resultSize;
@@ -602,8 +601,7 @@ namespace System.Net.Security
             Span<byte> buffer,
             bool isConfidential,
             bool isNtlm,
-            out int newOffset,
-            uint sequenceNumber)
+            out int newOffset)
         {
             SafeGssContextHandle gssContext = ((SafeDeleteNegoContext)securityContext).GssContext!;
 

--- a/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -510,7 +510,7 @@ namespace System.Net.Security
             bool isEmptyCredential = string.IsNullOrWhiteSpace(credential.UserName) ||
                                      string.IsNullOrWhiteSpace(credential.Password);
             bool ntlmOnly = string.Equals(package, NegotiationInfoClass.NTLM, StringComparison.OrdinalIgnoreCase);
-            if (ntlmOnly && isEmptyCredential)
+            if (ntlmOnly && isEmptyCredential && !isServer)
             {
                 // NTLM authentication is not possible with default credentials which are no-op
                 throw new PlatformNotSupportedException(SR.net_ntlm_not_possible_default_cred);
@@ -525,7 +525,7 @@ namespace System.Net.Security
             try
             {
                 return isEmptyCredential ?
-                    new SafeFreeNegoCredentials(false, string.Empty, string.Empty, string.Empty) :
+                    new SafeFreeNegoCredentials(ntlmOnly, string.Empty, string.Empty, string.Empty) :
                     new SafeFreeNegoCredentials(ntlmOnly, credential.UserName, credential.Password, credential.Domain);
             }
             catch (Exception ex)

--- a/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Windows.cs
@@ -288,8 +288,7 @@ namespace System.Net.Security
             ReadOnlySpan<byte> buffer,
             bool isConfidential,
             bool isNtlm,
-            [NotNull] ref byte[]? output,
-            uint sequenceNumber)
+            [NotNull] ref byte[]? output)
         {
             SecPkgContext_Sizes sizes = default;
             bool success = SSPIWrapper.QueryBlittableContextAttributes(GlobalSSPI.SSPIAuth, securityContext, Interop.SspiCli.ContextAttribute.SECPKG_ATTR_SIZES, ref sizes);
@@ -374,12 +373,11 @@ namespace System.Net.Security
             Span<byte> buffer,
             bool isConfidential,
             bool isNtlm,
-            out int newOffset,
-            uint sequenceNumber)
+            out int newOffset)
         {
             if (isNtlm)
             {
-                return DecryptNtlm(securityContext, buffer, isConfidential, out newOffset, sequenceNumber);
+                return DecryptNtlm(securityContext, buffer, isConfidential, out newOffset);
             }
 
             //
@@ -434,8 +432,7 @@ namespace System.Net.Security
             SafeDeleteContext securityContext,
             Span<byte> buffer,
             bool isConfidential,
-            out int newOffset,
-            uint sequenceNumber)
+            out int newOffset)
         {
             const int NtlmSignatureLength = 16;
 

--- a/src/libraries/Common/tests/System/Net/Security/FakeNegotiateServer.cs
+++ b/src/libraries/Common/tests/System/Net/Security/FakeNegotiateServer.cs
@@ -219,7 +219,7 @@ namespace System.Net.Security
                     // Validate mechListMIC, if present
                     if (mechListMIC is not null)
                     {
-                        _ntlmServer.VerifyMIC(_spnegoMechList, mechListMIC, 0);
+                        _ntlmServer.VerifyMIC(_spnegoMechList, mechListMIC);
                     }
                 }
                 else
@@ -262,8 +262,13 @@ namespace System.Net.Security
                             using (writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, (int)NegTokenResp.MechListMIC)))
                             {
                                 Span<byte> mic = stackalloc byte[16];
-                                _ntlmServer.GetMIC(_spnegoMechList, mic, 0);
+                                _ntlmServer.GetMIC(_spnegoMechList, mic);
                                 writer.WriteOctetString(mic);
+
+                                // MS-SPNG section 3.2.5.1 NTLM RC4 Key State for MechListMIC and First Signed Message
+                                // specifies that the RC4 sealing keys are reset back to the initial state for the
+                                // first message.
+                                _ntlmServer.ResetKeys();
                             }
                         }
                     }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
@@ -30,10 +30,19 @@ namespace System.Net.Mail
                             return null;
                         }
 
+                        ContextFlagsPal contextFlags = ContextFlagsPal.Connection | ContextFlagsPal.InitIntegrity;
+                        // Workaround for https://github.com/gssapi/gss-ntlmssp/issues/77
+                        // GSSAPI NTLM SSP does not support gss_wrap/gss_unwrap unless confidentiality
+                        // is negotiated.
+                        if (OperatingSystem.IsLinux())
+                        {
+                            contextFlags |= ContextFlagsPal.Confidentiality;
+                        }
+
                         _sessions[sessionCookie] =
                             clientContext =
                             new NTAuthentication(false, "Negotiate", credential, spn,
-                                                 ContextFlagsPal.Connection | ContextFlagsPal.InitIntegrity, channelBindingToken);
+                                                 contextFlags, channelBindingToken);
                     }
 
                     byte[]? byteResp;

--- a/src/libraries/System.Net.Mail/tests/Functional/LoopbackSmtpServer.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/LoopbackSmtpServer.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Mail;
+using System.Net.Security;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -22,6 +23,8 @@ namespace Systen.Net.Mail.Tests
         public bool ReceiveMultipleConnections = false;
         public bool SupportSmtpUTF8 = false;
         public bool AdvertiseNtlmAuthSupport = false;
+        public bool AdvertiseGssapiAuthSupport = false;
+        public NetworkCredential ExpectedGssapiCredential { get; set; }
 
         private bool _disposed = false;
         private readonly Socket _listenSocket;
@@ -114,7 +117,10 @@ namespace Systen.Net.Mail.Tests
 
                 await SendMessageAsync("250-localhost, mock server here");
                 if (SupportSmtpUTF8) await SendMessageAsync("250-SMTPUTF8");
-                await SendMessageAsync("250 AUTH PLAIN LOGIN" + (AdvertiseNtlmAuthSupport ? " NTLM" : ""));
+                await SendMessageAsync(
+                    "250 AUTH PLAIN LOGIN" +
+                    (AdvertiseNtlmAuthSupport ? " NTLM" : "") +
+                    (AdvertiseGssapiAuthSupport ? " GSSAPI" : ""));
 
                 while ((message = await ReceiveMessageAsync()) != null)
                 {
@@ -146,6 +152,44 @@ namespace Systen.Net.Mail.Tests
                             Password = Encoding.UTF8.GetString(Convert.FromBase64String(await ReceiveMessageAsync()));
                             UsernamePassword = Username + Password;
                             await SendMessageAsync("235 Authentication successful");
+                        }
+                        else if (parts[1].Equals("GSSAPI", StringComparison.OrdinalIgnoreCase))
+                        {
+                            Debug.Assert(ExpectedGssapiCredential != null);
+                            FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(ExpectedGssapiCredential) { ForceNegotiateVersion = true };
+                            FakeNegotiateServer fakeNegotiateServer = new FakeNegotiateServer(fakeNtlmServer);
+
+                            try
+                            {
+                                // Do the authentication loop
+                                byte[]? incomingBlob = Convert.FromBase64String(parts[2]);
+                                byte[]? outgoingBlob;
+                                do
+                                {
+                                    outgoingBlob = fakeNegotiateServer.GetOutgoingBlob(incomingBlob);
+                                    if (outgoingBlob != null)
+                                    {
+                                        await SendMessageAsync("334 " + Convert.ToBase64String(outgoingBlob));
+                                        incomingBlob = Convert.FromBase64String(await ReceiveMessageAsync());
+                                    }
+                                }
+                                while (!fakeNegotiateServer.IsAuthenticated);
+
+                                // Negotiate the SASL protection (no encryption and no signing)
+                                byte[] saslToken = new byte[] { 1, 0, 0, 0 };
+                                outgoingBlob = new byte[20]; // 16 bytes of NTLM signature, 4 bytes of content
+                                fakeNtlmServer.Wrap(saslToken, outgoingBlob);
+                                await SendMessageAsync("334 " + Convert.ToBase64String(outgoingBlob));
+                                incomingBlob = Convert.FromBase64String(await ReceiveMessageAsync());
+                                fakeNtlmServer.Unwrap(incomingBlob, saslToken);
+                                // TODO: Verify the token we got back
+
+                                await SendMessageAsync("235 Authentication successful");
+                            }
+                            catch (Exception e)
+                            {
+                                await SendMessageAsync("500 Unsuccessful authentication: " + e.ToString());
+                            }
                         }
                         else if (parts[1].Equals("NTLM", StringComparison.OrdinalIgnoreCase))
                         {

--- a/src/libraries/System.Net.Mail/tests/Functional/System.Net.Mail.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Mail/tests/Functional/System.Net.Mail.Functional.Tests.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-Android</TargetFrameworks>
+    <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AlternateViewCollectionTest.cs" />
@@ -11,22 +13,53 @@
     <Compile Include="AttachmentTest.cs" />
     <Compile Include="ContentDispositionTest.cs" />
     <Compile Include="ContentTypeTest.cs" />
-    <Compile Include="SmtpClientCredentialsTest.cs" />
     <Compile Include="HeaderCollectionTest.cs" />
     <Compile Include="LinkedResourceCollectionTest.cs" />
     <Compile Include="LinkedResourceTest.cs" />
-    <Compile Include="LoggingTest.cs" />
     <Compile Include="MailAddressCollectionTest.cs" />
     <Compile Include="MailAddressTest.cs" />
     <Compile Include="MailMessageTest.cs" />
-    <Compile Include="SmtpClientTest.cs" />
     <Compile Include="SmtpExceptionTest.cs" />
-    <Compile Include="LoopbackSmtpServer.cs" />
     <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs"
              Link="Common\System\Diagnostics\Tracing\TestEventListener.cs" />
     <Compile Include="$(CommonTestPath)System\IO\TempFile.cs"
              Link="Common\System\IO\TempFile.cs" />
     <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs"
              Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'Browser'">
+    <Compile Include="SmtpClientTest.cs" />
+    <Compile Include="SmtpClientCredentialsTest.cs" />
+    <Compile Include="LoggingTest.cs" />
+    <Compile Include="LoopbackSmtpServer.cs" />
+  </ItemGroup>
+
+  <!-- NTLM/Negotiate authentication fakes -->
+  <ItemGroup>
+    <Compile Include="$(CommonPath)System\Net\Security\MD4.cs"
+             Link="Common\System\Net\Security\MD4.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\RC4.cs"
+             Link="Common\System\Net\Security\RC4.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Security\FakeNtlmServer.cs"
+             Link="Common\System\Net\Security\FakeNtlmServer.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Security\FakeNegotiateServer.cs"
+             Link="Common\System\Net\Security\FakeNegotiateServer.cs" />
+  </ItemGroup>
+
+  <!-- Unix specific files (NT Authentication) -->
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'windows' and '$(TargetPlatformIdentifier)' != 'Browser'">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs"
+             Link="Common\Interop\Unix\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs"
+             Link="Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Security.Unix.cs"
+             Link="Common\System\Net\Capability.Security.Unix.cs" />
+  </ItemGroup>
+
+  <!-- Windows specific files (NT Authentication) -->
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Security.Windows.cs"
+             Link="Common\System\Net\Capability.Security.Windows.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -51,8 +51,6 @@ namespace System.Net.Security
         private bool _canRetryAuthentication;
         private ProtectionLevel _expectedProtectionLevel;
         private TokenImpersonationLevel _expectedImpersonationLevel;
-        private uint _writeSequenceNumber;
-        private uint _readSequenceNumber;
         private ExtendedProtectionPolicy? _extendedProtectionPolicy;
 
         /// <summary>
@@ -344,6 +342,8 @@ namespace System.Net.Security
         private async ValueTask<int> ReadAsync<TIOAdapter>(Memory<byte> buffer, CancellationToken cancellationToken)
             where TIOAdapter : IReadWriteAdapter
         {
+            Debug.Assert(_context is not null);
+
             if (Interlocked.Exchange(ref _readInProgress, 1) == 1)
             {
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "read"));
@@ -394,7 +394,7 @@ namespace System.Net.Security
 
                     // Decrypt into internal buffer, change "readBytes" to count now _Decrypted Bytes_
                     // Decrypted data start from zero offset, the size can be shrunk after decryption.
-                    _readBufferCount = readBytes = DecryptData(_readBuffer.AsSpan(0, readBytes), out _readBufferOffset);
+                    _readBufferCount = readBytes = _context.Decrypt(_readBuffer.AsSpan(0, readBytes), out _readBufferOffset);
                     if (readBytes == 0 && buffer.Length != 0)
                     {
                         // Read again.
@@ -481,6 +481,8 @@ namespace System.Net.Security
         private async Task WriteAsync<TIOAdapter>(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
             where TIOAdapter : IReadWriteAdapter
         {
+            Debug.Assert(_context is not null);
+
             if (Interlocked.Exchange(ref _writeInProgress, 1) == 1)
             {
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "write"));
@@ -494,7 +496,7 @@ namespace System.Net.Security
                     int encryptedBytes;
                     try
                     {
-                        encryptedBytes = EncryptData(buffer.Slice(0, chunkBytes).Span, ref _writeBuffer);
+                        encryptedBytes = _context.Encrypt(buffer.Slice(0, chunkBytes).Span, ref _writeBuffer);
                     }
                     catch (Exception e)
                     {
@@ -611,8 +613,6 @@ namespace System.Net.Security
 
             _expectedProtectionLevel = protectionLevel;
             _expectedImpersonationLevel = isServer ? impersonationLevel : TokenImpersonationLevel.None;
-            _writeSequenceNumber = 0;
-            _readSequenceNumber = 0;
 
             ContextFlagsPal flags = ContextFlagsPal.Connection;
 
@@ -953,26 +953,6 @@ namespace System.Net.Security
             }
 
             return message;
-        }
-
-        private int EncryptData(ReadOnlySpan<byte> buffer, [NotNull] ref byte[]? outBuffer)
-        {
-            Debug.Assert(_context != null);
-            ThrowIfFailed(authSuccessCheck: true);
-
-            // SSPI seems to ignore this sequence number.
-            ++_writeSequenceNumber;
-            return _context.Encrypt(buffer, ref outBuffer, _writeSequenceNumber);
-        }
-
-        private int DecryptData(Span<byte> buffer, out int newOffset)
-        {
-            Debug.Assert(_context != null);
-            ThrowIfFailed(authSuccessCheck: true);
-
-            // SSPI seems to ignore this sequence number.
-            ++_readSequenceNumber;
-            return _context.Decrypt(buffer, out newOffset, _readSequenceNumber);
         }
 
         private static void ThrowCredentialException(long error)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -384,7 +384,7 @@ namespace System.Net.Security
                 {
                     pBuffers = unmanagedBuffer
                 };
-                Interop.SECURITY_STATUS errorCode = (Interop.SECURITY_STATUS)GlobalSSPI.SSPISecureChannel.DecryptMessage(securityContext!, ref sdcInOut, 0);
+                Interop.SECURITY_STATUS errorCode = (Interop.SECURITY_STATUS)GlobalSSPI.SSPISecureChannel.DecryptMessage(securityContext!, ref sdcInOut, out _);
 
                 // Decrypt may repopulate the sec buffers, likely with header + data + trailer + empty.
                 // We need to find the data.

--- a/src/libraries/System.Net.Security/tests/UnitTests/NTAuthenticationTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/NTAuthenticationTests.cs
@@ -34,7 +34,7 @@ namespace System.Net.Security.Tests
 
             // Test MakeSignature on client side and decoding it on server side
             byte[]? output = null;
-            int len = ntAuth.MakeSignature(s_Hello, ref output);
+            int len = ntAuth.Wrap(s_Hello, ref output, true);
             Assert.NotNull(output);
             Assert.Equal(16 + s_Hello.Length, len);
             // Unseal the content and check it
@@ -48,10 +48,9 @@ namespace System.Net.Security.Tests
             byte[] serverSignedMessage = new byte[16 + s_Hello.Length];
             fakeNtlmServer.Seal(s_Hello, serverSignedMessage.AsSpan(16, s_Hello.Length));
             fakeNtlmServer.GetMIC(s_Hello, serverSignedMessage.AsSpan(0, 16), sequenceNumber: 0);
-            len = ntAuth.VerifySignature(serverSignedMessage);
+            len = ntAuth.Unwrap(serverSignedMessage, out int newOffset, out _);
             Assert.Equal(s_Hello.Length, len);
-            // NOTE: VerifySignature doesn't return the content on Windows
-            // Assert.Equal(s_Hello, serverSignedMessage.AsSpan(0, len).ToArray());
+            Assert.Equal(s_Hello, serverSignedMessage.AsSpan(newOffset, len).ToArray());
         }
 
         private void DoNtlmExchange(FakeNtlmServer fakeNtlmServer, NTAuthentication ntAuth)

--- a/src/libraries/System.Net.Security/tests/UnitTests/NTAuthenticationTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/NTAuthenticationTests.cs
@@ -39,15 +39,12 @@ namespace System.Net.Security.Tests
             Assert.Equal(16 + s_Hello.Length, len);
             // Unseal the content and check it
             byte[] temp = new byte[s_Hello.Length];
-            fakeNtlmServer.Unseal(output.AsSpan(16), temp);
+            fakeNtlmServer.Unwrap(output, temp);
             Assert.Equal(s_Hello, temp);
-            // Check the signature
-            fakeNtlmServer.VerifyMIC(temp, output.AsSpan(0, 16), sequenceNumber: 0);
 
             // Test creating signature on server side and decoding it with VerifySignature on client side 
             byte[] serverSignedMessage = new byte[16 + s_Hello.Length];
-            fakeNtlmServer.Seal(s_Hello, serverSignedMessage.AsSpan(16, s_Hello.Length));
-            fakeNtlmServer.GetMIC(s_Hello, serverSignedMessage.AsSpan(0, 16), sequenceNumber: 0);
+            fakeNtlmServer.Wrap(s_Hello, serverSignedMessage);
             len = ntAuth.Unwrap(serverSignedMessage, out int newOffset, out _);
             Assert.Equal(s_Hello.Length, len);
             Assert.Equal(s_Hello, serverSignedMessage.AsSpan(newOffset, len).ToArray());

--- a/src/native/libs/System.Net.Security.Native/entrypoints.c
+++ b/src/native/libs/System.Net.Security.Native/entrypoints.c
@@ -27,6 +27,8 @@ static const Entry s_securityNative[] =
     DllImportEntry(NetSecurityNative_ReleaseName)
     DllImportEntry(NetSecurityNative_Unwrap)
     DllImportEntry(NetSecurityNative_Wrap)
+    DllImportEntry(NetSecurityNative_GetMic)
+    DllImportEntry(NetSecurityNative_VerifyMic)
 };
 
 EXTERN_C const void* SecurityResolveDllImport(const char* name);

--- a/src/native/libs/System.Net.Security.Native/pal_gssapi.c
+++ b/src/native/libs/System.Net.Security.Native/pal_gssapi.c
@@ -502,14 +502,15 @@ uint32_t NetSecurityNative_ReleaseName(uint32_t* minorStatus, GssName** inputNam
 
 uint32_t NetSecurityNative_Wrap(uint32_t* minorStatus,
                                 GssCtxId* contextHandle,
-                                int32_t isEncrypt,
+                                int32_t* isEncrypt,
                                 uint8_t* inputBytes,
                                 int32_t count,
                                 PAL_GssBuffer* outBuffer)
 {
     assert(minorStatus != NULL);
     assert(contextHandle != NULL);
-    assert(isEncrypt == 1 || isEncrypt == 0);
+    assert(isEncrypt != NULL);
+    assert(*isEncrypt == 1 || *isEncrypt == 0);
     assert(inputBytes != NULL);
     assert(count >= 0);
     assert(outBuffer != NULL);
@@ -520,32 +521,35 @@ uint32_t NetSecurityNative_Wrap(uint32_t* minorStatus,
     GssBuffer inputMessageBuffer = {.length = (size_t)count, .value = inputBytes};
     GssBuffer gssBuffer;
     uint32_t majorStatus =
-        gss_wrap(minorStatus, contextHandle, isEncrypt, GSS_C_QOP_DEFAULT, &inputMessageBuffer, &confState, &gssBuffer);
+        gss_wrap(minorStatus, contextHandle, *isEncrypt, GSS_C_QOP_DEFAULT, &inputMessageBuffer, &confState, &gssBuffer);
 
     NetSecurityNative_MoveBuffer(&gssBuffer, outBuffer);
+    *isEncrypt = confState;
     return majorStatus;
 }
 
 uint32_t NetSecurityNative_Unwrap(uint32_t* minorStatus,
                                   GssCtxId* contextHandle,
+                                  int32_t* isEncrypt,
                                   uint8_t* inputBytes,
-                                  int32_t offset,
                                   int32_t count,
                                   PAL_GssBuffer* outBuffer)
 {
     assert(minorStatus != NULL);
     assert(contextHandle != NULL);
+    assert(isEncrypt != NULL);
     assert(inputBytes != NULL);
-    assert(offset >= 0);
     assert(count >= 0);
     assert(outBuffer != NULL);
 
     // count refers to the length of the input message. That is, the number of bytes of inputBytes
     // starting at offset that need to be wrapped.
-    GssBuffer inputMessageBuffer = {.length = (size_t)count, .value = inputBytes + offset};
+    int confState;
+    GssBuffer inputMessageBuffer = {.length = (size_t)count, .value = inputBytes};
     GssBuffer gssBuffer = {.length = 0, .value = NULL};
-    uint32_t majorStatus = gss_unwrap(minorStatus, contextHandle, &inputMessageBuffer, &gssBuffer, NULL, NULL);
+    uint32_t majorStatus = gss_unwrap(minorStatus, contextHandle, &inputMessageBuffer, &gssBuffer, &confState, NULL);
     NetSecurityNative_MoveBuffer(&gssBuffer, outBuffer);
+    *isEncrypt = confState;
     return majorStatus;
 }
 

--- a/src/native/libs/System.Net.Security.Native/pal_gssapi.c
+++ b/src/native/libs/System.Net.Security.Native/pal_gssapi.c
@@ -77,6 +77,8 @@ static gss_OID_desc gss_mech_ntlm_OID_desc = {.length = STRING_LENGTH(gss_ntlm_o
     PER_FUNCTION_BLOCK(gss_release_oid_set) \
     PER_FUNCTION_BLOCK(gss_unwrap) \
     PER_FUNCTION_BLOCK(gss_wrap) \
+    PER_FUNCTION_BLOCK(gss_get_mic) \
+    PER_FUNCTION_BLOCK(gss_verify_mic) \
     PER_FUNCTION_BLOCK(GSS_C_NT_USER_NAME) \
     PER_FUNCTION_BLOCK(GSS_C_NT_HOSTBASED_SERVICE)
 
@@ -108,6 +110,8 @@ static void* volatile s_gssLib = NULL;
 #define gss_release_oid_set(...)            gss_release_oid_set_ptr(__VA_ARGS__)
 #define gss_unwrap(...)                     gss_unwrap_ptr(__VA_ARGS__)
 #define gss_wrap(...)                       gss_wrap_ptr(__VA_ARGS__)
+#define gss_get_mic(...)                    gss_get_mic_ptr(__VA_ARGS__)
+#define gss_verify_mic(...)                 gss_verify_mic_ptr(__VA_ARGS__)
 
 #define GSS_C_NT_USER_NAME                  (*GSS_C_NT_USER_NAME_ptr)
 #define GSS_C_NT_HOSTBASED_SERVICE          (*GSS_C_NT_HOSTBASED_SERVICE_ptr)
@@ -542,6 +546,50 @@ uint32_t NetSecurityNative_Unwrap(uint32_t* minorStatus,
     GssBuffer gssBuffer = {.length = 0, .value = NULL};
     uint32_t majorStatus = gss_unwrap(minorStatus, contextHandle, &inputMessageBuffer, &gssBuffer, NULL, NULL);
     NetSecurityNative_MoveBuffer(&gssBuffer, outBuffer);
+    return majorStatus;
+}
+
+uint32_t NetSecurityNative_GetMic(uint32_t* minorStatus,
+                                  GssCtxId* contextHandle,
+                                  uint8_t* inputBytes,
+                                  int32_t inputLength,
+                                  PAL_GssBuffer* outBuffer)
+{
+    assert(minorStatus != NULL);
+    assert(contextHandle != NULL);
+    assert(inputBytes != NULL);
+    assert(inputLength >= 0);
+    assert(outBuffer != NULL);
+
+    GssBuffer inputMessageBuffer = {.length = (size_t)inputLength, .value = inputBytes};
+    GssBuffer gssBuffer;
+    uint32_t majorStatus =
+        gss_get_mic(minorStatus, contextHandle, GSS_C_QOP_DEFAULT, &inputMessageBuffer, &gssBuffer);
+
+    NetSecurityNative_MoveBuffer(&gssBuffer, outBuffer);
+    return majorStatus;
+}
+
+uint32_t NetSecurityNative_VerifyMic(uint32_t* minorStatus,
+                                     GssCtxId* contextHandle,
+                                     uint8_t* inputBytes,
+                                     int32_t inputLength,
+                                     uint8_t* tokenBytes,
+                                     int32_t tokenLength)
+{
+    assert(minorStatus != NULL);
+    assert(contextHandle != NULL);
+    assert(inputBytes != NULL);
+    assert(inputLength >= 0);
+    assert(tokenBytes != NULL);
+    assert(tokenLength >= 0);
+
+    GssBuffer inputMessageBuffer = {.length = (size_t)inputLength, .value = inputBytes};
+    GssBuffer tokenBuffer = {.length = (size_t)tokenLength, .value = tokenBytes};
+    GssBuffer gssBuffer;
+    uint32_t majorStatus =
+        gss_verify_mic(minorStatus, contextHandle, &inputMessageBuffer, &tokenBuffer, NULL);
+
     return majorStatus;
 }
 

--- a/src/native/libs/System.Net.Security.Native/pal_gssapi.h
+++ b/src/native/libs/System.Net.Security.Native/pal_gssapi.h
@@ -157,7 +157,7 @@ Shims the gss_wrap method.
 */
 PALEXPORT uint32_t NetSecurityNative_Wrap(uint32_t* minorStatus,
                                           GssCtxId* contextHandle,
-                                          int32_t isEncrypt,
+                                          int32_t* isEncrypt,
                                           uint8_t* inputBytes,
                                           int32_t count,
                                           PAL_GssBuffer* outBuffer);
@@ -167,8 +167,8 @@ Shims the gss_unwrap method.
 */
 PALEXPORT uint32_t NetSecurityNative_Unwrap(uint32_t* minorStatus,
                                             GssCtxId* contextHandle,
+                                            int32_t* isEncrypt,
                                             uint8_t* inputBytes,
-                                            int32_t offset,
                                             int32_t count,
                                             PAL_GssBuffer* outBuffer);
 

--- a/src/native/libs/System.Net.Security.Native/pal_gssapi.h
+++ b/src/native/libs/System.Net.Security.Native/pal_gssapi.h
@@ -173,6 +173,25 @@ PALEXPORT uint32_t NetSecurityNative_Unwrap(uint32_t* minorStatus,
                                             PAL_GssBuffer* outBuffer);
 
 /*
+Shims the gss_get_mic method.
+*/
+PALEXPORT uint32_t NetSecurityNative_GetMic(uint32_t* minorStatus,
+                                            GssCtxId* contextHandle,
+                                            uint8_t* inputBytes,
+                                            int32_t inputLength,
+                                            PAL_GssBuffer* outBuffer);
+
+/*
+Shims the gss_verify_mic method.
+*/
+PALEXPORT uint32_t NetSecurityNative_VerifyMic(uint32_t* minorStatus,
+                                               GssCtxId* contextHandle,
+                                               uint8_t* inputBytes,
+                                               int32_t inputLength,
+                                               uint8_t* tokenBytes,
+                                               int32_t tokenLength);
+
+/*
 Shims the gss_acquire_cred_with_password method with GSS_C_INITIATE.
 */
 PALEXPORT uint32_t NetSecurityNative_InitiateCredWithPassword(uint32_t* minorStatus,


### PR DESCRIPTION
Best reviewed commit by commit.

Firstly, it fixes an interoperability scenario for non-encrypted NTLM communication passed through `NegotiateStream` between Unix and Windows. It updates the `NegotiateStreamPal.Encrypt/Decrypt` Unix implementation to have the same quirk as the Windows implementation has.

Secondly, it fixes a bunch of bugs in the SmtpClient GSSAPI authentication and adds a loopback server test. This was also tested against a real Microsoft Exchange server to ensure that it works properly and that the encryption/decryption is applied correctly in context of NTLM authentication.
