### PR TITLE
Fold `TYP_STRUCT` indirect access to promoted locals

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -993,17 +993,17 @@ private:
             return IndirTransform::None;
         }
 
-        if (varDsc->lvPromoted)
-        {
-            // TODO-ADDR: For now we ignore promoted variables, they require additional
-            // changes in subsequent phases.
-            return IndirTransform::None;
-        }
-
-        // As we are only handling non-promoted STRUCT locals right now, the only
-        // possible transformation for non-STRUCT indirect uses is LCL_FLD.
         if (!varTypeIsStruct(indir))
         {
+            if (varDsc->lvPromoted)
+            {
+                // TODO-ADDR: support promoted locals here by moving the promotion morphing
+                // from pre-order to post-order.
+                return IndirTransform::None;
+            }
+
+            // As we are only handling non-promoted STRUCT locals right now, the only
+            // possible transformation for non-STRUCT indirect uses is LCL_FLD.
             assert(varDsc->TypeGet() == TYP_STRUCT);
             return IndirTransform::LclFld;
         }


### PR DESCRIPTION
These are mostly `OBJ(ADDR(LCL_VAR))` constructions, but can also be local fields.

Broadly positive [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1958227&view=results) with some regression due to how new forward substitutions affect various transformations. In particular, there is a regression on x86 due to more aggressive CSE that is replicated across many generated methods.

Also a nice TP win across the board.