### PR TITLE
[NativeAOT] Remove WaitForSuspend and some ordering cleanups.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/RhVolatile.h
+++ b/src/coreclr/nativeaot/Runtime/RhVolatile.h
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef __VOLATILE_H__
+#define __VOLATILE_H__
+
+template<typename T>
+inline
+T VolatileLoadWithoutBarrier(T const* pt)
+{
+    T val = *(T volatile const*)pt;
+    return val;
+}
+
+template<typename T>
+inline
+void VolatileStoreWithoutBarrier(T* pt, T val)
+{
+    *(T volatile*)pt = val;
+}
+
+template<typename T>
+inline
+void VolatileStoreWithoutBarrier(T* pt, nullptr_t val)
+{
+    *(T volatile*)pt = val;
+}
+
+#endif // __VOLATILE_H__

--- a/src/coreclr/nativeaot/Runtime/amd64/AsmMacros.inc
+++ b/src/coreclr/nativeaot/Runtime/amd64/AsmMacros.inc
@@ -395,7 +395,6 @@ endif ;; FEATURE_GC_STRESS
 EXTERN RhpGcAlloc                               : PROC
 EXTERN RhpValidateExInfoPop                     : PROC
 EXTERN RhDebugBreak                             : PROC
-EXTERN RhpWaitForSuspend2                       : PROC
 EXTERN RhpWaitForGC2                            : PROC
 EXTERN RhpReversePInvokeAttachOrTrapThread2     : PROC
 EXTERN RhExceptionHandling_FailedAllocation     : PROC

--- a/src/coreclr/nativeaot/Runtime/amd64/PInvoke.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/PInvoke.S
@@ -31,13 +31,8 @@ NESTED_ENTRY RhpPInvoke, _TEXT, NoHandler
         mov         qword ptr [rbx + OFFSETOF__PInvokeTransitionFrame__m_PreservedRegs], r11
 
         mov         qword ptr [rax + OFFSETOF__Thread__m_pTransitionFrame], rbx
-
-        test        dword ptr [C_VAR(RhpTrapThreads)], TrapThreadsFlags_TrapThreads
         pop_nonvol_reg rbx
-        jnz         0f                  // forward branch - predicted not taken
         ret
-0:
-        jmp         C_FUNC(RhpWaitForSuspend2)
 NESTED_END RhpPInvoke, _TEXT
 
 

--- a/src/coreclr/nativeaot/Runtime/arm/AsmMacros.h
+++ b/src/coreclr/nativeaot/Runtime/arm/AsmMacros.h
@@ -262,7 +262,6 @@ $Name
 ;;
         EXTERN RhpGcAlloc
         EXTERN RhDebugBreak
-        EXTERN RhpWaitForSuspend2
         EXTERN RhpWaitForGC2
         EXTERN RhpReversePInvokeAttachOrTrapThread2
         EXTERN RhExceptionHandling_FailedAllocation

--- a/src/coreclr/nativeaot/Runtime/arm/PInvoke.S
+++ b/src/coreclr/nativeaot/Runtime/arm/PInvoke.S
@@ -33,15 +33,8 @@ NESTED_ENTRY RhpPInvoke, _TEXT, NoHandler
         str     r0, [r5, #OFFSETOF__PInvokeTransitionFrame__m_pThread]
         str     r5, [r0, #OFFSETOF__Thread__m_pTransitionFrame]
 
-        ldr     r3, =C_FUNC(RhpTrapThreads)
-        ldr     r3, [r3]
-        cbnz    r3, LOCAL_LABEL(InvokeRareTrapThread)  // TrapThreadsFlags_None = 0
-
         EPILOG_POP "{r5,pc}"
 
-LOCAL_LABEL(InvokeRareTrapThread):
-        EPILOG_POP "{r5,lr}"
-        b       C_FUNC(RhpWaitForSuspend2)
 NESTED_END RhpPInvoke, _TEXT
 
 

--- a/src/coreclr/nativeaot/Runtime/arm/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/arm/PInvoke.asm
@@ -7,29 +7,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; RhpWaitForSuspend -- rare path for RhpPInvoke and RhpReversePInvokeReturn
-;;
-;;
-;; INPUT: none
-;;
-;; TRASHES: none
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-        NESTED_ENTRY RhpWaitForSuspend
-
-        PROLOG_PUSH {r0-r4,lr}     ; Need to save argument registers r0-r3 and lr, r4 is just for alignment
-        PROLOG_VPUSH {d0-d7}       ; Save float argument registers as well since they're volatile
-
-        bl          RhpWaitForSuspend2
-
-        EPILOG_VPOP {d0-d7}
-        EPILOG_POP  {r0-r4,pc}
-
-        NESTED_END RhpWaitForSuspend
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
 ;; RhpWaitForGCNoAbort
 ;;
 ;;

--- a/src/coreclr/nativeaot/Runtime/arm64/AsmMacros.h
+++ b/src/coreclr/nativeaot/Runtime/arm64/AsmMacros.h
@@ -96,7 +96,6 @@ OFFSETOF__Thread__m_alloc_context__alloc_limit      equ OFFSETOF__Thread__m_rgbA
     EXTERN RhpGcAlloc
     EXTERN RhExceptionHandling_FailedAllocation
     EXTERN RhDebugBreak
-    EXTERN RhpWaitForSuspend2
     EXTERN RhpWaitForGC2
     EXTERN RhpReversePInvokeAttachOrTrapThread2
     EXTERN RhThrowHwEx

--- a/src/coreclr/nativeaot/Runtime/arm64/PInvoke.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/PInvoke.S
@@ -20,56 +20,6 @@ TSF_DoNotTriggerGc_Bit          = 4
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
-// RhpWaitForSuspend -- rare path for RhpPInvoke and RhpReversePInvokeReturn
-//
-//
-// INPUT: none
-//
-// TRASHES: none
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    NESTED_ENTRY RhpWaitForSuspend, _TEXT, NoHandler
-
-        // FP and LR registers
-        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -0xA0            // Push down stack pointer and store FP and LR
-
-        // Need to save argument registers x0-x7 and the return buffer register x8
-        // Also save x9 which may be used for saving indirect call target
-        stp         x0, x1, [sp, #0x10]
-        stp         x2, x3, [sp, #0x20]
-        stp         x4, x5, [sp, #0x30]
-        stp         x6, x7, [sp, #0x40]
-        stp         x8, x9, [sp, #0x50]
-
-        // Save float argument registers as well since they are volatile
-        stp         d0, d1, [sp, #0x60]
-        stp         d2, d3, [sp, #0x70]
-        stp         d4, d5, [sp, #0x80]
-        stp         d6, d7, [sp, #0x90]
-
-        bl          RhpWaitForSuspend2
-
-        // Restore floating point registers
-        ldp            d0, d1, [sp, #0x60]
-        ldp            d2, d3, [sp, #0x70]
-        ldp            d4, d5, [sp, #0x80]
-        ldp            d6, d7, [sp, #0x90]
-
-        // Restore the argument registers
-        ldp            x0, x1, [sp, #0x10]
-        ldp            x2, x3, [sp, #0x20]
-        ldp            x4, x5, [sp, #0x30]
-        ldp            x6, x7, [sp, #0x40]
-        ldp            x8, x9, [sp, #0x50]
-
-        // Restore FP and LR registers, and free the allocated stack block
-        EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 0xA0
-        EPILOG_RETURN
-
-    NESTED_END RhpWaitForSuspend, _TEXT
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
 // RhpWaitForGCNoAbort
 //
 //
@@ -218,14 +168,7 @@ NESTED_ENTRY RhpPInvoke, _TEXT, NoHandler
 
         str     x1, [x0, #OFFSETOF__PInvokeTransitionFrame__m_pThread]
         str     x0, [x1, #OFFSETOF__Thread__m_pTransitionFrame]
-
-        PREPARE_EXTERNAL_VAR_INDIRECT_W RhpTrapThreads, 9
-
-        cbnz    w9, InvokeRareTrapThread  // TrapThreadsFlags_None = 0
         ret
-
-InvokeRareTrapThread:
-        b       C_FUNC(RhpWaitForSuspend2)
 NESTED_END RhpPInvoke, _TEXT
 
 

--- a/src/coreclr/nativeaot/Runtime/i386/AsmMacros.inc
+++ b/src/coreclr/nativeaot/Runtime/i386/AsmMacros.inc
@@ -179,7 +179,6 @@ G_HIGHEST_ADDRESS                           equ _g_highest_address
 G_EPHEMERAL_LOW                             equ _g_ephemeral_low
 G_EPHEMERAL_HIGH                            equ _g_ephemeral_high
 G_CARD_TABLE                                equ _g_card_table
-RhpWaitForSuspend2                          equ @RhpWaitForSuspend2@0
 RhpWaitForGC2                               equ @RhpWaitForGC2@4
 RhpReversePInvokeAttachOrTrapThread2        equ @RhpReversePInvokeAttachOrTrapThread2@4
 RhpTrapThreads                              equ _RhpTrapThreads
@@ -194,7 +193,6 @@ endif ;; FEATURE_GC_STRESS
 ;;
 EXTERN RhpGcAlloc                               : PROC
 EXTERN RhDebugBreak                             : PROC
-EXTERN RhpWaitForSuspend2                       : PROC
 EXTERN RhpWaitForGC2                            : PROC
 EXTERN RhpReversePInvokeAttachOrTrapThread2     : PROC
 EXTERN RhExceptionHandling_FailedAllocation     : PROC

--- a/src/coreclr/nativeaot/Runtime/i386/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/PInvoke.asm
@@ -11,33 +11,6 @@ include AsmMacros.inc
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; RhpWaitForSuspend -- rare path for RhpPInvoke and RhpReversePInvokeReturn
-;;
-;;
-;; INPUT: none
-;;
-;; TRASHES: none
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-_RhpWaitForSuspend proc public
-        push        ebp
-        mov         ebp, esp
-        push        eax
-        push        ecx
-        push        edx
-
-        call        RhpWaitForSuspend2
-
-        pop         edx
-        pop         ecx
-        pop         eax
-        pop         ebp
-        ret
-_RhpWaitForSuspend endp
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
 ;; RhpWaitForGCNoAbort
 ;;
 ;;

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -26,6 +26,7 @@
 #include "rhbinder.h"
 #include "stressLog.h"
 #include "RhConfig.h"
+#include "RhVolatile.h"
 
 #ifndef DACCESS_COMPILE
 
@@ -36,12 +37,6 @@ EXTERN_C NATIVEAOT_API void REDHAWK_CALLCONV RhHandleFree(void* handle);
 static int (*g_RuntimeInitializationCallback)();
 static Thread* g_RuntimeInitializingThread;
 
-#ifdef _MSC_VER
-extern "C" void _ReadWriteBarrier(void);
-#pragma intrinsic(_ReadWriteBarrier)
-#else // _MSC_VER
-#define _ReadWriteBarrier() __asm__ volatile("" : : : "memory")
-#endif // _MSC_VER
 #endif //!DACCESS_COMPILE
 
 PInvokeTransitionFrame* Thread::GetTransitionFrame()
@@ -79,15 +74,14 @@ void Thread::WaitForGC(PInvokeTransitionFrame* pTransitionFrame)
 
     do
     {
-        m_pTransitionFrame = pTransitionFrame;
+        // set preemptive mode
+        VolatileStoreWithoutBarrier(&m_pTransitionFrame, pTransitionFrame);
 
         Unhijack();
         RedhawkGCInterface::WaitForGCCompletion();
 
-        m_pTransitionFrame = NULL;
-
-        // We need to prevent compiler reordering between above write and below read.
-        _ReadWriteBarrier();
+        // must be in cooperative mode when checking the trap flag
+        VolatileStoreWithoutBarrier(&m_pTransitionFrame, NULL);
     }
     while (ThreadStore::IsTrapThreadsRequested());
 
@@ -115,7 +109,11 @@ bool Thread::CacheTransitionFrameForSuspend()
     if (m_pCachedTransitionFrame != NULL)
         return true;
 
-    PInvokeTransitionFrame* temp = m_pTransitionFrame;     // volatile read
+    // Once we see a thread posted a transition frame we can assume it will not enter cooperative mode.
+    // It may temporarily set the frame to NULL when checking the trap flag, but will revert.
+    // We can safely return true here and ache the frame.
+    // Make sure compiler emits only one read.
+    PInvokeTransitionFrame* temp = VolatileLoadWithoutBarrier(&m_pTransitionFrame);
     if (temp == NULL)
         return false;
 
@@ -144,21 +142,16 @@ void Thread::EnablePreemptiveMode()
 
     Unhijack();
 
-    // ORDERING -- this write must occur before checking the trap
-    m_pTransitionFrame = m_pDeferredTransitionFrame;
+    // set preemptive mode
+    VolatileStoreWithoutBarrier(&m_pTransitionFrame, m_pDeferredTransitionFrame);
 }
 
 void Thread::DisablePreemptiveMode()
 {
     ASSERT(ThreadStore::GetCurrentThread() == this);
 
-    // ORDERING -- this write must occur before checking the trap
-    m_pTransitionFrame = NULL;
-
-    // We need to prevent compiler reordering between above write and below read.  Both the read and the write
-    // are volatile, so it's possible that the particular semantic for volatile that MSVC provides is enough,
-    // but if not, this barrier would be required.  If so, it won't change anything to add the barrier.
-    _ReadWriteBarrier();
+    // must be in cooperative mode when checking the trap flag
+    VolatileStoreWithoutBarrier(&m_pTransitionFrame, NULL);
 
     if (ThreadStore::IsTrapThreadsRequested() && (this != ThreadStore::GetSuspendingThread()))
     {
@@ -1197,11 +1190,8 @@ FORCEINLINE bool Thread::InlineTryFastReversePInvoke(ReversePInvokeFrame * pFram
     // save the previous transition frame
     pFrame->m_savedPInvokeTransitionFrame = m_pTransitionFrame;
 
-    // set our mode to cooperative
-    m_pTransitionFrame = NULL;
-
-    // We need to prevent compiler reordering between above write and below read.
-    _ReadWriteBarrier();
+    // must be in cooperative mode when checking the trap flag
+    VolatileStoreWithoutBarrier(&m_pTransitionFrame, NULL);
 
     // now check if we need to trap the thread
     if (ThreadStore::IsTrapThreadsRequested())
@@ -1244,11 +1234,8 @@ void Thread::ReversePInvokeAttachOrTrapThread(ReversePInvokeFrame * pFrame)
     // save the previous transition frame
     pFrame->m_savedPInvokeTransitionFrame = m_pTransitionFrame;
 
-    // set our mode to cooperative
-    m_pTransitionFrame = NULL;
-
-    // We need to prevent compiler reordering between above write and below read.
-    _ReadWriteBarrier();
+    // must be in cooperative mode when checking the trap flag
+    VolatileStoreWithoutBarrier(&m_pTransitionFrame, NULL);
 
     // now check if we need to trap the thread
     if (ThreadStore::IsTrapThreadsRequested())
@@ -1277,19 +1264,21 @@ void Thread::EnsureRuntimeInitialized()
 
 FORCEINLINE void Thread::InlineReversePInvokeReturn(ReversePInvokeFrame * pFrame)
 {
-    m_pTransitionFrame = pFrame->m_savedPInvokeTransitionFrame;
+    // set our mode to preemptive
+    VolatileStoreWithoutBarrier(&m_pTransitionFrame, pFrame->m_savedPInvokeTransitionFrame);
 }
 
 FORCEINLINE void Thread::InlinePInvoke(PInvokeTransitionFrame * pFrame)
 {
     pFrame->m_pThread = this;
     // set our mode to preemptive
-    m_pTransitionFrame = pFrame;
+    VolatileStoreWithoutBarrier(&m_pTransitionFrame, pFrame);
 }
 
 FORCEINLINE void Thread::InlinePInvokeReturn(PInvokeTransitionFrame * pFrame)
 {
-    m_pTransitionFrame = NULL;
+    // must be in cooperative mode when checking the trap flag
+    VolatileStoreWithoutBarrier(&m_pTransitionFrame, NULL);
     if (ThreadStore::IsTrapThreadsRequested())
     {
         RhpWaitForGC2(pFrame);

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -257,7 +257,6 @@ public:
     //
     // Managed/unmanaged interop transitions support APIs
     //
-    void WaitForSuspend();
     void WaitForGC(PInvokeTransitionFrame* pTransitionFrame);
 
     void ReversePInvokeAttachOrTrapThread(ReversePInvokeFrame * pFrame);

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -282,13 +282,6 @@ void ThreadStore::ResumeAllThreads(bool waitForGCEvent)
     UnlockThreadStore();
 } // ResumeAllThreads
 
-void ThreadStore::WaitForSuspendComplete()
-{
-    uint32_t waitResult = m_SuspendCompleteEvent.Wait(INFINITE, false);
-    if (waitResult == WAIT_FAILED)
-        RhFailFast();
-}
-
 #ifndef DACCESS_COMPILE
 
 void ThreadStore::InitiateThreadAbort(Thread* targetThread, Object * threadAbortException, bool doRudeAbort)

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -82,9 +82,6 @@ ThreadStore * ThreadStore::Create(RuntimeInstance * pRuntimeInstance)
     if (NULL == pNewThreadStore)
         return NULL;
 
-    if (!pNewThreadStore->m_SuspendCompleteEvent.CreateManualEventNoThrow(true))
-        return NULL;
-
     pNewThreadStore->m_pRuntimeInstance = pRuntimeInstance;
 
     pNewThreadStore.SuppressRelease();
@@ -208,7 +205,6 @@ void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
     {
         GCHeapUtilities::GetGCHeap()->ResetWaitForGCEvent();
     }
-    m_SuspendCompleteEvent.Reset();
 
     // set the global trap for pinvoke leave and return
     RhpTrapThreads |= (uint32_t)TrapThreadsFlags::TrapThreads;
@@ -260,8 +256,6 @@ void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
         }
 
     } while (keepWaiting);
-
-    m_SuspendCompleteEvent.Set();
 }
 
 void ThreadStore::ResumeAllThreads(bool waitForGCEvent)

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -256,6 +256,16 @@ void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
         }
 
     } while (keepWaiting);
+
+#if defined(TARGET_ARM) || defined(TARGET_ARM64)
+    // Flush the store buffers on all CPUs, to ensure that all changes made so far are seen
+    // by the GC threads. This only matters on weak memory ordered processors as
+    // the strong memory ordered processors wouldn't have reordered the relevant writes.
+    // This is needed to synchronize threads that were running in preemptive mode thus were
+    // left alone by suspension to flush their writes that they made before they switched to
+    // preemptive mode.
+    PalFlushProcessWriteBuffers();
+#endif //TARGET_ARM || TARGET_ARM64
 }
 
 void ThreadStore::ResumeAllThreads(bool waitForGCEvent)
@@ -265,6 +275,16 @@ void ThreadStore::ResumeAllThreads(bool waitForGCEvent)
         pTargetThread->ResetCachedTransitionFrame();
     }
     END_FOREACH_THREAD
+
+#if defined(TARGET_ARM) || defined(TARGET_ARM64)
+        // Flush the store buffers on all CPUs, to ensure that they all see changes made
+        // by the GC threads. This only matters on weak memory ordered processors as
+        // the strong memory ordered processors wouldn't have reordered the relevant reads.
+        // This is needed to synchronize threads that were running in preemptive mode while
+        // the runtime was suspended and that will return to cooperative mode after the runtime
+        // is restarted.
+        PalFlushProcessWriteBuffers();
+#endif //TARGET_ARM || TARGET_ARM64
 
     RhpTrapThreads &= ~(uint32_t)TrapThreadsFlags::TrapThreads;
 

--- a/src/coreclr/nativeaot/Runtime/threadstore.h
+++ b/src/coreclr/nativeaot/Runtime/threadstore.h
@@ -64,7 +64,6 @@ public:
     void        ResumeAllThreads(bool waitForGCEvent);
 
     static bool IsTrapThreadsRequested();
-    void        WaitForSuspendComplete();
 };
 typedef DPTR(ThreadStore) PTR_ThreadStore;
 

--- a/src/coreclr/nativeaot/Runtime/threadstore.h
+++ b/src/coreclr/nativeaot/Runtime/threadstore.h
@@ -21,7 +21,6 @@ class ThreadStore
 
     SList<Thread>       m_ThreadList;
     PTR_RuntimeInstance m_pRuntimeInstance;
-    CLREventStatic      m_SuspendCompleteEvent;
     ReaderWriterLock    m_Lock;
 
 private:


### PR DESCRIPTION

- Noone, except the suspending thread, needs to wait for suspension to complete. Other threads just need to leave coop mode, otherwise can run. The original purpose for `WaitForSuspend ` is not very clear. 
- More explicit ordering when working with `m_pTransitionFrame`. 
We only need to enforce compiler ordering, but it is important.
- Process wide barriers around GC for weak architectures (since preemptive threads do not synchronize with GC).
