### PR TITLE
Make dotnet-pgo capable of handling dll conflicts by providing deconfliction options

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/CommandLineOptions.cs
+++ b/src/coreclr/tools/dotnet-pgo/CommandLineOptions.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         public DirectoryInfo DumpWorstOverlapGraphsTo;
         public int DumpWorstOverlapGraphs = -1;
         public bool InheritTimestamp;
+        public bool AutomaticReferences;
 
         public string[] HelpArgs = Array.Empty<string>();
 
@@ -126,6 +127,13 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 }
 
                 Reference = DefineFileOptionList(name: "r|reference", help: "If a reference is not located on disk at the same location as used in the process, it may be specified with a --reference parameter. Multiple --reference parameters may be specified. The wild cards * and ? are supported by this option.");
+
+                AutomaticReferences = true;
+                syntax.DefineOption(
+                    name: "automatic-references",
+                    value: ref AutomaticReferences,
+                    help: "Attempt to find references by using paths embedded in the trace file. Defaults to true.",
+                    requireValue: true);
 
                 ExcludeEventsBefore = Double.MinValue;
                 syntax.DefineOption(

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -1209,7 +1209,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         {
                             duplicateModuleAnalysis[simpleName] = candidatePaths = new HashSet<string>();
                         }
-                        duplicateModuleAnalysis[simpleName].Add(candidateFilePath);
+                        candidatePaths.Add(candidateFilePath);
                     }
                 }
 
@@ -1222,7 +1222,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     ModuleDesc loadedViaReference = null;
                     foreach (var module in modulesLoadedViaReference)
                     {
-                        if (String.Compare(module.Assembly.GetName().Name, assembliesWithDuplicates.Key, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (string.Equals(module.Assembly.GetName().Name, assembliesWithDuplicates.Key, StringComparison.OrdinalIgnoreCase))
                         {
                             loadedViaReference = module;
                             break;

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -1143,12 +1143,13 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     }
                 }
 
-                var tsc = new TraceTypeSystemContext(pgoProcess, clrInstanceId.Value, s_logger);
+                var tsc = new TraceTypeSystemContext(pgoProcess, clrInstanceId.Value, s_logger, commandLineOptions.AutomaticReferences);
 
                 if (commandLineOptions.VerboseWarnings)
                     PrintWarning($"{traceLog.EventsLost} Lost events");
 
                 bool filePathError = false;
+                HashSet<ModuleDesc> modulesLoadedViaReference = new HashSet<ModuleDesc>();
                 if (commandLineOptions.Reference != null)
                 {
                     foreach (FileInfo fileReference in commandLineOptions.Reference)
@@ -1162,7 +1163,9 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             }
                             else
                             {
-                                tsc.GetModuleFromPath(fileReference.FullName, throwIfNotLoadable: false);
+                                var module = tsc.GetModuleFromPath(fileReference.FullName, throwIfNotLoadable: false);
+                                if (module != null)
+                                    modulesLoadedViaReference.Add(module);
                             }
                         }
                         catch (Internal.TypeSystem.TypeSystemException.BadImageFormatException)
@@ -1180,6 +1183,64 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
                 if (!tsc.Initialize())
                     return -12;
+
+                Dictionary<string, HashSet<string>> duplicateModuleAnalysis = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+                foreach (var module in pgoProcess.EnumerateLoadedManagedModules())
+                {
+                    var managedModule = module.ManagedModule;
+
+                    if (module.ClrInstanceID != clrInstanceId.Value)
+                        continue;
+
+                    if (managedModule.ModuleFile != null)
+                    {
+                        string simpleName = managedModule.ModuleFile.Name;
+                        if (simpleName.EndsWith(".il"))
+                            simpleName = simpleName.Substring(0, simpleName.Length - 3);
+
+                        string filePathTemp = PgoTraceProcess.ComputeFilePathOnDiskForModule(managedModule);
+                        string candidateFilePath;
+
+                        // This path may be normalized
+                        if (File.Exists(filePathTemp) || !tsc._normalizedFilePathToFilePath.TryGetValue(filePathTemp, out candidateFilePath))
+                            candidateFilePath = filePathTemp;
+
+                        if (!duplicateModuleAnalysis.TryGetValue(simpleName, out HashSet<string> candidatePaths))
+                        {
+                            duplicateModuleAnalysis[simpleName] = candidatePaths = new HashSet<string>();
+                        }
+                        duplicateModuleAnalysis[simpleName].Add(candidateFilePath);
+                    }
+                }
+
+                bool duplicateError = false;
+                foreach (var assembliesWithDuplicates in duplicateModuleAnalysis)
+                {
+                    if (assembliesWithDuplicates.Value.Count == 1)
+                        continue;
+
+                    ModuleDesc loadedViaReference = null;
+                    foreach (var module in modulesLoadedViaReference)
+                    {
+                        if (String.Compare(module.Assembly.GetName().Name, assembliesWithDuplicates.Key, StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            loadedViaReference = module;
+                            break;
+                        }
+                    }
+                    if ((loadedViaReference == null)
+                        && commandLineOptions.AutomaticReferences) // AutomaticReferences set to false disables this error, as no more references can actually be loaded past this point and cause a problem.
+                    {
+                        duplicateError = true;
+                        PrintError($"Multiple assemblies with the same simple name loaded into the process. Specify the preferred module via the -reference parameter.");
+                        foreach (string path in assembliesWithDuplicates.Value)
+                        {
+                            PrintMessage(path);
+                        }
+                    }
+                }
+                if (duplicateError)
+                    return -13;
 
                 TraceRuntimeDescToTypeSystemDesc idParser = new TraceRuntimeDescToTypeSystemDesc(p, tsc, clrInstanceId.Value);
 
@@ -1201,6 +1262,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
                     bool matched = false;
                     bool mismatch = false;
+                    bool mismatchHandled = false;
                     foreach (var debugEntry in ecmaModule.PEReader.ReadDebugDirectory())
                     {
                         if (debugEntry.Type == DebugDirectoryEntryType.CodeView)
@@ -1210,9 +1272,19 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                                 continue;
                             if (codeViewData.Guid != e.ManagedPdbSignature)
                             {
-                                PrintError($"Dll mismatch between assembly located at \"{e.ModuleILPath}\" during trace collection and module \"{tsc.PEReaderToFilePath(ecmaModule.PEReader)}\"");
-                                mismatchErrors++;
-                                mismatch = true;
+                                if (modulesLoadedViaReference.Contains(ecmaModule) && duplicateModuleAnalysis[ecmaModule.Assembly.GetName().Name].Count > 1)
+                                {
+                                    // This is the case where a duplicate dll mismatch was avoided by specifying a -reference parameter
+                                    PrintMessage($"Disabling load of assembly data from assembly located at \"{e.ModuleILPath}\" during trace collection as module \"{tsc.PEReaderToFilePath(ecmaModule.PEReader)}\" is preferred, and does not match");
+                                    idParser.RemoveModuleIDFromLoader(e.ModuleID);
+                                    mismatchHandled = true;
+                                }
+                                else
+                                {
+                                    PrintError($"Dll mismatch between assembly located at \"{e.ModuleILPath}\" during trace collection and module \"{tsc.PEReaderToFilePath(ecmaModule.PEReader)}\"");
+                                    mismatchErrors++;
+                                    mismatch = true;
+                                }
                                 continue;
                             }
                             else
@@ -1222,7 +1294,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         }
                     }
 
-                    if (!matched && !mismatch)
+                    if (!matched && !mismatch && !mismatchHandled)
                     {
                         PrintMessage($"Unable to validate match between assembly located at \"{e.ModuleILPath}\" during trace collection and module \"{tsc.PEReaderToFilePath(ecmaModule.PEReader)}\"");
                     }

--- a/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
@@ -259,6 +259,15 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             }
         }
 
+        public void RemoveModuleIDFromLoader(long handle)
+        {
+            lock (_lock)
+            {
+                var moduleDesc = _modules[handle];
+                _modules.Remove(handle);
+            }
+        }
+
         public ModuleDesc ResolveModuleID(long handle, bool throwIfNotFound = true)
         {
             lock (_lock)


### PR DESCRIPTION
Now --reference will specify a prefferred dll, or if the developer is unable to specify a preferred dll, they can disable all automatic reference loading and specify the versions of all other dlls to be used.