### PR TITLE
Refactor JsonPropertyInfo initialization infrastructure and implement JsonPropertyInfo.AttributeProvider

### DIFF
--- a/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
+++ b/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
@@ -43,5 +43,24 @@ namespace System.Text.Json.Reflection
 
         private static bool HasJsonConstructorAttribute(ConstructorInfo constructorInfo)
             => constructorInfo.GetCustomAttribute<JsonConstructorAttribute>() != null;
+
+        public static TAttribute? GetUniqueCustomAttribute<TAttribute>(this MemberInfo memberInfo, bool inherit)
+            where TAttribute : Attribute
+        {
+            object[] attributes = memberInfo.GetCustomAttributes(typeof(TAttribute), inherit);
+
+            if (attributes.Length == 0)
+            {
+                return null;
+            }
+
+            if (attributes.Length == 1)
+            {
+                return (TAttribute)attributes[0];
+            }
+
+            ThrowHelper.ThrowInvalidOperationException_SerializationDuplicateAttribute(typeof(TAttribute), memberInfo);
+            return null;
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -67,7 +67,7 @@ namespace System.Text.Json.Serialization
             throw new InvalidOperationException(SR.NodeJsonObjectCustomConverterNotAllowedOnExtensionProperty);
         }
 
-        internal abstract JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo parentTypeInfo);
+        internal abstract JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, Type propertyType, JsonSerializerOptions options);
 
         internal abstract JsonParameterInfo CreateJsonParameterInfo();
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -32,7 +32,7 @@ namespace System.Text.Json.Serialization
         /// </returns>
         public abstract JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options);
 
-        internal override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo parentTypeInfo)
+        internal override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, Type propertyType, JsonSerializerOptions options)
         {
             Debug.Fail("We should never get here.");
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -69,9 +69,9 @@ namespace System.Text.Json.Serialization
 
         internal override ConverterStrategy ConverterStrategy => ConverterStrategy.Value;
 
-        internal sealed override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo parentTypeInfo)
+        internal sealed override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, Type propertyType, JsonSerializerOptions options)
         {
-            return new JsonPropertyInfo<T>(parentTypeInfo);
+            return new JsonPropertyInfo<T>(declaringTypeInfo.Type, propertyType, declaringTypeInfo, options);
         }
 
         internal sealed override JsonParameterInfo CreateJsonParameterInfo()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -32,9 +32,7 @@ namespace System.Text.Json
             Debug.Assert(memberInfo.DeclaringType != null, "Properties and fields always have a declaring type.");
             JsonConverter? converter = null;
 
-            JsonConverterAttribute? converterAttribute = (JsonConverterAttribute?)
-                GetAttributeThatCanHaveMultiple(memberInfo.DeclaringType, typeof(JsonConverterAttribute), memberInfo);
-
+            JsonConverterAttribute? converterAttribute = memberInfo.GetUniqueCustomAttribute<JsonConverterAttribute>(inherit: false);
             if (converterAttribute != null)
             {
                 converter = GetConverterFromAttribute(converterAttribute, typeToConvert, memberInfo);
@@ -176,9 +174,7 @@ namespace System.Text.Json
             // Priority 2: Attempt to get converter from [JsonConverter] on the type being converted.
             if (converter == null)
             {
-                JsonConverterAttribute? converterAttribute = (JsonConverterAttribute?)
-                    GetAttributeThatCanHaveMultiple(typeToConvert, typeof(JsonConverterAttribute));
-
+                JsonConverterAttribute? converterAttribute = typeToConvert.GetUniqueCustomAttribute<JsonConverterAttribute>(inherit: false);
                 if (converterAttribute != null)
                 {
                     converter = GetConverterFromAttribute(converterAttribute, typeToConvert: typeToConvert, memberInfo: null);
@@ -256,34 +252,6 @@ namespace System.Text.Json
             }
 
             return converter;
-        }
-
-        private static Attribute? GetAttributeThatCanHaveMultiple(Type classType, Type attributeType, MemberInfo memberInfo)
-        {
-            object[] attributes = memberInfo.GetCustomAttributes(attributeType, inherit: false);
-            return GetAttributeThatCanHaveMultiple(attributeType, classType, memberInfo, attributes);
-        }
-
-        internal static Attribute? GetAttributeThatCanHaveMultiple(Type classType, Type attributeType)
-        {
-            object[] attributes = classType.GetCustomAttributes(attributeType, inherit: false);
-            return GetAttributeThatCanHaveMultiple(attributeType, classType, null, attributes);
-        }
-
-        private static Attribute? GetAttributeThatCanHaveMultiple(Type attributeType, Type classType, MemberInfo? memberInfo, object[] attributes)
-        {
-            if (attributes.Length == 0)
-            {
-                return null;
-            }
-
-            if (attributes.Length == 1)
-            {
-                return (Attribute)attributes[0];
-            }
-
-            ThrowHelper.ThrowInvalidOperationException_SerializationDuplicateAttribute(attributeType, classType, memberInfo);
-            return default;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -27,21 +27,17 @@ namespace System.Text.Json
         public IList<JsonConverter> Converters => _converters;
 
         // This may return factory converter
-        internal JsonConverter? GetCustomConverterFromMember(Type? parentClassType, Type typeToConvert, MemberInfo? memberInfo)
+        internal JsonConverter? GetCustomConverterFromMember(Type typeToConvert, MemberInfo memberInfo)
         {
+            Debug.Assert(memberInfo.DeclaringType != null, "Properties and fields always have a declaring type.");
             JsonConverter? converter = null;
 
-            if (memberInfo != null)
+            JsonConverterAttribute? converterAttribute = (JsonConverterAttribute?)
+                GetAttributeThatCanHaveMultiple(memberInfo.DeclaringType, typeof(JsonConverterAttribute), memberInfo);
+
+            if (converterAttribute != null)
             {
-                Debug.Assert(parentClassType != null);
-
-                JsonConverterAttribute? converterAttribute = (JsonConverterAttribute?)
-                    GetAttributeThatCanHaveMultiple(parentClassType!, typeof(JsonConverterAttribute), memberInfo);
-
-                if (converterAttribute != null)
-                {
-                    converter = GetConverterFromAttribute(converterAttribute, typeToConvert, classTypeAttributeIsOn: parentClassType!, memberInfo);
-                }
+                converter = GetConverterFromAttribute(converterAttribute, typeToConvert, memberInfo);
             }
 
             return converter;
@@ -185,7 +181,7 @@ namespace System.Text.Json
 
                 if (converterAttribute != null)
                 {
-                    converter = GetConverterFromAttribute(converterAttribute, typeToConvert: typeToConvert, classTypeAttributeIsOn: typeToConvert, memberInfo: null);
+                    converter = GetConverterFromAttribute(converterAttribute, typeToConvert: typeToConvert, memberInfo: null);
                 }
             }
 
@@ -215,29 +211,30 @@ namespace System.Text.Json
         // This suppression needs to be removed. https://github.com/dotnet/runtime/issues/68878
         [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "The factory constructors are only invoked in the context of reflection serialization code paths " +
             "and are marked RequiresDynamicCode")]
-        private JsonConverter GetConverterFromAttribute(JsonConverterAttribute converterAttribute, Type typeToConvert, Type classTypeAttributeIsOn, MemberInfo? memberInfo)
+        private JsonConverter GetConverterFromAttribute(JsonConverterAttribute converterAttribute, Type typeToConvert, MemberInfo? memberInfo)
         {
             JsonConverter? converter;
 
-            Type? type = converterAttribute.ConverterType;
-            if (type == null)
+            Type declaringType = memberInfo?.DeclaringType ?? typeToConvert;
+            Type? converterType = converterAttribute.ConverterType;
+            if (converterType == null)
             {
                 // Allow the attribute to create the converter.
                 converter = converterAttribute.CreateConverter(typeToConvert);
                 if (converter == null)
                 {
-                    ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(classTypeAttributeIsOn, memberInfo, typeToConvert);
+                    ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(declaringType, memberInfo, typeToConvert);
                 }
             }
             else
             {
-                ConstructorInfo? ctor = type.GetConstructor(Type.EmptyTypes);
-                if (!typeof(JsonConverter).IsAssignableFrom(type) || ctor == null || !ctor.IsPublic)
+                ConstructorInfo? ctor = converterType.GetConstructor(Type.EmptyTypes);
+                if (!typeof(JsonConverter).IsAssignableFrom(converterType) || ctor == null || !ctor.IsPublic)
                 {
-                    ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeInvalid(classTypeAttributeIsOn, memberInfo);
+                    ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeInvalid(declaringType, memberInfo);
                 }
 
-                converter = (JsonConverter)Activator.CreateInstance(type)!;
+                converter = (JsonConverter)Activator.CreateInstance(converterType)!;
             }
 
             Debug.Assert(converter != null);
@@ -255,7 +252,7 @@ namespace System.Text.Json
                     return NullableConverterFactory.CreateValueConverter(underlyingType, converter);
                 }
 
-                ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(classTypeAttributeIsOn, memberInfo, typeToConvert);
+                ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(declaringType, memberInfo, typeToConvert);
             }
 
             return converter;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
@@ -31,11 +31,7 @@ namespace System.Text.Json.Serialization.Metadata
         private static JsonConverter GetConverter(JsonSerializerOptions options)
         {
             DefaultJsonTypeInfoResolver.RootDefaultInstance();
-            return GetEffectiveConverter(
-                    typeof(T),
-                    parentClassType: null, // A TypeInfo never has a "parent" class.
-                    memberInfo: null, // A TypeInfo never has a "parent" property.
-                    options);
+            return options.GetConverterForType(typeof(T));
         }
 
         internal override JsonParameterInfoValues[] GetParameterInfoValues()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
@@ -50,7 +50,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             _mutable = false;
 
-            JsonTypeInfo.ValidateType(type, null, null, options);
+            JsonTypeInfo.ValidateType(type);
             JsonTypeInfo typeInfo = CreateJsonTypeInfo(type, options);
 
             if (_modifiers != null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
@@ -48,9 +48,7 @@ namespace System.Text.Json.Serialization.Metadata
                 throw new InvalidOperationException(SR.Format(SR.FieldCannotBeVirtual, nameof(propertyInfo.IsProperty), nameof(propertyInfo.IsVirtual)));
             }
 
-            JsonPropertyInfo<T> jsonPropertyInfo = new JsonPropertyInfo<T>(parentTypeInfo: null);
-            jsonPropertyInfo.InitializeForSourceGen(options, propertyInfo);
-            return jsonPropertyInfo;
+            return new JsonPropertyInfo<T>(options, propertyInfo);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -115,6 +115,7 @@ namespace System.Text.Json.Serialization.Metadata
                 _ignoreCondition = value;
                 IsIgnored = value == JsonIgnoreCondition.Always;
                 _shouldSerialize = value != null ? GetShouldSerializeForIgnoreCondition(value.Value) : null;
+                _shouldSerializeIsExplicitlySet = false;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -114,11 +114,7 @@ namespace System.Text.Json.Serialization.Metadata
 
                 _ignoreCondition = value;
                 IsIgnored = value == JsonIgnoreCondition.Always;
-
-                if (value != null)
-                {
-                    _shouldSerialize = GetShouldSerializeForIgnoreCondition(value.Value);
-                }
+                _shouldSerialize = value != null ? GetShouldSerializeForIgnoreCondition(value.Value) : null; 
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -142,25 +142,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 VerifyMutable();
 
-                switch (_attributeProvider = value)
-                {
-                    case PropertyInfo propertyInfo:
-                        {
-                            MemberName = propertyInfo.Name;
-                            IsVirtual = propertyInfo.IsVirtual();
-                            MemberType = MemberTypes.Property;
-                            break;
-                        }
-                    case FieldInfo fieldInfo:
-                        {
-                            MemberName = fieldInfo.Name;
-                            MemberType = MemberTypes.Field;
-                            break;
-                        }
-                    default:
-                        // Don't set any metadata when value is unsupported MemberInfo type
-                        break;
-                }
+                _attributeProvider = value;
             }
         }
 
@@ -546,7 +528,26 @@ namespace System.Text.Json.Serialization.Metadata
         internal void InitializeUsingMemberReflection(MemberInfo memberInfo)
         {
             Debug.Assert(AttributeProvider == null);
-            Debug.Assert(memberInfo is FieldInfo or PropertyInfo);
+
+            switch (AttributeProvider = memberInfo)
+            {
+                case PropertyInfo propertyInfo:
+                    {
+                        MemberName = propertyInfo.Name;
+                        IsVirtual = propertyInfo.IsVirtual();
+                        MemberType = MemberTypes.Property;
+                        break;
+                    }
+                case FieldInfo fieldInfo:
+                    {
+                        MemberName = fieldInfo.Name;
+                        MemberType = MemberTypes.Field;
+                        break;
+                    }
+                default:
+                    Debug.Fail("Only FieldInfo and PropertyInfo members are supported.");
+                    break;
+            }
 
             DeterminePoliciesFromMember(memberInfo);
             DeterminePropertyNameFromMember(memberInfo);
@@ -557,7 +558,6 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             IsExtensionData = memberInfo.GetCustomAttribute<JsonExtensionDataAttribute>(inherit: false) != null;
-            AttributeProvider = memberInfo;
         }
 
         internal bool IgnoreDefaultValuesOnRead { get; private set; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -243,7 +243,7 @@ namespace System.Text.Json.Serialization.Metadata
             _isConfigured = true;
         }
 
-        internal void Configure()
+        internal virtual void Configure()
         {
             Debug.Assert(ParentTypeInfo != null, "We should have ensured parent is assigned in JsonTypeInfo");
             DeclaringTypeNumberHandling = ParentTypeInfo.NumberHandling;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -114,7 +114,7 @@ namespace System.Text.Json.Serialization.Metadata
 
                 _ignoreCondition = value;
                 IsIgnored = value == JsonIgnoreCondition.Always;
-                _shouldSerialize = value != null ? GetShouldSerializeForIgnoreCondition(value.Value) : null; 
+                _shouldSerialize = value != null ? GetShouldSerializeForIgnoreCondition(value.Value) : null;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -15,23 +15,17 @@ namespace System.Text.Json.Serialization.Metadata
     /// or a type's converter, if the current instance is a <see cref="JsonTypeInfo.PropertyInfoForTypeInfo"/>.
     internal sealed class JsonPropertyInfo<T> : JsonPropertyInfo
     {
-        /// <summary>
-        /// Returns true if the property's converter is external (a user's custom converter)
-        /// and the type to convert is not the same as the declared property type (polymorphic).
-        /// Used to determine whether to perform additional validation on the value returned by the
-        /// converter on deserialization.
-        /// </summary>
-        private bool _converterIsExternalAndPolymorphic;
-
         // Since a converter's TypeToConvert (which is the T value in this type) can be different than
         // the property's type, we track that and whether the property type can be null.
-        private bool _propertyTypeEqualsTypeToConvert;
+        private readonly bool _propertyTypeEqualsTypeToConvert;
 
         private Func<object, T>? _typedGet;
         private Action<object, T>? _typedSet;
 
-        internal JsonPropertyInfo(JsonTypeInfo? parentTypeInfo) : base(parentTypeInfo)
+        internal JsonPropertyInfo(Type declaringType, Type propertyType, JsonTypeInfo? parentTypeInfo, JsonSerializerOptions options)
+            : base(declaringType, propertyType, parentTypeInfo, options)
         {
+            _propertyTypeEqualsTypeToConvert = propertyType == typeof(T);
         }
 
         internal new Func<object, T>? Get
@@ -98,107 +92,57 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal JsonConverter<T> TypedEffectiveConverter { get; private set; } = null!;
 
-        internal override void Initialize(
-            Type declaringType,
-            Type declaredPropertyType,
-            ConverterStrategy converterStrategy,
-            MemberInfo? memberInfo,
-            bool isVirtual,
-            JsonConverter converter,
-            JsonIgnoreCondition? ignoreCondition,
-            JsonSerializerOptions options,
-            JsonTypeInfo? jsonTypeInfo = null,
-            bool isUserDefinedProperty = false)
+        private protected override void DetermineMemberAccessors(MemberInfo memberInfo)
         {
-            Debug.Assert(converter != null);
+            Debug.Assert(memberInfo is FieldInfo or PropertyInfo);
 
-            PropertyType = declaredPropertyType;
-            _propertyTypeEqualsTypeToConvert = typeof(T) == declaredPropertyType;
-            PropertyTypeCanBeNull = PropertyType.CanBeNull();
-            ConverterStrategy = converterStrategy;
-            if (jsonTypeInfo != null)
+            switch (memberInfo)
             {
-                JsonTypeInfo = jsonTypeInfo;
-            }
-
-            DefaultConverterForType = converter;
-            Options = options;
-            DeclaringType = declaringType;
-            MemberInfo = memberInfo;
-            IsVirtual = isVirtual;
-            IgnoreCondition = ignoreCondition;
-            IsIgnored = ignoreCondition == JsonIgnoreCondition.Always;
-
-            if (memberInfo != null)
-            {
-                if (!IsIgnored)
-                {
-                    switch (memberInfo)
+                case PropertyInfo propertyInfo:
                     {
-                        case PropertyInfo propertyInfo:
-                            {
-                                bool useNonPublicAccessors = propertyInfo.GetCustomAttribute<JsonIncludeAttribute>(inherit: false) != null;
+                        bool useNonPublicAccessors = propertyInfo.GetCustomAttribute<JsonIncludeAttribute>(inherit: false) != null;
 
-                                MethodInfo? getMethod = propertyInfo.GetMethod;
-                                if (getMethod != null && (getMethod.IsPublic || useNonPublicAccessors))
-                                {
-                                    Get = options.MemberAccessorStrategy.CreatePropertyGetter<T>(propertyInfo);
-                                }
+                        MethodInfo? getMethod = propertyInfo.GetMethod;
+                        if (getMethod != null && (getMethod.IsPublic || useNonPublicAccessors))
+                        {
+                            Get = Options.MemberAccessorStrategy.CreatePropertyGetter<T>(propertyInfo);
+                        }
 
-                                MethodInfo? setMethod = propertyInfo.SetMethod;
-                                if (setMethod != null && (setMethod.IsPublic || useNonPublicAccessors))
-                                {
-                                    Set = options.MemberAccessorStrategy.CreatePropertySetter<T>(propertyInfo);
-                                }
+                        MethodInfo? setMethod = propertyInfo.SetMethod;
+                        if (setMethod != null && (setMethod.IsPublic || useNonPublicAccessors))
+                        {
+                            Set = Options.MemberAccessorStrategy.CreatePropertySetter<T>(propertyInfo);
+                        }
 
-                                MemberType = MemberTypes.Property;
-
-                                break;
-                            }
-
-                        case FieldInfo fieldInfo:
-                            {
-                                Debug.Assert(fieldInfo.IsPublic);
-
-                                Get = options.MemberAccessorStrategy.CreateFieldGetter<T>(fieldInfo);
-
-                                if (!fieldInfo.IsInitOnly)
-                                {
-                                    Set = options.MemberAccessorStrategy.CreateFieldSetter<T>(fieldInfo);
-                                }
-
-                                MemberType = MemberTypes.Field;
-
-                                break;
-                            }
-
-                        default:
-                            {
-                                Debug.Fail($"Invalid memberInfo type: {memberInfo.GetType().FullName}");
-                                break;
-                            }
+                        break;
                     }
-                }
 
-                GetPolicies();
-            }
-            else if (!isUserDefinedProperty)
-            {
-                IsForTypeInfo = true;
-            }
+                case FieldInfo fieldInfo:
+                    {
+                        Debug.Assert(fieldInfo.IsPublic);
 
-            if (IgnoreCondition != null)
-            {
-                _shouldSerialize = GetShouldSerializeForIgnoreCondition(IgnoreCondition.Value);
+                        Get = Options.MemberAccessorStrategy.CreateFieldGetter<T>(fieldInfo);
+
+                        if (!fieldInfo.IsInitOnly)
+                        {
+                            Set = Options.MemberAccessorStrategy.CreateFieldSetter<T>(fieldInfo);
+                        }
+
+                        break;
+                    }
+
+                default:
+                    {
+                        Debug.Fail($"Invalid MemberInfo type: {memberInfo.MemberType}");
+                        break;
+                    }
             }
         }
 
-        internal void InitializeForSourceGen(JsonSerializerOptions options, JsonPropertyInfoValues<T> propertyInfo)
+        internal JsonPropertyInfo(JsonSerializerOptions options, JsonPropertyInfoValues<T> propertyInfo)
+            : this(propertyInfo.DeclaringType, propertyType: typeof(T), parentTypeInfo: null, options)
         {
-            Options = options;
-            ClrName = propertyInfo.PropertyName;
-
-            string name;
+            string? name;
 
             // Property name settings.
             if (propertyInfo.JsonPropertyName != null)
@@ -207,30 +151,27 @@ namespace System.Text.Json.Serialization.Metadata
             }
             else if (options.PropertyNamingPolicy == null)
             {
-                name = ClrName;
+                name = propertyInfo.PropertyName;
             }
             else
             {
-                name = options.PropertyNamingPolicy.ConvertName(ClrName);
+                name = options.PropertyNamingPolicy.ConvertName(propertyInfo.PropertyName);
             }
 
             // Compat: We need to do validation before we assign Name so that we get InvalidOperationException rather than ArgumentNullException
             if (name == null)
             {
-                ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNameNull(DeclaringType, this);
+                ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNameNull(this);
             }
 
             Name = name;
-
+            MemberName = propertyInfo.PropertyName;
+            MemberType = propertyInfo.IsProperty ? MemberTypes.Property : MemberTypes.Field;
             SrcGen_IsPublic = propertyInfo.IsPublic;
             SrcGen_HasJsonInclude = propertyInfo.HasJsonInclude;
-            SrcGen_IsExtensionData = propertyInfo.IsExtensionData;
-            PropertyType = typeof(T);
-            _propertyTypeEqualsTypeToConvert = true;
-            PropertyTypeCanBeNull = PropertyType.CanBeNull();
+            IsExtensionData = propertyInfo.IsExtensionData;
 
             JsonTypeInfo? propertyTypeInfo = propertyInfo.PropertyTypeInfo;
-            Type declaringType = propertyInfo.DeclaringType;
 
             JsonConverter<T>? typedCustomConverter = propertyInfo.Converter;
             CustomConverter = typedCustomConverter;
@@ -238,36 +179,18 @@ namespace System.Text.Json.Serialization.Metadata
             JsonConverter<T>? typedNonCustomConverter = propertyTypeInfo?.Converter as JsonConverter<T>;
             DefaultConverterForType = typedNonCustomConverter;
 
-            IsIgnored = propertyInfo.IgnoreCondition == JsonIgnoreCondition.Always;
-            if (!IsIgnored)
+            IgnoreCondition = propertyInfo.IgnoreCondition;
+            if (IgnoreCondition != JsonIgnoreCondition.Always)
             {
                 Get = propertyInfo.Getter!;
                 Set = propertyInfo.Setter;
             }
 
             JsonTypeInfo = propertyTypeInfo;
-            DeclaringType = declaringType;
-            IgnoreCondition = propertyInfo.IgnoreCondition;
-            MemberType = propertyInfo.IsProperty ? MemberTypes.Property : MemberTypes.Field;
             NumberHandling = propertyInfo.NumberHandling;
-
-            if (IgnoreCondition != null)
-            {
-                _shouldSerialize = GetShouldSerializeForIgnoreCondition(IgnoreCondition.Value);
-            }
         }
 
-        internal override void Configure()
-        {
-            base.Configure();
-
-            if (!IsForTypeInfo && !IsIgnored)
-            {
-                _converterIsExternalAndPolymorphic = !EffectiveConverter.IsInternalConverter && PropertyType != EffectiveConverter.TypeToConvert;
-            }
-        }
-
-        internal override void DetermineEffectiveConverter()
+        private protected override void DetermineEffectiveConverter()
         {
             JsonConverter? customConverter = CustomConverter;
             if (customConverter != null)
@@ -544,7 +467,7 @@ namespace System.Text.Json.Serialization.Metadata
             Set!(obj, typedValue);
         }
 
-        private Func<object, object?, bool> GetShouldSerializeForIgnoreCondition(JsonIgnoreCondition ignoreCondition)
+        private protected override Func<object, object?, bool> GetShouldSerializeForIgnoreCondition(JsonIgnoreCondition ignoreCondition)
         {
             switch (ignoreCondition)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -15,6 +15,14 @@ namespace System.Text.Json.Serialization.Metadata
     /// or a type's converter, if the current instance is a <see cref="JsonTypeInfo.PropertyInfoForTypeInfo"/>.
     internal sealed class JsonPropertyInfo<T> : JsonPropertyInfo
     {
+        /// <summary>
+        /// Returns true if the property's converter is external (a user's custom converter)
+        /// and the type to convert is not the same as the declared property type (polymorphic).
+        /// Used to determine whether to perform additional validation on the value returned by the
+        /// converter on deserialization.
+        /// </summary>
+        private bool _converterIsExternalAndPolymorphic;
+
         // Since a converter's TypeToConvert (which is the T value in this type) can be different than
         // the property's type, we track that and whether the property type can be null.
         private readonly bool _propertyTypeEqualsTypeToConvert;
@@ -188,6 +196,16 @@ namespace System.Text.Json.Serialization.Metadata
 
             JsonTypeInfo = propertyTypeInfo;
             NumberHandling = propertyInfo.NumberHandling;
+        }
+
+        internal override void Configure()
+        {
+            base.Configure();
+
+            if (!IsForTypeInfo && !IsIgnored)
+            {
+                _converterIsExternalAndPolymorphic = !EffectiveConverter.IsInternalConverter && PropertyType != EffectiveConverter.TypeToConvert;
+            }
         }
 
         private protected override void DetermineEffectiveConverter()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -51,35 +51,12 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal Func<JsonParameterInfoValues[]>? CtorParamInitFunc;
 
-        internal JsonPropertyInfo CreateProperty(
-            Type declaredPropertyType,
-            MemberInfo? memberInfo,
-            Type parentClassType,
-            bool isVirtual,
-            JsonConverter converter,
-            JsonSerializerOptions options,
-            JsonIgnoreCondition? ignoreCondition = null,
-            JsonTypeInfo? jsonTypeInfo = null,
-            JsonConverter? customConverter = null,
-            bool isUserDefinedProperty = false)
+        internal JsonPropertyInfo CreateProperty(Type propertyType, JsonConverter converter)
         {
             // Create the JsonPropertyInfo instance.
-            JsonPropertyInfo jsonPropertyInfo = converter.CreateJsonPropertyInfo(parentTypeInfo: this);
-
-            jsonPropertyInfo.Initialize(
-                parentClassType,
-                declaredPropertyType,
-                converterStrategy: converter.ConverterStrategy,
-                memberInfo,
-                isVirtual,
-                converter,
-                ignoreCondition,
-                options,
-                jsonTypeInfo,
-                isUserDefinedProperty: isUserDefinedProperty);
-
-            jsonPropertyInfo.CustomConverter = customConverter;
-
+            JsonPropertyInfo jsonPropertyInfo = converter.CreateJsonPropertyInfo(declaringTypeInfo: this, propertyType, Options);
+            jsonPropertyInfo.DefaultConverterForType = converter;
+            jsonPropertyInfo.ConverterStrategy = converter.ConverterStrategy;
             return jsonPropertyInfo;
         }
 
@@ -87,23 +64,11 @@ namespace System.Text.Json.Serialization.Metadata
         /// Create a <see cref="JsonPropertyInfo"/> for a given Type.
         /// See <seealso cref="PropertyInfoForTypeInfo"/>.
         /// </summary>
-        private JsonPropertyInfo CreatePropertyInfoForTypeInfo(
-            Type declaredPropertyType,
-            JsonConverter converter,
-            JsonSerializerOptions options,
-            JsonTypeInfo? jsonTypeInfo = null)
+        private JsonPropertyInfo CreatePropertyInfoForTypeInfo(JsonTypeInfo jsonTypeInfo, JsonConverter converter)
         {
-            JsonPropertyInfo jsonPropertyInfo = CreateProperty(
-                declaredPropertyType: declaredPropertyType,
-                memberInfo: null, // Not a real property so this is null.
-                parentClassType: ObjectType, // a dummy value (not used)
-                isVirtual: false,
-                converter: converter,
-                options: options,
-                jsonTypeInfo: jsonTypeInfo);
-
-            Debug.Assert(jsonPropertyInfo.IsForTypeInfo);
-
+            JsonPropertyInfo jsonPropertyInfo = CreateProperty(jsonTypeInfo.Type, converter: converter);
+            jsonPropertyInfo.JsonTypeInfo = jsonTypeInfo;
+            jsonPropertyInfo.IsForTypeInfo = true;
             return jsonPropertyInfo;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -212,9 +212,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         private static JsonNumberHandling? GetNumberHandlingForType(Type type)
         {
-            var numberHandlingAttribute =
-                (JsonNumberHandlingAttribute?)JsonSerializerOptions.GetAttributeThatCanHaveMultiple(type, typeof(JsonNumberHandlingAttribute));
-
+            JsonNumberHandlingAttribute? numberHandlingAttribute = type.GetUniqueCustomAttribute<JsonNumberHandlingAttribute>(inherit: false);
             return numberHandlingAttribute?.Handling;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -18,13 +17,7 @@ namespace System.Text.Json.Serialization.Metadata
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
         internal ReflectionJsonTypeInfo(JsonSerializerOptions options)
-            : this(
-                  GetEffectiveConverter(
-                    typeof(T),
-                    parentClassType: null, // A TypeInfo never has a "parent" class.
-                    memberInfo: null, // A TypeInfo never has a "parent" property.
-                    options),
-                  options)
+            : this(options.GetConverterForType(typeof(T)), options)
         {
         }
 
@@ -67,34 +60,32 @@ namespace System.Text.Json.Serialization.Metadata
         {
             Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object);
 
-            const BindingFlags bindingFlags =
+            const BindingFlags BindingFlags =
                 BindingFlags.Instance |
                 BindingFlags.Public |
                 BindingFlags.NonPublic |
                 BindingFlags.DeclaredOnly;
 
             Dictionary<string, JsonPropertyInfo>? ignoredMembers = null;
-            PropertyInfo[] properties = Type.GetProperties(bindingFlags);
             bool propertyOrderSpecified = false;
 
-            // PropertyCache is not accessed by other threads until the current JsonTypeInfo instance
-            //  is finished initializing and added to the cache on JsonSerializerOptions.
-            // Default 'capacity' to the common non-polymorphic + property case.
-            PropertyCache = CreatePropertyCache(capacity: properties.Length);
-
-            // We start from the most derived type.
-            Type? currentType = Type;
-
-            while (true)
+            // Walk through the inheritance hierarchy, starting from the most derived type upward.
+            for (Type? currentType = Type; currentType != null; currentType = currentType.BaseType)
             {
+                PropertyInfo[] properties = currentType.GetProperties(BindingFlags);
+
+                // PropertyCache is not accessed by other threads until the current JsonTypeInfo instance
+                // is finished initializing and added to the cache in JsonSerializerOptions.
+                // Default 'capacity' to the common non-polymorphic + property case.
+                PropertyCache ??= CreatePropertyCache(capacity: properties.Length);
+
                 foreach (PropertyInfo propertyInfo in properties)
                 {
-                    bool isVirtual = propertyInfo.IsVirtual();
                     string propertyName = propertyInfo.Name;
 
                     // Ignore indexers and virtual properties that have overrides that were [JsonIgnore]d.
                     if (propertyInfo.GetIndexParameters().Length > 0 ||
-                        PropertyIsOverridenAndIgnored(propertyName, propertyInfo.PropertyType, isVirtual, ignoredMembers))
+                        PropertyIsOverridenAndIgnored(propertyName, propertyInfo.PropertyType, propertyInfo.IsVirtual(), ignoredMembers))
                     {
                         continue;
                     }
@@ -104,11 +95,8 @@ namespace System.Text.Json.Serialization.Metadata
                         propertyInfo.SetMethod?.IsPublic == true)
                     {
                         CacheMember(
-                            currentType,
-                            propertyInfo.PropertyType,
-                            propertyInfo,
-                            isVirtual,
-                            NumberHandling,
+                            typeToConvert: propertyInfo.PropertyType,
+                            memberInfo: propertyInfo,
                             ref propertyOrderSpecified,
                             ref ignoredMembers);
                     }
@@ -123,7 +111,7 @@ namespace System.Text.Json.Serialization.Metadata
                     }
                 }
 
-                foreach (FieldInfo fieldInfo in currentType.GetFields(bindingFlags))
+                foreach (FieldInfo fieldInfo in currentType.GetFields(BindingFlags))
                 {
                     string fieldName = fieldInfo.Name;
 
@@ -139,11 +127,8 @@ namespace System.Text.Json.Serialization.Metadata
                         if (hasJsonInclude || Options.IncludeFields)
                         {
                             CacheMember(
-                                currentType,
-                                fieldInfo.FieldType,
-                                fieldInfo,
-                                isVirtual: false,
-                                NumberHandling,
+                                typeToConvert: fieldInfo.FieldType,
+                                memberInfo: fieldInfo,
                                 ref propertyOrderSpecified,
                                 ref ignoredMembers);
                         }
@@ -158,15 +143,9 @@ namespace System.Text.Json.Serialization.Metadata
                         // Non-public fields should not be included for (de)serialization.
                     }
                 }
+            }
 
-                currentType = currentType.BaseType;
-                if (currentType == null)
-                {
-                    break;
-                }
-
-                properties = currentType.GetProperties(bindingFlags);
-            };
+            Debug.Assert(PropertyCache != null);
 
             if (propertyOrderSpecified)
             {
@@ -175,21 +154,12 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
         private void CacheMember(
-            Type declaringType,
-            Type memberType,
+            Type typeToConvert,
             MemberInfo memberInfo,
-            bool isVirtual,
-            JsonNumberHandling? typeNumberHandling,
             ref bool propertyOrderSpecified,
             ref Dictionary<string, JsonPropertyInfo>? ignoredMembers)
         {
-            bool hasExtensionAttribute = memberInfo.GetCustomAttribute<JsonExtensionDataAttribute>(inherit: false) != null;
-            if (hasExtensionAttribute && ExtensionDataProperty != null)
-            {
-                ThrowHelper.ThrowInvalidOperationException_SerializationDuplicateTypeAttribute(Type, typeof(JsonExtensionDataAttribute));
-            }
-
-            JsonPropertyInfo? jsonPropertyInfo = AddProperty(memberInfo, memberType, declaringType, isVirtual, Options);
+            JsonPropertyInfo? jsonPropertyInfo = AddProperty(typeToConvert, memberInfo, Options);
             if (jsonPropertyInfo == null)
             {
                 // ignored invalid property
@@ -197,34 +167,24 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             Debug.Assert(jsonPropertyInfo.Name != null);
-
-            if (hasExtensionAttribute)
-            {
-                Debug.Assert(ExtensionDataProperty == null);
-                ExtensionDataProperty = jsonPropertyInfo;
-            }
-            else
-            {
-                CacheMember(jsonPropertyInfo, PropertyCache, ref ignoredMembers);
-                propertyOrderSpecified |= jsonPropertyInfo.Order != 0;
-            }
+            Debug.Assert(PropertyCache != null);
+            CacheMember(jsonPropertyInfo, PropertyCache, ref ignoredMembers);
+            propertyOrderSpecified |= jsonPropertyInfo.Order != 0;
         }
 
         private JsonPropertyInfo? AddProperty(
+            Type typeToConvert,
             MemberInfo memberInfo,
-            Type memberType,
-            Type parentClassType,
-            bool isVirtual,
             JsonSerializerOptions options)
         {
             JsonIgnoreCondition? ignoreCondition = memberInfo.GetCustomAttribute<JsonIgnoreAttribute>(inherit: false)?.Condition;
 
-            if (IsInvalidForSerialization(memberType))
+            if (IsInvalidForSerialization(typeToConvert))
             {
                 if (ignoreCondition == JsonIgnoreCondition.Always)
                     return null;
 
-                ThrowHelper.ThrowInvalidOperationException_CannotSerializeInvalidType(memberType, parentClassType, memberInfo);
+                ThrowHelper.ThrowInvalidOperationException_CannotSerializeInvalidType(typeToConvert, memberInfo.DeclaringType, memberInfo);
             }
 
             JsonConverter? customConverter;
@@ -232,27 +192,22 @@ namespace System.Text.Json.Serialization.Metadata
 
             try
             {
-                converter = GetConverter(
-                memberType,
-                parentClassType,
-                memberInfo,
-                options,
-                out customConverter);
+                converter = GetConverterFromMember(
+                    typeToConvert,
+                    memberInfo,
+                    options,
+                    out customConverter);
             }
             catch (InvalidOperationException) when (ignoreCondition == JsonIgnoreCondition.Always)
             {
                 return null;
             }
 
-            return CreateProperty(
-                declaredPropertyType: memberType,
-                memberInfo,
-                parentClassType,
-                isVirtual,
-                converter,
-                options,
-                ignoreCondition,
-                customConverter: customConverter);
+            JsonPropertyInfo jsonPropertyInfo = CreateProperty(typeToConvert, converter);
+            jsonPropertyInfo.IgnoreCondition = ignoreCondition;
+            jsonPropertyInfo.CustomConverter = customConverter;
+            jsonPropertyInfo.InitializeUsingMemberReflection(memberInfo);
+            return jsonPropertyInfo;
         }
 
         private static JsonNumberHandling? GetNumberHandlingForType(Type type)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
@@ -151,8 +151,8 @@ namespace System.Text.Json.Serialization.Metadata
                 {
                     if (hasJsonInclude)
                     {
-                        Debug.Assert(jsonPropertyInfo.ClrName != null, "ClrName is not set by source gen");
-                        ThrowHelper.ThrowInvalidOperationException_JsonIncludeOnNonPublicInvalid(jsonPropertyInfo.ClrName, jsonPropertyInfo.DeclaringType);
+                        Debug.Assert(jsonPropertyInfo.MemberName != null, "MemberName is not set by source gen");
+                        ThrowHelper.ThrowInvalidOperationException_JsonIncludeOnNonPublicInvalid(jsonPropertyInfo.MemberName, jsonPropertyInfo.DeclaringType);
                     }
 
                     continue;
@@ -160,17 +160,6 @@ namespace System.Text.Json.Serialization.Metadata
 
                 if (jsonPropertyInfo.MemberType == MemberTypes.Field && !hasJsonInclude && !Options.IncludeFields)
                 {
-                    continue;
-                }
-
-                if (jsonPropertyInfo.SrcGen_IsExtensionData)
-                {
-                    if (ExtensionDataProperty != null)
-                    {
-                        ThrowHelper.ThrowInvalidOperationException_SerializationDuplicateTypeAttribute(Type, typeof(JsonExtensionDataAttribute));
-                    }
-
-                    ExtensionDataProperty = jsonPropertyInfo;
                     continue;
                 }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -407,7 +407,7 @@ namespace System.Text.Json
             static void AppendStackFrame(StringBuilder sb, ref WriteStackFrame frame)
             {
                 // Append the property name.
-                string? propertyName = frame.JsonPropertyInfo?.ClrName;
+                string? propertyName = frame.JsonPropertyInfo?.MemberName;
                 if (propertyName == null)
                 {
                     // Attempt to get the JSON property name from the property name specified in re-entry.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -86,29 +86,29 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowArgumentException_CannotSerializeInvalidType(string paramName, Type type, Type? parentClassType, string? propertyName)
+        public static void ThrowArgumentException_CannotSerializeInvalidType(string paramName, Type typeToConvert, Type? declaringType, string? propertyName)
         {
-            if (parentClassType == null)
+            if (declaringType == null)
             {
                 Debug.Assert(propertyName == null);
-                throw new ArgumentException(SR.Format(SR.CannotSerializeInvalidType, type), paramName);
+                throw new ArgumentException(SR.Format(SR.CannotSerializeInvalidType, typeToConvert), paramName);
             }
 
             Debug.Assert(propertyName != null);
-            throw new ArgumentException(SR.Format(SR.CannotSerializeInvalidMember, type, propertyName, parentClassType), paramName);
+            throw new ArgumentException(SR.Format(SR.CannotSerializeInvalidMember, typeToConvert, propertyName, declaringType), paramName);
         }
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException_CannotSerializeInvalidType(Type type, Type? parentClassType, MemberInfo? memberInfo)
+        public static void ThrowInvalidOperationException_CannotSerializeInvalidType(Type typeToConvert, Type? declaringType, MemberInfo? memberInfo)
         {
-            if (parentClassType == null)
+            if (declaringType == null)
             {
                 Debug.Assert(memberInfo == null);
-                throw new InvalidOperationException(SR.Format(SR.CannotSerializeInvalidType, type));
+                throw new InvalidOperationException(SR.Format(SR.CannotSerializeInvalidType, typeToConvert));
             }
 
             Debug.Assert(memberInfo != null);
-            throw new InvalidOperationException(SR.Format(SR.CannotSerializeInvalidMember, type, memberInfo.Name, parentClassType));
+            throw new InvalidOperationException(SR.Format(SR.CannotSerializeInvalidMember, typeToConvert, memberInfo.Name, declaringType));
         }
 
         [DoesNotReturn]
@@ -201,9 +201,9 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException_SerializerPropertyNameNull(Type parentType, JsonPropertyInfo jsonPropertyInfo)
+        public static void ThrowInvalidOperationException_SerializerPropertyNameNull(JsonPropertyInfo jsonPropertyInfo)
         {
-            throw new InvalidOperationException(SR.Format(SR.SerializerPropertyNameNull, parentType, jsonPropertyInfo.MemberInfo?.Name));
+            throw new InvalidOperationException(SR.Format(SR.SerializerPropertyNameNull, jsonPropertyInfo.DeclaringType, jsonPropertyInfo.MemberName));
         }
 
         [DoesNotReturn]
@@ -267,11 +267,8 @@ namespace System.Text.Json
         [DoesNotReturn]
         public static void ThrowInvalidOperationException_NumberHandlingOnPropertyInvalid(JsonPropertyInfo jsonPropertyInfo)
         {
-            MemberInfo? memberInfo = jsonPropertyInfo.MemberInfo;
-            Debug.Assert(memberInfo != null);
             Debug.Assert(!jsonPropertyInfo.IsForTypeInfo);
-
-            throw new InvalidOperationException(SR.Format(SR.NumberHandlingOnPropertyInvalid, memberInfo.Name, memberInfo.DeclaringType));
+            throw new InvalidOperationException(SR.Format(SR.NumberHandlingOnPropertyInvalid, jsonPropertyInfo.MemberName, jsonPropertyInfo.DeclaringType));
         }
 
         [DoesNotReturn]
@@ -425,9 +422,9 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException_SerializationDataExtensionPropertyInvalid(Type type, JsonPropertyInfo jsonPropertyInfo)
+        public static void ThrowInvalidOperationException_SerializationDataExtensionPropertyInvalid(JsonPropertyInfo jsonPropertyInfo)
         {
-            throw new InvalidOperationException(SR.Format(SR.SerializationDataExtensionPropertyInvalid, type, jsonPropertyInfo.MemberInfo?.Name));
+            throw new InvalidOperationException(SR.Format(SR.SerializationDataExtensionPropertyInvalid, jsonPropertyInfo.PropertyType, jsonPropertyInfo.MemberName));
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -398,14 +398,9 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException_SerializationDuplicateAttribute(Type attribute, Type classType, MemberInfo? memberInfo)
+        public static void ThrowInvalidOperationException_SerializationDuplicateAttribute(Type attribute, MemberInfo memberInfo)
         {
-            string location = classType.ToString();
-            if (memberInfo != null)
-            {
-                location += $".{memberInfo.Name}";
-            }
-
+            string location = memberInfo is Type type ? type.ToString() : $"{memberInfo.DeclaringType}.{memberInfo.Name}";
             throw new InvalidOperationException(SR.Format(SR.SerializationDuplicateAttribute, attribute, location));
         }
 


### PR DESCRIPTION
Makes the following changes:

* Refactors `JsonPropertyInfo` initialization so that a minimal subset of required parameters are read-only and settable via constructors instead of property setters. Simplify initialization logic removing dead branches and unnecessary parameterization.
* Simplify the converter resolution logic, removing dead branches and unnecessary parameterization.
* Separate reflection-based `JsonPropertyInfo` metadata initialization into a separate method explicitly invoked by ReflectionJsonTypeInfo.
* Apply consistent naming conventions e.g. renaming `parentClassType` to `declaringType`, `ClrName` to `MemberName` and `memberType` to `typeToConvert`. Remove unused parameters.
* Implement `JsonPropertyInfo.AttributeProvider` and `IsExtensionData` properties as internal APIs.

Contributes to #63686.