### PR TITLE
add basic support for SNI different than URI in H3

### DIFF
--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -119,6 +119,7 @@
     <Reference Include="System.Console" Condition="'$(Configuration)' == 'Debug'" />
     <Reference Include="System.Diagnostics.Tracing" />
     <Reference Include="System.Memory" />
+    <Reference Include="System.Net.NameResolution" />
     <Reference Include="System.Net.Primitives" />
     <Reference Include="System.Net.Sockets" />
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Net.Quic.Implementations.MsQuic.Internal;
+using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
@@ -536,15 +537,32 @@ namespace System.Net.Quic.Implementations.MsQuic
                 // We don't have way how to set separate SNI and name for connection at this moment.
                 // If the name is actually IP address we can use it to make at least some cases work for people
                 // who want to bypass DNS but connect to specific virtual host.
-                if (!string.IsNullOrEmpty(_state.TargetHost) && !dnsHost.Equals(_state.TargetHost, StringComparison.InvariantCultureIgnoreCase) && IPAddress.TryParse(dnsHost, out IPAddress? address))
+                if (!dnsHost.Equals(_state.TargetHost, StringComparison.InvariantCultureIgnoreCase) && !string.IsNullOrEmpty(_state.TargetHost))
                 {
-                    // This is form of IPAddress and _state.TargetHost is set to different string
-                    Debug.Assert(!Monitor.IsEntered(_state), "!Monitor.IsEntered(_state)");
-                    MsQuicParameterHelpers.SetIPEndPointParam(MsQuicApi.Api, _state.Handle, QUIC_PARAM_CONN_REMOTE_ADDRESS, new IPEndPoint(address, port));
                     targetHost = _state.TargetHost!;
+                    if (IPAddress.TryParse(dnsHost, out IPAddress? address))
+                    {
+                        // This is form of IPAddress and _state.TargetHost is set to different string
+                        Debug.Assert(!Monitor.IsEntered(_state), "!Monitor.IsEntered(_state)");
+                        MsQuicParameterHelpers.SetIPEndPointParam(MsQuicApi.Api, _state.Handle, QUIC_PARAM_CONN_REMOTE_ADDRESS, new IPEndPoint(address, port));
+                    }
+                    else
+                    {
+                        IPAddress[] addresses = Dns.GetHostAddressesAsync(dnsHost, cancellationToken).GetAwaiter().GetResult();
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (addresses.Length == 0)
+                        {
+                            throw new SocketException((int)SocketError.HostNotFound);
+                        }
+                        Debug.Assert(!Monitor.IsEntered(_state), "!Monitor.IsEntered(_state)");
+                        // We can do something better than just using first IP but that is what
+                        // MsQuic does today anyway.
+                        MsQuicParameterHelpers.SetIPEndPointParam(MsQuicApi.Api, _state.Handle, QUIC_PARAM_CONN_REMOTE_ADDRESS, new IPEndPoint(addresses[0], port));
+                    }
                 }
                 else
                 {
+                    // We defer everything to MsQuic.
                     targetHost = dnsHost;
                 }
             }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -265,6 +265,8 @@ namespace System.Net.Quic.Tests
             string? receivedHostName = null;
 
             var listenerOptions = CreateQuicListenerOptions();
+            // loopback may resolve to IPv6
+            listenerOptions.ListenEndPoint = new IPEndPoint(IPAddress.IPv6Any, 0);
             listenerOptions.ServerAuthenticationOptions.ServerCertificate = null;
             listenerOptions.ServerAuthenticationOptions.ServerCertificateSelectionCallback = (sender, hostName) =>
             {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -255,8 +255,10 @@ namespace System.Net.Quic.Tests
             serverConnection.Dispose();
         }
 
-        [Fact]
-        public async Task ConnectWithIpSetsSni()
+        [Theory]
+        [InlineData("127.0.0.1")]
+        [InlineData("localhost")]
+        public async Task ConnectWithIpSetsSni(string destination)
         {
             X509Certificate2 certificate = System.Net.Test.Common.Configuration.Certificates.GetServerCertificate();
             string expectedName = "foobar";
@@ -274,7 +276,7 @@ namespace System.Net.Quic.Tests
 
             QuicClientConnectionOptions clientOptions = CreateQuicClientOptions();
             clientOptions.ClientAuthenticationOptions.TargetHost = expectedName;
-            clientOptions.RemoteEndPoint = new DnsEndPoint("127.0.0.1", listener.ListenEndPoint.Port);
+            clientOptions.RemoteEndPoint = new DnsEndPoint(destination, listener.ListenEndPoint.Port);
 
             (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection(clientOptions, listener);
             Assert.Equal(expectedName, receivedHostName);


### PR DESCRIPTION
We had minimal support for cases with IP address. This extends that with simple DNS lookup. While we can get more than one address and in Sockets we would try to try them all, this PR simply mimics MsQuic and only use first IP. 
That may be sufficient as this scenario mostly involve testing. Also in the future we can enhance whole connect (or MsQuic) to do something better.

fixes #57169
