### PR TITLE
Fix crash in GSSAPI on macOS

### DIFF
--- a/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -243,9 +243,9 @@ namespace System.Net.Security
                 // Save the inner context handle for further calls to NetSecurity
                 //
                 // For the first call `negoContext.GssContext` is invalid and we expect the
-                // inital handle to be returned from AcceptSecContext. For any subsequent
+                // inital handle to be returned from InitSecContext. For any subsequent
                 // call the handle should stay the same or it can be destroyed by the native
-                // AcceptSecContext call.
+                // InitSecContext call.
                 Debug.Assert(
                     negoContext.GssContext == contextHandle ||
                     negoContext.GssContext.IsInvalid ||

--- a/src/libraries/Common/src/System/Net/Security/Unix/SafeDeleteNegoContext.cs
+++ b/src/libraries/Common/src/System/Net/Security/Unix/SafeDeleteNegoContext.cs
@@ -13,7 +13,7 @@ namespace System.Net.Security
     {
         private SafeGssCredHandle? _acceptorCredential;
         private SafeGssNameHandle? _targetName;
-        private SafeGssContextHandle? _context;
+        private SafeGssContextHandle _context;
         private bool _isNtlmUsed;
 
         public SafeGssCredHandle AcceptorCredential
@@ -36,7 +36,7 @@ namespace System.Net.Security
             get { return _isNtlmUsed; }
         }
 
-        public SafeGssContextHandle? GssContext
+        public SafeGssContextHandle GssContext
         {
             get { return _context; }
         }
@@ -45,6 +45,7 @@ namespace System.Net.Security
             : base(credential)
         {
             Debug.Assert((null != credential), "Null credential in SafeDeleteNegoContext");
+            _context = new SafeGssContextHandle();
         }
 
         public SafeDeleteNegoContext(SafeFreeNegoCredentials credential, string targetName)
@@ -53,6 +54,7 @@ namespace System.Net.Security
             try
             {
                 _targetName = SafeGssNameHandle.CreateTarget(targetName);
+                _context = new SafeGssContextHandle();
             }
             catch
             {
@@ -63,7 +65,6 @@ namespace System.Net.Security
 
         public void SetGssContext(SafeGssContextHandle context)
         {
-            Debug.Assert(context != null && !context.IsInvalid, "Invalid context passed to SafeDeleteNegoContext");
             _context = context;
         }
 
@@ -76,11 +77,7 @@ namespace System.Net.Security
         {
             if (disposing)
             {
-                if (null != _context)
-                {
-                    _context.Dispose();
-                    _context = null;
-                }
+                _context.Dispose();
 
                 if (_targetName != null)
                 {


### PR DESCRIPTION
On macOS the gss_accept_sec_context/gss_init_sec_context APIs release the context handle when error occurs. The code didn't handle it properly and it would result in double-free and hard crash. Update the code to handle this situation properly.

Fixes #71463