### PR TITLE
[wasm] InterpToNativeGenerator: use invariant culture when generating C

### DIFF
--- a/src/tasks/WasmAppBuilder/InterpToNativeGenerator.cs
+++ b/src/tasks/WasmAppBuilder/InterpToNativeGenerator.cs
@@ -174,7 +174,7 @@ internal sealed class InterpToNativeGenerator
                     throw new InvalidSignatureCharException(c);
             }
 
-            return $"mono_wasm_interp_method_args_get_{char.ToLower(c)}arg (margs, {argIndex})";
+            return $"mono_wasm_interp_method_args_get_{char.ToLower(c, CultureInfo.InvariantCulture)}arg (margs, {argIndex})";
         }
     }
 }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -345,7 +345,14 @@ namespace Wasm.Build.Tests
             (int exitCode, string buildOutput) result;
             try
             {
-                result = AssertBuild(sb.ToString(), id, expectSuccess: options.ExpectSuccess, envVars: s_buildEnv.EnvVars);
+                var envVars = s_buildEnv.EnvVars;
+                if (options.ExtraBuildEnvironmentVariables is not null)
+                {
+                    envVars = new Dictionary<string, string>(s_buildEnv.EnvVars);
+                    foreach (var kvp in options.ExtraBuildEnvironmentVariables!)
+                        envVars[kvp.Key] = kvp.Value;
+                }
+                result = AssertBuild(sb.ToString(), id, expectSuccess: options.ExpectSuccess, envVars: envVars);
 
                 //AssertRuntimePackPath(result.buildOutput);
 
@@ -898,7 +905,8 @@ namespace Wasm.Build.Tests
         string? Verbosity                 = null,
         string? Label                     = null,
         string? TargetFramework           = null,
-        string? MainJS                    = null
+        string? MainJS                    = null,
+        IDictionary<string, string>? ExtraBuildEnvironmentVariables = null
     );
 
     public record BlazorBuildOptions

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 using Xunit.Abstractions;
@@ -113,6 +113,57 @@ namespace Wasm.Build.Tests
 
             output = RunAndTestWasmApp(buildArgs, buildDir: _projectDir, expectedExitCode: 42, host: host, id: id);
             Assert.Contains("Main running", output);
+        }
+
+        [Theory]
+        [BuildAndRun(host: RunHost.V8, parameters: new object[] { "tr_TR.UTF-8" })]
+        public void BuildNativeInNonEnglishCulture(BuildArgs buildArgs, string culture, RunHost host, string id)
+        {
+            // Check that we can generate interp tables in non-english cultures
+            // Prompted by https://github.com/dotnet/runtime/issues/71149
+
+            string code = @"
+                using System;
+                using System.Runtime.InteropServices;
+
+                Console.WriteLine($""square: {square(5)}"");
+                return 42;
+
+                [DllImport(""simple"")] static extern int square(int x);
+            ";
+
+            buildArgs = ExpandBuildArgs(buildArgs,
+                                        extraItems: @$"<NativeFileReference Include=""simple.c"" />",
+                                        extraProperties: buildArgs.AOT
+                                                            ? string.Empty
+                                                            : "<WasmBuildNative>true</WasmBuildNative>");
+
+            var extraEnvVars = new Dictionary<string, string> {
+                { "LANG", culture },
+                { "LC_ALL", culture },
+            };
+
+            (_, string output) = BuildProject(buildArgs,
+                                        id: id,
+                                        new BuildProjectOptions(
+                                            InitProject: () =>
+                                            {
+                                                File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), code);
+                                                File.Copy(Path.Combine(BuildEnvironment.TestAssetsPath, "native-libs", "simple.c"),
+                                                            Path.Combine(_projectDir!, "simple.c"));
+                                            },
+                                            Publish: buildArgs.AOT,
+                                            DotnetWasmFromRuntimePack: false,
+                                            ExtraBuildEnvironmentVariables: extraEnvVars
+                                            ));
+
+            output = RunAndTestWasmApp(buildArgs,
+                                       buildDir: _projectDir,
+                                       expectedExitCode: 42,
+                                       host: host,
+                                       id: id,
+                                       envVars: extraEnvVars);
+            Assert.Contains("square: 25", output);
         }
 
         private (BuildArgs, string) BuildForVariadicFunctionTests(string programText, BuildArgs buildArgs, string id)

--- a/src/tests/BuildWasmApps/testassets/native-libs/simple.c
+++ b/src/tests/BuildWasmApps/testassets/native-libs/simple.c
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+
+int square(int x)
+{
+    return x * x;
+}


### PR DESCRIPTION
.. functions.

Wasm native build in Turkish culture would fail with:
```
In file included from C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Runtime.Mono.browser-wasm\7.0.0-preview.6.22312.1\runtimes\browser-wasm\native\src\driver.c:37: (TaskId:242)
C:\Users\v-danche\myblazor\obj\Debug\net7.0\wasm\for-publish\wasm_m2n_invoke.g.h:13:18: error: implicit declaration of function 'mono_wasm_interp_method_args_get_─▒arg' is invalid in C99 [-Werror,-Wimplicit-function-declaration] (TaskId:242)
        int res = func (mono_wasm_interp_method_args_get_─▒arg (margs, 0)); (TaskId:242)
                        ^ (TaskId:242)
C:\Users\v-danche\myblazor\obj\Debug\net7.0\wasm\for-publish\wasm_m2n_invoke.g.h:23:18: error: implicit declaration of function 'mono_wasm_interp_method_args_get_─▒arg' is invalid in C99 [-Werror,-Wimplicit-function-declaration] (TaskId:242)
        int res = func (mono_wasm_interp_method_args_get_─▒arg (margs, 0), mono_wasm_interp_method_args_get_─▒arg (margs, 1), mono_wasm_interp_method_args_get_─▒arg (margs, 2)); (TaskId:242)
                        ^ (TaskId:242)
```

This is odd character in the function name is `'I'` converted (in Turkish) to lower case, which is not `'i'`.

Fixes https://github.com/dotnet/runtime/issues/71149