### PR TITLE
STJ: Add AggressiveInlining to CheckNotDisposed()

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -1090,7 +1090,7 @@ namespace System.Text.Json
         {
             if (_utf8Json.IsEmpty)
             {
-                ThrowHelper.ThrowObjectDisposedException_Utf8JsonWriter();
+                ThrowHelper.ThrowObjectDisposedException_JsonDocument();
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 
 namespace System.Text.Json
 {
@@ -1087,12 +1086,11 @@ namespace System.Text.Json
             database.CompleteAllocations();
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CheckNotDisposed()
         {
             if (_utf8Json.IsEmpty)
             {
-                throw new ObjectDisposedException(nameof(JsonDocument));
+                ThrowHelper.ThrowObjectDisposedException_Utf8JsonWriter();
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.Json
 {
@@ -1086,6 +1087,7 @@ namespace System.Text.Json
             database.CompleteAllocations();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CheckNotDisposed()
         {
             if (_utf8Json.IsEmpty)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -675,6 +675,12 @@ namespace System.Text.Json
         {
             throw new ObjectDisposedException(nameof(Utf8JsonWriter));
         }
+
+        [DoesNotReturn]
+        public static void ThrowObjectDisposedException_JsonDocument()
+        {
+            throw new ObjectDisposedException(nameof(JsonDocument));
+        }
     }
 
     internal enum ExceptionResource

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -239,6 +239,7 @@ namespace System.Text.Json
             _bitStack = default;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CheckNotDisposed()
         {
             if (_stream == null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -239,7 +239,6 @@ namespace System.Text.Json
             _bitStack = default;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CheckNotDisposed()
         {
             if (_stream == null)


### PR DESCRIPTION
Improves performance for the https://github.com/dotnet/runtime/issues/67176 benchmark (it regressed due to a different reason, but this looks like a low-hanging fruit and other workloads/benchmarks will benefit from this as well)

```csharp
private void CheckNotDisposed()
{
    if (_utf8Json.IsEmpty)
    {
        throw new ObjectDisposedException(nameof(JsonDocument));
    }
}
```

Currently, JIT rarely inlines methods with `throw` inside (mostly only when it sees foldable branches, etc.) because it knows that they usually come with a lot of size increase for the caller. Technically, it's not a big deal since such `throw` related pieces will be marked as cold and won't be involved. However, I think we need to wait for "partial compilation" feature in the JIT to be less conservative (because throw-blocks won't be even compiled) here or otherwise will see a huge positive jit-diffs.