### PR TITLE
[LoongArch64] Fixed the assert error

### DIFF
--- a/src/coreclr/jit/lsraloongarch64.cpp
+++ b/src/coreclr/jit/lsraloongarch64.cpp
@@ -271,6 +271,7 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_RSZ:
         case GT_ROR:
             srcCount = BuildBinaryUses(tree->AsOp());
+            buildInternalRegisterUses();
             assert(dstCount == 1);
             BuildDef(tree);
             break;


### PR DESCRIPTION
[LoongArch64] Fixed the assert error "(regRecord->assignedInterval == nullptr)" within the lsra.cpp


This is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.