### PR TITLE
Various createdump fixes. Smaller MacOS dump size, better logging/stats, misc cleanup, etc.

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -214,8 +214,6 @@ CrashInfo::GatherCrashInfo(MINIDUMP_TYPE minidumpType)
     {
         return false;
     }
-    // Join all adjacent memory regions
-    CombineMemoryRegions();
     return true;
 }
 

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -85,9 +85,9 @@ public:
     virtual ~CrashInfo();
 
     // Memory usage stats
-    uint64_t ModuleMappingsCB;
-    int DataTargetPagesAdded;
-    int EnumMemoryPagesAdded;
+    uint64_t m_cbModuleMappings;
+    int m_dataTargetPagesAdded;
+    int m_enumMemoryPagesAdded;
 
     bool Initialize();
     void CleanupAndResumeProcess();
@@ -148,12 +148,12 @@ private:
     bool GetDSOInfo();
     void VisitModule(uint64_t baseAddress, std::string& moduleName);
     void VisitProgramHeader(uint64_t loadbias, uint64_t baseAddress, ElfW(Phdr)* phdr);
-    bool EnumerateModuleMappings();
+    bool EnumerateMemoryRegions();
 #endif
     bool InitializeDAC();
     bool EnumerateManagedModules();
     bool UnwindAllThreads();
-    void ReplaceModuleMapping(CLRDATA_ADDRESS baseAddress, ULONG64 size, const std::string& pszName);
+    void AddOrReplaceModuleMapping(CLRDATA_ADDRESS baseAddress, ULONG64 size, const std::string& pszName);
     int InsertMemoryRegion(const MemoryRegion& region);
     uint32_t GetMemoryRegionFlags(uint64_t start);
     bool ValidRegion(const MemoryRegion& region);

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -84,6 +84,11 @@ public:
     CrashInfo(pid_t pid, bool gatherFrames, pid_t crashThread, uint32_t signal);
     virtual ~CrashInfo();
 
+    // Memory usage stats
+    uint64_t ModuleMappingsCB;
+    int DataTargetPagesAdded;
+    int EnumMemoryPagesAdded;
+
     bool Initialize();
     void CleanupAndResumeProcess();
     bool EnumerateAndSuspendThreads();
@@ -97,7 +102,7 @@ public:
     ModuleInfo* GetModuleInfoFromBaseAddress(uint64_t baseAddress);
     void AddModuleAddressRange(uint64_t startAddress, uint64_t endAddress, uint64_t baseAddress);
     void AddModuleInfo(bool isManaged, uint64_t baseAddress, IXCLRDataModule* pClrDataModule, const std::string& moduleName);
-    void InsertMemoryRegion(uint64_t address, size_t size);
+    int InsertMemoryRegion(uint64_t address, size_t size);
     static const MemoryRegion* SearchMemoryRegions(const std::set<MemoryRegion>& regions, const MemoryRegion& search);
 
     inline pid_t Pid() const { return m_pid; }
@@ -133,6 +138,7 @@ public:
 private:
 #ifdef __APPLE__
     bool EnumerateMemoryRegions();
+    void InitializeOtherMappings();
     bool TryFindDyLinker(mach_vm_address_t address, mach_vm_size_t size, bool* found);
     void VisitModule(MachOModule& module);
     void VisitSegment(MachOModule& module, const segment_command_64& segment);
@@ -148,7 +154,7 @@ private:
     bool EnumerateManagedModules();
     bool UnwindAllThreads();
     void ReplaceModuleMapping(CLRDATA_ADDRESS baseAddress, ULONG64 size, const std::string& pszName);
-    void InsertMemoryRegion(const MemoryRegion& region);
+    int InsertMemoryRegion(const MemoryRegion& region);
     uint32_t GetMemoryRegionFlags(uint64_t start);
     bool ValidRegion(const MemoryRegion& region);
     void Trace(const char* format, ...);

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -148,7 +148,6 @@ private:
     bool EnumerateManagedModules();
     bool UnwindAllThreads();
     void ReplaceModuleMapping(CLRDATA_ADDRESS baseAddress, ULONG64 size, const std::string& pszName);
-    void InsertMemoryBackedRegion(const MemoryRegion& region);
     void InsertMemoryRegion(const MemoryRegion& region);
     uint32_t GetMemoryRegionFlags(uint64_t start);
     bool ValidRegion(const MemoryRegion& region);

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -88,6 +88,7 @@ public:
     void CleanupAndResumeProcess();
     bool EnumerateAndSuspendThreads();
     bool GatherCrashInfo(MINIDUMP_TYPE minidumpType);
+    void CombineMemoryRegions();
     bool EnumerateMemoryRegionsWithDAC(MINIDUMP_TYPE minidumpType);
     bool ReadMemory(void* address, void* buffer, size_t size);                          // read memory and add to dump
     bool ReadProcessMemory(void* address, void* buffer, size_t size, size_t* read);     // read raw memory
@@ -151,7 +152,6 @@ private:
     void InsertMemoryRegion(const MemoryRegion& region);
     uint32_t GetMemoryRegionFlags(uint64_t start);
     bool ValidRegion(const MemoryRegion& region);
-    void CombineMemoryRegions();
     void Trace(const char* format, ...);
     void TraceVerbose(const char* format, ...);
 };

--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -160,7 +160,7 @@ CrashInfo::EnumerateMemoryRegions()
             break;
         }
     }
-    TRACE("AllMemoryRegions %06llx native ModuleMappings %06llx\n", cbAllMemoryRegions / PAGE_SIZE, ModuleMappingsCB / PAGE_SIZE);
+    TRACE("AllMemoryRegions %06llx native ModuleMappings %06llx\n", cbAllMemoryRegions / PAGE_SIZE, m_cbModuleMappings / PAGE_SIZE);
     return true;
 }
 
@@ -341,7 +341,7 @@ void CrashInfo::VisitSegment(MachOModule& module, const segment_command_64& segm
                 }
                 // Add this module segment to the module mappings list
                 m_moduleMappings.insert(newModule);
-                ModuleMappingsCB += newModule.Size();
+                m_cbModuleMappings += newModule.Size();
             }
             else
             {
@@ -353,7 +353,7 @@ void CrashInfo::VisitSegment(MachOModule& module, const segment_command_64& segm
                         newModule.Trace("VisitSegment: ");
                         existingModule->Trace(" overlapping: ");
                     }
-                    uint64_t numberPages = newModule.Size() / PAGE_SIZE;
+                    uint64_t numberPages = newModule.SizeInPages();
                     for (size_t p = 0; p < numberPages; p++, start += PAGE_SIZE, offset += PAGE_SIZE)
                     {
                         MemoryRegion gap(newModule.Flags(), start, start + PAGE_SIZE, offset, newModule.FileName());
@@ -366,7 +366,7 @@ void CrashInfo::VisitSegment(MachOModule& module, const segment_command_64& segm
                                 gap.Trace("VisitSegment: *");
                             }
                             m_moduleMappings.insert(gap);
-                            ModuleMappingsCB += gap.Size();
+                            m_cbModuleMappings += gap.Size();
                         }
                     }
                 }

--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -15,7 +15,7 @@ CrashInfo::Initialize()
     if (result != KERN_SUCCESS)
     {
         // Regardless of the reason (invalid process id or invalid signing/entitlements) it always returns KERN_FAILURE (5)
-        printf_error("Invalid process id: task_for_pid(%d) FAILED %s (%x)\n" m_pid, mach_error_string(result), result);
+        printf_error("Invalid process id: task_for_pid(%d) FAILED %s (%x)\n", m_pid, mach_error_string(result), result);
         printf_error("This failure may be because createdump or the application is not properly signed and entitled.\n");
         return false;
     }

--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -139,7 +139,7 @@ CrashInfo::EnumerateMemoryRegions()
         }
         else
         {
-            if ((info.protection & (VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE)) != 0)
+            if (info.share_mode != SM_EMPTY && (info.protection & (VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE)) != 0)
             {
                 MemoryRegion memoryRegion(ConvertProtectionFlags(info.protection), address, address + size, info.offset);
                 m_allMemoryRegions.insert(memoryRegion);

--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -15,9 +15,8 @@ CrashInfo::Initialize()
     if (result != KERN_SUCCESS)
     {
         // Regardless of the reason (invalid process id or invalid signing/entitlements) it always returns KERN_FAILURE (5)
-        printf_error("Invalid process id: task_for_pid(%d) FAILED %s (%x)\n"
-            "This failure may be because createdump or the application is not properly signed and entitled.\n",
-            m_pid, mach_error_string(result), result);
+        printf_error("Invalid process id: task_for_pid(%d) FAILED %s (%x)\n" m_pid, mach_error_string(result), result);
+        printf_error("This failure may be because createdump or the application is not properly signed and entitled.\n");
         return false;
     }
     return true;

--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -106,6 +106,7 @@ CrashInfo::EnumerateMemoryRegions()
     vm_region_submap_info_data_64_t info;
     mach_vm_address_t address = 1;
     mach_vm_size_t size = 0;
+    uint64_t cbAllMemoryRegions = 0;
     uint32_t depth = 0;
 
     // First enumerate and add all the regions
@@ -119,15 +120,15 @@ CrashInfo::EnumerateMemoryRegions()
             TRACE("mach_vm_region_recurse for address %016llx %08llx FAILED %s (%x)\n", address, size, mach_error_string(result), result);
             break;
         }
-        TRACE_VERBOSE("%016llx - %016llx (%06llx) %08llx %s %d %d %d %c%c%c %02x\n",
+        TRACE_VERBOSE("%016llx - %016llx (%06llx, %06llx) %08llx %s %d %d %c%c%c %02x\n",
             address,
             address + size,
             size / PAGE_SIZE,
+            info.pages_resident,
             info.offset,
             info.is_submap ? "sub" : "   ",
-            info.user_wired_count,
-            info.share_mode,
             depth,
+            info.share_mode,
             (info.protection & VM_PROT_READ) ? 'r' : '-',
             (info.protection & VM_PROT_WRITE) ? 'w' : '-',
             (info.protection & VM_PROT_EXECUTE) ? 'x' : '-',
@@ -142,6 +143,7 @@ CrashInfo::EnumerateMemoryRegions()
             {
                 MemoryRegion memoryRegion(ConvertProtectionFlags(info.protection), address, address + size, info.offset);
                 m_allMemoryRegions.insert(memoryRegion);
+                cbAllMemoryRegions += memoryRegion.Size();
             }
             address += size;
         }
@@ -158,22 +160,31 @@ CrashInfo::EnumerateMemoryRegions()
             break;
         }
     }
+    TRACE("AllMemoryRegions %06llx native ModuleMappings %06llx\n", cbAllMemoryRegions / PAGE_SIZE, ModuleMappingsCB / PAGE_SIZE);
+    return true;
+}
 
-    // Filter out the module regions from the memory regions gathered
+void
+CrashInfo::InitializeOtherMappings()
+{
+    uint64_t cbOtherMappings = 0;
+
+    // Filter out the module regions from the memory regions gathered. The m_moduleMappings list needs
+    // to include all the native and managed module regions.
     for (const MemoryRegion& region : m_allMemoryRegions)
     {
         std::set<MemoryRegion>::iterator found = m_moduleMappings.find(region);
         if (found == m_moduleMappings.end())
         {
             m_otherMappings.insert(region);
+            cbOtherMappings += region.Size();
         }
         else
         {
             // Skip any region that is fully contained in a module region
             if (!found->Contains(region))
             {
-                TRACE("Region:   ");
-                region.Trace();
+                region.Trace("Region:   ");
 
                 // Now add all the gaps in "region" left by the module regions
                 uint64_t previousEndAddress = region.StartAddress();
@@ -185,9 +196,9 @@ CrashInfo::EnumerateMemoryRegions()
                         MemoryRegion gap(region.Flags(), previousEndAddress, found->StartAddress(), region.Offset());
                         if (gap.Size() > 0)
                         {
-                            TRACE("     Gap: ");
-                            gap.Trace();
+                            gap.Trace("     Gap: ");
                             m_otherMappings.insert(gap);
+                            cbOtherMappings += gap.Size();
                         }
                         previousEndAddress = found->EndAddress();
                     }
@@ -196,14 +207,14 @@ CrashInfo::EnumerateMemoryRegions()
                 MemoryRegion endgap(region.Flags(), previousEndAddress, region.EndAddress(), region.Offset());
                 if (endgap.Size() > 0)
                 {
-                    TRACE("   EndGap:");
-                    endgap.Trace();
+                    endgap.Trace("  EndGap: ");
                     m_otherMappings.insert(endgap);
+                    cbOtherMappings += endgap.Size();
                 }
             }
         }
     }
-    return true;
+    TRACE("OtherMappings: %06llx\n", cbOtherMappings / PAGE_SIZE);
 }
 
 bool
@@ -320,24 +331,45 @@ void CrashInfo::VisitSegment(MachOModule& module, const segment_command_64& segm
             _ASSERTE(end > 0);
 
             // Add module memory region if not already on the list
-            MemoryRegion moduleRegion(regionFlags, start, end, offset);
-            const auto& found = m_moduleMappings.find(moduleRegion);
-            if (found == m_moduleMappings.end())
+            MemoryRegion newModule(regionFlags, start, end, offset, module.Name());
+            std::set<MemoryRegion>::iterator existingModule = m_moduleMappings.find(newModule);
+            if (existingModule == m_moduleMappings.end())
             {
                 if (g_diagnosticsVerbose)
                 {
-                    TRACE_VERBOSE("VisitSegment: ");
-                    moduleRegion.Trace();
+                    newModule.Trace("VisitSegment: ");
                 }
                 // Add this module segment to the module mappings list
-                m_moduleMappings.insert(moduleRegion);
+                m_moduleMappings.insert(newModule);
+                ModuleMappingsCB += newModule.Size();
             }
             else
             {
-                TRACE("VisitSegment: WARNING: ");
-                moduleRegion.Trace();
-                TRACE("       is overlapping: ");
-                found->Trace();
+                // Skip the new module region if it is fully contained in an existing module region
+                if (!existingModule->Contains(newModule))
+                {
+                    if (g_diagnosticsVerbose)
+                    {
+                        newModule.Trace("VisitSegment: ");
+                        existingModule->Trace(" overlapping: ");
+                    }
+                    uint64_t numberPages = newModule.Size() / PAGE_SIZE;
+                    for (size_t p = 0; p < numberPages; p++, start += PAGE_SIZE, offset += PAGE_SIZE)
+                    {
+                        MemoryRegion gap(newModule.Flags(), start, start + PAGE_SIZE, offset, newModule.FileName());
+
+                        const auto& found = m_moduleMappings.find(gap);
+                        if (found != m_moduleMappings.end())
+                        {
+                            if (g_diagnosticsVerbose)
+                            {
+                                gap.Trace("VisitSegment: *");
+                            }
+                            m_moduleMappings.insert(gap);
+                            ModuleMappingsCB += gap.Size();
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -219,6 +219,7 @@ CrashInfo::EnumerateModuleMappings()
             if (moduleName != nullptr && *moduleName == '/')
             {
                 m_moduleMappings.insert(memoryRegion);
+                ModuleMappingsCB += memoryRegion.Size();
             }
             else
             {
@@ -235,7 +236,7 @@ CrashInfo::EnumerateModuleMappings()
 
     if (g_diagnostics)
     {
-        TRACE("Module mappings:\n");
+        TRACE("Module mappings (%06llx):\n", ModuleMappingsCB / PAGE_SIZE);
         for (const MemoryRegion& region : m_moduleMappings)
         {
             region.Trace();

--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -226,7 +226,7 @@ CrashInfo::EnumerateModuleMappings()
             }
             if (linuxGateAddress != nullptr && reinterpret_cast<void*>(start) == linuxGateAddress)
             {
-                InsertMemoryBackedRegion(memoryRegion);
+                InsertMemoryRegion(memoryRegion);
             }
             free(moduleName);
             free(permissions);

--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -143,7 +143,7 @@ CrashInfo::GetAuxvEntries()
 // Get the module mappings for the core dump NT_FILE notes
 //
 bool
-CrashInfo::EnumerateModuleMappings()
+CrashInfo::EnumerateMemoryRegions()
 {
     // Here we read /proc/<pid>/maps file in order to parse it and figure out what it says
     // about a library we are looking for. This file looks something like this:
@@ -219,7 +219,7 @@ CrashInfo::EnumerateModuleMappings()
             if (moduleName != nullptr && *moduleName == '/')
             {
                 m_moduleMappings.insert(memoryRegion);
-                ModuleMappingsCB += memoryRegion.Size();
+                m_cbModuleMappings += memoryRegion.Size();
             }
             else
             {
@@ -236,7 +236,7 @@ CrashInfo::EnumerateModuleMappings()
 
     if (g_diagnostics)
     {
-        TRACE("Module mappings (%06llx):\n", ModuleMappingsCB / PAGE_SIZE);
+        TRACE("Module mappings (%06llx):\n", m_cbModuleMappings / PAGE_SIZE);
         for (const MemoryRegion& region : m_moduleMappings)
         {
             region.Trace();

--- a/src/coreclr/debug/createdump/crashreportwriter.cpp
+++ b/src/coreclr/debug/createdump/crashreportwriter.cpp
@@ -41,6 +41,7 @@ CrashReportWriter::WriteCrashReport(const std::string& dumpFileName)
         }
         WriteCrashReport();
         CloseWriter();
+        printf_status("Crash report successfully written\n");
     }
     catch (const std::exception& e)
     {

--- a/src/coreclr/debug/createdump/createdumpunix.cpp
+++ b/src/coreclr/debug/createdump/createdumpunix.cpp
@@ -3,7 +3,7 @@
 
 #include "createdump.h"
 
-#if !defined(PAGE_SIZE) && (defined(__arm__) || defined(__aarch64__) || defined(__loongarch64))
+#if defined(__arm__) || defined(__aarch64__) || defined(__loongarch64)
 long g_pageSize = 0;
 #endif
 

--- a/src/coreclr/debug/createdump/createdumpunix.cpp
+++ b/src/coreclr/debug/createdump/createdumpunix.cpp
@@ -74,7 +74,7 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
     }
     if (!dumpWriter.WriteDump())
     {
-        printf_error( "Writing dump FAILED\n");
+        printf_error("Writing dump FAILED\n");
 
         // Delete the partial dump file on error
         remove(dumpPath.c_str());

--- a/src/coreclr/debug/createdump/createdumpunix.cpp
+++ b/src/coreclr/debug/createdump/createdumpunix.cpp
@@ -22,6 +22,7 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
 #if !defined(PAGE_SIZE) && (defined(__arm__) || defined(__aarch64__) || defined(__loongarch64))
     g_pageSize = sysconf(_SC_PAGESIZE);
 #endif
+    TRACE("PAGE_SIZE %d\n", PAGE_SIZE);
 
     // Initialize the crash info 
     if (!crashInfo->Initialize())

--- a/src/coreclr/debug/createdump/createdumpunix.cpp
+++ b/src/coreclr/debug/createdump/createdumpunix.cpp
@@ -19,7 +19,7 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
     bool result = false;
 
     // Initialize PAGE_SIZE
-#if !defined(PAGE_SIZE) && (defined(__arm__) || defined(__aarch64__) || defined(__loongarch64))
+#if defined(__arm__) || defined(__aarch64__) || defined(__loongarch64)
     g_pageSize = sysconf(_SC_PAGESIZE);
 #endif
     TRACE("PAGE_SIZE %d\n", PAGE_SIZE);

--- a/src/coreclr/debug/createdump/createdumpunix.cpp
+++ b/src/coreclr/debug/createdump/createdumpunix.cpp
@@ -82,6 +82,22 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
     }
     result = true;
 exit:
+    if (kill(pid, 0) == 0)
+    {
+        printf_status("Target process is alive\n");
+    }
+    else
+    {
+        int err = errno;
+        if (err == ESRCH)
+        {
+            printf_error("Target process terminated\n");
+        }
+        else
+        {
+            printf_error("kill(%d, 0) FAILED %s (%d)\n", pid, strerror(err), err);
+        }
+    }
     crashInfo->CleanupAndResumeProcess();
     return result;
 }

--- a/src/coreclr/debug/createdump/datatarget.cpp
+++ b/src/coreclr/debug/createdump/datatarget.cpp
@@ -122,7 +122,7 @@ DumpDataTarget::ReadVirtual(
         *done = 0;
         return E_FAIL;
     }
-    m_crashInfo.DataTargetPagesAdded += m_crashInfo.InsertMemoryRegion(address, read);
+    m_crashInfo.m_dataTargetPagesAdded += m_crashInfo.InsertMemoryRegion(address, read);
     *done = read;
     return S_OK;
 }

--- a/src/coreclr/debug/createdump/datatarget.cpp
+++ b/src/coreclr/debug/createdump/datatarget.cpp
@@ -122,6 +122,7 @@ DumpDataTarget::ReadVirtual(
         *done = 0;
         return E_FAIL;
     }
+    m_crashInfo.DataTargetPagesAdded += m_crashInfo.InsertMemoryRegion(address, read);
     *done = read;
     return S_OK;
 }

--- a/src/coreclr/debug/createdump/dumpwritermacho.cpp
+++ b/src/coreclr/debug/createdump/dumpwritermacho.cpp
@@ -92,26 +92,23 @@ DumpWriter::BuildSegmentLoadCommands()
 {
     for (const MemoryRegion& memoryRegion : m_crashInfo.MemoryRegions())
     {
-        if (memoryRegion.IsBackedByMemory())
-        {
-            uint64_t size = memoryRegion.Size();
-            uint32_t prot = ConvertFlags(memoryRegion.Permissions());
+        uint64_t size = memoryRegion.Size();
+        uint32_t prot = ConvertFlags(memoryRegion.Permissions());
 
-            segment_command_64 segment = {
-                LC_SEGMENT_64,                  // uint32_t cmd;
-                sizeof(segment_command_64),     // uint32_t cmdsize;
-                {0},                            // char segname[16];
-                memoryRegion.StartAddress(),    // uint64_t vmaddr;   
-                size,                           // uint64_t vmsize;
-                0,                              // uint64_t fileoff;
-                size,                           // uint64_t filesize;
-                prot,                           // uint32_t maxprot;
-                prot,                           // uint32_t initprot;
-                0,                              // uint32_t nsects;
-                0                               // uint32_t flags;
-            };
-            m_segmentLoadCommands.push_back(segment);
-        }
+        segment_command_64 segment = {
+            LC_SEGMENT_64,                  // uint32_t cmd;
+            sizeof(segment_command_64),     // uint32_t cmdsize;
+            {0},                            // char segname[16];
+            memoryRegion.StartAddress(),    // uint64_t vmaddr;   
+            size,                           // uint64_t vmsize;
+            0,                              // uint64_t fileoff;
+            size,                           // uint64_t filesize;
+            prot,                           // uint32_t maxprot;
+            prot,                           // uint32_t initprot;
+            0,                              // uint32_t nsects;
+            0                               // uint32_t flags;
+        };
+        m_segmentLoadCommands.push_back(segment);
     }
 
     // Add special memory region containing the process and thread info

--- a/src/coreclr/debug/createdump/main.cpp
+++ b/src/coreclr/debug/createdump/main.cpp
@@ -268,7 +268,7 @@ GetLastErrorString()
     }
 #endif
     char buffer[64];
-    sprintf(buffer, "(%d)", error);
+    snprintf(buffer, sizeof(buffer), "(%d)", error);
     result.append(buffer);
     return result;
 }

--- a/src/coreclr/debug/createdump/main.cpp
+++ b/src/coreclr/debug/createdump/main.cpp
@@ -40,10 +40,13 @@ FILE *g_logfile = nullptr;
 FILE *g_stdout = stdout;
 bool g_diagnostics = false;
 bool g_diagnosticsVerbose = false;
+uint64_t g_ticksPerMS = 0;
+uint64_t g_startTime = 0;
+uint64_t GetTickFrequency();
+uint64_t GetTimeStamp();
+
 #ifdef HOST_UNIX
 bool g_checkForSingleFile = false;
-uint64_t g_ticksPerMS = 0;
-uint64_t GetTickFrequency();
 #endif
 
 //
@@ -188,8 +191,6 @@ int __cdecl main(const int argc, const char* argv[])
     {
         help = true;
     }
-    g_ticksPerMS = GetTickFrequency() / 1000000UL;
-    TRACE("TickFrequency: %d ticks per ms\n", g_ticksPerMS);
 #endif
 
     if (help)
@@ -198,6 +199,10 @@ int __cdecl main(const int argc, const char* argv[])
         printf_error("%s", g_help);
         return -1;
     }
+
+    g_ticksPerMS = GetTickFrequency() / 1000UL;
+    g_startTime = GetTimeStamp();
+    TRACE("TickFrequency: %d ticks per ms\n", g_ticksPerMS);
 
     ArrayHolder<char> tmpPath = new char[MAX_LONGPATH];
     if (dumpPathTemplate == nullptr)
@@ -218,10 +223,11 @@ int __cdecl main(const int argc, const char* argv[])
 
     if (CreateDump(dumpPathTemplate, pid, dumpType, minidumpType, crashReport, crashThread, signal))
     {
-        printf_status("Dump successfully written\n");
+        printf_status("Dump successfully written in %llums\n", GetTimeStamp() - g_startTime);
     }
     else
     {
+        printf_error("Failure took %llums\n", GetTimeStamp() - g_startTime);
         exitCode = -1;
     }
 
@@ -308,8 +314,6 @@ printf_error(const char* format, ...)
     va_end(args);
 }
 
-#ifdef HOST_UNIX
-
 uint64_t
 GetTickFrequency()
 {
@@ -319,7 +323,7 @@ GetTickFrequency()
     return ret.QuadPart;
 }
 
-static uint64_t
+uint64_t
 GetTimeStamp()
 {
     LARGE_INTEGER ret;
@@ -327,6 +331,8 @@ GetTimeStamp()
     QueryPerformanceCounter(&ret);
     return ret.QuadPart / g_ticksPerMS;
 }
+
+#ifdef HOST_UNIX
 
 static void
 trace_prefix()

--- a/src/coreclr/debug/createdump/memoryregion.h
+++ b/src/coreclr/debug/createdump/memoryregion.h
@@ -16,8 +16,7 @@ enum MEMORY_REGION_FLAGS : uint32_t
     // PF_R        = 0x04,      // Read
     MEMORY_REGION_FLAG_PERMISSIONS_MASK = 0x0f,
     MEMORY_REGION_FLAG_SHARED = 0x10,
-    MEMORY_REGION_FLAG_PRIVATE = 0x20,
-    MEMORY_REGION_FLAG_MEMORY_BACKED = 0x40
+    MEMORY_REGION_FLAG_PRIVATE = 0x20
 };
 
 struct MemoryRegion
@@ -95,7 +94,6 @@ public:
 
     uint32_t Permissions() const { return m_flags & MEMORY_REGION_FLAG_PERMISSIONS_MASK; }
     inline uint32_t Flags() const { return m_flags; }
-    bool IsBackedByMemory() const { return (m_flags & MEMORY_REGION_FLAG_MEMORY_BACKED) != 0; }
     inline uint64_t StartAddress() const { return m_startAddress; }
     inline uint64_t EndAddress() const { return m_endAddress; }
     inline uint64_t Size() const { return m_endAddress - m_startAddress; }
@@ -115,7 +113,7 @@ public:
 
     void Trace() const
     {
-        TRACE("%" PRIA PRIx64 " - %" PRIA PRIx64 " (%06" PRIx64 ") %" PRIA PRIx64 " %c%c%c%c%c%c %02x %s\n",
+        TRACE("%" PRIA PRIx64 " - %" PRIA PRIx64 " (%06" PRIx64 ") %" PRIA PRIx64 " %c%c%c%c%c %02x %s\n",
             m_startAddress,
             m_endAddress,
             Size() / PAGE_SIZE,
@@ -125,7 +123,6 @@ public:
             (m_flags & PF_X) ? 'x' : '-',
             (m_flags & MEMORY_REGION_FLAG_SHARED) ? 's' : '-',
             (m_flags & MEMORY_REGION_FLAG_PRIVATE) ? 'p' : '-',
-            (m_flags & MEMORY_REGION_FLAG_MEMORY_BACKED) ? 'b' : '-',
             m_flags,
             m_fileName.c_str());
     }

--- a/src/coreclr/debug/createdump/memoryregion.h
+++ b/src/coreclr/debug/createdump/memoryregion.h
@@ -53,7 +53,8 @@ public:
     MemoryRegion(uint32_t flags, uint64_t start, uint64_t end) :
         m_flags(flags),
         m_startAddress(start),
-        m_endAddress(end)
+        m_endAddress(end),
+        m_offset(0)
     {
         assert((start & ~PAGE_MASK) == 0);
         assert((end & ~PAGE_MASK) == 0);
@@ -111,9 +112,10 @@ public:
         return (m_startAddress <= rhs.m_startAddress) && (m_endAddress >= rhs.m_endAddress);
     }
 
-    void Trace() const
+    void Trace(const char* prefix = "") const
     {
-        TRACE("%" PRIA PRIx64 " - %" PRIA PRIx64 " (%06" PRIx64 ") %" PRIA PRIx64 " %c%c%c%c%c %02x %s\n",
+        TRACE("%s%" PRIA PRIx64 " - %" PRIA PRIx64 " (%06" PRIx64 ") %" PRIA PRIx64 " %c%c%c%c%c %02x %s\n",
+            prefix,
             m_startAddress,
             m_endAddress,
             Size() / PAGE_SIZE,

--- a/src/coreclr/debug/createdump/memoryregion.h
+++ b/src/coreclr/debug/createdump/memoryregion.h
@@ -98,6 +98,7 @@ public:
     inline uint64_t StartAddress() const { return m_startAddress; }
     inline uint64_t EndAddress() const { return m_endAddress; }
     inline uint64_t Size() const { return m_endAddress - m_startAddress; }
+    inline uint64_t SizeInPages() const { return Size() / PAGE_SIZE; }
     inline uint64_t Offset() const { return m_offset; }
     inline const std::string& FileName() const { return m_fileName; }
 

--- a/src/coreclr/debug/createdump/memoryregion.h
+++ b/src/coreclr/debug/createdump/memoryregion.h
@@ -2,7 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if !defined(PAGE_SIZE) && (defined(__arm__) || defined(__aarch64__) || defined(__loongarch64))
-#define PAGE_SIZE sysconf(_SC_PAGESIZE)
+extern long g_pageSize;
+#define PAGE_SIZE g_pageSize
 #endif
 
 #undef PAGE_MASK 

--- a/src/coreclr/debug/createdump/threadinfo.cpp
+++ b/src/coreclr/debug/createdump/threadinfo.cpp
@@ -369,8 +369,8 @@ ThreadInfo::GetThreadStack()
     {
         MemoryRegion search(0, startAddress, startAddress + PAGE_SIZE);
         const MemoryRegion* region = CrashInfo::SearchMemoryRegions(m_crashInfo.OtherMappings(), search);
-        if (region != nullptr) {
-
+        if (region != nullptr)
+        {
             // Use the mapping found for the size of the thread's stack
             size = region->EndAddress() - startAddress;
 

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -757,6 +757,12 @@ static void sigterm_handler(int code, siginfo_t *siginfo, void *context)
 {
     if (PALIsInitialized())
     {
+        CLRConfigNoCache enableDumpOnSigTerm = CLRConfigNoCache::Get("EnableDumpOnSigTerm", /*noprefix*/ false, &getenv);
+        DWORD val = 0;
+        if (enableDumpOnSigTerm.IsSet() && enableDumpOnSigTerm.TryAsInteger(10, val) && val == 1)
+        {
+            PROCCreateCrashDumpIfEnabled(code);
+        }
         // g_pSynchronizationManager shouldn't be null if PAL is initialized.
         _ASSERTE(g_pSynchronizationManager != nullptr);
 

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2459,7 +2459,7 @@ PROCCreateCrashDump(
         int result = waitpid(childpid, &wstatus, 0);
         if (result != childpid)
         {
-            ERROR("PROCCreateCrashDump: waitpid() FAILED result %d wstatus %d errno %s (%d)\n",
+            fprintf(stderr, "Problem waiting for createdump: waitpid() FAILED result %d wstatus %d errno %s (%d)\n",
                 result, wstatus, strerror(errno), errno);
             return false;
         }

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -213,8 +213,7 @@ void HandleTerminationRequest(int terminationExitCode)
     {
         SetLatchedExitCode(terminationExitCode);
 
-        DWORD enabled = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EnableDumpOnSigTerm);
-        ForceEEShutdown(enabled == 1 ? SCA_TerminateProcessWhenShutdownComplete : SCA_ExitProcessWhenShutdownComplete);
+        ForceEEShutdown(SCA_ExitProcessWhenShutdownComplete);
     }
 }
 #endif


### PR DESCRIPTION
Fix where CombineMemoryRegions is called and perf fix for PAGE_SIZE on MacOS M1.

Remove MEMORY_REGION_FLAG_MEMORY_BACKED flags because it was always set now.

Add better memory tracing and memory region stats.

Fix MacOS native module regions when overlapping with existing.

Fix MacOS adding the managed modules to the module mapping list before the "other mappings" is built.

Don't add share_mode == SM_EMPTY regions for MacOS coredumps. Fixes the large M1 dumps.