### PR TITLE
Throw NullRef in some delegate construction scenarios

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Delegate.cs
@@ -157,7 +157,7 @@ namespace System
         private void InitializeClosedInstanceWithGVMResolution(object firstParameter, RuntimeMethodHandle tokenOfGenericVirtualMethod)
         {
             if (firstParameter is null)
-                throw new ArgumentException(SR.Arg_DlgtNullInst);
+                throw new NullReferenceException();
 
             IntPtr functionResolution = TypeLoaderExports.GVMLookupForSlot(firstParameter, tokenOfGenericVirtualMethod);
 
@@ -185,7 +185,7 @@ namespace System
         private void InitializeClosedInstanceToInterface(object firstParameter, IntPtr dispatchCell)
         {
             if (firstParameter is null)
-                throw new ArgumentException(SR.Arg_DlgtNullInst);
+                throw new NullReferenceException();
 
             m_functionPointer = RuntimeImports.RhpResolveInterfaceMethod(firstParameter, dispatchCell);
             m_firstParameter = firstParameter;


### PR DESCRIPTION
Apparently constructing a delegate to a virtual/interface method throws `NullReferenceException` instead of `ArgumentException` (that is thrown for non-virtual cases).

System.Collections.Immutable tests are testing for this for some reason.