### PR TITLE
[wasm][debugger] Fix get properties from an object of a library without pdb

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -972,5 +972,27 @@ namespace DebuggerTests
                 bp.Value["locations"][0]["columnNumber"].Value<int>(),
                 "Evaluate");
         }
+
+        [Fact] 
+        public async Task InspectPropertiesOfObjectFromLibraryWithPdbDeleted()
+        {
+            var expression = $"{{ invoke_static_method('[debugger-test] DebugWithoutSymbols:Run'); }}";
+
+            await EvaluateAndCheck(
+                "window.setTimeout(function() {" + expression + "; }, 1);",
+                "dotnet://debugger-test.dll/debugger-test.cs", 1146, 8,
+                "Run",
+                wait_for_event_fn: async (pause_location) =>
+                {
+                    var exc_props = await GetObjectOnFrame(pause_location["callFrames"][0], "exc");
+                    await CheckProps(exc_props, new
+                    {
+                        propA = TNumber(10),
+                        propB = TNumber(20),
+                        propC = TNumber(30)
+                    }, "exc");
+                }
+            );
+        }
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test-with-pdb-deleted/debugger-test-with-pdb-deleted.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-pdb-deleted/debugger-test-with-pdb-deleted.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  <Target Name="DeleteDebugSymbolFile" AfterTargets="Build">
+        <Message Text="Deleting $(OutDir)debugger-test-with-pdb-deleted.pdb"/>
+        <Delete Files="$(OutDir)debugger-test-with-pdb-deleted.pdb" />
+  </Target>
+</Project>

--- a/src/mono/wasm/debugger/tests/debugger-test-with-pdb-deleted/debugger-test-with-pdb-deleted.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-pdb-deleted/debugger-test-with-pdb-deleted.csproj
@@ -3,7 +3,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <Target Name="DeleteDebugSymbolFile" AfterTargets="Build">
-        <Message Text="Deleting $(OutDir)debugger-test-with-pdb-deleted.pdb"/>
-        <Delete Files="$(OutDir)debugger-test-with-pdb-deleted.pdb" />
+    <Message Text="Deleting $(OutDir)debugger-test-with-pdb-deleted.pdb"/>
+    <Delete Files="$(OutDir)debugger-test-with-pdb-deleted.pdb" />
   </Target>
 </Project>

--- a/src/mono/wasm/debugger/tests/debugger-test-with-pdb-deleted/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-pdb-deleted/test.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace DebuggerTests
+{
+    public class ClassWithPdbDeleted
+    {
+        private int propA {get;}
+        public int propB {get;}
+        protected int propC {get;}
+        public ClassWithPdbDeleted()
+        {
+            propA = 10;
+            propB = 20;
+            propC = 30;
+            Console.WriteLine(propA);
+            Console.WriteLine(propB);
+            Console.WriteLine(propC);
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1136,3 +1136,14 @@ public static class DefaultInterfaceMethod
     }
 }
 #endregion
+public class DebugWithoutSymbols
+{
+    public static void Run()
+    {
+        var asm = System.Reflection.Assembly.LoadFrom("debugger-test-with-pdb-deleted.dll");
+        var myType = asm.GetType("DebuggerTests.ClassWithPdbDeleted");
+        var myMethod = myType.GetConstructor(new Type[] { });
+        var exc = myMethod.Invoke(new object[]{});
+        System.Diagnostics.Debugger.Break();
+    }
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly\ApplyUpdateReferencedAssembly.csproj" />
     <ProjectReference Include="..\debugger-test-with-full-debug-type\debugger-test-with-full-debug-type.csproj" Private="true"/>
     <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" Private="true"/>
+    <ProjectReference Include="..\debugger-test-with-pdb-deleted\debugger-test-with-pdb-deleted.csproj" Private="true"/>
   </ItemGroup>
 
   <Target Name="PrepareForWasmBuildApp" DependsOnTargets="Build">
@@ -49,6 +50,7 @@
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)native"/>
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)lib\$(NetCoreAppCurrent)"/>
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-special-char-in-path.dll" />
+      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-pdb-deleted.dll" />
 
       <WasmExtraFilesToDeploy Include="@(ReferenceCopyLocalPaths)" />
     </ItemGroup>


### PR DESCRIPTION
When we don't have pdb we still can get some information about the methods like attributes (public, private, protected, etc) which are used for a better debugger experience.

Before this implementation when we call:
```
MethodInfoWithDebugInformation getterInfo = await sdbHelper.GetMethodInfo(getMethodId, token);
MethodAttributes getterAttrs = getterInfo.Info.Attributes;
```
`GetMethodInfo` returned `null` because we didn't add method without debug info and then it throws an exception on `getterInfo.Info.Attributes` because `getterInfo` was null.

Fixes #71456 