### PR TITLE
We should return the error when there is one

### DIFF
--- a/src/coreclr/debug/dbgutil/dbgutil.cpp
+++ b/src/coreclr/debug/dbgutil/dbgutil.cpp
@@ -115,7 +115,7 @@ namespace
         }
 
         *directoryRVA = sectionRVA;
-        return S_OK;
+        return hr;
     }
 }
 


### PR DESCRIPTION
In case we fail to read some virtual memory (e.g. in [this](https://github.com/microsoft/clrmd/pull/1033) case), we should fail the API call.