### PR TITLE
[debugger] Fix debugging on Mac and iOS

### DIFF
--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4479,13 +4479,15 @@ mini_init (const char *filename)
 #endif
 
 	mono_interp_stub_init ();
+
+	mono_components_init ();
+
+	mono_component_debugger ()->parse_options (mono_debugger_agent_get_sdb_options ());
+
 #ifndef DISABLE_INTERPRETER
 	if (mono_use_interpreter)
 		mono_ee_interp_init (mono_interp_opts_string);
 #endif
-	mono_components_init ();
-
-	mono_component_debugger ()->parse_options (mono_debugger_agent_get_sdb_options ());
 
 	mono_os_mutex_init_recursive (&jit_mutex);
 


### PR DESCRIPTION
We need to set this:
`mini_get_debug_options ()->mdb_optimizations = TRUE;`
before initialize the interpreter, otherwise the interpreter optimizations will be turned on and we will not be able to see the correct variable values.
https://github.com/dotnet/runtime/blob/4adb1172658f74e6a513bece426005d7f2ba7a04/src/mono/mono/mini/interp/interp.c#L8123

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1558698
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1513227