### PR TITLE
Spill non-morphable split args on non-ARM targets

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -991,16 +991,9 @@ void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
         // For RyuJIT backend we will expand a Multireg arg into a GT_FIELD_LIST
         // with multiple indirections, so here we consider spilling it into a tmp LclVar.
         //
-        CLANG_FORMAT_COMMENT_ANCHOR;
-#ifdef TARGET_ARM
-        bool isMultiRegArg = (arg.AbiInfo.NumRegs > 0) && (arg.AbiInfo.NumRegs + arg.AbiInfo.GetStackSlotsNumber() > 1);
-#else
-        bool isMultiRegArg = (arg.AbiInfo.NumRegs > 1);
-#endif
-
         if (varTypeIsStruct(argx) && !arg.m_needTmp)
         {
-            if (isMultiRegArg)
+            if ((arg.AbiInfo.NumRegs > 0) && ((arg.AbiInfo.NumRegs + arg.AbiInfo.GetStackSlotsNumber()) > 1))
             {
                 if ((argx->gtFlags & GTF_PERSISTENT_SIDE_EFFECTS) != 0)
                 {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71375/Runtime_71375.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71375/Runtime_71375.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Intrinsics;
+using System.Runtime.CompilerServices;
+
+public class Runtime_71375
+{
+    public static int Main()
+    {
+        return Problem() ? 101 : 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int VarArgs(int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, Vector128<int> splitArg, __arglist) => splitArg.GetElement(0);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Problem()
+    {
+        return VarArgs(0, 0, 0, 0, 0, 0, Vector128<int>.AllBitsSet, __arglist()) != -1;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71375/Runtime_71375.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71375/Runtime_71375.cs
@@ -8,14 +8,19 @@ public class Runtime_71375
 {
     public static int Main()
     {
-        return Problem() ? 101 : 100;
+        // At the time of writing this test, the calling convention for incoming vector parameters on
+        // Windows ARM64 was broken, so only the fact that "Problem" compiled without asserts was
+        // checked. If/once the above is fixed, this test should be changed to actually call "Problem".
+        RuntimeHelpers.PrepareMethod(typeof(Runtime_71375).GetMethod("Problem").MethodHandle);
+
+        return 100;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static int VarArgs(int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, Vector128<int> splitArg, __arglist) => splitArg.GetElement(0);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static bool Problem()
+    public static bool Problem()
     {
         return VarArgs(0, 0, 0, 0, 0, 0, Vector128<int>.AllBitsSet, __arglist()) != -1;
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71375/Runtime_71375.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71375/Runtime_71375.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- The test tests Windows ARM64 Varargs (managed) calling convention -->
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'arm64'">true</CLRTestTargetUnsupported>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1259,6 +1259,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_4044/GitHub_4044/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/188</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_71375/*">
+            <Issue>https://github.com/dotnet/runtimelab/issues/155: Varargs</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/**">
             <Issue>CoreCLR test</Issue>
         </ExcludeList>


### PR DESCRIPTION
That is, on Windows ARM64 and LA.

Fixes #71375.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1849621&view=ms.vss-build-web.run-extensions-tab) as expected.