### PR TITLE
Disable ConnectWithRevocation_StapledOcsp on RHEL and CentOS 7

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -101,12 +101,17 @@ namespace System.Net.Security.Tests
         }
 
         [PlatformSpecific(TestPlatforms.Linux)]
-        [Theory]
+        [ConditionalTheory]
         [OuterLoop("Subject to system load race conditions")]
         [InlineData(false)]
         [InlineData(true)]
         public Task ConnectWithRevocation_StapledOcsp(bool offlineContext)
         {
+            if (PlatformDetection.IsRedHatFamily7)
+            {
+                throw new SkipTestException("Active test issue https://github.com/dotnet/runtime/issues/71037");
+            }
+
             // Offline will only work if
             // a) the revocation has been checked recently enough that it is cached, or
             // b) the server stapled the response

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -107,7 +107,7 @@ namespace System.Net.Security.Tests
         [InlineData(true)]
         public Task ConnectWithRevocation_StapledOcsp(bool offlineContext)
         {
-            if (PlatformDetection.IsRedHatFamily7)
+            if (PlatformDetection.IsRedHatFamily7 && !offlineContext)
             {
                 throw new SkipTestException("Active test issue https://github.com/dotnet/runtime/issues/71037");
             }


### PR DESCRIPTION
Best as I can tell, the test is only failing on RHEL7 and CentOS 7, so let's disable it there for now.

Contributes to https://github.com/dotnet/runtime/issues/71037.