### PR TITLE
Fix: using default value for nullable enum parameter throws ArgumentException

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -569,14 +569,15 @@ namespace System
 
             Debug.Assert(argSetupState.parameters != null);
             object? incomingParam = argSetupState.parameters[index];
-            bool nullable = type.ToEETypePtr().IsNullable;
 
             // Handle default parameters
             if ((incomingParam == System.Reflection.Missing.Value) && paramType == DynamicInvokeParamType.In)
             {
                 incomingParam = GetDefaultValue(argSetupState.targetMethodOrDelegate, type, index);
-                if (incomingParam != null && nullable)
+                if (incomingParam != null && type.ToEETypePtr().IsNullable)
                 {
+                    // In case if the parameter is nullable Enum type the ParameterInfo.DefaultValue returns a raw value which
+                    // needs to be parsed to the Enum type, for more info: https://github.com/dotnet/runtime/issues/12924
                     EETypePtr nullableType = type.ToEETypePtr().NullableType;
                     if (nullableType.IsEnum)
                     {
@@ -589,6 +590,7 @@ namespace System
             }
 
             RuntimeTypeHandle widenAndCompareType = type;
+            bool nullable = type.ToEETypePtr().IsNullable;
             if (nullable)
             {
                 widenAndCompareType = new RuntimeTypeHandle(type.ToEETypePtr().NullableType);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -569,12 +569,13 @@ namespace System
 
             Debug.Assert(argSetupState.parameters != null);
             object? incomingParam = argSetupState.parameters[index];
+            bool nullable = type.ToEETypePtr().IsNullable;
 
             // Handle default parameters
             if ((incomingParam == System.Reflection.Missing.Value) && paramType == DynamicInvokeParamType.In)
             {
                 incomingParam = GetDefaultValue(argSetupState.targetMethodOrDelegate, type, index);
-                if (incomingParam != null && type.ToEETypePtr().IsNullable)
+                if (incomingParam != null && nullable)
                 {
                     // In case if the parameter is nullable Enum type the ParameterInfo.DefaultValue returns a raw value which
                     // needs to be parsed to the Enum type, for more info: https://github.com/dotnet/runtime/issues/12924
@@ -590,7 +591,6 @@ namespace System
             }
 
             RuntimeTypeHandle widenAndCompareType = type;
-            bool nullable = type.ToEETypePtr().IsNullable;
             if (nullable)
             {
                 widenAndCompareType = new RuntimeTypeHandle(type.ToEETypePtr().NullableType);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -209,7 +209,7 @@ namespace System.Reflection
                         {
                             if (arg != null && sigType.IsNullableOfT)
                             {
-                                // In case if the parameter is nullable Enum type ParameterInfo.DefaultValue returns a raw value which
+                                // In case if the parameter is nullable Enum type the ParameterInfo.DefaultValue returns a raw value which
                                 // needs to be parsed to the Enum type, for more info: https://github.com/dotnet/runtime/issues/12924
                                 Type argumentType = sigType.GetGenericArguments()[0];
                                 if (argumentType.IsEnum)

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -209,8 +209,8 @@ namespace System.Reflection
                         {
                             if (arg != null && sigType.IsNullableOfT)
                             {
-                                // ParameterInfo.DefaultValue returns the raw value if the enum is nullable that needs
-                                // to be parsed to the Enum type more info: https://github.com/dotnet/runtime/issues/12924
+                                // In case if the parameter is nullable Enum type ParameterInfo.DefaultValue returns a raw value which
+                                // needs to be parsed to the Enum type, for more info: https://github.com/dotnet/runtime/issues/12924
                                 Type argumentType = sigType.GetGenericArguments()[0];
                                 if (argumentType.IsEnum)
                                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -207,6 +207,11 @@ namespace System.Reflection
                         }
                         else
                         {
+                            if (arg != null && sigType.IsNullableOfT && sigType.GetGenericArguments()[0].IsEnum)
+                            {
+                                arg = Enum.ToObject(sigType.GetGenericArguments()[0], arg);
+                            }
+
                             isValueType = sigType.CheckValue(ref arg, ref copyBackArg, binder, culture, invokeAttr);
                         }
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -207,9 +207,15 @@ namespace System.Reflection
                         }
                         else
                         {
-                            if (arg != null && sigType.IsNullableOfT && sigType.GetGenericArguments()[0].IsEnum)
+                            if (arg != null && sigType.IsNullableOfT)
                             {
-                                arg = Enum.ToObject(sigType.GetGenericArguments()[0], arg);
+                                // ParameterInfo.DefaultValue returns the raw value if the enum is nullable that needs
+                                // to be parsed to the Enum type more info: https://github.com/dotnet/runtime/issues/12924
+                                Type argumentType = sigType.GetGenericArguments()[0];
+                                if (argumentType.IsEnum)
+                                {
+                                    arg = Enum.ToObject(argumentType, arg);
+                                }
                             }
 
                             isValueType = sigType.CheckValue(ref arg, ref copyBackArg, binder, culture, invokeAttr);

--- a/src/libraries/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/MethodInfoTests.cs
@@ -742,7 +742,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        public static void InvokeNullableEnumParameterDefualtNull()
+        public static void InvokeNullableEnumParameterDefaultNull()
         {
             MethodInfo method = typeof(EnumMethods).GetMethod("NullableEnumDefaultNull", BindingFlags.Static | BindingFlags.NonPublic);
 
@@ -753,7 +753,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        public static void InvokeNullableEnumParameterNoDefual()
+        public static void InvokeNullableEnumParameterNoDefault()
         {
             MethodInfo method = typeof(EnumMethods).GetMethod("NullableEnumNoDefault", BindingFlags.Static | BindingFlags.NonPublic);
 
@@ -1229,10 +1229,12 @@ namespace System.Reflection.Tests
         {
             return yesNo;
         }
+
         static YesNo? NullableEnumDefaultNull(YesNo? yesNo = null)
         {
             return yesNo;
         }
+
         static YesNo? NullableEnumNoDefault(YesNo? yesNo)
         {
             return yesNo;

--- a/src/libraries/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/MethodInfoTests.cs
@@ -709,6 +709,61 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        public static void InvokeNullableEnumParameterDefaultNo()
+        {
+            MethodInfo method = typeof(EnumMethods).GetMethod("NullableEnumDefaultNo", BindingFlags.Static | BindingFlags.NonPublic);
+
+            Assert.Null(method.Invoke(null, new object?[] { default(object) }));
+            Assert.Equal(YesNo.No, method.Invoke(null, new object?[] { YesNo.No }));
+            Assert.Equal(YesNo.Yes, method.Invoke(null, new object?[] { YesNo.Yes }));
+            Assert.Equal(YesNo.No, method.Invoke(null, new object?[] { Type.Missing }));
+        } 
+
+        [Fact]
+        public static void InvokeNullableEnumParameterDefaultYes()
+        {
+            MethodInfo method = typeof(EnumMethods).GetMethod("NullableEnumDefaultYes", BindingFlags.Static | BindingFlags.NonPublic);
+
+            Assert.Null(method.Invoke(null, new object?[] { default(object) }));
+            Assert.Equal(YesNo.No, method.Invoke(null, new object?[] { YesNo.No }));
+            Assert.Equal(YesNo.Yes, method.Invoke(null, new object?[] { YesNo.Yes }));
+            Assert.Equal(YesNo.Yes, method.Invoke(null, new object?[] { Type.Missing }));
+        }
+
+        [Fact]
+        public static void InvokeNonNullableEnumParameterDefaultYes()
+        {
+            MethodInfo method = typeof(EnumMethods).GetMethod("NonNullableEnumDefaultYes", BindingFlags.Static | BindingFlags.NonPublic);
+
+            Assert.Equal(YesNo.No, method.Invoke(null, new object[] { default(object) }));
+            Assert.Equal(YesNo.No, method.Invoke(null, new object[] { YesNo.No }));
+            Assert.Equal(YesNo.Yes, method.Invoke(null, new object[] { YesNo.Yes }));
+            Assert.Equal(YesNo.Yes, method.Invoke(null, new object[] { Type.Missing }));
+        }
+
+        [Fact]
+        public static void InvokeNullableEnumParameterDefualtNull()
+        {
+            MethodInfo method = typeof(EnumMethods).GetMethod("NullableEnumDefaultNull", BindingFlags.Static | BindingFlags.NonPublic);
+
+            Assert.Null(method.Invoke(null, new object?[] { default(object) }));
+            Assert.Equal(YesNo.No, method.Invoke(null, new object?[] { YesNo.No }));
+            Assert.Equal(YesNo.Yes, method.Invoke(null, new object?[] { YesNo.Yes }));
+            Assert.Null(method.Invoke(null, new object?[] { Type.Missing }));
+        }
+
+        [Fact]
+        public static void InvokeNullableEnumParameterNoDefual()
+        {
+            MethodInfo method = typeof(EnumMethods).GetMethod("NullableEnumNoDefault", BindingFlags.Static | BindingFlags.NonPublic);
+
+            Assert.Null(method.Invoke(null, new object?[] { default(object) }));
+            Assert.Equal(YesNo.No, method.Invoke(null, new object?[] { YesNo.No }));
+            Assert.Equal(YesNo.Yes, method.Invoke(null, new object?[] { YesNo.Yes }));
+            Assert.Throws<ArgumentException>(() => method.Invoke(null, new object?[] { Type.Missing }));
+        }
+
+        [Fact]
         public void ValueTypeMembers_WithOverrides()
         {
             ValueTypeWithOverrides obj = new() { Id = 1 };
@@ -1140,6 +1195,12 @@ namespace System.Reflection.Tests
         public int GetId() => Id;
     }
 
+    public enum YesNo
+    {
+        No = 0,
+        Yes = 1,
+    }
+
     public static class EnumMethods
     {
         public static bool PassColorsInt(ColorsInt color)
@@ -1152,6 +1213,29 @@ namespace System.Reflection.Tests
         {
             Assert.Equal(ColorsShort.Red, color);
             return true;
+        }
+
+        static YesNo NonNullableEnumDefaultYes(YesNo yesNo = YesNo.Yes)
+        {
+            return yesNo;
+        }
+
+        static YesNo? NullableEnumDefaultNo(YesNo? yesNo = YesNo.No)
+        {
+            return yesNo;
+        }
+
+        static YesNo? NullableEnumDefaultYes(YesNo? yesNo = YesNo.Yes)
+        {
+            return yesNo;
+        }
+        static YesNo? NullableEnumDefaultNull(YesNo? yesNo = null)
+        {
+            return yesNo;
+        }
+        static YesNo? NullableEnumNoDefault(YesNo? yesNo)
+        {
+            return yesNo;
         }
     }
 #pragma warning restore 0414


### PR DESCRIPTION
Fix: [Type.Missing doesn't convert to nullable enum in Method.Invoke](https://github.com/dotnet/runtime/issues/70925)

The root cause is: [ParameterInfo.DefaultValue returns the raw value if the enum is nullable](https://github.com/dotnet/runtime/issues/12924). So the root cause is a known issue and we choose to not fix for compatibility reason: 
https://github.com/dotnet/runtime/blob/fd31f1f01a1c755c965e6f20b3dfd08933e27808/src/coreclr/System.Private.CoreLib/src/System/Reflection/MdConstant.cs#L16-L20

Though for `MethodInfo.Invoke`  we could parse the raw value into the corresponding `Enum` and avoid throwing ArgumentException

Fixes https://github.com/dotnet/runtime/issues/70925