### PR TITLE
[wasm] Don't pollute VS Code TS suggestions with node

### DIFF
--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -260,7 +260,7 @@ function initializeImportsAndExports(
     replacements.readAsync = readAsync_like;
     replacements.requireOut = module.imports.require;
     const originalUpdateGlobalBufferAndViews = replacements.updateGlobalBufferAndViews;
-    replacements.updateGlobalBufferAndViews = (buffer: Buffer) => {
+    replacements.updateGlobalBufferAndViews = (buffer: ArrayBufferLike) => {
         originalUpdateGlobalBufferAndViews(buffer);
         afterUpdateGlobalBufferAndViews(buffer);
     };

--- a/src/mono/wasm/runtime/memory.ts
+++ b/src/mono/wasm/runtime/memory.ts
@@ -218,7 +218,7 @@ export function getF64(offset: _MemOffset): number {
 
 let max_int64_big: BigInt;
 let min_int64_big: BigInt;
-export function afterUpdateGlobalBufferAndViews(buffer: Buffer): void {
+export function afterUpdateGlobalBufferAndViews(buffer: ArrayBufferLike): void {
     if (is_bigint_supported) {
         max_int64_big = BigInt("9223372036854775807");
         min_int64_big = BigInt("-9223372036854775808");

--- a/src/mono/wasm/runtime/tsconfig.shared.json
+++ b/src/mono/wasm/runtime/tsconfig.shared.json
@@ -10,6 +10,7 @@
         "lib": [
             "esnext"
         ],
+        "types": []
     },
     "exclude": [
         "dotnet.d.ts",

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+import "node/buffer"; // we use the Buffer type to type some of Emscripten's APIs
 import { bind_runtime_method } from "./method-binding";
 import { CharPtr, EmscriptenModule, ManagedPointer, NativePointer, VoidPtr, Int32Ptr } from "./types/emscripten";
 


### PR DESCRIPTION
Set `types` explicitly to `[]`, so that we don't get `globalThis` bindings from `node_modules/@types/node`.  This affects the type inference for functions like `setTimeout` which should have return type `number` in browsers, not `NodeJS.Timer`.