### PR TITLE
Implement new metadata knobs as internal APIs

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/Common/JsonHelpers.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
 using System.Collections.Generic;
 
 namespace System.Text.Json
@@ -22,6 +23,42 @@ namespace System.Text.Json
             return false;
 #else
             return dictionary.TryAdd(key, value);
+#endif
+        }
+
+        /// <summary>
+        /// Provides an in-place, stable sorting implementation for List.
+        /// </summary>
+        internal static void StableSortByKey<T, TKey>(this List<T> items, Func<T, TKey> keySelector)
+            where TKey : unmanaged, IComparable<TKey>
+        {
+#if NET6_0_OR_GREATER
+            Span<T> span = CollectionsMarshal.AsSpan(items);
+
+            // Tuples implement lexical ordering OOTB which can be used to encode stable sorting
+            // using the actual key as the first element and index as the second element.
+            const int StackallocThreshold = 32;
+            Span<(TKey, int)> keys = span.Length <= StackallocThreshold
+                ? (stackalloc (TKey, int)[StackallocThreshold]).Slice(0, span.Length)
+                : new (TKey, int)[span.Length];
+
+            for (int i = 0; i < keys.Length; i++)
+            {
+                keys[i] = (keySelector(span[i]), i);
+            }
+
+            MemoryExtensions.Sort(keys, span);
+#else
+            T[] arrayCopy = items.ToArray();
+            (TKey, int)[] keys = new (TKey, int)[arrayCopy.Length];
+            for (int i = 0; i < keys.Length; i++)
+            {
+                keys[i] = (keySelector(items[i]), i);
+            }
+
+            Array.Sort(keys, arrayCopy);
+            items.Clear();
+            items.AddRange(arrayCopy);
 #endif
         }
     }

--- a/src/libraries/System.Text.Json/Common/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/Common/JsonHelpers.cs
@@ -53,7 +53,7 @@ namespace System.Text.Json
             (TKey, int)[] keys = new (TKey, int)[arrayCopy.Length];
             for (int i = 0; i < keys.Length; i++)
             {
-                keys[i] = (keySelector(items[i]), i);
+                keys[i] = (keySelector(arrayCopy[i]), i);
             }
 
             Array.Sort(keys, arrayCopy);

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -4,7 +4,6 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -16,7 +15,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
-using Microsoft.CodeAnalysis.Text;
 
 namespace System.Text.Json.SourceGeneration
 {

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -668,4 +668,7 @@
   <data name="JsonPolymorphismOptionsAssociatedWithDifferentJsonTypeInfo" xml:space="preserve">
     <value>Parameter already associated with a different JsonTypeInfo instance.</value>
   </data>
+  <data name="SerializationCallbacksNotSupported" xml:space="preserve">
+    <value>Serialization callbacks are not supported in metadata kind '{0}'.</value>
+  </data>
 </root>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -364,6 +364,7 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Reference Include="System.Reflection.Emit.Lightweight" />
     <Reference Include="System.Reflection.Primitives" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Runtime.Loader" />
     <Reference Include="System.Text.Encoding.Extensions" />
     <Reference Include="System.Threading" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.KeyCollection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.KeyCollection.cs
@@ -30,7 +30,7 @@ namespace System.Text.Json
 
             IEnumerator IEnumerable.GetEnumerator()
             {
-                foreach (KeyValuePair<string, T?> item in _parent)
+                foreach (KeyValuePair<string, T> item in _parent)
                 {
                     yield return item.Key;
                 }
@@ -49,7 +49,7 @@ namespace System.Text.Json
                     ThrowHelper.ThrowArgumentOutOfRangeException_ArrayIndexNegative(nameof(index));
                 }
 
-                foreach (KeyValuePair<string, T?> item in _parent)
+                foreach (KeyValuePair<string, T> item in _parent)
                 {
                     if (index >= propertyNameArray.Length)
                     {
@@ -62,7 +62,7 @@ namespace System.Text.Json
 
             public IEnumerator<string> GetEnumerator()
             {
-                foreach (KeyValuePair<string, T?> item in _parent)
+                foreach (KeyValuePair<string, T> item in _parent)
                 {
                     yield return item.Key;
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.ValueCollection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.ValueCollection.cs
@@ -10,12 +10,12 @@ namespace System.Text.Json
     {
         private ValueCollection? _valueCollection;
 
-        public ICollection<T?> GetValueCollection()
+        public ICollection<T> GetValueCollection()
         {
             return _valueCollection ??= new ValueCollection(this);
         }
 
-        private sealed class ValueCollection : ICollection<T?>
+        private sealed class ValueCollection : ICollection<T>
         {
             private readonly JsonPropertyDictionary<T> _parent;
 
@@ -30,26 +30,26 @@ namespace System.Text.Json
 
             IEnumerator IEnumerable.GetEnumerator()
             {
-                foreach (KeyValuePair<string, T?> item in _parent)
+                foreach (KeyValuePair<string, T> item in _parent)
                 {
                     yield return item.Value;
                 }
             }
 
-            public void Add(T? jsonNode) => ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
+            public void Add(T jsonNode) => ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
 
             public void Clear() => ThrowHelper.ThrowNotSupportedException_CollectionIsReadOnly();
 
-            public bool Contains(T? jsonNode) => _parent.ContainsValue(jsonNode);
+            public bool Contains(T jsonNode) => _parent.ContainsValue(jsonNode);
 
-            public void CopyTo(T?[] nodeArray, int index)
+            public void CopyTo(T[] nodeArray, int index)
             {
                 if (index < 0)
                 {
                     ThrowHelper.ThrowArgumentOutOfRangeException_ArrayIndexNegative(nameof(index));
                 }
 
-                foreach (KeyValuePair<string, T?> item in _parent)
+                foreach (KeyValuePair<string, T> item in _parent)
                 {
                     if (index >= nodeArray.Length)
                     {
@@ -60,15 +60,15 @@ namespace System.Text.Json
                 }
             }
 
-            public IEnumerator<T?> GetEnumerator()
+            public IEnumerator<T> GetEnumerator()
             {
-                foreach (KeyValuePair<string, T?> item in _parent)
+                foreach (KeyValuePair<string, T> item in _parent)
                 {
                     yield return item.Value;
                 }
             }
 
-            bool ICollection<T?>.Remove(T? node) => throw ThrowHelper.GetNotSupportedException_CollectionIsReadOnly();
+            bool ICollection<T>.Remove(T node) => throw ThrowHelper.GetNotSupportedException_CollectionIsReadOnly();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
@@ -3,38 +3,39 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Text.Json
 {
     /// <summary>
-    /// Keeps both a List and Dictionary in sync to enable determinstic enumeration ordering of List
+    /// Keeps both a List and Dictionary in sync to enable deterministic enumeration ordering of List
     /// and performance benefits of Dictionary once a threshold is hit.
     /// </summary>
-    internal sealed partial class JsonPropertyDictionary<T> where T : class
+    internal sealed partial class JsonPropertyDictionary<T> where T : class?
     {
         private const int ListToDictionaryThreshold = 9;
 
-        private Dictionary<string, T?>? _propertyDictionary;
-        private readonly List<KeyValuePair<string, T?>> _propertyList;
+        private Dictionary<string, T>? _propertyDictionary;
+        private readonly List<KeyValuePair<string, T>> _propertyList;
 
-        private StringComparer _stringComparer;
+        private readonly StringComparer _stringComparer;
 
         public JsonPropertyDictionary(bool caseInsensitive)
         {
             _stringComparer = caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-            _propertyList = new List<KeyValuePair<string, T?>>();
+            _propertyList = new List<KeyValuePair<string, T>>();
         }
 
         public JsonPropertyDictionary(bool caseInsensitive, int capacity)
         {
             _stringComparer = caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-            _propertyList = new List<KeyValuePair<string, T?>>(capacity);
+            _propertyList = new List<KeyValuePair<string, T>>(capacity);
         }
 
         // Enable direct access to the List for performance reasons.
-        public List<KeyValuePair<string, T?>> List => _propertyList;
+        public List<KeyValuePair<string, T>> List => _propertyList;
 
-        public void Add(string propertyName, T? value)
+        public void Add(string propertyName, T value)
         {
             if (IsReadOnly)
             {
@@ -49,7 +50,7 @@ namespace System.Text.Json
             AddValue(propertyName, value);
         }
 
-        public void Add(KeyValuePair<string, T?> property)
+        public void Add(KeyValuePair<string, T> property)
         {
             if (IsReadOnly)
             {
@@ -116,9 +117,9 @@ namespace System.Text.Json
             return TryRemoveProperty(propertyName, out _);
         }
 
-        public bool Contains(KeyValuePair<string, T?> item)
+        public bool Contains(KeyValuePair<string, T> item)
         {
-            foreach (KeyValuePair<string, T?> existing in this)
+            foreach (KeyValuePair<string, T> existing in this)
             {
                 if (ReferenceEquals(item.Value, existing.Value) && _stringComparer.Equals(item.Key, existing.Key))
                 {
@@ -129,14 +130,14 @@ namespace System.Text.Json
             return false;
         }
 
-        public void CopyTo(KeyValuePair<string, T?>[] array, int index)
+        public void CopyTo(KeyValuePair<string, T>[] array, int index)
         {
             if (index < 0)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException_ArrayIndexNegative(nameof(index));
             }
 
-            foreach (KeyValuePair<string, T?> item in _propertyList)
+            foreach (KeyValuePair<string, T> item in _propertyList)
             {
                 if (index >= array.Length)
                 {
@@ -147,9 +148,9 @@ namespace System.Text.Json
             }
         }
 
-        public IEnumerator<KeyValuePair<string, T?>> GetEnumerator()
+        public IEnumerator<KeyValuePair<string, T>> GetEnumerator()
         {
-            foreach (KeyValuePair<string, T?> item in _propertyList)
+            foreach (KeyValuePair<string, T> item in _propertyList)
             {
                 yield return item;
             }
@@ -157,9 +158,9 @@ namespace System.Text.Json
 
         public ICollection<string> Keys => GetKeyCollection();
 
-        public ICollection<T?> Values => GetValueCollection();
+        public ICollection<T> Values => GetValueCollection();
 
-        public bool TryGetValue(string propertyName, out T? value)
+        public bool TryGetValue(string propertyName, [MaybeNullWhen(false)] out T value)
         {
             if (propertyName is null)
             {
@@ -172,7 +173,7 @@ namespace System.Text.Json
             }
             else
             {
-                foreach (KeyValuePair<string, T?> item in _propertyList)
+                foreach (KeyValuePair<string, T> item in _propertyList)
                 {
                     if (_stringComparer.Equals(propertyName, item.Key))
                     {
@@ -188,6 +189,7 @@ namespace System.Text.Json
 
         public bool IsReadOnly { get; set; }
 
+        [DisallowNull]
         public T? this[string propertyName]
         {
             get
@@ -207,7 +209,7 @@ namespace System.Text.Json
             }
         }
 
-        public T? SetValue(string propertyName, T? value, Action? assignParent = null)
+        public T? SetValue(string propertyName, T value, Action? assignParent = null)
         {
             if (IsReadOnly)
             {
@@ -229,7 +231,7 @@ namespace System.Text.Json
                 if (JsonHelpers.TryAdd(_propertyDictionary, propertyName, value))
                 {
                     assignParent?.Invoke();
-                    _propertyList.Add(new KeyValuePair<string, T?>(propertyName, value));
+                    _propertyList.Add(new KeyValuePair<string, T>(propertyName, value));
                     return null;
                 }
 
@@ -250,7 +252,7 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    KeyValuePair<string, T?> current = _propertyList[i];
+                    KeyValuePair<string, T> current = _propertyList[i];
                     if (ReferenceEquals(current.Value, value))
                     {
                         // Ignore if the same value.
@@ -261,20 +263,20 @@ namespace System.Text.Json
                 }
 
                 assignParent?.Invoke();
-                _propertyList[i] = new KeyValuePair<string, T?>(propertyName, value);
+                _propertyList[i] = new KeyValuePair<string, T>(propertyName, value);
             }
             else
             {
                 assignParent?.Invoke();
                 _propertyDictionary?.Add(propertyName, value);
-                _propertyList.Add(new KeyValuePair<string, T?>(propertyName, value));
+                _propertyList.Add(new KeyValuePair<string, T>(propertyName, value));
                 Debug.Assert(existing == null);
             }
 
             return existing;
         }
 
-        private void AddValue(string propertyName, T? value)
+        private void AddValue(string propertyName, T value)
         {
             if (!TryAddValue(propertyName, value))
             {
@@ -282,7 +284,7 @@ namespace System.Text.Json
             }
         }
 
-        internal bool TryAddValue(string propertyName, T? value)
+        internal bool TryAddValue(string propertyName, T value)
         {
             if (IsReadOnly)
             {
@@ -307,7 +309,7 @@ namespace System.Text.Json
                 }
             }
 
-            _propertyList.Add(new KeyValuePair<string, T?>(propertyName, value));
+            _propertyList.Add(new KeyValuePair<string, T>(propertyName, value));
             return true;
         }
 
@@ -319,9 +321,9 @@ namespace System.Text.Json
             }
         }
 
-        internal bool ContainsValue(T? value)
+        internal bool ContainsValue(T value)
         {
-            foreach (T? item in GetValueCollection())
+            foreach (T item in GetValueCollection())
             {
                 if (ReferenceEquals(item, value))
                 {
@@ -332,9 +334,9 @@ namespace System.Text.Json
             return false;
         }
 
-        public KeyValuePair<string, T?>? FindValue(T? value)
+        public KeyValuePair<string, T>? FindValue(T value)
         {
-            foreach (KeyValuePair<string, T?> item in this)
+            foreach (KeyValuePair<string, T> item in this)
             {
                 if (ReferenceEquals(item.Value, value))
                 {
@@ -352,7 +354,7 @@ namespace System.Text.Json
                 return _propertyDictionary.ContainsKey(propertyName);
             }
 
-            foreach (KeyValuePair<string, T?> item in _propertyList)
+            foreach (KeyValuePair<string, T> item in _propertyList)
             {
                 if (_stringComparer.Equals(propertyName, item.Key))
                 {
@@ -367,7 +369,7 @@ namespace System.Text.Json
         {
             for (int i = 0; i < _propertyList.Count; i++)
             {
-                KeyValuePair<string, T?> current = _propertyList[i];
+                KeyValuePair<string, T> current = _propertyList[i];
                 if (_stringComparer.Equals(propertyName, current.Key))
                 {
                     return i;
@@ -377,9 +379,9 @@ namespace System.Text.Json
             return -1;
         }
 
-        public bool TryGetPropertyValue(string propertyName, out T? value) => TryGetValue(propertyName, out value);
+        public bool TryGetPropertyValue(string propertyName, [MaybeNullWhen(false)] out T value) => TryGetValue(propertyName, out value);
 
-        public bool TryRemoveProperty(string propertyName, out T? existing)
+        public bool TryRemoveProperty(string propertyName, [MaybeNullWhen(false)] out T existing)
         {
             if (IsReadOnly)
             {
@@ -399,7 +401,7 @@ namespace System.Text.Json
 
             for (int i = 0; i < _propertyList.Count; i++)
             {
-                KeyValuePair<string, T?> current = _propertyList[i];
+                KeyValuePair<string, T> current = _propertyList[i];
 
                 if (_stringComparer.Equals(current.Key, propertyName))
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyInfoDictionaryValueList.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyInfoDictionaryValueList.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json
     {
         private readonly JsonPropertyDictionary<JsonPropertyInfo> _parent;
         private List<JsonPropertyInfo>? _items;
-        private JsonTypeInfo _parentTypeInfo;
+        private readonly JsonTypeInfo _parentTypeInfo;
 
         [MemberNotNullWhen(false, nameof(_items))]
         public bool IsReadOnly => _items == null;
@@ -21,7 +21,7 @@ namespace System.Text.Json
 
         public JsonPropertyInfo this[int index]
         {
-            get => IsReadOnly ? _parent.List[index].Value! : _items[index];
+            get => IsReadOnly ? _parent.List[index].Value : _items[index];
             set
             {
                 if (IsReadOnly)
@@ -47,10 +47,8 @@ namespace System.Text.Json
                 // We cannot ensure keys won't change while editing therefore we operate on the internal copy.
                 // Once we're done editing FinishEditingAndMakeReadOnly should be called then we switch to operating directly on _parent
                 _items = new List<JsonPropertyInfo>(_parent.Count);
-                foreach (var kv in _parent.List)
+                foreach (KeyValuePair<string, JsonPropertyInfo> kv in _parent.List)
                 {
-                    Debug.Assert(kv.Value != null, $"{nameof(JsonPropertyDictionary<JsonPropertyInfo>)} contains null value");
-
                     // we need to do this so that property cannot be copied over elsewhere
                     // since source gen properties do not have parents by default
                     kv.Value.EnsureChildOf(parentTypeInfo);
@@ -65,8 +63,10 @@ namespace System.Text.Json
 
             // We do not know if any of the keys needs to be updated therefore we need to re-create cache
             _parent.Clear();
+            // Perform a final sort of properties before rebuilding the cache
+            _items.StableSortByKey(static prop => prop.Order);
 
-            foreach (var item in _items)
+            foreach (JsonPropertyInfo item in _items)
             {
                 string key = item.Name;
                 if (!_parent.TryAddValue(key, item))
@@ -110,14 +110,14 @@ namespace System.Text.Json
 
             if (IsReadOnly)
             {
-                foreach (KeyValuePair<string, JsonPropertyInfo?> item in _parent)
+                foreach (KeyValuePair<string, JsonPropertyInfo> item in _parent)
                 {
                     if (index >= array.Length)
                     {
                         ThrowHelper.ThrowArgumentException_ArrayTooSmall(nameof(array));
                     }
 
-                    array[index++] = item.Value!;
+                    array[index++] = item.Value;
                 }
             }
             else
@@ -131,7 +131,7 @@ namespace System.Text.Json
             if (IsReadOnly)
             {
                 int index = 0;
-                foreach (var kv in _parent.List)
+                foreach (KeyValuePair<string, JsonPropertyInfo> kv in _parent.List)
                 {
                     if (kv.Value == item)
                     {
@@ -181,9 +181,9 @@ namespace System.Text.Json
         {
             if (IsReadOnly)
             {
-                foreach (KeyValuePair<string, JsonPropertyInfo?> item in _parent)
+                foreach (KeyValuePair<string, JsonPropertyInfo> item in _parent)
                 {
-                    yield return item.Value!;
+                    yield return item.Value;
                 }
             }
             else

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IDictionary.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Nodes
 {
     public partial class JsonObject : IDictionary<string, JsonNode?>
     {
-        private JsonPropertyDictionary<JsonNode>? _dictionary;
+        private JsonPropertyDictionary<JsonNode?>? _dictionary;
 
         /// <summary>
         ///   Adds an element with the provided property name and value to the <see cref="JsonObject"/>.
@@ -267,7 +267,7 @@ namespace System.Text.Json.Nodes
             }
 
             bool caseInsensitive = Options.HasValue ? Options.Value.PropertyNameCaseInsensitive : false;
-            var dictionary = new JsonPropertyDictionary<JsonNode>(caseInsensitive);
+            var dictionary = new JsonPropertyDictionary<JsonNode?>(caseInsensitive);
             if (_jsonElement.HasValue)
             {
                 JsonElement jElement = _jsonElement.Value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -38,10 +38,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 obj = jsonTypeInfo.CreateObject()!;
 
-                if (obj is IJsonOnDeserializing onDeserializing)
-                {
-                    onDeserializing.OnDeserializing();
-                }
+                jsonTypeInfo.OnDeserializing?.Invoke(obj);
 
                 // Process all properties.
                 while (true)
@@ -142,10 +139,7 @@ namespace System.Text.Json.Serialization.Converters
                         state.ReferenceId = null;
                     }
 
-                    if (obj is IJsonOnDeserializing onDeserializing)
-                    {
-                        onDeserializing.OnDeserializing();
-                    }
+                    jsonTypeInfo.OnDeserializing?.Invoke(obj);
 
                     state.Current.ReturnValue = obj;
                     state.Current.ObjectState = StackFrameObjectState.CreatedObject;
@@ -255,10 +249,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
             }
 
-            if (obj is IJsonOnDeserialized onDeserialized)
-            {
-                onDeserialized.OnDeserialized();
-            }
+            jsonTypeInfo.OnDeserialized?.Invoke(obj);
 
             // Unbox
             Debug.Assert(obj != null);
@@ -292,15 +283,12 @@ namespace System.Text.Json.Serialization.Converters
                     JsonSerializer.WriteMetadataForObject(this, ref state, writer);
                 }
 
-                if (obj is IJsonOnSerializing onSerializing)
-                {
-                    onSerializing.OnSerializing();
-                }
+                jsonTypeInfo.OnSerializing?.Invoke(obj);
 
-                List<KeyValuePair<string, JsonPropertyInfo?>> properties = jsonTypeInfo.PropertyCache!.List;
+                List<KeyValuePair<string, JsonPropertyInfo>> properties = jsonTypeInfo.PropertyCache!.List;
                 for (int i = 0; i < properties.Count; i++)
                 {
-                    JsonPropertyInfo jsonPropertyInfo = properties[i].Value!;
+                    JsonPropertyInfo jsonPropertyInfo = properties[i].Value;
                     if (jsonPropertyInfo.CanSerialize)
                     {
                         // Remember the current property for JsonPath support if an exception is thrown.
@@ -316,14 +304,14 @@ namespace System.Text.Json.Serialization.Converters
                 }
 
                 // Write extension data after the normal properties.
-                JsonPropertyInfo? dataExtensionProperty = jsonTypeInfo.DataExtensionProperty;
-                if (dataExtensionProperty?.CanSerialize == true)
+                JsonPropertyInfo? extensionDataProperty = jsonTypeInfo.ExtensionDataProperty;
+                if (extensionDataProperty?.CanSerialize == true)
                 {
                     // Remember the current property for JsonPath support if an exception is thrown.
-                    state.Current.JsonPropertyInfo = dataExtensionProperty;
-                    state.Current.NumberHandling = dataExtensionProperty.EffectiveNumberHandling;
+                    state.Current.JsonPropertyInfo = extensionDataProperty;
+                    state.Current.NumberHandling = extensionDataProperty.EffectiveNumberHandling;
 
-                    bool success = dataExtensionProperty.GetMemberAndWriteJsonExtensionData(obj, ref state, writer);
+                    bool success = extensionDataProperty.GetMemberAndWriteJsonExtensionData(obj, ref state, writer);
                     Debug.Assert(success);
 
                     state.Current.EndProperty();
@@ -342,19 +330,15 @@ namespace System.Text.Json.Serialization.Converters
                         JsonSerializer.WriteMetadataForObject(this, ref state, writer);
                     }
 
-                    if (obj is IJsonOnSerializing onSerializing)
-                    {
-                        onSerializing.OnSerializing();
-                    }
+                    jsonTypeInfo.OnSerializing?.Invoke(obj);
 
                     state.Current.ProcessedStartToken = true;
                 }
 
-                List<KeyValuePair<string, JsonPropertyInfo?>>? propertyList = jsonTypeInfo.PropertyCache!.List!;
+                List<KeyValuePair<string, JsonPropertyInfo>> propertyList = jsonTypeInfo.PropertyCache!.List;
                 while (state.Current.EnumeratorIndex < propertyList.Count)
                 {
-                    JsonPropertyInfo? jsonPropertyInfo = propertyList![state.Current.EnumeratorIndex].Value;
-                    Debug.Assert(jsonPropertyInfo != null);
+                    JsonPropertyInfo jsonPropertyInfo = propertyList[state.Current.EnumeratorIndex].Value;
                     if (jsonPropertyInfo.CanSerialize)
                     {
                         state.Current.JsonPropertyInfo = jsonPropertyInfo;
@@ -383,14 +367,14 @@ namespace System.Text.Json.Serialization.Converters
                 // Write extension data after the normal properties.
                 if (state.Current.EnumeratorIndex == propertyList.Count)
                 {
-                    JsonPropertyInfo? dataExtensionProperty = jsonTypeInfo.DataExtensionProperty;
-                    if (dataExtensionProperty?.CanSerialize == true)
+                    JsonPropertyInfo? extensionDataProperty = jsonTypeInfo.ExtensionDataProperty;
+                    if (extensionDataProperty?.CanSerialize == true)
                     {
                         // Remember the current property for JsonPath support if an exception is thrown.
-                        state.Current.JsonPropertyInfo = dataExtensionProperty;
-                        state.Current.NumberHandling = dataExtensionProperty.EffectiveNumberHandling;
+                        state.Current.JsonPropertyInfo = extensionDataProperty;
+                        state.Current.NumberHandling = extensionDataProperty.EffectiveNumberHandling;
 
-                        if (!dataExtensionProperty.GetMemberAndWriteJsonExtensionData(obj, ref state, writer))
+                        if (!extensionDataProperty.GetMemberAndWriteJsonExtensionData(obj, ref state, writer))
                         {
                             return false;
                         }
@@ -416,10 +400,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
             }
 
-            if (obj is IJsonOnSerialized onSerialized)
-            {
-                onSerialized.OnSerialized();
-            }
+            jsonTypeInfo.OnSerialized?.Invoke(obj);
 
             return true;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
@@ -54,13 +54,12 @@ namespace System.Text.Json.Serialization.Converters
 
             Debug.Assert(typeInfo.ParameterCache != null);
 
-            List<KeyValuePair<string, JsonParameterInfo?>> cache = typeInfo.ParameterCache.List;
+            List<KeyValuePair<string, JsonParameterInfo>> cache = typeInfo.ParameterCache.List;
             object?[] arguments = ArrayPool<object>.Shared.Rent(cache.Count);
 
             for (int i = 0; i < typeInfo.ParameterCount; i++)
             {
-                JsonParameterInfo? parameterInfo = cache[i].Value;
-                Debug.Assert(parameterInfo != null);
+                JsonParameterInfo parameterInfo = cache[i].Value;
                 arguments[parameterInfo.ClrInfo.Position] = parameterInfo.DefaultValue;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
@@ -34,16 +34,16 @@ namespace System.Text.Json.Serialization.Converters
             switch (jsonParameterInfo.ClrInfo.Position)
             {
                 case 0:
-                    success = TryRead<TArg0>(ref state, ref reader, jsonParameterInfo, out arguments.Arg0);
+                    success = TryRead(ref state, ref reader, jsonParameterInfo, out arguments.Arg0);
                     break;
                 case 1:
-                    success = TryRead<TArg1>(ref state, ref reader, jsonParameterInfo, out arguments.Arg1);
+                    success = TryRead(ref state, ref reader, jsonParameterInfo, out arguments.Arg1);
                     break;
                 case 2:
-                    success = TryRead<TArg2>(ref state, ref reader, jsonParameterInfo, out arguments.Arg2);
+                    success = TryRead(ref state, ref reader, jsonParameterInfo, out arguments.Arg2);
                     break;
                 case 3:
-                    success = TryRead<TArg3>(ref state, ref reader, jsonParameterInfo, out arguments.Arg3);
+                    success = TryRead(ref state, ref reader, jsonParameterInfo, out arguments.Arg3);
                     break;
                 default:
                     Debug.Fail("More than 4 params: we should be in override for LargeObjectWithParameterizedConstructorConverter.");
@@ -86,11 +86,10 @@ namespace System.Text.Json.Serialization.Converters
 
             var arguments = new Arguments<TArg0, TArg1, TArg2, TArg3>();
 
-            List<KeyValuePair<string, JsonParameterInfo?>> cache = typeInfo.ParameterCache!.List;
+            List<KeyValuePair<string, JsonParameterInfo>> cache = typeInfo.ParameterCache!.List;
             for (int i = 0; i < typeInfo.ParameterCount; i++)
             {
-                JsonParameterInfo? parameterInfo = cache[i].Value;
-                Debug.Assert(parameterInfo != null);
+                JsonParameterInfo parameterInfo = cache[i].Value;
 
                 // We can afford not to set default values for ctor arguments when we should't deserialize because the
                 // type parameters of the `Arguments` type provide default semantics that work well with value types.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -49,10 +49,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 obj = (T)CreateObject(ref state.Current);
 
-                if (obj is IJsonOnDeserializing onDeserializing)
-                {
-                    onDeserializing.OnDeserializing();
-                }
+                jsonTypeInfo.OnDeserializing?.Invoke(obj);
 
                 if (argumentState.FoundPropertyCount > 0)
                 {
@@ -83,7 +80,7 @@ namespace System.Text.Json.Serialization.Converters
 
                         if (useExtensionProperty)
                         {
-                            Debug.Assert(jsonPropertyInfo == state.Current.JsonTypeInfo.DataExtensionProperty);
+                            Debug.Assert(jsonPropertyInfo == state.Current.JsonTypeInfo.ExtensionDataProperty);
                             state.Current.JsonPropertyNameAsString = dataExtKey;
                             JsonSerializer.CreateDataExtensionProperty(obj, jsonPropertyInfo, options);
                         }
@@ -175,10 +172,7 @@ namespace System.Text.Json.Serialization.Converters
                     state.ReferenceId = null;
                 }
 
-                if (obj is IJsonOnDeserializing onDeserializing)
-                {
-                    onDeserializing.OnDeserializing();
-                }
+                jsonTypeInfo.OnDeserializing?.Invoke(obj);
 
                 if (argumentState.FoundPropertyCount > 0)
                 {
@@ -194,7 +188,7 @@ namespace System.Text.Json.Serialization.Converters
                         }
                         else
                         {
-                            Debug.Assert(jsonPropertyInfo == state.Current.JsonTypeInfo.DataExtensionProperty);
+                            Debug.Assert(jsonPropertyInfo == state.Current.JsonTypeInfo.ExtensionDataProperty);
 
                             JsonSerializer.CreateDataExtensionProperty(obj, jsonPropertyInfo, options);
                             object extDictionary = jsonPropertyInfo.GetValueAsObject(obj)!;
@@ -216,10 +210,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
             }
 
-            if (obj is IJsonOnDeserialized onDeserialized)
-            {
-                onDeserialized.OnDeserialized();
-            }
+            jsonTypeInfo.OnDeserialized?.Invoke(obj);
 
             // Unbox
             Debug.Assert(obj != null);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -48,7 +48,7 @@ namespace System.Text.Json
             // Determine if we should use the extension property.
             if (jsonPropertyInfo == JsonPropertyInfo.s_missingProperty)
             {
-                JsonPropertyInfo? dataExtProperty = state.Current.JsonTypeInfo.DataExtensionProperty;
+                JsonPropertyInfo? dataExtProperty = state.Current.JsonTypeInfo.ExtensionDataProperty;
                 if (dataExtProperty != null && dataExtProperty.HasGetter && dataExtProperty.HasSetter)
                 {
                     state.Current.JsonPropertyNameAsString = JsonHelpers.Utf8GetString(unescapedPropertyName);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -50,7 +50,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             Debug.Assert(getter is null or Func<object, object?> or Func<object, T>);
 
-            CheckMutable();
+            VerifyMutable();
 
             if (getter is null)
             {
@@ -74,7 +74,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             Debug.Assert(setter is null or Action<object, object?> or Action<object, T>);
 
-            CheckMutable();
+            VerifyMutable();
 
             if (setter is null)
             {
@@ -89,7 +89,7 @@ namespace System.Text.Json.Serialization.Metadata
             else
             {
                 Action<object, object?> untypedSet = (Action<object, object?>)setter;
-                _typedSet = ((obj, value) => untypedSet(obj, (T)value!));
+                _typedSet = ((obj, value) => untypedSet(obj, value));
                 _untypedSet = untypedSet;
             }
         }
@@ -137,7 +137,7 @@ namespace System.Text.Json.Serialization.Metadata
                     {
                         case PropertyInfo propertyInfo:
                             {
-                                bool useNonPublicAccessors = GetAttribute<JsonIncludeAttribute>(propertyInfo) != null;
+                                bool useNonPublicAccessors = propertyInfo.GetCustomAttribute<JsonIncludeAttribute>(inherit: false) != null;
 
                                 MethodInfo? getMethod = propertyInfo.GetMethod;
                                 if (getMethod != null && (getMethod.IsPublic || useNonPublicAccessors))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -88,5 +88,33 @@ namespace System.Text.Json.Serialization.Metadata
                 HasSerialize = value != null;
             }
         }
+
+        private protected void MapInterfaceTypesToCallbacks()
+        {
+            // Callbacks currently only supported in object kinds
+            // TODO: extend to collections/dictionaries
+            if (Kind == JsonTypeInfoKind.Object)
+            {
+                if (typeof(IJsonOnSerializing).IsAssignableFrom(typeof(T)))
+                {
+                    OnSerializing = static obj => ((IJsonOnSerializing)obj).OnSerializing();
+                }
+
+                if (typeof(IJsonOnSerialized).IsAssignableFrom(typeof(T)))
+                {
+                    OnSerialized = static obj => ((IJsonOnSerialized)obj).OnSerialized();
+                }
+
+                if (typeof(IJsonOnDeserializing).IsAssignableFrom(typeof(T)))
+                {
+                    OnDeserializing = static obj => ((IJsonOnDeserializing)obj).OnDeserializing();
+                }
+
+                if (typeof(IJsonOnDeserialized).IsAssignableFrom(typeof(T)))
+                {
+                    OnDeserialized = static obj => ((IJsonOnDeserialized)obj).OnDeserialized();
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json
 {
@@ -661,6 +662,12 @@ namespace System.Text.Json
         public static void ThrowInvalidOperationException_ExpectedChar(JsonTokenType tokenType)
         {
             throw GetInvalidOperationException("char", tokenType);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_SerializationCallbacksNotSupported(JsonTypeInfoKind typeInfoKind)
+        {
+            throw GetInvalidOperationException(SR.Format(SR.SerializationCallbacksNotSupported, typeInfoKind));
         }
 
         [DoesNotReturn]


### PR DESCRIPTION
Performs internal refactorings in the metadata layer in anticipation of new APIs to be incorporated (cf. https://github.com/dotnet/runtime/issues/63686#issuecomment-1168617171, pending review of #71123). 

### Changes made

* Adds `ExtensionDataProperty`, serialization callback, and `Order` knobs to the metadata as internal properties.
* Improves XML documentation for the newly shipped APIs.
* Ensures that the property sorting imlpementation is stable.
* Fix an issue with nullability annotations in `JsonPropertyDictionary`.

Contributes to #63686.