### PR TITLE
[wasm] Clean up debugger tests output

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -130,9 +130,9 @@ submit-tests-helix:
 run-debugger-tests:
 	rm -f $(TOP)/artifacts/bin/DebuggerTestSuite/x64/Debug/*log; \
 	if [ ! -z "$(TEST_FILTER)" ]; then \
-		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) -v minimal -l trx --results-directory $(TOP)/artifacts/log/$(CONFIG) --filter "Category!=failing&FullyQualifiedName~$(TEST_FILTER)" $(TEST_ARGS); \
+	$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) "-l:trx;LogFileName=DebuggerTestsResults.xml" --results-directory $(TOP)/artifacts/log/$(CONFIG) --filter "Category!=failing&FullyQualifiedName~$(TEST_FILTER)" $(TEST_ARGS); \
 	else \
-		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) -v minimal -l trx --results-directory $(TOP)/artifacts/log/$(CONFIG) --filter "Category!=failing" $(TEST_ARGS); \
+		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) "-l:trx;LogFileName=DebuggerTestsResults.xml" --results-directory $(TOP)/artifacts/log/$(CONFIG) --filter "Category!=failing" $(TEST_ARGS); \
 	fi
 
 build-dbg-proxy:

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -130,9 +130,9 @@ submit-tests-helix:
 run-debugger-tests:
 	rm -f $(TOP)/artifacts/bin/DebuggerTestSuite/x64/Debug/*log; \
 	if [ ! -z "$(TEST_FILTER)" ]; then \
-		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) --filter "Category!=failing&FullyQualifiedName~$(TEST_FILTER)" $(TEST_ARGS); \
+		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) -v minimal -l trx --results-directory $(TOP)/artifacts/log/$(CONFIG) --filter "Category!=failing&FullyQualifiedName~$(TEST_FILTER)" $(TEST_ARGS); \
 	else \
-		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) --filter "Category!=failing" $(TEST_ARGS); \
+		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) -v minimal -l trx --results-directory $(TOP)/artifacts/log/$(CONFIG) --filter "Category!=failing" $(TEST_ARGS); \
 	fi
 
 build-dbg-proxy:

--- a/src/mono/wasm/debugger/DebuggerTestSuite/ArrayTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/ArrayTests.cs
@@ -6,11 +6,14 @@ using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
     public class ArrayTests : DebuggerTests
     {
+        public ArrayTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
 
         [Theory]
         [InlineData(19, 8, "PrimitiveTypeLocals", false, 0, false)]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/AssignmentTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/AssignmentTests.cs
@@ -1,16 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
     public class AssignmentTests : DebuggerTests
     {
+        public AssignmentTests(ITestOutputHelper testOutput)
+                : base(testOutput)
+        {}
+
         public static TheoryData<string, JObject, JObject> GetTestData => new TheoryData<string, JObject, JObject>
         {
             { "MONO_TYPE_OBJECT",      TObject("object", is_null: true),                        TObject("object") },

--- a/src/mono/wasm/debugger/DebuggerTestSuite/AsyncTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/AsyncTests.cs
@@ -7,11 +7,14 @@ using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
     public class AsyncTests : DebuggerTests
     {
+        public AsyncTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
 
         // FIXME: method with multiple async blocks - so that we have two separate classes for that method!
         // FIXME: nested blocks

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BadHarnessInitTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BadHarnessInitTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 using Xunit;
+using Xunit.Abstractions;
 
 #nullable enable
 
@@ -14,6 +15,9 @@ namespace DebuggerTests
 {
     public class BadHarnessInitTests : DebuggerTests
     {
+        public BadHarnessInitTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
+
         public override async Task InitializeAsync() => await Task.CompletedTask;
 
         [ConditionalFact(nameof(RunningOnChrome))]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -9,12 +9,16 @@ using Newtonsoft.Json.Linq;
 using System.IO;
 using Xunit;
 using Xunit.Sdk;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
 
     public class BreakpointTests : DebuggerTests
     {
+        public BreakpointTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
+
         [ConditionalFact(nameof(RunningOnChrome))]
         public async Task CreateGoodBreakpoint()
         {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CallFunctionOnTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CallFunctionOnTests.cs
@@ -7,12 +7,15 @@ using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
 
     public class CallFunctionOnTests : DebuggerTests
     {
+        public CallFunctionOnTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
 
         // This tests `callFunctionOn` with a function that the vscode-js-debug extension uses
         // Using this here as a non-trivial test case

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
@@ -9,12 +9,16 @@ using Newtonsoft.Json.Linq;
 using System.Threading;
 using Xunit;
 using System.Collections.Generic;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
 
     public class CustomViewTests : DebuggerTests
     {
+        public CustomViewTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
+
         [ConditionalFact(nameof(RunningOnChrome))]
         public async Task UsingDebuggerDisplay()
         {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DateTimeTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DateTimeTests.cs
@@ -5,11 +5,14 @@ using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
     public class DateTimeTests : DebuggerTests
     {
+        public DateTimeTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
 
         [Theory]
         [InlineData("en-US", "dddd, MMMM d, yyyy h:mm:ss tt", "dddd, MMMM d, yyyy", "h:mm:ss tt", "M/d/yyyy", "h:mm tt")]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -71,7 +71,7 @@ namespace DebuggerTests
 
         static protected string FindTestPath()
         {
-            string test_app_path = Environment.GetEnvironmentVariable("DEBUGGER_TEST_PATH");
+            string test_app_path = EnvironmentVariables.DebuggerTestPath;
 
             if (string.IsNullOrEmpty(test_app_path))
             {
@@ -106,7 +106,7 @@ namespace DebuggerTests
             {
                 if (s_testLogPath == null)
                 {
-                    string logPathVar = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
+                    string logPathVar = EnvironmentVariables.TestLogPath;
                     logPathVar = string.IsNullOrEmpty(logPathVar) ? Environment.CurrentDirectory : logPathVar;
                     Interlocked.CompareExchange(ref s_testLogPath, logPathVar, null);
                 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestFirefox.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestFirefox.cs
@@ -8,13 +8,14 @@ using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests;
 
 public class DebuggerTestFirefox : DebuggerTestBase
 {
     internal FirefoxInspectorClient _client;
-    public DebuggerTestFirefox(string driver = "debugger-driver.html"):base(driver)
+    public DebuggerTestFirefox(ITestOutputHelper testOutput, string driver = "debugger-driver.html"):base(testOutput, driver)
     {
         if (insp.Client is not FirefoxInspectorClient)
             throw new Exception($"Bug: client should be {nameof(FirefoxInspectorClient)} for use with {nameof(DebuggerTestFirefox)}");
@@ -47,8 +48,8 @@ public class DebuggerTestFirefox : DebuggerTestBase
         {
             var script_id = args?["source"]?["actor"].Value<string>();
             var url = args?["source"]?["sourceMapBaseURL"]?.Value<string>();
-            /*Console.WriteLine(script_id);
-            Console.WriteLine(args);*/
+            /*_testOutput.WriteLine(script_id);
+            _testOutput.WriteLine(args);*/
             if (script_id.StartsWith("dotnet://"))
             {
                 var dbgUrl = args?["source"]?["dotNetUrl"]?.Value<string>();
@@ -186,7 +187,7 @@ public class DebuggerTestFirefox : DebuggerTestBase
         var res = await cli.SendCommand(method, args, token);
         if (!res.IsOk)
         {
-            Console.WriteLine($"Failed to run command {method} with args: {args?.ToString()}\nresult: {res.Error.ToString()}");
+            _testOutput.WriteLine($"Failed to run command {method} with args: {args?.ToString()}\nresult: {res.Error.ToString()}");
             Assert.True(false, $"SendCommand for {method} failed with {res.Error.ToString()}");
         }
         var wait_res = await WaitFor(waitForEvent);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
@@ -18,6 +18,9 @@
     <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
 
     <Compile Include="..\BrowserDebugProxy\Common\*.cs" />
+
+    <Compile Include="$(LibrariesProjectRoot)Microsoft.Extensions.Logging\tests\DI.Common\Common\src\XunitLoggerFactoryExtensions.cs" />
+    <Compile Include="$(LibrariesProjectRoot)Microsoft.Extensions.Logging\tests\DI.Common\Common\src\XunitLoggerProvider.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DelegateTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DelegateTests.cs
@@ -7,12 +7,15 @@ using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
 
     public class DelegateTests : DebuggerTests
     {
+        public DelegateTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
 
         [ConditionalTheory(nameof(RunningOnChrome))]
         [InlineData(0, 53, 8, "DelegatesTest", false)]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EnvironmentVariables.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EnvironmentVariables.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+#nullable enable
+
+namespace DebuggerTests;
+
+internal static class EnvironmentVariables
+{
+    public static readonly string? DebuggerTestPath = Environment.GetEnvironmentVariable("DEBUGGER_TEST_PATH");
+    public static readonly string? TestLogPath      = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
+}

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -9,12 +9,16 @@ using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
     // TODO: static async, static method args
     public class EvaluateOnCallFrameTests : DebuggerTests
     {
+        public EvaluateOnCallFrameTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
+
         public static IEnumerable<object[]> InstanceMethodsTestData(string type_name)
         {
             yield return new object[] { type_name, "InstanceMethod", "InstanceMethod", false };
@@ -88,7 +92,7 @@ namespace DebuggerTests
            {
                var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
                var DTProp = new DateTime(2010, 9, 8, 7, 6, 5).AddMinutes(10);
-               Console.WriteLine ($"------- test running the bits..");
+               _testOutput.WriteLine ($"------- test running the bits..");
                await EvaluateOnCallFrameAndCheck(id,
                    ("g", TNumber(400)),
                    ("h", TNumber(123)),
@@ -101,7 +105,7 @@ namespace DebuggerTests
                    ("me.DTProp.Second + (me.IntProp - 5)", TNumber(DTProp.Second + 4)))
                     .ConfigureAwait(false);
 
-               Console.WriteLine ($"------- test done!");
+               _testOutput.WriteLine ($"------- test done!");
            });
 
         [Theory]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
@@ -7,12 +7,16 @@ using Newtonsoft.Json.Linq;
 using System.Threading;
 using Xunit;
 using Xunit.Sdk;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
 
     public class ExceptionTests : DebuggerTests
     {
+        public ExceptionTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
+
         [ConditionalFact(nameof(RunningOnChrome))]
         public async Task ExceptionTestAll()
         {
@@ -107,7 +111,7 @@ namespace DebuggerTests
                         // return if we hit a managed exception, or an uncaught one
                         if (pause_location["data"]?["objectId"]?.Value<string>()?.StartsWith("dotnet:object:", StringComparison.Ordinal) == true)
                         {
-                            Console.WriteLine($"Hit an unexpected managed exception, with function name: {actual_fn_name}. {pause_location}");
+                            _testOutput.WriteLine($"Hit an unexpected managed exception, with function name: {actual_fn_name}. {pause_location}");
                             throw new XunitException($"Hit an unexpected managed exception, with function name: {actual_fn_name}");
                         }
 
@@ -176,7 +180,7 @@ namespace DebuggerTests
             }
             catch (ArgumentException ae)
             {
-                Console.WriteLine($"{ae}");
+                _testOutput.WriteLine($"{ae}");
                 var eo = JObject.Parse(ae.Message);
 
                 AssertEqual(line, eo["exceptionDetails"]?["lineNumber"]?.Value<int>(), "lineNumber");
@@ -296,7 +300,7 @@ namespace DebuggerTests
                     break;
                 }
             }
-            Console.WriteLine ($"* Resumed {count} times");
+            _testOutput.WriteLine ($"* Resumed {count} times");
 
             var eval_expr = "window.setTimeout(function() { invoke_static_method (" +
                 $"'{entry_method_name}'" +

--- a/src/mono/wasm/debugger/DebuggerTestSuite/GetPropertiesTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/GetPropertiesTests.cs
@@ -9,11 +9,15 @@ using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Sdk;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
     public class GetPropertiesTests : DebuggerTests
     {
+        public GetPropertiesTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
+
         public static TheoryData<string, bool?, bool?, string[], Dictionary<string, (JObject, bool)>, bool> ClassGetPropertiesTestData(bool is_async)
         {
             // FIXME: invoking getter on the hidden(base) properties - is that supported??
@@ -416,7 +420,7 @@ namespace DebuggerTests
             }
         }
 
-        private static void AssertHasOnlyExpectedProperties(string[] expected_names, IEnumerable<JObject> actual)
+        private void AssertHasOnlyExpectedProperties(string[] expected_names, IEnumerable<JObject> actual)
         {
             bool fail = false;
             var exp = new HashSet<string>(expected_names);
@@ -425,7 +429,7 @@ namespace DebuggerTests
             {
                 if (!exp.Contains(obj["name"]?.Value<string>()))
                 {
-                    Console.WriteLine($"Unexpected: {obj}");
+                    _testOutput.WriteLine($"Unexpected: {obj}");
                     fail = true;
                 }
             }
@@ -433,7 +437,7 @@ namespace DebuggerTests
             var act = new HashSet<string>(actual.Select(a => a["name"].Value<string>()));
             foreach (var obj in expected_names.Where(ename => !act.Contains(ename)))
             {
-                Console.WriteLine($"Missing: {obj}");
+                _testOutput.WriteLine($"Missing: {obj}");
                 fail = true;
             }
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/HarnessTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HarnessTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 #nullable enable
 
@@ -13,6 +14,9 @@ namespace DebuggerTests
 {
     public class HarnessTests : DebuggerTests
     {
+        public HarnessTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
+
         [ConditionalFact(nameof(RunningOnChrome))]
         public async Task TimedOutWaitingForInvalidBreakpoint()
         {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
@@ -1,19 +1,20 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using System.IO;
 using Xunit;
-using System.Threading;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
     public class HotReloadTests : DebuggerTests
     {
+        public HotReloadTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
+
         [ConditionalFact(nameof(RunningOnChrome))]
         public async Task DebugHotReloadMethodChangedUserBreak()
         {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -13,8 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using System.Runtime.ExceptionServices;
-using Microsoft.AspNetCore.Routing.Tree;
-using System.Globalization;
+using Xunit.Abstractions;
 
 #nullable enable
 
@@ -40,27 +38,32 @@ namespace DebuggerTests
 
         protected static Lazy<ILoggerFactory> s_loggerFactory = new(() =>
         {
-            return LoggerFactory.Create(builder =>
-                    builder
-                        // .AddFile(logFilePath, minimumLevel: LogLevel.Debug)
-                        .AddSimpleConsole(options =>
-                            {
-                                options.SingleLine = true;
-                                options.TimestampFormat = "[HH:mm:ss] ";
-                            })
-                           .AddFilter(null, LogLevel.Trace));
+            return LoggerFactory.Create(builder => {});
+            //return LoggerFactory.Create(builder =>
+                    ////builder
+                        ////// .AddFile(logFilePath, minimumLevel: LogLevel.Debug)
+                        ////.AddSimpleConsole(options =>
+                            ////{
+                                ////options.SingleLine = true;
+                                ////options.TimestampFormat = "[HH:mm:ss] ";
+                            ////})
+                           ////.AddFilter(null, LogLevel.Debug));
         });
 
         protected ILogger _logger;
         public int Id { get; init; }
 
-        public Inspector(int testId)
+        public Inspector(int testId, ITestOutputHelper testOutput)
         {
             Id = testId;
             _cancellationTokenSource = new CancellationTokenSource();
             Token = _cancellationTokenSource.Token;
 
-            _logger = s_loggerFactory.Value.CreateLogger($"{nameof(Inspector)}-{Id}");
+            if (Id == 0)
+                s_loggerFactory.Value.AddXunit(testOutput);
+
+            _logger = s_loggerFactory.Value
+                            .CreateLogger($"{nameof(Inspector)}-{Id}");
             if (DebuggerTestBase.RunningOnChrome)
                 Client = new InspectorClient(_logger);
             else

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
@@ -37,18 +37,20 @@ namespace DebuggerTests
         private Exception? _isFailingWithException;
 
         protected static Lazy<ILoggerFactory> s_loggerFactory = new(() =>
-        {
-            return LoggerFactory.Create(builder => {});
-            //return LoggerFactory.Create(builder =>
-                    ////builder
-                        ////// .AddFile(logFilePath, minimumLevel: LogLevel.Debug)
-                        ////.AddSimpleConsole(options =>
-                            ////{
-                                ////options.SingleLine = true;
-                                ////options.TimestampFormat = "[HH:mm:ss] ";
-                            ////})
-                           ////.AddFilter(null, LogLevel.Debug));
-        });
+            LoggerFactory.Create(builder =>
+            {
+                if (TestOptions.LogToConsole)
+                {
+                    builder
+                        .AddSimpleConsole(options =>
+                            {
+                                options.SingleLine = true;
+                                options.TimestampFormat = "[HH:mm:ss] ";
+                            })
+                           .AddFilter(null, LogLevel.Debug);
+                        // .AddFile(logFilePath, minimumLevel: LogLevel.Debug)
+                }
+            }));
 
         protected ILogger _logger;
         public int Id { get; init; }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using Xunit.Sdk;
+using Xunit.Abstractions;
 
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
 
@@ -16,6 +16,8 @@ namespace DebuggerTests
 
     public class MiscTests : DebuggerTests
     {
+        public MiscTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
 
         [Fact]
         public void CheckThatAllSourcesAreSent()
@@ -525,7 +527,7 @@ namespace DebuggerTests
                 $"'{entry_method_name}'," +
                 (call_other ? "true" : "false") +
                 "); }, 1);";
-            Console.WriteLine($"{eval_expr}");
+            _testOutput.WriteLine($"{eval_expr}");
 
             var pause_location = await EvaluateAndCheck(eval_expr, debugger_test_loc, line, col, invoke_async ? "MoveNext" : method_name);
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MonoJsTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MonoJsTests.cs
@@ -8,11 +8,15 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
     public class MonoJsTests : DebuggerTests
     {
+        public MonoJsTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
+
         [ConditionalFact(nameof(RunningOnChrome))]
         public async Task BadRaiseDebugEventsTest()
         {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/PointerTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/PointerTests.cs
@@ -7,12 +7,15 @@ using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
 
     public class PointerTests : DebuggerTests
     {
+        public PointerTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
 
         public static TheoryData<string, string, string, int, string, bool> PointersTestData =>
             new TheoryData<string, string, string, int, string, bool>

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SetNextIpTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SetNextIpTests.cs
@@ -8,12 +8,15 @@ using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using System.IO;
 using Xunit;
-using System.Threading;
+using Xunit.Abstractions;
 
 namespace DebuggerTests;
 
 public class SetNextIpTests : DebuggerTests
 {
+    public SetNextIpTests(ITestOutputHelper testOutput) : base(testOutput)
+    {}
+
     [ConditionalFact(nameof(RunningOnChrome))]
     public async Task SetAndCheck()
     {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SetVariableValueTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SetVariableValueTests.cs
@@ -9,11 +9,15 @@ using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
     public class SetVariableValueTests : DebuggerTests
     {
+        public SetVariableValueTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
+
         [ConditionalTheory(nameof(RunningOnChrome))]
         [InlineData("a", 1, 30, 130)]
         [InlineData("a", 1, -30, -130)]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Settings.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Settings.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+#nullable enable
+
+namespace DebuggerTests;
+
+internal static class TestOptions
+{
+    internal static readonly bool LogToConsole        = Environment.GetEnvironmentVariable("SKIP_LOG_TO_CONSOLE") != "1";
+}

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
@@ -6,11 +6,15 @@ using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
     public class SteppingTests : DebuggerTests
     {
+        public SteppingTests(ITestOutputHelper testOutput) : base(testOutput)
+        {}
+
         [Fact]
         public async Task TrivalStepping()
         {
@@ -343,7 +347,7 @@ namespace DebuggerTests
                     await CheckObject(locals, "this", "Math.NestedInMath");
                 }
             );
-            Console.WriteLine(wait_res);
+            _testOutput.WriteLine(wait_res.ToString());
 
 #if false // Disabled for now, as we don't have proper async traces
             var locals = await GetProperties(wait_res["callFrames"][2]["callFrameId"].Value<string>());

--- a/src/mono/wasm/debugger/DebuggerTestSuite/TestHarnessProxy.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/TestHarnessProxy.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.WebAssembly.Diagnostics;
+using Xunit.Abstractions;
 
 #nullable enable
 
@@ -33,7 +34,7 @@ namespace DebuggerTests
         private static readonly ConcurrentDictionary<int, WeakReference<Action<RunLoopExitState>>> s_exitHandlers = new();
         private static readonly ConcurrentDictionary<string, RunLoopExitState> s_statusTable = new();
 
-        public static Task Start(string appPath, string pagePath, string url)
+        public static Task Start(string appPath, string pagePath, string url, ITestOutputHelper testOutput)
         {
             lock (proxyLock)
             {
@@ -48,12 +49,15 @@ namespace DebuggerTests
                     })
                     .ConfigureLogging(logging =>
                     {
-                        logging.AddSimpleConsole(options =>
-                                {
-                                    options.SingleLine = true;
-                                    options.TimestampFormat = "[HH:mm:ss] ";
-                                })
-                                .AddFilter("DevToolsProxy", LogLevel.Debug)
+                        logging
+                                .ClearProviders()
+                                .AddXunit(testOutput)
+                                //.AddSimpleConsole(options =>
+                                //{
+                                    //options.SingleLine = true;
+                                    //options.TimestampFormat = "[HH:mm:ss] ";
+                                //})
+                                //.AddFilter("DevToolsProxy", LogLevel.Debug)
                                 .AddFile(Path.Combine(DebuggerTestBase.TestLogPath, "proxy.log"),
                                             minimumLevel: LogLevel.Trace,
                                             levelOverrides: new Dictionary<string, LogLevel>
@@ -63,7 +67,7 @@ namespace DebuggerTests
                                             outputTemplate: "{Timestamp:o} [{Level:u3}] {SourceContext}: {Message}{NewLine}{Exception}")
                                 .AddFilter(null, LogLevel.Information);
                     })
-                .ConfigureServices((ctx, services) =>
+                    .ConfigureServices((ctx, services) =>
                     {
                         services.Configure<TestHarnessOptions>(ctx.Configuration);
                         services.Configure<TestHarnessOptions>(options =>
@@ -79,7 +83,7 @@ namespace DebuggerTests
                 hostTask = host.StartAsync(cts.Token);
             }
 
-            Console.WriteLine("WebServer Ready!");
+            testOutput.WriteLine("WebServer Ready!");
             return hostTask;
         }
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/TestHarnessProxy.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/TestHarnessProxy.cs
@@ -49,15 +49,22 @@ namespace DebuggerTests
                     })
                     .ConfigureLogging(logging =>
                     {
-                        logging
-                                .ClearProviders()
-                                .AddXunit(testOutput)
-                                //.AddSimpleConsole(options =>
-                                //{
-                                    //options.SingleLine = true;
-                                    //options.TimestampFormat = "[HH:mm:ss] ";
-                                //})
-                                //.AddFilter("DevToolsProxy", LogLevel.Debug)
+                        if (TestOptions.LogToConsole)
+                        {
+                            logging.AddSimpleConsole(options =>
+                                    {
+                                        options.SingleLine = true;
+                                        options.TimestampFormat = "[HH:mm:ss] ";
+                                    })
+                                    .AddFilter("DevToolsProxy", LogLevel.Debug);
+                        }
+                        else
+                        {
+                            // remove the default logger - console
+                            logging.ClearProviders();
+                        }
+
+                        logging.AddXunit(testOutput)
                                 .AddFile(Path.Combine(DebuggerTestBase.TestLogPath, "proxy.log"),
                                             minimumLevel: LogLevel.Trace,
                                             levelOverrides: new Dictionary<string, LogLevel>

--- a/src/mono/wasm/debugger/DebuggerTestSuite/WasmHostProvider.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/WasmHostProvider.cs
@@ -80,7 +80,7 @@ internal abstract class WasmHostProvider : IDisposable
         {
             _process.Exited += (_, _) =>
             {
-                Console.WriteLine ($"**Browser died!**");
+                //Console.WriteLine ($"**Browser died!**");
                 Dispose();
             };
 

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -213,7 +213,7 @@ function _handle_fetched_asset(asset: AssetEntry, url?: string) {
 
     const bytes = new Uint8Array(asset.buffer);
     if (ctx.tracing)
-        console.log(`MONO_WASM: Loaded:${asset.name} as ${asset.behavior} size ${bytes.length} from ${url}`);
+        console.trace(`MONO_WASM: Loaded:${asset.name} as ${asset.behavior} size ${bytes.length} from ${url}`);
 
     const virtualName: string = typeof (asset.virtual_path) === "string"
         ? asset.virtual_path
@@ -244,7 +244,7 @@ function _handle_fetched_asset(asset: AssetEntry, url?: string) {
                 fileName = fileName.substr(1);
             if (parentDirectory) {
                 if (ctx.tracing)
-                    console.log(`MONO_WASM: Creating directory '${parentDirectory}'`);
+                    console.trace(`MONO_WASM: Creating directory '${parentDirectory}'`);
 
                 Module.FS_createPath(
                     "/", parentDirectory, true, true // fixme: should canWrite be false?
@@ -254,7 +254,7 @@ function _handle_fetched_asset(asset: AssetEntry, url?: string) {
             }
 
             if (ctx.tracing)
-                console.log(`MONO_WASM: Creating file '${fileName}' in directory '${parentDirectory}'`);
+                console.trace(`MONO_WASM: Creating file '${fileName}' in directory '${parentDirectory}'`);
 
             if (!mono_wasm_load_data_archive(bytes, parentDirectory)) {
                 Module.FS_createDataFile(
@@ -498,7 +498,7 @@ async function mono_download_assets(config: MonoConfig | MonoConfigError | undef
             ++parallel_count;
             if (parallel_count == max_parallel_downloads) {
                 if (ctx!.tracing)
-                    console.log("MONO_WASM: Throttling further parallel downloads");
+                    console.trace("MONO_WASM: Throttling further parallel downloads");
 
                 throttling_promise = new Promise((resolve) => {
                     throttling_promise_resolve = resolve;
@@ -537,10 +537,10 @@ async function mono_download_assets(config: MonoConfig | MonoConfigError | undef
                 }
                 if (asset.name === attemptUrl) {
                     if (ctx!.tracing)
-                        console.log(`MONO_WASM: Attempting to fetch '${attemptUrl}'`);
+                        console.trace(`MONO_WASM: Attempting to fetch '${attemptUrl}'`);
                 } else {
                     if (ctx!.tracing)
-                        console.log(`MONO_WASM: Attempting to fetch '${attemptUrl}' for ${asset.name}`);
+                        console.trace(`MONO_WASM: Attempting to fetch '${attemptUrl}' for ${asset.name}`);
                 }
                 try {
                     const response = await runtimeHelpers.fetch(attemptUrl);
@@ -567,7 +567,7 @@ async function mono_download_assets(config: MonoConfig | MonoConfigError | undef
             --parallel_count;
             if (throttling_promise && parallel_count == ((max_parallel_downloads / 2) | 0)) {
                 if (ctx!.tracing)
-                    console.log("MONO_WASM: Resuming more parallel downloads");
+                    console.trace("MONO_WASM: Resuming more parallel downloads");
                 throttling_promise_resolve!();
                 throttling_promise = undefined;
             }
@@ -611,8 +611,8 @@ function finalize_assets(config: MonoConfig | MonoConfigError | undefined): void
 
         ctx.loaded_files.forEach(value => MONO.loaded_files.push(value.url));
         if (ctx.tracing) {
-            console.log("MONO_WASM: loaded_assets: " + JSON.stringify(ctx.loaded_assets));
-            console.log("MONO_WASM: loaded_files: " + JSON.stringify(ctx.loaded_files));
+            console.trace("MONO_WASM: loaded_assets: " + JSON.stringify(ctx.loaded_assets));
+            console.trace("MONO_WASM: loaded_files: " + JSON.stringify(ctx.loaded_files));
         }
     } catch (err: any) {
         Module.printErr("MONO_WASM: Error in finalize_assets: " + err);

--- a/src/tests/BuildWasmApps/Wasm.Debugger.Tests/Wasm.Debugger.Tests.csproj
+++ b/src/tests/BuildWasmApps/Wasm.Debugger.Tests/Wasm.Debugger.Tests.csproj
@@ -46,6 +46,11 @@
       <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export BROWSER_PATH_FOR_TESTS=$HELIX_CORRELATION_PAYLOAD/firefox/firefox" />
     </ItemGroup>
 
+    <ItemGroup Label="Don't log to console on CI" Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+      <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export SKIP_LOG_TO_CONSOLE=1" />
+      <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set SKIP_LOG_TO_CONSOLE=1" />
+    </ItemGroup>
+
     <PropertyGroup>
       <_DotnetCommand Condition="'$(OS)' != 'Windows_NT'">dotnet</_DotnetCommand>
       <_DotnetCommand Condition="'$(OS)' == 'Windows_NT'">dotnet.exe</_DotnetCommand>


### PR DESCRIPTION
- Pipe all the tests output to xunit, which will show up in the results file, and test failures
- On CI, don't log anything to console
- For local runs, log to console by default
  - this can be changed by setting `SKIP_LOG_TO_CONSOLE=1`.