### PR TITLE
Re-create profile data on profile-use-only mode

### DIFF
--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -1185,16 +1185,13 @@ void MulticoreJitManager::StartProfile(AppDomain * pDomain, AssemblyBinder *pBin
 
     if ((pProfile != NULL) && (pProfile[0] != 0)) // Ignore empty file name, just same as StopProfile
     {
-        bool gatherProfile = (int)CLRConfig::GetConfigValue(CLRConfig::INTERNAL_MultiCoreJitNoProfileGather) == 0;
-
         MulticoreJitRecorder * pRecorder = new (nothrow) MulticoreJitRecorder(
             pDomain,
-            pBinder,
-            gatherProfile);
+            pBinder);
 
         if (pRecorder != NULL)
         {
-            gatherProfile = pRecorder->CanGatherProfile();
+            bool gatherProfile = (int)CLRConfig::GetConfigValue(CLRConfig::INTERNAL_MultiCoreJitNoProfileGather) == 0;
 
             m_pMulticoreJitRecorder = pRecorder;
 
@@ -1204,9 +1201,11 @@ void MulticoreJitManager::StartProfile(AppDomain * pDomain, AssemblyBinder *pBin
 
             MulticoreJitTrace(("MulticoreJitRecorder session %d created: %x", sessionID, hr));
 
-            if ((hr == COR_E_BADIMAGEFORMAT) || SUCCEEDED(hr)) // Ignore COR_E_BADIMAGEFORMAT, always record new profile
+            if ((hr == COR_E_BADIMAGEFORMAT) || (SUCCEEDED(hr) && gatherProfile)) // Ignore COR_E_BADIMAGEFORMAT, always record new profile
             {
-                m_fRecorderActive = gatherProfile;
+                m_pMulticoreJitRecorder->Activate();
+
+                m_fRecorderActive = m_pMulticoreJitRecorder->CanGatherProfile();
             }
 
             _FireEtwMulticoreJit(W("STARTPROFILE"), W("Recorder"), m_fRecorderActive, hr, 0);

--- a/src/coreclr/vm/multicorejitimpl.h
+++ b/src/coreclr/vm/multicorejitimpl.h
@@ -646,7 +646,7 @@ private:
 
 public:
 
-    MulticoreJitRecorder(AppDomain * pDomain, AssemblyBinder * pBinder, bool fRecorderActive)
+    MulticoreJitRecorder(AppDomain * pDomain, AssemblyBinder * pBinder)
         : m_stats(pDomain->GetMulticoreJitManager().GetStats())
         , m_ModuleList(nullptr)
         , m_JitInfoArray(nullptr)
@@ -656,18 +656,8 @@ public:
         m_pDomain = pDomain;
         m_pBinder = pBinder;
 
-        if (fRecorderActive)
-        {
-            m_ModuleList = new (nothrow) RecorderModuleInfo[MAX_MODULES];
-        }
-
         m_ModuleCount = 0;
         m_ModuleDepCount = 0;
-
-        if (fRecorderActive)
-        {
-            m_JitInfoArray = new (nothrow) RecorderInfo[MAX_METHODS];
-        }
 
         m_JitInfoCount = 0;
         m_fFirstMethod = true;
@@ -713,6 +703,14 @@ public:
 
         return (m_JitInfoCount >= (LONG) MAX_METHODS) ||
                (m_ModuleCount  >= MAX_MODULES);
+    }
+
+    void Activate()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        m_ModuleList = new (nothrow) RecorderModuleInfo[MAX_MODULES];
+        m_JitInfoArray = new (nothrow) RecorderInfo[MAX_METHODS];
     }
 
     void RecordMethodJitOrLoad(MethodDesc * pMethod, bool application);


### PR DESCRIPTION
If a BADIMAGEFORMAT error occurs due to incorrect profile data in the multicorejit player, the profile data must be regenerated.
The profile-use-only mode, which uses only multicorejit player, must be operated the same way.

This patch activate multicorejit recorder to re-create the profile data when the multicorejit player cannot be executed due to BADIMAGEFORMAT error on profile-use-only mode.

