### PR TITLE
Fix Avx2.cs comments

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx2.cs
@@ -2225,22 +2225,22 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// __m128i _mm_sllv_epi32 (__m128i a, __m128i count)
-        ///   VPSLLVD xmm, ymm, xmm/m128
+        ///   VPSLLVD xmm, xmm, xmm/m128
         /// </summary>
         public static Vector128<int> ShiftLeftLogicalVariable(Vector128<int> value, Vector128<uint> count) => ShiftLeftLogicalVariable(value, count);
         /// <summary>
         /// __m128i _mm_sllv_epi32 (__m128i a, __m128i count)
-        ///   VPSLLVD xmm, ymm, xmm/m128
+        ///   VPSLLVD xmm, xmm, xmm/m128
         /// </summary>
         public static Vector128<uint> ShiftLeftLogicalVariable(Vector128<uint> value, Vector128<uint> count) => ShiftLeftLogicalVariable(value, count);
         /// <summary>
         /// __m128i _mm_sllv_epi64 (__m128i a, __m128i count)
-        ///   VPSLLVQ xmm, ymm, xmm/m128
+        ///   VPSLLVQ xmm, xmm, xmm/m128
         /// </summary>
         public static Vector128<long> ShiftLeftLogicalVariable(Vector128<long> value, Vector128<ulong> count) => ShiftLeftLogicalVariable(value, count);
         /// <summary>
         /// __m128i _mm_sllv_epi64 (__m128i a, __m128i count)
-        ///   VPSLLVQ xmm, ymm, xmm/m128
+        ///   VPSLLVQ xmm, xmm, xmm/m128
         /// </summary>
         public static Vector128<ulong> ShiftLeftLogicalVariable(Vector128<ulong> value, Vector128<ulong> count) => ShiftLeftLogicalVariable(value, count);
 


### PR DESCRIPTION
This should eventually also fix the [docs](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.intrinsics.x86.avx2.shiftleftlogicalvariable?view=net-6.0#system-runtime-intrinsics-x86-avx2-shiftleftlogicalvariable(system-runtime-intrinsics-vector128((system-int32))-system-runtime-intrinsics-vector128((system-uint32)))) and the tooltip in Visual Studio (or maybe not?):
![image](https://user-images.githubusercontent.com/11244291/176499688-6bd15154-8079-4c46-bfce-53ae59ab812b.png)
