### PR TITLE
Exclude root folder's .md files as well from triggering CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution to .NET Runtime
 
-You can contribute to .NET Runtime with issues and PRs. Simply filing issues for problems you encounter is a great way to contribute. Contributing implementations is greatly appreciated. 
+You can contribute to .NET Runtime with issues and PRs. Simply filing issues for problems you encounter is a great way to contribute. Contributing implementations is greatly appreciated.
 
 ## Reporting Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution to .NET Runtime
 
-You can contribute to .NET Runtime with issues and PRs. Simply filing issues for problems you encounter is a great way to contribute. Contributing implementations is greatly appreciated.
+You can contribute to .NET Runtime with issues and PRs. Simply filing issues for problems you encounter is a great way to contribute. Contributing implementations is greatly appreciated. 
 
 ## Reporting Issues
 

--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -8,7 +8,7 @@ trigger:
     - '*'
     - src/libraries/System.Private.CoreLib/*
     exclude:
-    - **.md
+    - '**.md'
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -8,7 +8,7 @@ trigger:
     - '*'
     - src/libraries/System.Private.CoreLib/*
     exclude:
-    - /**/*.md
+    - **.md
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -9,7 +9,7 @@ trigger:
     - '*'
     - src/libraries/System.Private.CoreLib/*
     exclude:
-    - **.md
+    - '**.md'
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -9,7 +9,7 @@ trigger:
     - '*'
     - src/libraries/System.Private.CoreLib/*
     exclude:
-    - /**/*.md
+    - **.md
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -8,7 +8,7 @@ trigger:
     - '*'
     - src/libraries/System.Private.CoreLib/*
     exclude:
-    - **.md
+    - '**.md'
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -8,7 +8,7 @@ trigger:
     - '*'
     - src/libraries/System.Private.CoreLib/*
     exclude:
-    - /**/*.md
+    - **.md
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -15,7 +15,7 @@ pr:
     - docs/manpages/*
     - eng/pipelines/global-build.yml
     exclude:
-    - /**/*.md
+    - **.md
     - .github/*
     - docs/*
     - eng/pipelines/coreclr/*.*

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -15,7 +15,7 @@ pr:
     - docs/manpages/*
     - eng/pipelines/global-build.yml
     exclude:
-    - **.md
+    - '**.md'
     - .github/*
     - docs/*
     - eng/pipelines/coreclr/*.*

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -10,7 +10,7 @@ trigger:
     include:
     - '*'
     exclude:
-    - /**/*.md
+    - **.md
     - eng/Version.Details.xml
     - .github/*
     - docs/*
@@ -35,7 +35,7 @@ pr:
     include:
     - '*'
     exclude:
-    - /**/*.md
+    - **.md
     - eng/Version.Details.xml
     - .github/*
     - docs/*

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -10,7 +10,7 @@ trigger:
     include:
     - '*'
     exclude:
-    - **.md
+    - '**.md'
     - eng/Version.Details.xml
     - .github/*
     - docs/*
@@ -35,7 +35,7 @@ pr:
     include:
     - '*'
     exclude:
-    - **.md
+    - '**.md'
     - eng/Version.Details.xml
     - .github/*
     - docs/*

--- a/eng/pipelines/runtime-llvm.yml
+++ b/eng/pipelines/runtime-llvm.yml
@@ -12,7 +12,7 @@ trigger:
     - '*'
     - docs/manpages/*
     exclude:
-    - /**/*.md
+    - **.md
     - eng/Version.Details.xml
     - .github/*
     - docs/*
@@ -38,7 +38,7 @@ pr:
     - '*'
     - docs/manpages/*
     exclude:
-    - /**/*.md
+    - **.md
     - eng/Version.Details.xml
     - .github/*
     - docs/*

--- a/eng/pipelines/runtime-llvm.yml
+++ b/eng/pipelines/runtime-llvm.yml
@@ -12,7 +12,7 @@ trigger:
     - '*'
     - docs/manpages/*
     exclude:
-    - **.md
+    - '**.md'
     - eng/Version.Details.xml
     - .github/*
     - docs/*
@@ -38,7 +38,7 @@ pr:
     - '*'
     - docs/manpages/*
     exclude:
-    - **.md
+    - '**.md'
     - eng/Version.Details.xml
     - .github/*
     - docs/*

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -10,7 +10,7 @@ trigger:
     - '*'
     - docs/manpages/*
     exclude:
-    - **.md
+    - '**.md'
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -10,7 +10,7 @@ trigger:
     - '*'
     - docs/manpages/*
     exclude:
-    - /**/*.md
+    - **.md
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/runtime-richnav.yml
+++ b/eng/pipelines/runtime-richnav.yml
@@ -8,7 +8,7 @@ trigger:
     include:
     - '*'
     exclude:
-    - **.md
+    - '**.md'
     - eng/Version.Details.xml
     - .github/*
     - docs/*

--- a/eng/pipelines/runtime-richnav.yml
+++ b/eng/pipelines/runtime-richnav.yml
@@ -8,7 +8,7 @@ trigger:
     include:
     - '*'
     exclude:
-    - /**/*.md
+    - **.md
     - eng/Version.Details.xml
     - .github/*
     - docs/*

--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -11,7 +11,7 @@ trigger:
     include:
     - '*'
     exclude:
-    - /**/*.md
+    - **.md
     - eng/Version.Details.xml
     - .github/*
     - docs/*
@@ -37,7 +37,7 @@ pr:
     - '*'
     - docs/manpages/*
     exclude:
-    - /**/*.md
+    - **.md
     - eng/Version.Details.xml
     - .github/*
     - docs/*

--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -11,7 +11,7 @@ trigger:
     include:
     - '*'
     exclude:
-    - **.md
+    - '**.md'
     - eng/Version.Details.xml
     - .github/*
     - docs/*
@@ -37,7 +37,7 @@ pr:
     - '*'
     - docs/manpages/*
     exclude:
-    - **.md
+    - '**.md'
     - eng/Version.Details.xml
     - .github/*
     - docs/*

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -12,7 +12,7 @@ trigger:
     - '*'
     - docs/manpages/*
     exclude:
-    - /**/*.md
+    - **.md
     - eng/Version.Details.xml
     - .github/*
     - docs/*
@@ -38,7 +38,7 @@ pr:
     - '*'
     - docs/manpages/*
     exclude:
-    - /**/*.md
+    - **.md
     - eng/Version.Details.xml
     - .github/*
     - docs/*

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -12,7 +12,7 @@ trigger:
     - '*'
     - docs/manpages/*
     exclude:
-    - **.md
+    - '**.md'
     - eng/Version.Details.xml
     - .github/*
     - docs/*
@@ -38,7 +38,7 @@ pr:
     - '*'
     - docs/manpages/*
     exclude:
-    - **.md
+    - '**.md'
     - eng/Version.Details.xml
     - .github/*
     - docs/*

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -12,7 +12,7 @@ trigger:
     - '*'
     - docs/manpages/*
     exclude:
-    - **.md
+    - '**.md'
     - eng/Version.Details.xml
     - .github/*
     - docs/*
@@ -29,7 +29,7 @@ pr:
     - '*'
     - docs/manpages/*
     exclude:
-    - **.md
+    - '**.md'
     - eng/Version.Details.xml
     - .github/*
     - docs/*

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -12,7 +12,7 @@ trigger:
     - '*'
     - docs/manpages/*
     exclude:
-    - /**/*.md
+    - **.md
     - eng/Version.Details.xml
     - .github/*
     - docs/*
@@ -29,7 +29,7 @@ pr:
     - '*'
     - docs/manpages/*
     exclude:
-    - /**/*.md
+    - **.md
     - eng/Version.Details.xml
     - .github/*
     - docs/*


### PR DESCRIPTION
Came up in discussion of https://github.com/dotnet/runtime/pull/71394

I will make another commit to update `CONTRIBUTING.md` to make sure it works as expected.