### PR TITLE
Implement test checking whether CET is active

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -11,6 +11,7 @@ parameters:
   liveLibrariesBuildConfig: ''
   crossgen2: false
   compositeBuildMode: false
+  useCodeFlowEnforcement: ''
   helixQueues: ''
   condition: true
   stagedBuild: false
@@ -111,6 +112,13 @@ jobs:
     - ${{ if ne(parameters.runtimeVariant, '') }}:
       - name: runtimeVariantArg
         value: '/p:RuntimeVariant=${{ parameters.runtimeVariant }}'
+
+    - name: codeFlowEnforcementArg
+      value: ''
+
+    - ${{ if ne(parameters.useCodeFlowEnforcement, '') }}:
+      - name: codeFlowEnforcementArg
+        value: '/p:UseCodeFlowEnforcement=${{ parameters.useCodeFlowEnforcement }}'
 
     - name: crossgenArg
       value: ''
@@ -301,8 +309,8 @@ jobs:
     # during product build (so that we could zip up the files in their final test location
     # and directly unzip them there after download). Unfortunately the logic to copy
     # the native artifacts to the final test folders is dependent on availability of the
-    # managed test artifacts.
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) copynativeonly $(logRootNameArg)Native $(testTreeFilterArg) $(runtimeFlavorArgs) $(crossgenArg) $(buildConfig) $(archType) $(priorityArg) $(librariesOverrideArg)
+    # managed test artifacts. This step also generates the final test execution scripts.
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) copynativeonly $(logRootNameArg)Native $(testTreeFilterArg) $(runtimeFlavorArgs) $(crossgenArg) $(buildConfig) $(archType) $(priorityArg) $(librariesOverrideArg) $(codeFlowEnforcementArg)
       displayName: Copy native test components to test output folder
 
 

--- a/eng/pipelines/runtime-cet.yml
+++ b/eng/pipelines/runtime-cet.yml
@@ -82,3 +82,4 @@ jobs:
     jobParameters:
       testGroup: innerloop
       liveLibrariesBuildConfig: release
+      useCodeFlowEnforcement: true

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -83,6 +83,10 @@
     </ProjectReference>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(RequiresCodeFlowEnforcement)' == 'true'">
+    <CLRTestTargetUnsupported Condition="'$(UseCodeFlowEnforcement)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+
   <!-- Determine if this project should be built or not -->
   <PropertyGroup>
     <BuildAllProjects Condition="'$(BuildAllProjects)' == ''">false</BuildAllProjects>

--- a/src/tests/baseservices/CET/CETCheck.cpp
+++ b/src/tests/baseservices/CET/CETCheck.cpp
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <intrin.h>
+
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
+extern "C" __declspec(dllexport) __int64 ReadShadowStackPointer()
+{
+    return _rdsspq();
+}
+#endif

--- a/src/tests/baseservices/CET/CETCheck.cpp
+++ b/src/tests/baseservices/CET/CETCheck.cpp
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
 #include <intrin.h>
 
-#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
 extern "C" __declspec(dllexport) __int64 ReadShadowStackPointer()
 {
     return _rdsspq();

--- a/src/tests/baseservices/CET/CMakeLists.txt
+++ b/src/tests/baseservices/CET/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(cet_check SHARED CETCheck.cpp)
+
+# add the install targets
+install (TARGETS cet_check DESTINATION bin)

--- a/src/tests/baseservices/CET/CheckCETPresence.cs
+++ b/src/tests/baseservices/CET/CheckCETPresence.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+static class Program
+{
+    public static int Main()
+    {
+        Console.WriteLine("Checking whether codeflow enforcement technology (CET) is active");
+        // TODO: perform the actual CET check
+        // For now return failure to let us see that the test has actually run.
+        return 101;
+    }
+}

--- a/src/tests/baseservices/CET/CheckCETPresence.cs
+++ b/src/tests/baseservices/CET/CheckCETPresence.cs
@@ -2,14 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.InteropServices;
 
 static class Program
 {
+    [DllImport("cet_check.dll")]
+    private static extern long ReadShadowStackPointer();
+    
     public static int Main()
     {
         Console.WriteLine("Checking whether codeflow enforcement technology (CET) is active");
-        // TODO: perform the actual CET check
-        // For now return failure to let us see that the test has actually run.
-        return 101;
+        long ssp = ReadShadowStackPointer();
+        Console.WriteLine("Shadow stack pointer: 0x{0:x16}", ssp);
+        // Non-zero shadow stack pointer value confirms that CET is active on the runtime processor.
+        return ssp != 0 ? 100 : 101;
     }
 }

--- a/src/tests/baseservices/CET/CheckCETPresence.csproj
+++ b/src/tests/baseservices/CET/CheckCETPresence.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RequiresCodeFlowEnforcement>true</RequiresCodeFlowEnforcement>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/CET/CheckCETPresence.csproj
+++ b/src/tests/baseservices/CET/CheckCETPresence.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <RequiresCodeFlowEnforcement>true</RequiresCodeFlowEnforcement>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64' or '$(TargetOS)' != 'windows'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/baseservices/CET/CheckCETPresence.csproj
+++ b/src/tests/baseservices/CET/CheckCETPresence.csproj
@@ -3,8 +3,12 @@
     <OutputType>Exe</OutputType>
     <RequiresCodeFlowEnforcement>true</RequiresCodeFlowEnforcement>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -486,6 +486,7 @@
       <GroupBuildCmd>$(GroupBuildCmd) "/p:RuntimeFlavor=$(RuntimeFlavor)"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) "/p:RuntimeVariant=$(RuntimeVariant)"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) "/p:CLRTestBuildAllTargets=$(CLRTestBuildAllTargets)"</GroupBuildCmd>
+      <GroupBuildCmd>$(GroupBuildCmd) "/p:UseCodeFlowEnforcement=$(UseCodeFlowEnforcement)"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) "/p:__TestGroupToBuild=$(__TestGroupToBuild)"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) "/p:__SkipRestorePackages=1"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) /nodeReuse:false</GroupBuildCmd>


### PR DESCRIPTION
As part of Control Flow Enforcement Technology (CET) testing we need
to make sure that CET is actually active on the execution machines;
otherwise subtle infra changes could easily regress the testing by
inadvertently deactivating CET without anyone noticing. This change
introduces an initial CET availability test for this purpose.

Thanks

Tomas

P.S. In practice this initial commit only introduces the necessary infra
changes required for implementing the CET test. I have verified in the private
run

https://dev.azure.com/dnceng/public/_build/results?buildId=1855384&view=ms.vss-test-web.build-test-results-tab&runId=48818082&resultId=100238&paneView=debug

that the new test gets now built and run and it fails as expected. I need
help regarding its actual implementation, according to JanV we likely need
a bit of native interop to read the value of the SSP register, I'm definitely
no expert in this field.