### PR TITLE
[wasm] Add Vector128.OnesComplement SIMD intrinsic

### DIFF
--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -11194,9 +11194,9 @@ MONO_RESTORE_WARNING
 		case OP_WASM_ONESCOMPLEMENT:
 			LLVMTypeRef i4v128_t = LLVMVectorType (i4_t, 4);
 			LLVMTypeRef ret_t = LLVMTypeOf (lhs);
-			LLVMValueRef cast = LLVMBuildBitCast (builder, lhs, i4v128_t, "cast_to_4_x_i32");
+			LLVMValueRef cast = LLVMBuildBitCast (builder, lhs, i4v128_t, "");
 			LLVMValueRef result = LLVMBuildNot (builder, cast, "wasm_not");
-			values [ins->dreg] = LLVMBuildBitCast (builder, result, ret_t, "cast_back");
+			values [ins->dreg] = LLVMBuildBitCast (builder, result, ret_t, "");
 			break;
 #endif
 

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -11191,13 +11191,14 @@ MONO_RESTORE_WARNING
 		}
 #endif
 #ifdef TARGET_WASM
-		case OP_WASM_ONESCOMPLEMENT:
+		case OP_WASM_ONESCOMPLEMENT: {
 			LLVMTypeRef i4v128_t = LLVMVectorType (i4_t, 4);
 			LLVMTypeRef ret_t = LLVMTypeOf (lhs);
 			LLVMValueRef cast = LLVMBuildBitCast (builder, lhs, i4v128_t, "");
 			LLVMValueRef result = LLVMBuildNot (builder, cast, "wasm_not");
 			values [ins->dreg] = LLVMBuildBitCast (builder, result, ret_t, "");
 			break;
+		}
 #endif
 
 		case OP_DUMMY_USE:

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -11190,6 +11190,15 @@ MONO_RESTORE_WARNING
 			break;
 		}
 #endif
+#ifdef TARGET_WASM
+		case OP_WASM_ONESCOMPLEMENT:
+			LLVMTypeRef i4v128_t = LLVMVectorType (i4_t, 4);
+			LLVMTypeRef ret_t = LLVMTypeOf (lhs);
+			LLVMValueRef cast = LLVMBuildBitCast (builder, lhs, i4v128_t, "cast_to_4_x_i32");
+			LLVMValueRef result = LLVMBuildNot (builder, cast, "wasm_not");
+			values [ins->dreg] = LLVMBuildBitCast (builder, result, ret_t, "cast_back");
+			break;
+#endif
 
 		case OP_DUMMY_USE:
 			break;

--- a/src/mono/mono/mini/mini-ops.h
+++ b/src/mono/mono/mini/mini-ops.h
@@ -1763,3 +1763,7 @@ MINI_OP3(OP_ARM64_SQRDMLSH_BYSCALAR, "arm64_sqrdmlsh_byscalar", XREG, XREG, XREG
 MINI_OP3(OP_ARM64_SQRDMLSH_SCALAR, "arm64_sqrdmlsh_scalar", XREG, XREG, XREG, XREG)
 
 #endif // TARGET_ARM64
+
+#if defined(TARGET_WASM)
+MINI_OP(OP_WASM_ONESCOMPLEMENT, "wasm_onescomplement", XREG, XREG, NONE)
+#endif

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -390,6 +390,14 @@ emit_simd_ins_for_unary_op (MonoCompile *cfg, MonoClass *klass, MonoMethodSignat
 		g_assert_not_reached ();
 	}
 	return emit_simd_ins_for_sig (cfg, klass, op, -1, arg_type, fsig, args);
+#elif defined(TARGET_WASM)
+	switch (id)
+	{
+	case SN_OnesComplement:
+		return emit_simd_ins_for_sig (cfg, klass, OP_WASM_ONESCOMPLEMENT, -1, arg_type, fsig, args);
+	default:
+		return NULL;
+	}
 #else
 	return NULL;
 #endif

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -434,7 +434,7 @@
     </ItemGroup>
 
     <Message Text="Stripping symbols from dotnet.wasm ..." Importance="High" Condition="'$(WasmNativeStrip)' == 'true'" />
-    <Exec Command="wasm-opt$(_ExeExt) --enable-exception-handling @(WasmOptConfigurationFlags, ' ') --strip-dwarf &quot;$(_WasmIntermediateOutputPath)dotnet.wasm&quot; -o &quot;$(_WasmIntermediateOutputPath)dotnet.wasm&quot;"
+    <Exec Command="wasm-opt$(_ExeExt) --enable-simd --enable-exception-handling @(WasmOptConfigurationFlags, ' ') --strip-dwarf &quot;$(_WasmIntermediateOutputPath)dotnet.wasm&quot; -o &quot;$(_WasmIntermediateOutputPath)dotnet.wasm&quot;"
           Condition="'$(WasmNativeStrip)' == 'true'"
           IgnoreStandardErrorWarningFormat="true"
           EnvironmentVariables="@(EmscriptenEnvVars)" />


### PR DESCRIPTION
Add wasm specific implementation of `Vector128.OnesComplement` method.

Example compilation output. Managed:

    static Vector128<double> SimdTest3(Vector128<double> input)
    {
        return Vector128.OnesComplement(input);
    }

IR:

    BB3:                                              ; preds = %BB2
      %cast_to_4_x_i32 = bitcast <2 x double> %simd_vtype to <4 x i32>
      %wasm_not = xor <4 x i32> %cast_to_4_x_i32, <i32 -1, i32 -1, i32 -1, i32 -1>
      %cast_back = bitcast <4 x i32> %wasm_not to <2 x double>
      br label %BB4

wasm - Debug configuration:

    (func Wasm_Console_V8_CJS_Sample_Test_SimdTest3_System_Runtime_Intrinsics_Vector128_1_double(param $0 i32, $1 i32, $2 i32))
     local $3 i32
     local $4 i32
     local $5 v128
     local $6 v128
     0x00cf955a: global.get $__stack_pointer
     0x00cf955c: local.set $3
     0x00cf955e: i32.const 16
     0x00cf9560: local.set $4
     0x00cf9562: local.get $3
     0x00cf9564: local.get $4
     0x00cf9566: i32.sub
     0x00cf9567: drop
     0x00cf9568: local.get $1
     0x00cf956a: v128.load align:4    [SIMD]
     0x00cf956e: local.set $5
     0x00cf9570: local.get $5
     0x00cf9572: v128.not    [SIMD]
     0x00cf9574: local.set $6
     0x00cf9576: local.get $6
     0x00cf9578: drop
     0x00cf9579: local.get $0
     0x00cf957b: local.get $6
     0x00cf957d: v128.store    [SIMD]
     0x00cf9581: return

wasm - Release configuration:

    (func idx:7866(param $0 i32, $1 i32, $2 i32))
     0x00185b37: local.get $0
     0x00185b39: local.get $1
     0x00185b3b: v128.load align:4    [SIMD]
     0x00185b3f: v128.not    [SIMD]
     0x00185b41: v128.store    [SIMD]
