### PR TITLE
Fix ordering issue in JSON

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyInfoDictionaryValueList.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyInfoDictionaryValueList.cs
@@ -63,8 +63,6 @@ namespace System.Text.Json
 
             // We do not know if any of the keys needs to be updated therefore we need to re-create cache
             _parent.Clear();
-            // Perform a final sort of properties before rebuilding the cache
-            _items.StableSortByKey(static prop => prop.Order);
 
             foreach (JsonPropertyInfo item in _items)
             {


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/71449 we've added non-public API which still hasn't been reviewed by API reviews but we've also changed behavior so that sorting of properties happens twice which means if API doesn't end up approved we'll end up with unexpected behavior because we will always re-sort and user can only influence items with same internally set Order and since it is not public it's not possible to change that. This change is adding simple test to make sure behavior is expected. If API gets approved then it should be adjusted accordingly