### PR TITLE
Allow UTF-8 BOM in BinaryData When Deserializing

### DIFF
--- a/src/libraries/System.Memory.Data/src/System/BinaryData.cs
+++ b/src/libraries/System.Memory.Data/src/System/BinaryData.cs
@@ -275,8 +275,13 @@ namespace System
         [RequiresUnreferencedCode(JsonSerializerRequiresUnreferencedCode)]
         public T? ToObjectFromJson<T>(JsonSerializerOptions? options = default)
         {
-            using var stream = new ReadOnlyMemoryStream(_bytes);
-            return JsonSerializer.Deserialize<T>(stream, options);
+            ReadOnlySpan<byte> span = _bytes.Span;
+
+            // Check for the UTF-8 byte order mark (BOM) EF BB BF
+            if (span.Length > 2 && span[0] == 0xEF && span[1] == 0xBB && span[2] == 0xBF)
+                span = span.Slice(3);
+
+            return JsonSerializer.Deserialize<T>(span, options);
         }
 
         /// <summary>

--- a/src/libraries/System.Memory.Data/src/System/BinaryData.cs
+++ b/src/libraries/System.Memory.Data/src/System/BinaryData.cs
@@ -275,7 +275,8 @@ namespace System
         [RequiresUnreferencedCode(JsonSerializerRequiresUnreferencedCode)]
         public T? ToObjectFromJson<T>(JsonSerializerOptions? options = default)
         {
-            return JsonSerializer.Deserialize<T>(_bytes.Span, options);
+            using var stream = new ReadOnlyMemoryStream(_bytes);
+            return JsonSerializer.Deserialize<T>(stream, options);
         }
 
         /// <summary>

--- a/src/libraries/System.Memory.Data/tests/BinaryDataTests.cs
+++ b/src/libraries/System.Memory.Data/tests/BinaryDataTests.cs
@@ -400,6 +400,22 @@ namespace System.Tests
         }
 
         [Fact]
+        public void ToObjectHandlesBOM()
+        {
+            TestModel payload = new TestModel { A = "string", B = 42, C = true };
+            using var buffer = new MemoryStream();
+            using var writer = new StreamWriter(buffer, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+            writer.Write(JsonSerializer.Serialize(payload));
+            writer.Flush();
+
+            BinaryData data = new BinaryData(buffer.ToArray());
+            var model = data.ToObjectFromJson<TestModel>();
+            Assert.Equal(payload.A, model.A);
+            Assert.Equal(payload.B, model.B);
+            Assert.Equal(payload.C, model.C);
+        }
+
+        [Fact]
         public void ToObjectThrowsExceptionOnIncompatibleType()
         {
             TestModel payload = new TestModel { A = "value", B = 5, C = true };


### PR DESCRIPTION
Fixes #71447

Slice away the UTF-8 BOM in the beginning of the `BinaryData` before invoking `JsonSerializer.Deserialize` in `BinaryData.ToObjectFromJson` to conform to the API's expectation