### PR TITLE
[LoongArch64] Fixed the assert error within the "CodeGen::genCodeForNullCheck()"

### DIFF
--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -6420,12 +6420,10 @@ void CodeGen::genCodeForPhysReg(GenTreePhysReg* tree)
 void CodeGen::genCodeForNullCheck(GenTreeIndir* tree)
 {
     assert(tree->OperIs(GT_NULLCHECK));
-    assert(!tree->gtOp1->isContained());
-    regNumber addrReg = genConsumeReg(tree->gtOp1);
 
-    regNumber targetReg = REG_R0;
+    genConsumeRegs(tree->gtOp1);
 
-    GetEmitter()->emitIns_R_R_I(INS_ld_w, EA_4BYTE, targetReg, addrReg, 0);
+    GetEmitter()->emitInsLoadStoreOp(ins_Load(tree->TypeGet()), emitActualTypeSize(tree), REG_R0, tree);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -3498,7 +3498,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             if (id->idIsReloc())
             {
                 ssize_t imm = (ssize_t)tgtIG->igOffs;
-                imm         = (ssize_t)emitCodeBlock + imm - (ssize_t)dstRW;
+                imm         = (ssize_t)emitCodeBlock + imm - (ssize_t)(dstRW - writeableOffset);
                 assert((imm & 3) == 0);
 
                 int doff = (int)(imm & 0x800);
@@ -6284,14 +6284,13 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
         {
             // If the local var is a gcref or byref, the local var better be untracked, because we have
             // no logic here to track local variable lifetime changes, like we do in the contained case
-            // above. E.g., for a `str r0,[r1]` for byref `r1` to local `V01`, we won't store the local
+            // above. E.g., for a `st a0,[a1]` for byref `a1` to local `V01`, we won't store the local
             // `V01` and so the emitter can't update the GC lifetime for `V01` if this is a variable birth.
-            GenTreeLclVarCommon* varNode = addr->AsLclVarCommon();
-            unsigned             lclNum  = varNode->GetLclNum();
-            LclVarDsc*           varDsc  = emitComp->lvaGetDesc(lclNum);
+            LclVarDsc* varDsc = emitComp->lvaGetDesc(addr->AsLclVarCommon());
             assert(!varDsc->lvTracked);
         }
 #endif // DEBUG
+
         // Then load/store dataReg from/to [addrReg]
         emitIns_R_R_I(ins, attr, dataReg, addr->GetRegNum(), 0);
     }


### PR DESCRIPTION
[LoongArch64] Fixed the assert error "!tree->gtOp1->isContained()"  within the "CodeGen::genCodeForNullCheck()"

This is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.