### PR TITLE
Fix some null reference exceptions and improve nullable annotations

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/DSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAAndroid.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Internal.Cryptography;
 using Microsoft.Win32.SafeHandles;
@@ -22,7 +23,7 @@ namespace System.Security.Cryptography
             private const int SignatureStackBufSize = 72;
             private const int BitsPerByte = 8;
 
-            private Lazy<SafeDsaHandle> _key = null!;
+            private Lazy<SafeDsaHandle>? _key;
 
             public DSAAndroid()
                 : this(2048)
@@ -150,7 +151,7 @@ namespace System.Security.Cryptography
                 if (disposing)
                 {
                     FreeKey();
-                    _key = null!;
+                    _key = null;
                 }
 
                 base.Dispose(disposing);
@@ -169,7 +170,7 @@ namespace System.Security.Cryptography
                 }
             }
 
-            private static void CheckInvalidKey(SafeDsaHandle key)
+            private static void CheckInvalidKey([NotNull] SafeDsaHandle key)
             {
                 if (key == null || key.IsInvalid)
                 {
@@ -357,6 +358,7 @@ namespace System.Security.Cryptography
                 return Interop.AndroidCrypto.DsaVerify(key, hash, signature);
             }
 
+            [MemberNotNull(nameof(_key))]
             private void ThrowIfDisposed()
             {
                 if (_key == null)
@@ -375,6 +377,7 @@ namespace System.Security.Cryptography
                 return key;
             }
 
+            [MemberNotNull(nameof(_key))]
             private void SetKey(SafeDsaHandle newKey)
             {
                 // Do not call ThrowIfDisposed here, as it breaks the SafeEvpPKey ctor
@@ -386,7 +389,7 @@ namespace System.Security.Cryptography
                 _key = new Lazy<SafeDsaHandle>(newKey);
             }
 
-            internal SafeDsaHandle DuplicateKeyHandle() => _key.Value.DuplicateHandle();
+            internal SafeDsaHandle DuplicateKeyHandle() => GetKey().DuplicateHandle();
 
             private static readonly KeySizes[] s_legalKeySizes = new KeySizes[] { new KeySizes(minSize: 1024, maxSize: 3072, skipSize: 1024) };
         }

--- a/src/libraries/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.Versioning;
 using Internal.Cryptography;
@@ -21,7 +22,7 @@ namespace System.Security.Cryptography
         private const int SignatureStackBufSize = 72;
         private const int BitsPerByte = 8;
 
-        private Lazy<SafeDsaHandle> _key = null!;
+        private Lazy<SafeDsaHandle>? _key;
 
         [UnsupportedOSPlatform("android")]
         [UnsupportedOSPlatform("browser")]
@@ -154,7 +155,7 @@ namespace System.Security.Cryptography
             if (disposing)
             {
                 FreeKey();
-                _key = null!;
+                _key = null;
             }
 
             base.Dispose(disposing);
@@ -345,6 +346,7 @@ namespace System.Security.Cryptography
             return Interop.Crypto.DsaVerify(key, hash, signature);
         }
 
+        [MemberNotNull(nameof(_key))]
         private void ThrowIfDisposed()
         {
             if (_key == null)
@@ -352,6 +354,7 @@ namespace System.Security.Cryptography
                 throw new ObjectDisposedException(nameof(DSAOpenSsl));
             }
         }
+
 
         private SafeDsaHandle GetKey()
         {
@@ -363,6 +366,7 @@ namespace System.Security.Cryptography
             return key;
         }
 
+        [MemberNotNull(nameof(_key))]
         private void SetKey(SafeDsaHandle newKey)
         {
             // Do not call ThrowIfDisposed here, as it breaks the SafeEvpPKey ctor

--- a/src/libraries/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -355,7 +355,6 @@ namespace System.Security.Cryptography
             }
         }
 
-
         private SafeDsaHandle GetKey()
         {
             ThrowIfDisposed();

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroid.Derive.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroid.Derive.cs
@@ -78,6 +78,7 @@ namespace System.Security.Cryptography
             private byte[]? DeriveSecretAgreement(ECDiffieHellmanPublicKey otherPartyPublicKey, IncrementalHash? hasher)
             {
                 Debug.Assert(otherPartyPublicKey != null);
+                Debug.Assert(_key is not null); // Callers should have checked for null
 
                 // Ensure that this ECDH object contains a private key by attempting a parameter export
                 // which will throw an OpenSslCryptoException if no private key is available

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroid.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Security.Cryptography
@@ -9,7 +10,7 @@ namespace System.Security.Cryptography
     {
         public sealed partial class ECDiffieHellmanAndroid : ECDiffieHellman
         {
-            private ECAndroid _key;
+            private ECAndroid? _key;
 
             public ECDiffieHellmanAndroid(ECCurve curve)
             {
@@ -45,7 +46,7 @@ namespace System.Security.Cryptography
                 if (disposing)
                 {
                     _key?.Dispose();
-                    _key = null!;
+                    _key = null;
                 }
 
                 base.Dispose(disposing);
@@ -118,8 +119,13 @@ namespace System.Security.Cryptography
                 base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
             }
 
-            internal SafeEcKeyHandle DuplicateKeyHandle() => _key.UpRefKeyHandle();
+            internal SafeEcKeyHandle DuplicateKeyHandle()
+            {
+                ThrowIfDisposed();
+                return _key.UpRefKeyHandle();
+            }
 
+            [MemberNotNull(nameof(_key))]
             private void ThrowIfDisposed()
             {
                 if (_key == null)

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroidPublicKey.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroidPublicKey.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Security.Cryptography
@@ -9,7 +10,7 @@ namespace System.Security.Cryptography
     {
         internal sealed class ECDiffieHellmanAndroidPublicKey : ECDiffieHellmanPublicKey
         {
-            private ECAndroid _key;
+            private ECAndroid? _key;
 
             internal ECDiffieHellmanAndroidPublicKey(SafeEcKeyHandle ecKeyHandle)
             {
@@ -62,7 +63,7 @@ namespace System.Security.Cryptography
                 if (disposing)
                 {
                     _key?.Dispose();
-                    _key = null!;
+                    _key = null;
                 }
 
                 base.Dispose(disposing);
@@ -73,6 +74,7 @@ namespace System.Security.Cryptography
                 return GetKey().DuplicateHandle();
             }
 
+            [MemberNotNull(nameof(_key))]
             private void ThrowIfDisposed()
             {
                 if (_key == null)

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.Derive.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.Derive.cs
@@ -75,6 +75,7 @@ namespace System.Security.Cryptography
         private byte[]? DeriveSecretAgreement(ECDiffieHellmanPublicKey otherPartyPublicKey, IncrementalHash? hasher)
         {
             Debug.Assert(otherPartyPublicKey != null);
+            Debug.Assert(_key is not null); // Callers should validate prior.
 
             // Ensure that this ECDH object contains a private key by attempting a parameter export
             // which will throw an OpenSslCryptoException if no private key is available

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 using Microsoft.Win32.SafeHandles;
 
@@ -8,7 +9,7 @@ namespace System.Security.Cryptography
 {
     public sealed partial class ECDiffieHellmanOpenSsl : ECDiffieHellman
     {
-        private ECOpenSsl _key;
+        private ECOpenSsl? _key;
 
         [UnsupportedOSPlatform("android")]
         [UnsupportedOSPlatform("browser")]
@@ -55,7 +56,7 @@ namespace System.Security.Cryptography
             if (disposing)
             {
                 _key?.Dispose();
-                _key = null!;
+                _key = null;
             }
 
             base.Dispose(disposing);
@@ -128,6 +129,7 @@ namespace System.Security.Cryptography
             base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
         }
 
+        [MemberNotNull(nameof(_key))]
         private void ThrowIfDisposed()
         {
             if (_key == null)

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSslPublicKey.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSslPublicKey.cs
@@ -1,13 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Security.Cryptography
 {
     internal sealed class ECDiffieHellmanOpenSslPublicKey : ECDiffieHellmanPublicKey
     {
-        private ECOpenSsl _key;
+        private ECOpenSsl? _key;
 
         internal ECDiffieHellmanOpenSslPublicKey(SafeEvpPKeyHandle pkeyHandle)
         {
@@ -69,7 +70,7 @@ namespace System.Security.Cryptography
             if (disposing)
             {
                 _key?.Dispose();
-                _key = null!;
+                _key = null;
             }
 
             base.Dispose(disposing);
@@ -99,9 +100,10 @@ namespace System.Security.Cryptography
             }
         }
 
+        [MemberNotNull(nameof(_key))]
         private void ThrowIfDisposed()
         {
-            if (_key == null)
+            if (_key is null)
             {
                 throw new ObjectDisposedException(nameof(ECDiffieHellmanOpenSslPublicKey));
             }

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaAndroid.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Internal.Cryptography;
 using Microsoft.Win32.SafeHandles;
@@ -15,7 +16,7 @@ namespace System.Security.Cryptography
             // secp521r1 maxes out at 139 bytes, so 256 should always be enough
             private const int SignatureStackBufSize = 256;
 
-            private ECAndroid _key;
+            private ECAndroid? _key;
 
             /// <summary>
             /// Create an ECDsaAndroid algorithm with a named curve.
@@ -250,7 +251,7 @@ namespace System.Security.Cryptography
                 if (disposing)
                 {
                     _key?.Dispose();
-                    _key = null!;
+                    _key = null;
                 }
 
                 base.Dispose(disposing);
@@ -323,8 +324,13 @@ namespace System.Security.Cryptography
                 base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
             }
 
-            internal SafeEcKeyHandle DuplicateKeyHandle() => _key.UpRefKeyHandle();
+            internal SafeEcKeyHandle DuplicateKeyHandle()
+            {
+                ThrowIfDisposed();
+                return _key.UpRefKeyHandle();
+            }
 
+            [MemberNotNull(nameof(_key))]
             private void ThrowIfDisposed()
             {
                 if (_key == null)

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.Versioning;
 using Internal.Cryptography;
@@ -14,7 +15,7 @@ namespace System.Security.Cryptography
         // secp521r1 maxes out at 139 bytes, so 256 should always be enough
         private const int SignatureStackBufSize = 256;
 
-        private ECOpenSsl _key;
+        private ECOpenSsl? _key;
 
         /// <summary>
         /// Create an ECDsaOpenSsl algorithm with a named curve.
@@ -260,7 +261,7 @@ namespace System.Security.Cryptography
             if (disposing)
             {
                 _key?.Dispose();
-                _key = null!;
+                _key = null;
             }
 
             base.Dispose(disposing);
@@ -333,6 +334,7 @@ namespace System.Security.Cryptography
             base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
         }
 
+        [MemberNotNull(nameof(_key))]
         private void ThrowIfDisposed()
         {
             if (_key == null)

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Formats.Asn1;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -17,7 +18,7 @@ namespace System.Security.Cryptography
         {
             private const int BitsPerByte = 8;
 
-            private Lazy<SafeRsaHandle> _key;
+            private Lazy<SafeRsaHandle>? _key;
 
             public RSAAndroid()
                 : this(2048)
@@ -534,7 +535,7 @@ namespace System.Security.Cryptography
                 if (disposing)
                 {
                     FreeKey();
-                    _key = null!;
+                    _key = null;
                 }
 
                 base.Dispose(disposing);
@@ -586,6 +587,7 @@ namespace System.Security.Cryptography
                 return true;
             }
 
+            [MemberNotNull(nameof(_key))]
             private void ThrowIfDisposed()
             {
                 if (_key == null)
@@ -848,7 +850,11 @@ namespace System.Security.Cryptography
                 throw PaddingModeNotSupported();
             }
 
-            internal SafeRsaHandle DuplicateKeyHandle() => _key.Value.DuplicateHandle();
+            internal SafeRsaHandle DuplicateKeyHandle()
+            {
+                ThrowIfDisposed();
+                return _key.Value.DuplicateHandle();
+            }
 
             private static Exception PaddingModeNotSupported() =>
                 new CryptographicException(SR.Cryptography_InvalidPaddingMode);

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Formats.Asn1;
 using System.IO;
 using System.Runtime.Versioning;
@@ -16,7 +17,7 @@ namespace System.Security.Cryptography
     {
         private const int BitsPerByte = 8;
 
-        private Lazy<SafeEvpPKeyHandle> _key;
+        private Lazy<SafeEvpPKeyHandle>? _key;
 
         [UnsupportedOSPlatform("android")]
         [UnsupportedOSPlatform("browser")]
@@ -636,7 +637,7 @@ namespace System.Security.Cryptography
             if (disposing)
             {
                 FreeKey();
-                _key = null!;
+                _key = null;
             }
 
             base.Dispose(disposing);
@@ -651,7 +652,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_key))]
+        [MemberNotNull(nameof(_key))]
         private void SetKey(SafeEvpPKeyHandle newKey)
         {
             Debug.Assert(!newKey.IsInvalid);
@@ -700,6 +701,7 @@ namespace System.Security.Cryptography
             return true;
         }
 
+        [MemberNotNull(nameof(_key))]
         private void ThrowIfDisposed()
         {
             if (_key == null)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -87,7 +87,7 @@ namespace System.Security.Cryptography
         /// <returns>A SafeHandle for the DSA key in OpenSSL</returns>
         public SafeEvpPKeyHandle DuplicateKeyHandle()
         {
-            SafeDsaHandle currentKey = _key.Value;
+            SafeDsaHandle currentKey = GetKey();
             SafeEvpPKeyHandle pkeyHandle = Interop.Crypto.EvpPkeyCreate();
 
             try

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
@@ -75,7 +75,7 @@ namespace System.Security.Cryptography
         /// <returns>A SafeHandle for the EC_KEY key in OpenSSL</returns>
         public SafeEvpPKeyHandle DuplicateKeyHandle()
         {
-            SafeEcKeyHandle currentKey = _key.Value;
+            SafeEcKeyHandle currentKey = GetKey();
             SafeEvpPKeyHandle pkeyHandle = Interop.Crypto.EvpPkeyCreate();
 
             try

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -75,6 +75,7 @@ namespace System.Security.Cryptography
         /// <returns>A SafeHandle for the EC_KEY key in OpenSSL</returns>
         public SafeEvpPKeyHandle DuplicateKeyHandle()
         {
+            ThrowIfDisposed();
             SafeEcKeyHandle currentKey = _key.Value;
             SafeEvpPKeyHandle pkeyHandle = Interop.Crypto.EvpPkeyCreate();
 


### PR DESCRIPTION
The following snippets can cause NullReferenceExceptions:


```C#
using System.Security.Cryptography;

// Snippet
DSAOpenSsl dsa = new();
dsa.Dispose();
_ = dsa.DuplicateKeyHandle(); // 💥

// Snippet
ECDiffieHellmanOpenSsl ecdh = new();
ecdh.Dispose();
_ = ecdh.DuplicateKeyHandle(); // 💥

// Snippet
ECDsaOpenSsl ecdsa = new();
ecdsa.Dispose();
_ = ecdsa.DuplicateKeyHandle(); // 💥
```

This fixes those null reference exceptions, and improves the nullable annotations to more accurately reflect that the internal handles can be null.