### PR TITLE
JIT: Avoid introducing GT_NULLCHECK in gtTryRemoveBoxUpstreamEffects

### DIFF
--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -69,10 +69,8 @@ void Compiler::optCheckFlagsAreSet(unsigned    methodFlag,
 // optEarlyProp: The entry point of the early value propagation.
 //
 // Notes:
-//    This phase performs an SSA-based value propagation, including
-//      1. Array length propagation.
-//      2. Runtime type handle propagation.
-//      3. Null check folding.
+//    This phase performs an SSA-based value propagation, including array
+//    length propagation and null check folding.
 //
 //    For array length propagation, a demand-driven SSA-based backwards tracking of constant
 //    array lengths is performed at each array length reference site which is in form of a
@@ -82,10 +80,6 @@ void Compiler::optCheckFlagsAreSet(unsigned    methodFlag,
 //    at the original array allocation site where we can grab the array length. The
 //    GT_ARR_LENGTH node will then be rewritten to a GT_CNS_INT node if the array length is
 //    constant.
-//
-//    Similarly, the same algorithm also applies to rewriting a method table (also known as
-//    vtable) reference site which is in form of GT_INDIR node. The base pointer, which is
-//    an object reference pointer, is treated in the same way as an array reference pointer.
 //
 //    Null check folding tries to find GT_INDIR(obj + const) that GT_NULLCHECK(obj) can be folded into
 //    and removed. Currently, the algorithm only matches GT_INDIR and GT_NULLCHECK in the same basic block.

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -13866,7 +13866,8 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
         if (options == BR_REMOVE_AND_NARROW || options == BR_REMOVE_AND_NARROW_WANT_TYPE_HANDLE)
         {
             JITDUMP(" to read first byte of struct via modified [%06u]\n", dspTreeID(copySrc));
-            gtChangeOperToNullCheck(copySrc, compCurBB);
+            copySrc->ChangeOper(GT_IND);
+            copySrc->ChangeType(TYP_BYTE);
         }
         else
         {


### PR DESCRIPTION
Adding GT_NULLCHECK nodes requires knowledge of which basic block the
nullcheck will end up in. We do not have this easily available in all
places this method is called, and regardless using GT_NULLCHECK here has
minimal diffs.

Alternative we could store the `BasicBlock` together with `GenTreeBox::gtCopyStmtWhenInlinedBoxValue`,
but the diffs here are so small that I didn't bother.

Fix #71193

Also an unrelated comment clean-up that I have noticed while looking at early prop (we do not do this optimization here anymore).