### PR TITLE
[wasm][debugger]Fix debugging when it's using a external library without debug information

### DIFF
--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -980,7 +980,7 @@ mono_has_pdb_checksum (char *raw_data, uint32_t raw_data_len)
 				debug_dir.major_version   = read16(data + 8);
 				debug_dir.minor_version   = read16(data + 10);
 				debug_dir.type            = read32(data + 12);
-				if (debug_dir.type == DEBUG_DIR_PDB_CHECKSUM || debug_dir.type == DEBUG_DIR_REPRODUCIBLE)
+				if (debug_dir.type == DEBUG_DIR_PDB_CHECKSUM || debug_dir.type == DEBUG_DIR_ENTRY_CODEVIEW)
 					return TRUE;
 			}
 		}

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -806,7 +806,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal int PdbAge { get; }
         internal System.Guid PdbGuid { get; }
         internal string PdbName { get; }
-        internal bool PdbInformationAvailable { get; }
+        internal bool CodeViewInformationAvailable { get; }
         public bool TriedToLoadSymbolsOnDemand { get; set; }
 
         private readonly Dictionary<int, SourceFile> _documentIdToSourceFileTable = new Dictionary<int, SourceFile>();
@@ -829,11 +829,14 @@ namespace Microsoft.WebAssembly.Diagnostics
             if (entries.Length > 0)
             {
                 var codeView = entries[0];
-                CodeViewDebugDirectoryData codeViewData = peReader.ReadCodeViewDebugDirectoryData(codeView);
-                PdbAge = codeViewData.Age;
-                PdbGuid = codeViewData.Guid;
-                PdbName = codeViewData.Path;
-                PdbInformationAvailable = true;
+                if (codeView.Type == DebugDirectoryEntryType.CodeView)
+                {
+                    CodeViewDebugDirectoryData codeViewData = peReader.ReadCodeViewDebugDirectoryData(codeView);
+                    PdbAge = codeViewData.Age;
+                    PdbGuid = codeViewData.Guid;
+                    PdbName = codeViewData.Path;
+                    CodeViewInformationAvailable = true;
+                }
             }
             asmMetadataReader = PEReaderExtensions.GetMetadataReader(peReader);
             var asmDef = asmMetadataReader.GetAssemblyDefinition();

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -1130,7 +1130,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             ExecutionContext context = GetContext(sessionId);
             if (urlSymbolServerList.Count == 0)
                 return null;
-            if (asm.TriedToLoadSymbolsOnDemand || !asm.PdbInformationAvailable)
+            if (asm.TriedToLoadSymbolsOnDemand || !asm.CodeViewInformationAvailable)
                 return null;
             asm.TriedToLoadSymbolsOnDemand = true;
             var pdbName = Path.GetFileName(asm.PdbName);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -610,7 +610,8 @@ namespace Microsoft.WebAssembly.Diagnostics
                 assembly = store.GetAssemblyByName(aname + ".dll");
             if (assembly == null)
             {
-                return Result.Err("Assembly '" + aname + "' not found.");
+                return Result.Err($"Assembly '{aname}' not found," +
+                                    $"needed to get method location of '{typeName}:{methodName}'");
             }
 
             TypeInfo type = assembly.GetTypeByName(typeName);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -886,7 +886,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
             if (type == null)
             {
-                type = new TypeInfo(asm, typeName, typeToken, logger);
+                type = asm.CreateTypeInfo(typeName, typeToken);
             }
 
             types[typeId] = new TypeInfoWithDebugInformation(type, typeId, typeName);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -859,9 +859,9 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public async Task<MethodInfo> CreateMethodInfoFromRuntimeInformation (AssemblyInfo asm, int methodId, string methodName, int methodToken, CancellationToken token )
         {
-            var typeToken = await GetTypeTokenFromMethod(methodId, token);
-            asm.TypesByToken.TryGetValue(typeToken, out TypeInfo typeInfo);
-            var attrs =  await GetAttributesFromMethod(methodId, token);
+            var typeToken = await GetTypeTokenFromMethodId(methodId, token);
+            TypeInfo typeInfo = asm.TypesByToken[typeToken];
+            var attrs =  await GetAttributesFromMethodId(methodId, token);
             return new MethodInfo(asm, methodName, methodToken, typeInfo, attrs);
         }
         public async Task<TypeInfoWithDebugInformation> GetTypeInfo(int typeId, CancellationToken token)
@@ -975,7 +975,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             return stringDebuggerCmdReader.ReadInt32();
         }
 
-        public async Task<MethodAttributes> GetAttributesFromMethod(int methodId, CancellationToken token)
+        public async Task<MethodAttributes> GetAttributesFromMethodId(int methodId, CancellationToken token)
         {
             using var commandParamsWriter = new MonoBinaryWriter();
             commandParamsWriter.Write(methodId);
@@ -985,7 +985,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             return (MethodAttributes) flags;
         }
 
-        public async Task<int> GetTypeTokenFromMethod(int methodId, CancellationToken token)
+        public async Task<int> GetTypeTokenFromMethodId(int methodId, CancellationToken token)
         {
             using var commandParamsWriter = new MonoBinaryWriter();
             commandParamsWriter.Write(methodId);
@@ -1163,7 +1163,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             var methodInfo = await GetMethodInfo(methodId, token);
             if (methodInfo != null)
                 return methodInfo.Info.IsStatic();
-            var attrs = await GetAttributesFromMethod(methodId, token);
+            var attrs = await GetAttributesFromMethodId(methodId, token);
             return (attrs & MethodAttributes.Static) > 0;
         }
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1255,6 +1255,7 @@ namespace DebuggerTests
                 pdb_base64 = Convert.ToBase64String(bytes);
             }
 
+            Task<JObject> bpResolved = WaitForBreakpointResolvedEvent();
             var load_assemblies = JObject.FromObject(new
             {
                 expression = $"{{ let asm_b64 = '{asm_base64}'; let pdb_b64 = '{pdb_base64}'; invoke_static_method('[debugger-test] LoadDebuggerTestALC:LoadLazyAssemblyInALC', asm_b64, pdb_b64); }}"
@@ -1263,7 +1264,8 @@ namespace DebuggerTests
             Result load_assemblies_res = await cli.SendCommand("Runtime.evaluate", load_assemblies, token);
 
             Assert.True(load_assemblies_res.IsOk);
-            Thread.Sleep(1000);
+            await bpResolved;
+
             var run_method = JObject.FromObject(new
             {
                 expression = "window.setTimeout(function() { invoke_static_method('[debugger-test] LoadDebuggerTestALC:RunMethodInALC', '" + type_name + "',  '" + method_name + "'); }, 1);"

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -975,14 +975,20 @@ namespace DebuggerTests
                 "Evaluate");
         }
 
-        [Fact] 
-        public async Task InspectPropertiesOfObjectFromLibraryWithPdbDeleted()
+        [Theory]
+        [InlineData(
+            "DebugWithDeletedPdb",
+            1146)]
+        [InlineData(
+            "DebugWithoutDebugSymbols",
+            1158)]
+        public async Task InspectPropertiesOfObjectFromExternalLibrary(string className, int line)
         {
-            var expression = $"{{ invoke_static_method('[debugger-test] DebugWithoutSymbols:Run'); }}";
+            var expression = $"{{ invoke_static_method('[debugger-test] {className}:Run'); }}";
 
             await EvaluateAndCheck(
                 "window.setTimeout(function() {" + expression + "; }, 1);",
-                "dotnet://debugger-test.dll/debugger-test.cs", 1146, 8,
+                "dotnet://debugger-test.dll/debugger-test.cs", line, 8,
                 "Run",
                 wait_for_event_fn: async (pause_location) =>
                 {
@@ -991,7 +997,8 @@ namespace DebuggerTests
                     {
                         propA = TNumber(10),
                         propB = TNumber(20),
-                        propC = TNumber(30)
+                        propC = TNumber(30),
+                        d = TNumber(40)
                     }, "exc");
                 }
             );

--- a/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols/debugger-test-without-debug-symbols.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols/debugger-test-without-debug-symbols.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+  </PropertyGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols/test.cs
@@ -2,13 +2,13 @@ using System;
 
 namespace DebuggerTests
 {
-    public class ClassWithPdbDeleted
+    public class ClassWithoutDebugSymbols
     {
         private int propA {get;}
         public int propB {get;}
         protected int propC {get;}
         public int d;
-        public ClassWithPdbDeleted()
+        public ClassWithoutDebugSymbols()
         {
             propA = 10;
             propB = 20;

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -45,7 +45,7 @@ namespace DebuggerTests
 
         public static void EvaluateLocalsFromAnotherAssembly()
         {
-            var asm = System.Reflection.Assembly.LoadFrom("debugger-test-with-source-link.dll");
+            var asm = System.Reflection.Assembly.LoadFrom("lazy-debugger-test.dll");
             var myType = asm.GetType("DebuggerTests.ClassToCheckFieldValue");
             var myMethod = myType.GetConstructor(new Type[] { });
             var a = myMethod.Invoke(new object[]{});

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1136,12 +1136,24 @@ public static class DefaultInterfaceMethod
     }
 }
 #endregion
-public class DebugWithoutSymbols
+public class DebugWithDeletedPdb
 {
     public static void Run()
     {
         var asm = System.Reflection.Assembly.LoadFrom("debugger-test-with-pdb-deleted.dll");
         var myType = asm.GetType("DebuggerTests.ClassWithPdbDeleted");
+        var myMethod = myType.GetConstructor(new Type[] { });
+        var exc = myMethod.Invoke(new object[]{});
+        System.Diagnostics.Debugger.Break();
+    }
+}
+
+public class DebugWithoutDebugSymbols
+{
+    public static void Run()
+    {
+        var asm = System.Reflection.Assembly.LoadFrom("debugger-test-without-debug-symbols.dll");
+        var myType = asm.GetType("DebuggerTests.ClassWithoutDebugSymbols");
         var myMethod = myType.GetConstructor(new Type[] { });
         var exc = myMethod.Invoke(new object[]{});
         System.Diagnostics.Debugger.Break();

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -18,16 +18,17 @@
     <WasmExtraFilesToDeploy Include="weather.json" />
 
     <!-- We want to bundle these assemblies, so build them first -->
-    <ProjectReference Include="..\lazy-debugger-test\lazy-debugger-test.csproj" Private="true"/>
-    <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" Private="true"/>
-    <ProjectReference Include="..\library-dependency-debugger-test1\library-dependency-debugger-test1.csproj" Private="true"/>
-    <ProjectReference Include="..\library-dependency-debugger-test2\library-dependency-debugger-test2.csproj" Private="true"/>
-    <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" Private="true"/>
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly\ApplyUpdateReferencedAssembly.csproj" />
-    <ProjectReference Include="..\debugger-test-with-full-debug-type\debugger-test-with-full-debug-type.csproj" Private="true"/>
     <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" Private="true"/>
-    <ProjectReference Include="..\debugger-test-with-pdb-deleted\debugger-test-with-pdb-deleted.csproj" Private="true"/>
-    <ProjectReference Include="..\debugger-test-without-debug-symbols\debugger-test-without-debug-symbols.csproj" Private="true"/>
+    <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" Private="true" />
+
+    <ProjectReference Include="..\lazy-debugger-test\lazy-debugger-test.csproj" SkipUseReferenceAssembly="true" />
+    <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" SkipUseReferenceAssembly="true" />
+    <ProjectReference Include="..\debugger-test-with-full-debug-type\debugger-test-with-full-debug-type.csproj" SkipUseReferenceAssembly="true" />
+    <ProjectReference Include="..\debugger-test-with-pdb-deleted\debugger-test-with-pdb-deleted.csproj" SkipUseReferenceAssembly="true" />
+    <ProjectReference Include="..\debugger-test-without-debug-symbols\debugger-test-without-debug-symbols.csproj" SkipUseReferenceAssembly="true" />
+    <ProjectReference Include="..\library-dependency-debugger-test1\library-dependency-debugger-test1.csproj" SkipUseReferenceAssembly="true" />
+    <ProjectReference Include="..\library-dependency-debugger-test2\library-dependency-debugger-test2.csproj" SkipUseReferenceAssembly="true" />
   </ItemGroup>
 
   <Target Name="PrepareForWasmBuildApp" DependsOnTargets="Build">
@@ -35,7 +36,7 @@
            Text="Cannot find %24(MicrosoftNetCoreAppRuntimePackRidDir)=$(MicrosoftNetCoreAppRuntimePackRidDir)native. Make sure to set the runtime configuration with %24(RuntimeConfiguration). Current value: $(RuntimeConfiguration)" />
 
     <PropertyGroup>
-      <EnableDefaultWasmAssembliesToBundle>false</EnableDefaultWasmAssembliesToBundle>    
+      <EnableDefaultWasmAssembliesToBundle>false</EnableDefaultWasmAssembliesToBundle>
       <WasmAppDir>$(AppDir)</WasmAppDir>
       <WasmMainJSPath>debugger-main.js</WasmMainJSPath>
       <!-- like is used on blazor -->
@@ -46,16 +47,19 @@
 
     <ItemGroup>
       <WasmAssembliesToBundle Include="$(OutDir)\$(TargetFileName)" />
-      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-source-link.dll" />
-      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-full-debug-type.dll" />
-      <WasmAssembliesToBundle Include="$(MicrosoftNetCoreAppRuntimePackRidDir)\lib\$(NetCoreappCurrent)\System.Runtime.InteropServices.JavaScript.dll" />
-      <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)native"/>
-      <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)lib\$(NetCoreAppCurrent)"/>
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-special-char-in-path.dll" />
-      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-pdb-deleted.dll" />
-      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-without-debug-symbols.dll" />
+      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-source-link.dll" />
+      <WasmAssembliesToBundle Include="$(MicrosoftNetCoreAppRuntimePackRidDir)\lib\$(NetCoreappCurrent)\System.Runtime.InteropServices.JavaScript.dll" />
+
+      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\lazy-debugger-test-embedded.dll" />
+      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\lazy-debugger-test.dll" />
+      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\debugger-test-with-full-debug-type.dll" />
+      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\debugger-test-with-pdb-deleted.dll" />
+      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\debugger-test-without-debug-symbols.dll" />
 
       <WasmExtraFilesToDeploy Include="@(ReferenceCopyLocalPaths)" />
+      <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)native"/>
+      <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)lib\$(NetCoreAppCurrent)"/>
     </ItemGroup>
   </Target>
   <Target Name="PreserveEnCAssembliesFromLinking"

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -21,12 +21,16 @@
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly\ApplyUpdateReferencedAssembly.csproj" />
     <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" Private="true"/>
     <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" Private="true" />
+    <!-- loaded by *tests*, and not the test app -->
+    <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" SkipUseReferenceAssembly="true" Private="true" />
 
+    <!-- These are only loaded dynamically -->
     <ProjectReference Include="..\lazy-debugger-test\lazy-debugger-test.csproj" SkipUseReferenceAssembly="true" />
-    <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="..\debugger-test-with-full-debug-type\debugger-test-with-full-debug-type.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="..\debugger-test-with-pdb-deleted\debugger-test-with-pdb-deleted.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="..\debugger-test-without-debug-symbols\debugger-test-without-debug-symbols.csproj" SkipUseReferenceAssembly="true" />
+
+    <!-- a?? -->
     <ProjectReference Include="..\library-dependency-debugger-test1\library-dependency-debugger-test1.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="..\library-dependency-debugger-test2\library-dependency-debugger-test2.csproj" SkipUseReferenceAssembly="true" />
   </ItemGroup>
@@ -51,7 +55,7 @@
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-source-link.dll" />
       <WasmAssembliesToBundle Include="$(MicrosoftNetCoreAppRuntimePackRidDir)\lib\$(NetCoreappCurrent)\System.Runtime.InteropServices.JavaScript.dll" />
 
-      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\lazy-debugger-test-embedded.dll" />
+      <!-- Assemblies only dynamically loaded -->
       <WasmFilesToIncludeInFileSystem Include="$(OutDir)\lazy-debugger-test.dll" />
       <WasmFilesToIncludeInFileSystem Include="$(OutDir)\debugger-test-with-full-debug-type.dll" />
       <WasmFilesToIncludeInFileSystem Include="$(OutDir)\debugger-test-with-pdb-deleted.dll" />

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -25,14 +25,13 @@
     <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" SkipUseReferenceAssembly="true" Private="true" />
 
     <!-- These are only loaded dynamically -->
-    <ProjectReference Include="..\lazy-debugger-test\lazy-debugger-test.csproj" SkipUseReferenceAssembly="true" />
-    <ProjectReference Include="..\debugger-test-with-full-debug-type\debugger-test-with-full-debug-type.csproj" SkipUseReferenceAssembly="true" />
-    <ProjectReference Include="..\debugger-test-with-pdb-deleted\debugger-test-with-pdb-deleted.csproj" SkipUseReferenceAssembly="true" />
-    <ProjectReference Include="..\debugger-test-without-debug-symbols\debugger-test-without-debug-symbols.csproj" SkipUseReferenceAssembly="true" />
-
-    <!-- a?? -->
-    <ProjectReference Include="..\library-dependency-debugger-test1\library-dependency-debugger-test1.csproj" SkipUseReferenceAssembly="true" />
-    <ProjectReference Include="..\library-dependency-debugger-test2\library-dependency-debugger-test2.csproj" SkipUseReferenceAssembly="true" />
+    <_AssemblyOnlyInVFS Include="lazy-debugger-test" />
+    <_AssemblyOnlyInVFS Include="debugger-test-with-full-debug-type" />
+    <_AssemblyOnlyInVFS Include="debugger-test-with-pdb-deleted" />
+    <_AssemblyOnlyInVFS Include="debugger-test-without-debug-symbols" />
+    <_AssemblyOnlyInVFS Include="library-dependency-debugger-test1" />
+    <_AssemblyOnlyInVFS Include="library-dependency-debugger-test2" />
+    <ProjectReference Include="@(_AssemblyOnlyInVFS -> '../%(Identity)/%(Identity).csproj')" SkipUseReferenceAssembly="true" />
   </ItemGroup>
 
   <Target Name="PrepareForWasmBuildApp" DependsOnTargets="Build">
@@ -56,10 +55,7 @@
       <WasmAssembliesToBundle Include="$(MicrosoftNetCoreAppRuntimePackRidDir)\lib\$(NetCoreappCurrent)\System.Runtime.InteropServices.JavaScript.dll" />
 
       <!-- Assemblies only dynamically loaded -->
-      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\lazy-debugger-test.dll" />
-      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\debugger-test-with-full-debug-type.dll" />
-      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\debugger-test-with-pdb-deleted.dll" />
-      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\debugger-test-without-debug-symbols.dll" />
+      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\%(_AssemblyOnlyInVFS.Identity).dll" />
 
       <WasmExtraFilesToDeploy Include="@(ReferenceCopyLocalPaths)" />
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)native"/>

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -19,19 +19,19 @@
 
     <!-- We want to bundle these assemblies, so build them first -->
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly\ApplyUpdateReferencedAssembly.csproj" />
-    <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" Private="true"/>
-    <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" Private="true" />
+    <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" ReferenceOutputAssembly="false" Private="true" />
     <!-- loaded by *tests*, and not the test app -->
-    <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" SkipUseReferenceAssembly="true" Private="true" />
+    <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" ReferenceOutputAssembly="false" Private="true" />
 
     <!-- These are only loaded dynamically -->
-    <_AssemblyOnlyInVFS Include="lazy-debugger-test" />
-    <_AssemblyOnlyInVFS Include="debugger-test-with-full-debug-type" />
-    <_AssemblyOnlyInVFS Include="debugger-test-with-pdb-deleted" />
-    <_AssemblyOnlyInVFS Include="debugger-test-without-debug-symbols" />
-    <_AssemblyOnlyInVFS Include="library-dependency-debugger-test1" />
-    <_AssemblyOnlyInVFS Include="library-dependency-debugger-test2" />
-    <ProjectReference Include="@(_AssemblyOnlyInVFS -> '../%(Identity)/%(Identity).csproj')" SkipUseReferenceAssembly="true" />
+    <_AssemblyForDynamicLoading Include="lazy-debugger-test" />
+    <_AssemblyForDynamicLoading Include="debugger-test-with-full-debug-type" />
+    <_AssemblyForDynamicLoading Include="debugger-test-with-pdb-deleted" />
+    <_AssemblyForDynamicLoading Include="debugger-test-without-debug-symbols" />
+    <_AssemblyForDynamicLoading Include="library-dependency-debugger-test1" />
+    <_AssemblyForDynamicLoading Include="library-dependency-debugger-test2" />
+    <ProjectReference Include="@(_AssemblyForDynamicLoading -> '../%(Identity)/%(Identity).csproj')" ReferenceOutputAssembly="false" Private="true" />
   </ItemGroup>
 
   <Target Name="PrepareForWasmBuildApp" DependsOnTargets="Build">
@@ -55,9 +55,12 @@
       <WasmAssembliesToBundle Include="$(MicrosoftNetCoreAppRuntimePackRidDir)\lib\$(NetCoreappCurrent)\System.Runtime.InteropServices.JavaScript.dll" />
 
       <!-- Assemblies only dynamically loaded -->
-      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\%(_AssemblyOnlyInVFS.Identity).dll" />
+      <WasmFilesToIncludeInFileSystem Include="$(OutDir)\%(_AssemblyForDynamicLoading.Identity).dll" />
 
+      <WasmExtraFilesToDeploy Include="$(OutDir)\%(_AssemblyForDynamicLoading.Identity).*" />
+      <WasmExtraFilesToDeploy Include="$(OutDir)\lazy-debugger-test-embedded.*" />
       <WasmExtraFilesToDeploy Include="@(ReferenceCopyLocalPaths)" />
+
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)native"/>
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)lib\$(NetCoreAppCurrent)"/>
     </ItemGroup>

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\debugger-test-with-full-debug-type\debugger-test-with-full-debug-type.csproj" Private="true"/>
     <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" Private="true"/>
     <ProjectReference Include="..\debugger-test-with-pdb-deleted\debugger-test-with-pdb-deleted.csproj" Private="true"/>
+    <ProjectReference Include="..\debugger-test-without-debug-symbols\debugger-test-without-debug-symbols.csproj" Private="true"/>
   </ItemGroup>
 
   <Target Name="PrepareForWasmBuildApp" DependsOnTargets="Build">
@@ -52,6 +53,7 @@
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)lib\$(NetCoreAppCurrent)"/>
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-special-char-in-path.dll" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-pdb-deleted.dll" />
+      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-without-debug-symbols.dll" />
 
       <WasmExtraFilesToDeploy Include="@(ReferenceCopyLocalPaths)" />
     </ItemGroup>

--- a/src/mono/wasm/debugger/tests/lazy-debugger-test/lazy-debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/lazy-debugger-test/lazy-debugger-test.cs
@@ -11,3 +11,15 @@ public partial class LazyMath
         return c;
     }
 }
+
+namespace DebuggerTests
+{
+    public class ClassToCheckFieldValue
+    {
+        public int valueToCheck;
+        public ClassToCheckFieldValue()
+        {
+            valueToCheck = 20;
+        }
+    }
+}


### PR DESCRIPTION
As we don't receive any debug information for assemblies generated without debug information to improve startup performance of debugger.

If we want to look at objects from assemblies without debug information we get the information that we need to do it from runtime side where there is all the information needed.

Without this PR:
![image](https://user-images.githubusercontent.com/4503299/176957737-e3e3bfbf-a9a2-4c9e-a8ce-2d95e532eea7.png)

With this PR:
![image](https://user-images.githubusercontent.com/4503299/176957815-e4aa346d-99d8-4948-9800-911dd911075a.png)
