### PR TITLE
Use llvm-objcopy for regular and cross builds

### DIFF
--- a/eng/native/configuretools.cmake
+++ b/eng/native/configuretools.cmake
@@ -34,7 +34,7 @@ if(NOT WIN32 AND NOT CLR_CMAKE_TARGET_BROWSER)
       "${TOOLSET_PREFIX}${exec}")
 
     if (EXEC_LOCATION_${exec} STREQUAL "EXEC_LOCATION_${exec}-NOTFOUND")
-      message(FATAL_ERROR "Unable to find toolchain executable. Name: ${exec}, Prefix: ${TOOLSET_PREFIX}.")
+      message(FATAL_ERROR "Unable to find toolchain executable. Name: '${exec}', Prefix: '${TOOLSET_PREFIX}.'")
     endif()
     set(${var} ${EXEC_LOCATION_${exec}} PARENT_SCOPE)
   endfunction()
@@ -42,7 +42,6 @@ if(NOT WIN32 AND NOT CLR_CMAKE_TARGET_BROWSER)
   locate_toolchain_exec(ar CMAKE_AR)
   locate_toolchain_exec(nm CMAKE_NM)
   locate_toolchain_exec(ranlib CMAKE_RANLIB)
-  locate_toolchain_exec(objcopy CMAKE_OBJCOPY)
 
   if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     locate_toolchain_exec(link CMAKE_LINKER)
@@ -50,14 +49,14 @@ if(NOT WIN32 AND NOT CLR_CMAKE_TARGET_BROWSER)
 
   if(NOT CLR_CMAKE_TARGET_OSX AND NOT CLR_CMAKE_TARGET_MACCATALYST AND NOT CLR_CMAKE_TARGET_IOS AND NOT CLR_CMAKE_TARGET_TVOS AND (NOT CLR_CMAKE_TARGET_ANDROID OR CROSS_ROOTFS))
     locate_toolchain_exec(objdump CMAKE_OBJDUMP)
+    locate_toolchain_exec(objcopy CMAKE_OBJCOPY)
+
 
     if(CLR_CMAKE_TARGET_ANDROID)
       set(TOOLSET_PREFIX ${ANDROID_TOOLCHAIN_PREFIX})
     elseif(CMAKE_CROSSCOMPILING AND NOT DEFINED CLR_CROSS_COMPONENTS_BUILD AND
         CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv8l|armv7l|armv6l|aarch64|arm|s390x|ppc64le)$")
       set(TOOLSET_PREFIX "${TOOLCHAIN}-")
-    elseif(CLR_CMAKE_TARGET_ALPINE_LINUX AND CMAKE_C_COMPILER_VERSION VERSION_LESS 8.0)
-      set(TOOLSET_PREFIX "")
     endif()
 
   endif()

--- a/eng/native/configuretools.cmake
+++ b/eng/native/configuretools.cmake
@@ -42,6 +42,7 @@ if(NOT WIN32 AND NOT CLR_CMAKE_TARGET_BROWSER)
   locate_toolchain_exec(ar CMAKE_AR)
   locate_toolchain_exec(nm CMAKE_NM)
   locate_toolchain_exec(ranlib CMAKE_RANLIB)
+  locate_toolchain_exec(objcopy CMAKE_OBJCOPY)
 
   if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     locate_toolchain_exec(link CMAKE_LINKER)
@@ -55,11 +56,10 @@ if(NOT WIN32 AND NOT CLR_CMAKE_TARGET_BROWSER)
     elseif(CMAKE_CROSSCOMPILING AND NOT DEFINED CLR_CROSS_COMPONENTS_BUILD AND
         CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv8l|armv7l|armv6l|aarch64|arm|s390x|ppc64le)$")
       set(TOOLSET_PREFIX "${TOOLCHAIN}-")
-    else()
+    elseif(CLR_CMAKE_TARGET_ALPINE_LINUX AND CMAKE_C_COMPILER_VERSION VERSION_LESS 8.0)
       set(TOOLSET_PREFIX "")
     endif()
 
-    locate_toolchain_exec(objcopy CMAKE_OBJCOPY)
   endif()
 endif()
 

--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -427,7 +427,7 @@ function(strip_symbols targetName outputFilename)
         POST_BUILD
         VERBATIM
         COMMAND ${CMAKE_OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
-        COMMAND ${CMAKE_OBJCOPY} --strip-unneeded ${strip_source_file}
+        COMMAND ${CMAKE_OBJCOPY} --strip-debug --strip-unneeded ${strip_source_file}
         COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
         COMMENT "Stripping symbols from ${strip_source_file} into file ${strip_destination_file}"
         )


### PR DESCRIPTION
This change enables using `llvm-objcopy` instead of the gnu `objcopy` for
building runtime. The benefit for cross build is that the host machine
no longer needs to have cross-architecture gnu `objcopy` installed.

There was an attempt to enable `llvm-objcopy` in the past, but it was
reverted due to a problem with `objcopy` in llvm 9 that incorrectly
didn't strip debug symbols when `--strip-unneeded` option was specified.
I have fixed that by adding `--strip-debug` in addition to the`--strip-unneeded`.