### PR TITLE
Reduce allocation overhead of Enumerable.Order{Descending}

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/OrderBy.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderBy.cs
@@ -23,7 +23,7 @@ namespace System.Linq
         /// This method compares elements by using the default comparer <see cref="Comparer{T}.Default"/>.
         /// </remarks>
         public static IOrderedEnumerable<T> Order<T>(this IEnumerable<T> source) =>
-            OrderBy(source, static element => element);
+            OrderBy(source, EnumerableSorter<T>.IdentityFunc);
 
         /// <summary>
         /// Sorts the elements of a sequence in ascending order.
@@ -42,7 +42,7 @@ namespace System.Linq
         /// If comparer is <see langword="null"/>, the default comparer <see cref="Comparer{T}.Default"/> is used to compare elements.
         /// </remarks>
         public static IOrderedEnumerable<T> Order<T>(this IEnumerable<T> source, IComparer<T>? comparer) =>
-            OrderBy(source, static element => element, comparer);
+            OrderBy(source, EnumerableSorter<T>.IdentityFunc, comparer);
 
         public static IOrderedEnumerable<TSource> OrderBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
             => new OrderedEnumerable<TSource, TKey>(source, keySelector, null, false, null);
@@ -66,7 +66,7 @@ namespace System.Linq
         /// This method compares elements by using the default comparer <see cref="Comparer{T}.Default"/>.
         /// </remarks>
         public static IOrderedEnumerable<T> OrderDescending<T>(this IEnumerable<T> source) =>
-            OrderByDescending(source, static element => element);
+            OrderByDescending(source, EnumerableSorter<T>.IdentityFunc);
 
         /// <summary>
         /// Sorts the elements of a sequence in descending order.
@@ -85,7 +85,7 @@ namespace System.Linq
         /// If comparer is <see langword="null"/>, the default comparer <see cref="Comparer{T}.Default"/> is used to compare elements.
         /// </remarks>
         public static IOrderedEnumerable<T> OrderDescending<T>(this IEnumerable<T> source, IComparer<T>? comparer) =>
-            OrderByDescending(source, static element => element, comparer);
+            OrderByDescending(source, EnumerableSorter<T>.IdentityFunc, comparer);
 
         public static IOrderedEnumerable<TSource> OrderByDescending<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
             new OrderedEnumerable<TSource, TKey>(source, keySelector, null, true, null);


### PR DESCRIPTION
Enumerable.OrderBy{Descending} buffers the input into an array.  It then allocates a TKey[] from that input to store the keys, and allocates an int[] that's what's actually sorted based on those keys.  The enumerator uses that sorted int[] then to decide what element from the buffered input to yield next.  In the case of the new Order and OrderDescending methods, though, that TKey[] isn't required; it's just a copy of the buffered input, so we can avoid it.

|  Method |         Toolchain | Length |         Mean | Ratio | Allocated | Alloc Ratio |
|-------- |------------------ |------- |-------------:|------:|----------:|------------:|
|   Order | \main\corerun.exe |      5 |     625.1 ns |  1.00 |     448 B |        1.00 |
|   Order |   \pr\corerun.exe |      5 |     596.0 ns |  0.95 |     384 B |        0.86 |
|         |                   |        |              |       |           |             |
| OrderBy | \main\corerun.exe |      5 |     617.5 ns |  1.00 |     448 B |        1.00 |
| OrderBy |   \pr\corerun.exe |      5 |     625.3 ns |  1.01 |     448 B |        1.00 |
|         |                   |        |              |       |           |             |
|   Order | \main\corerun.exe |     50 |  12,843.7 ns |  1.00 |    1344 B |        1.00 |
|   Order |   \pr\corerun.exe |     50 |  10,852.7 ns |  0.85 |     920 B |        0.68 |
|         |                   |        |              |       |           |             |
| OrderBy | \main\corerun.exe |     50 |  10,693.7 ns |  1.00 |    1344 B |        1.00 |
| OrderBy |   \pr\corerun.exe |     50 |  10,555.1 ns |  0.98 |    1344 B |        1.00 |
|         |                   |        |              |       |           |             |
|   Order | \main\corerun.exe |    500 | 216,455.8 ns |  1.00 |   10344 B |        1.00 |
|   Order |   \pr\corerun.exe |    500 | 216,948.5 ns |  1.00 |    6320 B |        0.61 |
|         |                   |        |              |       |           |             |
| OrderBy | \main\corerun.exe |    500 | 237,440.7 ns |  1.00 |   10344 B |        1.00 |
| OrderBy |   \pr\corerun.exe |    500 | 216,897.4 ns |  0.91 |   10344 B |        1.00 |

```C#
[Params(5, 50, 500)]
public int Length { get; set; }

private string[] _arr;

private static readonly Func<IEnumerable<string>, IEnumerable<string>> s_order = typeof(Enumerable).GetMethod("Order", new[] { typeof(IEnumerable<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(string)).CreateDelegate<Func<IEnumerable<string>, IEnumerable<string>>>();
private static readonly Func<IEnumerable<string>, Func<string, string>, IEnumerable<string>> s_orderBy = typeof(Enumerable).GetMethod("OrderBy", new[] { typeof(IEnumerable<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(Func<,>).MakeGenericType(Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(1)) })!.MakeGenericMethod(typeof(string), typeof(string)).CreateDelegate<Func<IEnumerable<string>, Func<string, string>, IEnumerable<string>>>();

[GlobalSetup]
public void Setup() => _arr = Enumerable.Range(1, Length).Select(i => i.ToString()).Reverse().ToArray();

[Benchmark]
public void Order()
{
    foreach (string item in s_order(_arr)) { }
}

[Benchmark]
public void OrderBy()
{
    foreach (string item in s_orderBy(_arr, i => i)) { }
}
```