### PR TITLE
Fix OSX thread_set_state calls in CONTEXT_SetThreadContextOnPort

### DIFF
--- a/src/coreclr/pal/src/thread/context.cpp
+++ b/src/coreclr/pal/src/thread/context.cpp
@@ -1394,10 +1394,15 @@ CONTEXT_SetThreadContextOnPort(
 
         StateCount = sizeof(State) / sizeof(natural_t);
 
-        MachRet = thread_set_state(Port,
-                                   StateFlavor,
-                                   (thread_state_t)&State,
-                                   StateCount);
+        do
+        {
+            MachRet = thread_set_state(Port,
+                                       StateFlavor,
+                                       (thread_state_t)&State,
+                                       StateCount);
+        }
+        while (MachRet == KERN_ABORTED);
+
         if (MachRet != KERN_SUCCESS)
         {
             ASSERT("thread_set_state(THREAD_STATE) failed: %d\n", MachRet);
@@ -1498,10 +1503,15 @@ CONTEXT_SetThreadContextOnPort(
         }
 #endif
 
-        MachRet = thread_set_state(Port,
-                                   StateFlavor,
-                                   (thread_state_t)&State,
-                                   StateCount);
+        do
+        {
+            MachRet = thread_set_state(Port,
+                                       StateFlavor,
+                                       (thread_state_t)&State,
+                                       StateCount);
+        }
+        while (MachRet == KERN_ABORTED);
+
         if (MachRet != KERN_SUCCESS)
         {
             ASSERT("thread_set_state(FLOAT_STATE) failed: %d\n", MachRet);


### PR DESCRIPTION
While testing an issue, I've found that if signals are delivered on the
thread that is a target of the `thread_set_state`, the thread_set_state
sometimes fails with `KERN_ABORTED`. This happens due to the signal
interrupting the `thread_set_state`. Retrying the `thread_set_state`
succeeds and everything works correctly.

This change adds retry loop over the `thread_set_state` calls in the
`CONTEXT_SetThreadContextOnPort`. There are other usages of `thread_set_state`
in the hardware exception handling code, but those are not subject to
the issue.

I have verified the fix using a testing script that fires a signal
to the corerun process in a loop and ran coreclr pri 1 tests on
the same machine at the same time. Before my change, I was getting an assert
very quickly.