### PR TITLE
Implement type loader support for thread statics

### DIFF
--- a/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
+++ b/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
@@ -367,16 +367,4 @@ COOP_PINVOKE_HELPER(void *, RhNewInterfaceDispatchCell, (MethodTable * pInterfac
 }
 #endif // FEATURE_CACHED_INTERFACE_DISPATCH
 
-COOP_PINVOKE_HELPER(PTR_UInt8, RhGetThreadLocalStorageForDynamicType, (uint32_t uOffset, uint32_t tlsStorageSize, uint32_t numTlsCells))
-{
-    Thread * pCurrentThread = ThreadStore::GetCurrentThread();
-
-    PTR_UInt8 pResult = pCurrentThread->GetThreadLocalStorageForDynamicType(uOffset);
-    if (pResult != NULL || tlsStorageSize == 0 || numTlsCells == 0)
-        return pResult;
-
-    ASSERT(tlsStorageSize > 0 && numTlsCells > 0);
-    return pCurrentThread->AllocateThreadLocalStorageForDynamicType(uOffset, tlsStorageSize, numTlsCells);
-}
-
 #endif // DACCESS_COMPILE

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -30,9 +30,6 @@ class Thread;
 #define TOP_OF_STACK_MARKER ((PInvokeTransitionFrame*)(ptrdiff_t)-1)
 #define REDIRECTED_THREAD_MARKER ((PInvokeTransitionFrame*)(ptrdiff_t)-2)
 
-#define DYNAMIC_TYPE_TLS_OFFSET_FLAG 0x80000000
-
-
 enum SyncRequestResult
 {
     TryAgain,
@@ -98,10 +95,6 @@ struct ThreadBuffer
 #ifdef FEATURE_GC_STRESS
     uint32_t                m_uRand;                                // current per-thread random number
 #endif // FEATURE_GC_STRESS
-
-    // Thread Statics Storage for dynamic types
-    uint32_t          m_numDynamicTypesTlsCells;
-    PTR_PTR_UInt8   m_pDynamicTypesTlsCells;
 
 };
 
@@ -200,9 +193,6 @@ public:
 
     void                GetStackBounds(PTR_VOID * ppStackLow, PTR_VOID * ppStackHigh);
 
-    PTR_UInt8           AllocateThreadLocalStorageForDynamicType(uint32_t uTlsTypeOffset, uint32_t tlsStorageSize, uint32_t numTlsCells);
-
-    PTR_UInt8           GetThreadLocalStorageForDynamicType(uint32_t uTlsTypeOffset);
     PTR_UInt8           GetThreadLocalStorage(uint32_t uTlsIndex, uint32_t uTlsStartOffset);
 
     void                PushExInfo(ExInfo * pExInfo);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -349,6 +349,12 @@ namespace Internal.Runtime.Augments
             return ThreadStatics.GetThreadStaticBaseForType(*(TypeManagerSlot**)cookie, (int)*((IntPtr*)(cookie) + 1));
         }
 
+        public static int GetHighestStaticThreadStaticIndex(TypeManagerHandle typeManager)
+        {
+            RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.ThreadStaticRegion, out int length);
+            return length / IntPtr.Size;
+        }
+
         public static unsafe int ObjectHeaderSize => sizeof(EETypePtr);
 
         [DebuggerGuidedStepThroughAttribute]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/TypeLoaderCallbacks.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/TypeLoaderCallbacks.cs
@@ -17,7 +17,7 @@ namespace Internal.Runtime.Augments
     {
         public abstract TypeManagerHandle GetModuleForMetadataReader(MetadataReader reader);
         public abstract bool TryGetConstructedGenericTypeForComponents(RuntimeTypeHandle genericTypeDefinitionHandle, RuntimeTypeHandle[] genericTypeArgumentHandles, out RuntimeTypeHandle runtimeTypeHandle);
-        public abstract int GetThreadStaticsSizeForDynamicType(int index, out int numTlsCells);
+        public abstract IntPtr GetThreadStaticGCDescForDynamicType(TypeManagerHandle handle, int index);
         public abstract IntPtr GenericLookupFromContextAndSignature(IntPtr context, IntPtr signature, out IntPtr auxResult);
         public abstract bool GetRuntimeMethodHandleComponents(RuntimeMethodHandle runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle, out MethodNameAndSignature nameAndSignature, out RuntimeTypeHandle[] genericMethodArgs);
         public abstract RuntimeMethodHandle GetRuntimeMethodHandleForComponents(RuntimeTypeHandle declaringTypeHandle, string methodName, RuntimeSignature methodSignature, RuntimeTypeHandle[] genericMethodArgs);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
@@ -96,7 +96,18 @@ namespace Internal.Runtime
             // Get a pointer to the beginning of the module's Thread Static section. Then get a pointer
             // to the MethodTable that represents a memory map for thread statics storage.
             threadStaticRegion = (IntPtr*)RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.ThreadStaticRegion, out length);
-            return RuntimeImports.RhNewObject(new EETypePtr(threadStaticRegion[typeTlsIndex]));
+
+            IntPtr gcDesc;
+            if (typeTlsIndex < (length / IntPtr.Size))
+            {
+                gcDesc = threadStaticRegion[typeTlsIndex];
+            }
+            else
+            {
+                gcDesc = Internal.Runtime.Augments.RuntimeAugments.TypeLoaderCallbacks.GetThreadStaticGCDescForDynamicType(typeManager, typeTlsIndex);
+            }
+
+            return RuntimeImports.RhNewObject(new EETypePtr(gcDesc));
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -449,10 +449,6 @@ namespace System.Runtime
         internal static extern int RhGetThunkSize();
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhGetThreadLocalStorageForDynamicType")]
-        internal static extern IntPtr RhGetThreadLocalStorageForDynamicType(int index, int tlsStorageSize, int numTlsCells);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhResolveDispatchOnType")]
         // For my life cannot figure out the ordering of modifiers this is expecting.
 #pragma warning disable IDE0036

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
@@ -13,22 +13,6 @@ namespace System.Runtime
     [ReflectionBlocked]
     public static class TypeLoaderExports
     {
-        public static IntPtr GetThreadStaticsForDynamicType(int index)
-        {
-            IntPtr result = RuntimeImports.RhGetThreadLocalStorageForDynamicType(index, 0, 0);
-            if (result != IntPtr.Zero)
-                return result;
-
-            int numTlsCells;
-            int tlsStorageSize = RuntimeAugments.TypeLoaderCallbacks.GetThreadStaticsSizeForDynamicType(index, out numTlsCells);
-            result = RuntimeImports.RhGetThreadLocalStorageForDynamicType(index, tlsStorageSize, numTlsCells);
-
-            if (result == IntPtr.Zero)
-                throw new OutOfMemoryException();
-
-            return result;
-        }
-
         public static unsafe void ActivatorCreateInstanceAny(ref object ptrToData, IntPtr pEETypePtr)
         {
             EETypePtr pEEType = new EETypePtr(pEETypePtr);

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -735,6 +735,8 @@ namespace Internal.Runtime.TypeLoader
                         MemoryHelpers.FreeMemory(nonGcStaticData);
                     if (writableDataPtr != IntPtr.Zero)
                         MemoryHelpers.FreeMemory(writableDataPtr);
+                    if (threadStaticIndex != IntPtr.Zero)
+                        MemoryHelpers.FreeMemory(threadStaticIndex);
                 }
             }
         }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -980,7 +980,7 @@ namespace Internal.Runtime.TypeLoader
             RuntimeTypeHandle rtt = EETypeCreator.CreateEEType(type, state);
 
             if (state.ThreadDataSize != 0)
-                TypeLoaderEnvironment.Instance.RegisterDynamicThreadStaticsInfo(state.HalfBakedRuntimeTypeHandle, state.ThreadStaticOffset, state.ThreadDataSize, state.ThreadStaticDesc);
+                TypeLoaderEnvironment.Instance.RegisterDynamicThreadStaticsInfo(state.HalfBakedRuntimeTypeHandle, state.ThreadStaticOffset, state.ThreadStaticDesc);
 
             TypeLoaderLogger.WriteLine("Allocated new type " + type.ToString() + " with hashcode value = 0x" + type.GetHashCode().LowLevelToString() + " with MethodTable = " + rtt.ToIntPtr().LowLevelToString() + " of size " + rtt.ToEETypePtr()->BaseSize.LowLevelToString());
         }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -977,13 +977,10 @@ namespace Internal.Runtime.TypeLoader
 
             Debug.Assert(type is DefType || type is ArrayType || type is PointerType || type is ByRefType);
 
-            if (state.ThreadDataSize != 0)
-                state.ThreadStaticOffset = TypeLoaderEnvironment.Instance.GetNextThreadStaticsOffsetValue();
-
             RuntimeTypeHandle rtt = EETypeCreator.CreateEEType(type, state);
 
             if (state.ThreadDataSize != 0)
-                TypeLoaderEnvironment.Instance.RegisterDynamicThreadStaticsInfo(state.HalfBakedRuntimeTypeHandle, state.ThreadStaticOffset, state.ThreadDataSize);
+                TypeLoaderEnvironment.Instance.RegisterDynamicThreadStaticsInfo(state.HalfBakedRuntimeTypeHandle, state.ThreadStaticOffset, state.ThreadDataSize, state.ThreadStaticDesc);
 
             TypeLoaderLogger.WriteLine("Allocated new type " + type.ToString() + " with hashcode value = 0x" + type.GetHashCode().LowLevelToString() + " with MethodTable = " + rtt.ToIntPtr().LowLevelToString() + " of size " + rtt.ToEETypePtr()->BaseSize.LowLevelToString());
         }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -523,7 +523,6 @@ namespace Internal.Runtime.TypeLoader
 
         public IntPtr? ClassConstructorPointer;
         public IntPtr GcStaticDesc;
-        public IntPtr GcStaticEEType;
         public IntPtr ThreadStaticDesc;
         public bool AllocatedStaticGCDesc;
         public bool AllocatedThreadStaticGCDesc;
@@ -695,10 +694,6 @@ namespace Internal.Runtime.TypeLoader
 
                             case BagElementKind.ThreadStaticDesc:
                                 ThreadStaticDesc = NativeLayoutInfo.LoadContext.GetGCStaticInfo(typeInfoParser.GetUnsigned());
-                                break;
-
-                            case BagElementKind.GcStaticEEType:
-                                GcStaticEEType = NativeLayoutInfo.LoadContext.GetGCStaticInfo(typeInfoParser.GetUnsigned());
                                 break;
 
                             default:

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.StaticsLookup.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.StaticsLookup.cs
@@ -224,10 +224,10 @@ namespace Internal.Runtime.TypeLoader
             return result;
         }
 
-        public void RegisterDynamicThreadStaticsInfo(RuntimeTypeHandle runtimeTypeHandle, uint offsetValue, int storageSize, IntPtr gcDesc)
+        public void RegisterDynamicThreadStaticsInfo(RuntimeTypeHandle runtimeTypeHandle, uint offsetValue, IntPtr gcDesc)
         {
             bool registered = false;
-            Debug.Assert(offsetValue != 0 && storageSize > 0 && runtimeTypeHandle.IsDynamicType());
+            Debug.Assert(offsetValue != 0 && runtimeTypeHandle.IsDynamicType());
 
             IntPtr typeManager = runtimeTypeHandle.GetTypeManager().GetIntPtrUNSAFE();
 

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.StaticsLookup.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.StaticsLookup.cs
@@ -3,13 +3,10 @@
 
 
 using System;
-using System.Runtime;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Threading;
 
-using Internal.Runtime;
 using Internal.Runtime.Augments;
 
 using Internal.NativeFormat;
@@ -18,15 +15,12 @@ namespace Internal.Runtime.TypeLoader
 {
     public sealed partial class TypeLoaderEnvironment
     {
-        private const int DynamicTypeTlsOffsetFlag = unchecked((int)0x80000000);
-
         // To keep the synchronization simple, we execute all TLS registration/lookups under a global lock
         private Lock _threadStaticsLock = new Lock();
 
         // Counter to keep track of generated offsets for TLS cells of dynamic types;
-        private int _maxTlsCells;
-        private LowLevelDictionary<RuntimeTypeHandle, uint> _dynamicGenericsThreadStatics = new LowLevelDictionary<RuntimeTypeHandle, uint>();
-        private LowLevelDictionary<uint, int> _dynamicGenericsThreadStaticSizes = new LowLevelDictionary<uint, int>();
+        private LowLevelDictionary<IntPtr, uint> _maxThreadLocalIndex = new LowLevelDictionary<IntPtr, uint>();
+        private LowLevelDictionary<IntPtr, LowLevelDictionary<uint, IntPtr>> _dynamicGenericsThreadStaticDescs = new LowLevelDictionary<IntPtr, LowLevelDictionary<uint, IntPtr>>();
 
         // Various functions in static access need to create permanent pointers for use by thread static lookup.
         #region GC/Non-GC Statics
@@ -197,62 +191,64 @@ namespace Internal.Runtime.TypeLoader
                 return index.HasValue ? staticInfoLookup.GetIntPtrFromIndex(index.Value) : IntPtr.Zero;
             }
 
-            // Not found in hashtable... must be a dynamically created type
-            Debug.Assert(!runtimeTypeHandle.IsDynamicType());
-            // Not yet implemented...
+            // Not found in hashtable... might be a dynamically created type
+            if (runtimeTypeHandle.IsDynamicType())
+            {
+                unsafe
+                {
+                    MethodTable* typeAsEEType = runtimeTypeHandle.ToEETypePtr();
+                    if (typeAsEEType->DynamicThreadStaticsIndex != IntPtr.Zero)
+                        return typeAsEEType->DynamicThreadStaticsIndex;
+                }
+            }
 
             // Type has no GC statics
             return IntPtr.Zero;
         }
 
-        public int TryGetThreadStaticsSizeForDynamicType(int index, out int numTlsCells)
+        public IntPtr GetThreadStaticGCDescForDynamicType(TypeManagerHandle typeManagerHandle, uint index)
         {
-            Debug.Assert((index & DynamicTypeTlsOffsetFlag) == DynamicTypeTlsOffsetFlag);
-
-            numTlsCells = _maxTlsCells;
-
             using (LockHolder.Hold(_threadStaticsLock))
             {
-                int storageSize;
-                if (_dynamicGenericsThreadStaticSizes.TryGetValue((uint)index, out storageSize))
-                    return storageSize;
+                return _dynamicGenericsThreadStaticDescs[typeManagerHandle.GetIntPtrUNSAFE()][index];
             }
-
-            Debug.Assert(false);
-            return 0;
         }
 
-        public uint GetNextThreadStaticsOffsetValue()
+        public uint GetNextThreadStaticsOffsetValue(TypeManagerHandle typeManagerHandle)
         {
-            // Highest bit of the TLS offset used as a flag to indicate that it's a special TLS offset of a dynamic type
-            var result = 0x80000000 | (uint)_maxTlsCells;
-            // Use checked arithmetics to ensure there aren't any overflows/truncations
-            _maxTlsCells = checked(_maxTlsCells + 1);
+            if (!_maxThreadLocalIndex.TryGetValue(typeManagerHandle.GetIntPtrUNSAFE(), out uint result))
+                result = (uint)RuntimeAugments.GetHighestStaticThreadStaticIndex(typeManagerHandle);
+
+            _maxThreadLocalIndex[typeManagerHandle.GetIntPtrUNSAFE()] = checked(++result);
+
             return result;
         }
 
-        public void RegisterDynamicThreadStaticsInfo(RuntimeTypeHandle runtimeTypeHandle, uint offsetValue, int storageSize)
+        public void RegisterDynamicThreadStaticsInfo(RuntimeTypeHandle runtimeTypeHandle, uint offsetValue, int storageSize, IntPtr gcDesc)
         {
             bool registered = false;
             Debug.Assert(offsetValue != 0 && storageSize > 0 && runtimeTypeHandle.IsDynamicType());
 
+            IntPtr typeManager = runtimeTypeHandle.GetTypeManager().GetIntPtrUNSAFE();
+
             _threadStaticsLock.Acquire();
             try
             {
-                // Sanity check to make sure we do not register thread statics for the same type more than once
-                uint temp;
-                Debug.Assert(!_dynamicGenericsThreadStatics.TryGetValue(runtimeTypeHandle, out temp) && storageSize > 0);
-
-                _dynamicGenericsThreadStatics.Add(runtimeTypeHandle, offsetValue);
-                _dynamicGenericsThreadStaticSizes.Add(offsetValue, storageSize);
+                if (!_dynamicGenericsThreadStaticDescs.TryGetValue(typeManager, out LowLevelDictionary<uint, IntPtr> gcDescs))
+                {
+                    _dynamicGenericsThreadStaticDescs.Add(typeManager, gcDescs = new LowLevelDictionary<uint, IntPtr>());
+                }
+                gcDescs.Add(offsetValue, gcDesc);
                 registered = true;
             }
             finally
             {
                 if (!registered)
                 {
-                    _dynamicGenericsThreadStatics.Remove(runtimeTypeHandle);
-                    _dynamicGenericsThreadStaticSizes.Remove(offsetValue);
+                    if (_dynamicGenericsThreadStaticDescs.TryGetValue(typeManager, out LowLevelDictionary<uint, IntPtr> gcDescs))
+                    {
+                        gcDescs.Remove(offsetValue);
+                    }
                 }
 
                 _threadStaticsLock.Release();

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -35,9 +35,9 @@ namespace Internal.Runtime.TypeLoader
             return TypeLoaderEnvironment.Instance.TryGetConstructedGenericTypeForComponents(genericTypeDefinitionHandle, genericTypeArgumentHandles, out runtimeTypeHandle);
         }
 
-        public override int GetThreadStaticsSizeForDynamicType(int index, out int numTlsCells)
+        public override IntPtr GetThreadStaticGCDescForDynamicType(TypeManagerHandle typeManagerHandle, int index)
         {
-            return TypeLoaderEnvironment.Instance.TryGetThreadStaticsSizeForDynamicType(index, out numTlsCells);
+            return TypeLoaderEnvironment.Instance.GetThreadStaticGCDescForDynamicType(typeManagerHandle, (uint)index);
         }
 
         public override IntPtr GenericLookupFromContextAndSignature(IntPtr context, IntPtr signature, out IntPtr auxResult)

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormat.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormat.cs
@@ -57,7 +57,6 @@ namespace Internal.NativeFormat
         BaseTypeSize                = 0x4f,
         GenericVarianceInfo         = 0x50,
         DelegateInvokeSignature     = 0x51,
-        GcStaticEEType              = 0x52,
 
         // Add new custom bag elements that don't match to something you'd find in the ECMA metadata here.
     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -953,7 +953,7 @@ namespace ILCompiler.DependencyAnalysis
         private ISymbolNode GetStaticsNode(NodeFactory context, out BagElementKind staticsBagKind)
         {
             ISymbolNode symbol = context.GCStaticEEType(GCPointerMap.FromStaticLayout(_type.GetClosestDefType()));
-            staticsBagKind = BagElementKind.GcStaticEEType;
+            staticsBagKind = BagElementKind.GcStaticDesc;
 
             return symbol;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -961,7 +961,7 @@ namespace ILCompiler.DependencyAnalysis
         private ISymbolNode GetThreadStaticsNode(NodeFactory context, out BagElementKind staticsBagKind)
         {
             ISymbolNode symbol = context.GCStaticEEType(GCPointerMap.FromThreadStaticLayout(_type.GetClosestDefType()));
-            staticsBagKind = BagElementKind.End; // GC static EETypes not yet implemented in type loader
+            staticsBagKind = BagElementKind.ThreadStaticDesc;
 
             return symbol;
         }

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.main.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.main.cs
@@ -72,7 +72,7 @@ new CoreFXTestLibrary.Internal.TestInfo("DynamicListTests.TestSortWithComparer",
 #endif
 //new CoreFXTestLibrary.Internal.TestInfo("RdExperienceTests.TestRdExperience", () => global::RdExperienceTests.TestRdExperience(), null),
 new CoreFXTestLibrary.Internal.TestInfo("StaticsTests.TestStatics", () => global::StaticsTests.TestStatics(), null),
-//new CoreFXTestLibrary.Internal.TestInfo("ThreadLocalStatics.TLSTesting.ThreadLocalStatics_Test", () => global::ThreadLocalStatics.TLSTesting.ThreadLocalStatics_Test(), null),
+new CoreFXTestLibrary.Internal.TestInfo("ThreadLocalStatics.TLSTesting.ThreadLocalStatics_Test", () => global::ThreadLocalStatics.TLSTesting.ThreadLocalStatics_Test(), null),
 #if UNIVERSAL_GENERICS
 new CoreFXTestLibrary.Internal.TestInfo("UnivConstCalls.Test.TestRefTypeCallsOnNonGenClass", () => global::UnivConstCalls.Test.TestRefTypeCallsOnNonGenClass(), null),
 new CoreFXTestLibrary.Internal.TestInfo("UnivConstCalls.Test.TestUSCCallsOnNonGenStruct", () => global::UnivConstCalls.Test.TestUSCCallsOnNonGenStruct(), null),

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/rd.xml
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/rd.xml
@@ -126,6 +126,18 @@
         <Method Name=".ctor" Dynamic="Required All" />
       </Type>
 
+      <Type Name="ThreadLocalStatics.T1">
+        <Method Name=".ctor" Dynamic="Required All" />
+      </Type>
+      <Type Name="ThreadLocalStatics.T2">
+        <Method Name=".ctor" Dynamic="Required All" />
+      </Type>
+      <Type Name="ThreadLocalStatics.T4">
+        <Method Name=".ctor" Dynamic="Required All" />
+      </Type>
+      <Type Name="ThreadLocalStatics.T5">
+        <Method Name=".ctor" Dynamic="Required All" />
+      </Type>
 
       <Type Name="ConstraintsTests+TypeWithPublicCtor">
         <Method Name=".ctor" Dynamic="Required All" />


### PR DESCRIPTION
We do threadstatics differently from .NET Native and this wasn't implemented.

Fixes #70878 that was reaching a failfast because we couldn't build the target of GVM dispatch at runtime due to the unhandled dictionary cell.

I've homed the threadstatic bases under the type manager of the template type. We could potentially make a new type manager, but they currently use this one.

Deleted some more .NET Native leftovers.

Had to update the DynamicGeneric test RD.XML because the test was assuming .NET Native behavior where the ctors are always kept on types that escape the dataflow analysis.