### PR TITLE
[wasm] Drop active issue on fixed NodeJS test

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/AbortTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/AbortTest.cs
@@ -17,7 +17,6 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/63673", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJS))]
         public async Task Abort_ConnectAndAbort_ThrowsWebSocketExceptionWithmessage(Uri server)
         {
             using (var cws = new ClientWebSocket())


### PR DESCRIPTION
The test was fixed in the https://github.com/dotnet/runtime/pull/69858.
Here I'm only dropping the active issue attribute.

Fixes https://github.com/dotnet/runtime/issues/63673