### PR TITLE
Add Generic Enum.TryFormat()

### DIFF
--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1046,8 +1046,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 bt2 = WhichTypeIsBetter(bofs1.Type2(), bofs2.Type2(), type2);
             }
 
-            Debug.Assert(Enum.IsDefined(typeof(BetterType), bt1));
-            Debug.Assert(Enum.IsDefined(typeof(BetterType), bt2));
+            Debug.Assert(Enum.IsDefined(bt1));
+            Debug.Assert(Enum.IsDefined(bt2));
             int res = bt1 switch
             {
                 BetterType.Left => -1,
@@ -1550,7 +1550,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 bt = WhichTypeIsBetter(uofs1.GetType(), uofs2.GetType(), typeArg);
             }
 
-            Debug.Assert(Enum.IsDefined(typeof(BetterType), bt));
+            Debug.Assert(Enum.IsDefined(bt));
             return bt switch
             {
                 BetterType.Left => -1,

--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -565,7 +565,7 @@ namespace Microsoft.Win32
                 throw new ArgumentException(SR.Arg_RegValStrLenBug, nameof(name));
             }
 
-            if (!Enum.IsDefined(typeof(RegistryValueKind), valueKind))
+            if (!Enum.IsDefined(valueKind))
             {
                 throw new ArgumentException(SR.Arg_RegBadKeyKind, nameof(valueKind));
             }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -480,7 +480,7 @@ namespace System.Diagnostics
             }
             set
             {
-                if (!Enum.IsDefined(typeof(ProcessPriorityClass), value))
+                if (!Enum.IsDefined(value))
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ProcessPriorityClass));
                 }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -161,7 +161,7 @@ namespace System.Diagnostics
             get => _windowStyle;
             set
             {
-                if (!Enum.IsDefined(typeof(ProcessWindowStyle), value))
+                if (!Enum.IsDefined(value))
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ProcessWindowStyle));
                 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.cs
@@ -371,7 +371,7 @@ namespace System.Drawing.Printing
             get { return _printRange; }
             set
             {
-                if (!Enum.IsDefined(typeof(PrintRange), value))
+                if (!Enum.IsDefined(value))
                     throw new InvalidEnumArgumentException(nameof(value), unchecked((int)value), typeof(PrintRange));
 
                 _printRange = value;

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.cs
@@ -112,10 +112,10 @@ namespace System
 
         public static string GetFolderPath(SpecialFolder folder, SpecialFolderOption option)
         {
-            if (!Enum.IsDefined(typeof(SpecialFolder), folder))
+            if (!Enum.IsDefined(folder))
                 throw new ArgumentOutOfRangeException(nameof(folder), folder, SR.Format(SR.Arg_EnumIllegalVal, folder));
 
-            if (option != SpecialFolderOption.None && !Enum.IsDefined(typeof(SpecialFolderOption), option))
+            if (option != SpecialFolderOption.None && !Enum.IsDefined(option))
                 throw new ArgumentOutOfRangeException(nameof(option), option, SR.Format(SR.Arg_EnumIllegalVal, option));
 
             return GetFolderPathCore(folder, option);

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -3271,10 +3271,21 @@ namespace System
                 if (value is IFormattable)
                 {
                     // If the value can format itself directly into our buffer, do so.
+
                     if (value is ISpanFormattable)
                     {
-                        int charsWritten;
-                        if (((ISpanFormattable)value).TryFormat(_destination.Slice(_pos), out charsWritten, default, _provider)) // constrained call avoiding boxing for value types
+                        if (((ISpanFormattable)value).TryFormat(_destination.Slice(_pos), out int charsWritten, default, _provider)) // constrained call avoiding boxing for value types
+                        {
+                            _pos += charsWritten;
+                            return true;
+                        }
+
+                        return Fail();
+                    }
+
+                    if (typeof(T).IsEnum)
+                    {
+                        if (Enum.TryFormatUnconstrained(value, _destination.Slice(_pos), out int charsWritten))
                         {
                             _pos += charsWritten;
                             return true;
@@ -3318,8 +3329,18 @@ namespace System
                     // If the value can format itself directly into our buffer, do so.
                     if (value is ISpanFormattable)
                     {
-                        int charsWritten;
-                        if (((ISpanFormattable)value).TryFormat(_destination.Slice(_pos), out charsWritten, format, _provider)) // constrained call avoiding boxing for value types
+                        if (((ISpanFormattable)value).TryFormat(_destination.Slice(_pos), out int charsWritten, format, _provider)) // constrained call avoiding boxing for value types
+                        {
+                            _pos += charsWritten;
+                            return true;
+                        }
+
+                        return Fail();
+                    }
+
+                    if (typeof(T).IsEnum)
+                    {
+                        if (Enum.TryFormatUnconstrained(value, _destination.Slice(_pos), out int charsWritten, format))
                         {
                             _pos += charsWritten;
                             return true;

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/NeutralResourcesLanguageAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/NeutralResourcesLanguageAttribute.cs
@@ -21,7 +21,7 @@ namespace System.Resources
         {
             ArgumentNullException.ThrowIfNull(cultureName);
 
-            if (!Enum.IsDefined(typeof(UltimateResourceFallbackLocation), location))
+            if (!Enum.IsDefined(location))
                 throw new ArgumentException(SR.Format(SR.Arg_InvalidNeutralResourcesLanguage_FallbackLoc, location));
 
             CultureName = cultureName;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
@@ -305,10 +305,23 @@ namespace System.Runtime.CompilerServices
             if (value is IFormattable)
             {
                 // If the value can format itself directly into our buffer, do so.
+
                 if (value is ISpanFormattable)
                 {
                     int charsWritten;
                     while (!((ISpanFormattable)value).TryFormat(_chars.Slice(_pos), out charsWritten, default, _provider)) // constrained call avoiding boxing for value types
+                    {
+                        Grow();
+                    }
+
+                    _pos += charsWritten;
+                    return;
+                }
+
+                if (typeof(T).IsEnum)
+                {
+                    int charsWritten;
+                    while (!Enum.TryFormatUnconstrained(value, _chars.Slice(_pos), out charsWritten))
                     {
                         Grow();
                     }
@@ -329,6 +342,7 @@ namespace System.Runtime.CompilerServices
                 AppendStringDirect(s);
             }
         }
+
         /// <summary>Writes the specified value to the handler.</summary>
         /// <param name="value">The value to write.</param>
         /// <param name="format">The format string.</param>
@@ -357,6 +371,18 @@ namespace System.Runtime.CompilerServices
                 {
                     int charsWritten;
                     while (!((ISpanFormattable)value).TryFormat(_chars.Slice(_pos), out charsWritten, format, _provider)) // constrained call avoiding boxing for value types
+                    {
+                        Grow();
+                    }
+
+                    _pos += charsWritten;
+                    return;
+                }
+
+                if (typeof(T).IsEnum)
+                {
+                    int charsWritten;
+                    while (!Enum.TryFormatUnconstrained(value, _chars.Slice(_pos), out charsWritten, format))
                     {
                         Grow();
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -2640,6 +2640,17 @@ namespace System.Text
                             AppendFormattedWithTempSpace(value, 0, format: null);
                         }
                     }
+                    else if (typeof(T).IsEnum)
+                    {
+                        if (Enum.TryFormatUnconstrained(value, _stringBuilder.RemainingCurrentChunk, out int charsWritten))
+                        {
+                            _stringBuilder.m_ChunkLength += charsWritten;
+                        }
+                        else
+                        {
+                            AppendFormattedWithTempSpace(value, 0, format: null);
+                        }
+                    }
                     else
                     {
                         _stringBuilder.Append(((IFormattable)value).ToString(format: null, _provider)); // constrained call avoiding boxing for value types
@@ -2690,6 +2701,17 @@ namespace System.Text
                         {
                             // Not enough room in the current chunk.  Take the slow path that formats into temporary space
                             // and then copies the result into the StringBuilder.
+                            AppendFormattedWithTempSpace(value, 0, format);
+                        }
+                    }
+                    else if (typeof(T).IsEnum)
+                    {
+                        if (Enum.TryFormatUnconstrained(value, _stringBuilder.RemainingCurrentChunk, out int charsWritten, format))
+                        {
+                            _stringBuilder.m_ChunkLength += charsWritten;
+                        }
+                        else
+                        {
                             AppendFormattedWithTempSpace(value, 0, format);
                         }
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -692,7 +692,7 @@ namespace System
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static string GetArgumentName(ExceptionArgument argument)
         {
-            Debug.Assert(Enum.IsDefined(typeof(ExceptionArgument), argument),
+            Debug.Assert(Enum.IsDefined(argument),
                 "The enum value is not defined, please check the ExceptionArgument Enum.");
 
             return argument.ToString();
@@ -912,7 +912,7 @@ namespace System
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static string GetResourceString(ExceptionResource resource)
         {
-            Debug.Assert(Enum.IsDefined(typeof(ExceptionResource), resource),
+            Debug.Assert(Enum.IsDefined(resource),
                 "The enum value is not defined, please check the ExceptionResource Enum.");
 
             return SR.GetResourceString(resource.ToString());

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -17,8 +17,6 @@ namespace System
         {
             DebugAssertInCtor();
 
-            // if (!Enum.IsDefined(typeof(UriKind), uriKind)) -- We currently believe that Enum.IsDefined() is too slow
-            // to be used here.
             if ((int)uriKind < (int)UriKind.RelativeOrAbsolute || (int)uriKind > (int)UriKind.Relative)
             {
                 throw new ArgumentException(SR.Format(SR.net_uri_InvalidUriKind, uriKind));
@@ -622,8 +620,6 @@ namespace System
         //
         internal static Uri? CreateHelper(string uriString, bool dontEscape, UriKind uriKind, ref UriFormatException? e, in UriCreationOptions creationOptions = default)
         {
-            // if (!Enum.IsDefined(typeof(UriKind), uriKind)) -- We currently believe that Enum.IsDefined() is too slow
-            // to be used here.
             if ((int)uriKind < (int)UriKind.RelativeOrAbsolute || (int)uriKind > (int)UriKind.Relative)
             {
                 throw new ArgumentException(SR.Format(SR.net_uri_InvalidUriKind, uriKind));

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/OptimizerPatterns.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/OptimizerPatterns.cs
@@ -242,7 +242,7 @@ namespace System.Xml.Xsl.IlGen
         /// </summary>
         public void AddPattern(OptimizerPatternName pattern)
         {
-            Debug.Assert(Enum.IsDefined(typeof(OptimizerPatternName), pattern));
+            Debug.Assert(Enum.IsDefined(pattern));
             Debug.Assert((int)pattern < 32);
             Debug.Assert(!_isReadOnly, "This OptimizerPatterns instance is read-only.");
             _patterns |= (1 << (int)pattern);
@@ -253,7 +253,7 @@ namespace System.Xml.Xsl.IlGen
         /// </summary>
         public bool MatchesPattern(OptimizerPatternName pattern)
         {
-            Debug.Assert(Enum.IsDefined(typeof(OptimizerPatternName), pattern));
+            Debug.Assert(Enum.IsDefined(pattern));
             return (_patterns & (1 << (int)pattern)) != 0;
         }
 

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2366,6 +2366,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("EnumFormat")] string? format) { throw null; }
         [System.ObsoleteAttribute("The provider argument is not used. Use ToString(String) instead.")]
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("EnumFormat")] string? format, System.IFormatProvider? provider) { throw null; }
+        public static bool TryFormat<TEnum>(TEnum value, System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("EnumFormat")] System.ReadOnlySpan<char> format) where TEnum : struct { throw null; }
         public static bool TryParse(System.Type enumType, System.ReadOnlySpan<char> value, bool ignoreCase, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? result) { throw null; }
         public static bool TryParse(System.Type enumType, System.ReadOnlySpan<char> value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? result) { throw null; }
         public static bool TryParse(System.Type enumType, string? value, bool ignoreCase, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? result) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2366,7 +2366,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("EnumFormat")] string? format) { throw null; }
         [System.ObsoleteAttribute("The provider argument is not used. Use ToString(String) instead.")]
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("EnumFormat")] string? format, System.IFormatProvider? provider) { throw null; }
-        public static bool TryFormat<TEnum>(TEnum value, System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("EnumFormat")] System.ReadOnlySpan<char> format) where TEnum : struct { throw null; }
+        public static bool TryFormat<TEnum>(TEnum value, System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("EnumFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>)) where TEnum : struct { throw null; }
         public static bool TryParse(System.Type enumType, System.ReadOnlySpan<char> value, bool ignoreCase, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? result) { throw null; }
         public static bool TryParse(System.Type enumType, System.ReadOnlySpan<char> value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? result) { throw null; }
         public static bool TryParse(System.Type enumType, string? value, bool ignoreCase, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? result) { throw null; }

--- a/src/libraries/System.Runtime/tests/System/EnumTests.cs
+++ b/src/libraries/System.Runtime/tests/System/EnumTests.cs
@@ -1986,6 +1986,249 @@ namespace System.Tests
             yield return new object[] { AttributeTargets.Class | AttributeTargets.Delegate, "G", "Class, Delegate" };
         }
 
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public static void ToString_TryFormat(bool validateDestinationSpanSizeCheck, bool validateExtraSpanSpaceNotFilled)
+        {
+            // Format "D": the decimal equivalent of the value is returned.
+            // Format "X": value in hex form without a leading "0x"
+            // Format "F": value is treated as a bit field that contains one or more flags that consist of one or more bits.
+            // If value is equal to a combination of named enumerated constants, a delimiter-separated list of the names
+            // of those constants is returned. value is searched for flags, going from the flag with the largest value
+            // to the smallest value. For each flag that corresponds to a bit field in value, the name of the constant
+            // is concatenated to the delimiter-separated list. The value of that flag is then excluded from further
+            // consideration, and the search continues for the next flag.
+            // If value is not equal to a combination of named enumerated constants, the decimal equivalent of value is returned.
+            // Format "G": if value is equal to a named enumerated constant, the name of that constant is returned.
+            // Otherwise, if "[Flags]" present, do as Format "F" - else return the decimal value of "value".
+
+            // "D": SByte
+            TryFormat(SByteEnum.Min, "D", "-128", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(SByteEnum.One, "D", "1", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(SByteEnum.Two, "D", "2", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((SByteEnum)99, "D", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(SByteEnum.Max, "D", "127", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "D": Byte
+            TryFormat(ByteEnum.Min, "D", "0", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(ByteEnum.One, "D", "1", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(ByteEnum.Two, "D", "2", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((ByteEnum)99, "D", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(ByteEnum.Max, "D", "255", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "D": Int16
+            TryFormat(Int16Enum.Min, "D", "-32768", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int16Enum.One, "D", "1", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int16Enum.Two, "D", "2", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int16Enum)99, "D", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int16Enum.Max, "D", "32767", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "D": UInt16
+            TryFormat(UInt16Enum.Min, "D", "0", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt16Enum.One, "D", "1", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt16Enum.Two, "D", "2", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt16Enum)99, "D", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt16Enum.Max, "D", "65535", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "D": Int32
+            TryFormat(Int32Enum.Min, "D", "-2147483648", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int32Enum.One, "D", "1", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int32Enum.Two, "D", "2", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int32Enum)99, "D", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int32Enum.Max, "D", "2147483647", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "D": UInt32
+            TryFormat(UInt32Enum.Min, "D", "0", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt32Enum.One, "D", "1", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt32Enum.Two, "D", "2", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt32Enum)99, "D", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt32Enum.Max, "D", "4294967295", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "D": Int64
+            TryFormat(Int64Enum.Min, "D", "-9223372036854775808", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int64Enum.One, "D", "1", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int64Enum.Two, "D", "2", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int64Enum)99, "D", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int64Enum.Max, "D", "9223372036854775807", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "D": UInt64
+            TryFormat(UInt64Enum.Min, "D", "0", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt64Enum.One, "D", "1", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt64Enum.Two, "D", "2", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt64Enum)99, "D", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt64Enum.Max, "D", "18446744073709551615", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "D": SimpleEnum
+            TryFormat(SimpleEnum.Red, "D", "1", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "X": SByte
+            TryFormat(SByteEnum.Min, "X", "80", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(SByteEnum.One, "X", "01", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(SByteEnum.Two, "X", "02", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((SByteEnum)99, "X", "63", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(SByteEnum.Max, "X", "7F", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "X": Byte
+            TryFormat(ByteEnum.Min, "X", "00", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(ByteEnum.One, "X", "01", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(ByteEnum.Two, "X", "02", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((ByteEnum)99, "X", "63", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(ByteEnum.Max, "X", "FF", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "X": Int16
+            TryFormat(Int16Enum.Min, "X", "8000", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int16Enum.One, "X", "0001", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int16Enum.Two, "X", "0002", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int16Enum)99, "X", "0063", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int16Enum.Max, "X", "7FFF", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "X": UInt16
+            TryFormat(UInt16Enum.Min, "X", "0000", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt16Enum.One, "X", "0001", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt16Enum.Two, "X", "0002", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt16Enum)99, "X", "0063", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt16Enum.Max, "X", "FFFF", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "X": UInt32
+            TryFormat(UInt32Enum.Min, "X", "00000000", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt32Enum.One, "X", "00000001", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt32Enum.Two, "X", "00000002", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt32Enum)99, "X", "00000063", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt32Enum.Max, "X", "FFFFFFFF", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "X": Int32
+            TryFormat(Int32Enum.Min, "X", "80000000", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int32Enum.One, "X", "00000001", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int32Enum.Two, "X", "00000002", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int32Enum)99, "X", "00000063", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int32Enum.Max, "X", "7FFFFFFF", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "X:" Int64
+            TryFormat(Int64Enum.Min, "X", "8000000000000000", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int64Enum.One, "X", "0000000000000001", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int64Enum.Two, "X", "0000000000000002", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int64Enum)99, "X", "0000000000000063", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int64Enum.Max, "X", "7FFFFFFFFFFFFFFF", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "X": UInt64
+            TryFormat(UInt64Enum.Min, "X", "0000000000000000", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt64Enum.One, "X", "0000000000000001", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt64Enum.Two, "X", "0000000000000002", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt64Enum)99, "X", "0000000000000063", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt64Enum.Max, "X", "FFFFFFFFFFFFFFFF", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "X": SimpleEnum
+            TryFormat(SimpleEnum.Red, "X", "00000001", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "F": SByte
+            TryFormat(SByteEnum.Min, "F", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(SByteEnum.One | SByteEnum.Two, "F", "One, Two", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((SByteEnum)5, "F", "5", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(SByteEnum.Max, "F", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "F": Byte
+            TryFormat(ByteEnum.Min, "F", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(ByteEnum.One | ByteEnum.Two, "F", "One, Two", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((ByteEnum)5, "F", "5", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(ByteEnum.Max, "F", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "F": Int16
+            TryFormat(Int16Enum.Min, "F", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int16Enum.One | Int16Enum.Two, "F", "One, Two", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int16Enum)5, "F", "5", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int16Enum.Max, "F", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "F": UInt16
+            TryFormat(UInt16Enum.Min, "F", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt16Enum.One | UInt16Enum.Two, "F", "One, Two", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt16Enum)5, "F", "5", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt16Enum.Max, "F", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "F": Int32
+            TryFormat(Int32Enum.Min, "F", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int32Enum.One | Int32Enum.Two, "F", "One, Two", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int32Enum)5, "F", "5", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int32Enum.Max, "F", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "F": UInt32
+            TryFormat(UInt32Enum.Min, "F", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt32Enum.One | UInt32Enum.Two, "F", "One, Two", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt32Enum)5, "F", "5", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt32Enum.Max, "F", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "F": Int64
+            TryFormat(Int64Enum.Min, "F", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int64Enum.One | Int64Enum.Two, "F", "One, Two", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int64Enum)5, "F", "5", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(Int64Enum.Max, "F", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "F": UInt64
+            TryFormat(UInt64Enum.Min, "F", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt64Enum.One | UInt64Enum.Two, "F", "One, Two", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt64Enum)5, "F", "5", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(UInt64Enum.Max, "F", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "F": SimpleEnum
+            TryFormat(SimpleEnum.Red, "F", "Red", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat(SimpleEnum.Blue, "F", "Blue", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((SimpleEnum)99, "F", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((SimpleEnum)0, "F", "0", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // Not found
+
+            // "F": Flags Attribute
+            TryFormat(AttributeTargets.Class | AttributeTargets.Delegate, "F", "Class, Delegate", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "G": SByte
+            TryFormat(SByteEnum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((SByteEnum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+            TryFormat(SByteEnum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "G": Byte
+            TryFormat(ByteEnum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((ByteEnum)0xff, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((ByteEnum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+            TryFormat(ByteEnum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "G": Int16
+            TryFormat(Int16Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int16Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+            TryFormat(Int16Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "G": UInt16
+            TryFormat(UInt16Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt16Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+            TryFormat(UInt16Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "G": Int32
+            TryFormat(Int32Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int32Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+            TryFormat(Int32Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "G": UInt32
+            TryFormat(UInt32Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt32Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+            TryFormat(UInt32Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "G": Int64
+            TryFormat(Int64Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((Int64Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+            TryFormat(Int64Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "G": UInt64
+            TryFormat(UInt64Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((UInt64Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+            TryFormat(UInt64Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+
+            // "G": SimpleEnum
+            TryFormat((SimpleEnum)99, "G", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((SimpleEnum)99, "G", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            TryFormat((SimpleEnum)0, "G", "0", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // Not found
+
+            // "G": Flags Attribute
+            TryFormat(AttributeTargets.Class | AttributeTargets.Delegate, "G", "Class, Delegate", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+        }
+
 #pragma warning disable 618 // ToString with IFormatProvider is marked as Obsolete.
         [Theory]
         [MemberData(nameof(ToString_Format_TestData))]
@@ -2053,6 +2296,86 @@ namespace System.Tests
             // Format string is case insensitive
             Assert.Equal(expected, Enum.Format(enumType, value, format.ToUpperInvariant()));
             Assert.Equal(expected, Enum.Format(enumType, value, format.ToLowerInvariant()));
+        }
+
+        // Select test here, to avoid rewriting input params, as MemberData will does work for generic methods
+        private static void TryFormat<TEnum>(TEnum value, ReadOnlySpan<char> format, string expected, bool validateDestinationSpanSizeCheck, bool validateExtraSpanSpaceNotFilled) where TEnum : struct, Enum
+        {
+            if (validateDestinationSpanSizeCheck)
+            {
+                TryFormat_WithDestinationSpanSizeTooSmall_ReturnsFalseWithNoCharsWritten(value, format, expected);
+            }
+            if (validateExtraSpanSpaceNotFilled)
+            {
+                TryFormat_WithDestinationSpanLargerThanExpected_ReturnsTrueWithExpectedAndExtraSpaceNotFilled(value, format, expected);
+            }
+            else
+            {
+                TryFormat_WithValidParameters_ReturnsTrueWithExpected(value, format, expected);
+            }
+        }
+
+        private static void TryFormat_WithValidParameters_ReturnsTrueWithExpected<TEnum>(TEnum value, ReadOnlySpan<char> format, string expected) where TEnum : struct, Enum
+        {
+            Span<char> destination = new char[expected.Length];
+
+            Assert.True(Enum.TryFormat(value, destination, out int charsWritten, format));
+            Assert.Equal(expected, destination.ToString());
+            Assert.Equal(expected.Length, charsWritten);
+        }
+
+        private static void TryFormat_WithDestinationSpanSizeTooSmall_ReturnsFalseWithNoCharsWritten<TEnum>(TEnum value, ReadOnlySpan<char> format, string expected) where TEnum : struct, Enum
+        {
+            var oneLessThanExpectedLength = expected.Length - 1;
+            Span<char> destination = new char[oneLessThanExpectedLength];
+
+            Assert.False(Enum.TryFormat(value, destination, out int charsWritten, format));
+            Assert.Equal(new string('\0', oneLessThanExpectedLength), destination.ToString());
+            Assert.Equal(0, charsWritten);
+        }
+
+        private static void TryFormat_WithDestinationSpanLargerThanExpected_ReturnsTrueWithExpectedAndExtraSpaceNotFilled<TEnum>(TEnum value, ReadOnlySpan<char> format, string expected) where TEnum : struct, Enum
+        {
+            var oneMoreThanExpectedLength = expected.Length + 1;
+            Span<char> destination = new char[oneMoreThanExpectedLength];
+
+            Assert.True(Enum.TryFormat(value, destination, out int charsWritten, format));
+            Assert.Equal(expected + '\0', destination.ToString());
+            Assert.Equal(expected.Length, charsWritten);
+        }
+
+        [Fact]
+        private static void TryFormat_WithEmptySpan_ReturnsFalseWithNoCharsWritten()
+        {
+            Span<char> destination = new char[0];
+
+            Assert.False(Enum.TryFormat(SimpleEnum.Green, destination, out int charsWritten, "G"));
+            Assert.Equal("", destination.ToString());
+            Assert.Equal(0, charsWritten);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        [InlineData("   \t")]
+        [InlineData("a")]
+        [InlineData("ab")]
+        [InlineData("abc")]
+        [InlineData("gg")]
+        [InlineData("dd")]
+        [InlineData("xx")]
+        [InlineData("ff")]
+        private static void TryFormat_WithInvalidFormat_ReturnsFalseWithNoCharsWritten(string format)
+        {
+            var expecedEnum = SimpleEnum.Green;
+            string expected = nameof(expecedEnum);
+            Span<char> destination = new char[expected.Length];
+
+            Assert.False(Enum.TryFormat(expecedEnum, destination, out int charsWritten, format));
+            Assert.Equal(new string('\0', expected.Length), destination.ToString());
+            Assert.Equal(0, charsWritten);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/EnumTests.cs
+++ b/src/libraries/System.Runtime/tests/System/EnumTests.cs
@@ -2179,54 +2179,57 @@ namespace System.Tests
             // "F": Flags Attribute
             TryFormat(AttributeTargets.Class | AttributeTargets.Delegate, "F", "Class, Delegate", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
 
-            // "G": SByte
-            TryFormat(SByteEnum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
-            TryFormat((SByteEnum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
-            TryFormat(SByteEnum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            foreach (string defaultFormatSpecifier in new[] { "G", null, "" })
+            {
+                // "G": SByte
+                TryFormat(SByteEnum.Min, defaultFormatSpecifier, "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                TryFormat((SByteEnum)3, defaultFormatSpecifier, "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+                TryFormat(SByteEnum.Max, defaultFormatSpecifier, "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
 
-            // "G": Byte
-            TryFormat(ByteEnum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
-            TryFormat((ByteEnum)0xff, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
-            TryFormat((ByteEnum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
-            TryFormat(ByteEnum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                // "G": Byte
+                TryFormat(ByteEnum.Min, defaultFormatSpecifier, "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                TryFormat((ByteEnum)0xff, defaultFormatSpecifier, "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                TryFormat((ByteEnum)3, defaultFormatSpecifier, "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+                TryFormat(ByteEnum.Max, defaultFormatSpecifier, "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
 
-            // "G": Int16
-            TryFormat(Int16Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
-            TryFormat((Int16Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
-            TryFormat(Int16Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                // "G": Int16
+                TryFormat(Int16Enum.Min, defaultFormatSpecifier, "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                TryFormat((Int16Enum)3, defaultFormatSpecifier, "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+                TryFormat(Int16Enum.Max, defaultFormatSpecifier, "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
 
-            // "G": UInt16
-            TryFormat(UInt16Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
-            TryFormat((UInt16Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
-            TryFormat(UInt16Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                // "G": UInt16
+                TryFormat(UInt16Enum.Min, defaultFormatSpecifier, "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                TryFormat((UInt16Enum)3, defaultFormatSpecifier, "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+                TryFormat(UInt16Enum.Max, defaultFormatSpecifier, "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
 
-            // "G": Int32
-            TryFormat(Int32Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
-            TryFormat((Int32Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
-            TryFormat(Int32Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                // "G": Int32
+                TryFormat(Int32Enum.Min, defaultFormatSpecifier, "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                TryFormat((Int32Enum)3, defaultFormatSpecifier, "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+                TryFormat(Int32Enum.Max, defaultFormatSpecifier, "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
 
-            // "G": UInt32
-            TryFormat(UInt32Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
-            TryFormat((UInt32Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
-            TryFormat(UInt32Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                // "G": UInt32
+                TryFormat(UInt32Enum.Min, defaultFormatSpecifier, "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                TryFormat((UInt32Enum)3, defaultFormatSpecifier, "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+                TryFormat(UInt32Enum.Max, defaultFormatSpecifier, "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
 
-            // "G": Int64
-            TryFormat(Int64Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
-            TryFormat((Int64Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
-            TryFormat(Int64Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                // "G": Int64
+                TryFormat(Int64Enum.Min, defaultFormatSpecifier, "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                TryFormat((Int64Enum)3, defaultFormatSpecifier, "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+                TryFormat(Int64Enum.Max, defaultFormatSpecifier, "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
 
-            // "G": UInt64
-            TryFormat(UInt64Enum.Min, "G", "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
-            TryFormat((UInt64Enum)3, "G", "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
-            TryFormat(UInt64Enum.Max, "G", "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                // "G": UInt64
+                TryFormat(UInt64Enum.Min, defaultFormatSpecifier, "Min", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                TryFormat((UInt64Enum)3, defaultFormatSpecifier, "3", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // No [Flags] attribute
+                TryFormat(UInt64Enum.Max, defaultFormatSpecifier, "Max", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
 
-            // "G": SimpleEnum
-            TryFormat((SimpleEnum)99, "G", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
-            TryFormat((SimpleEnum)99, "G", "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
-            TryFormat((SimpleEnum)0, "G", "0", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // Not found
+                // "G": SimpleEnum
+                TryFormat((SimpleEnum)99, defaultFormatSpecifier, "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                TryFormat((SimpleEnum)99, defaultFormatSpecifier, "99", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                TryFormat((SimpleEnum)0, defaultFormatSpecifier, "0", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled); // Not found
 
-            // "G": Flags Attribute
-            TryFormat(AttributeTargets.Class | AttributeTargets.Delegate, "G", "Class, Delegate", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+                // "G": Flags Attribute
+                TryFormat(AttributeTargets.Class | AttributeTargets.Delegate, defaultFormatSpecifier, "Class, Delegate", validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            }
         }
 
 #pragma warning disable 618 // ToString with IFormatProvider is marked as Obsolete.
@@ -2313,6 +2316,11 @@ namespace System.Tests
             {
                 TryFormat_WithValidParameters_ReturnsTrueWithExpected(value, format, expected);
             }
+
+            if (format.Length == 1 && char.IsAsciiLetterUpper(format[0]))
+            {
+                TryFormat(value, (ReadOnlySpan<char>)new char[1] { char.ToLowerInvariant(format[0]) }, expected, validateDestinationSpanSizeCheck, validateExtraSpanSpaceNotFilled);
+            }
         }
 
         private static void TryFormat_WithValidParameters_ReturnsTrueWithExpected<TEnum>(TEnum value, ReadOnlySpan<char> format, string expected) where TEnum : struct, Enum
@@ -2326,7 +2334,7 @@ namespace System.Tests
 
         private static void TryFormat_WithDestinationSpanSizeTooSmall_ReturnsFalseWithNoCharsWritten<TEnum>(TEnum value, ReadOnlySpan<char> format, string expected) where TEnum : struct, Enum
         {
-            var oneLessThanExpectedLength = expected.Length - 1;
+            int oneLessThanExpectedLength = expected.Length - 1;
             Span<char> destination = new char[oneLessThanExpectedLength];
 
             Assert.False(Enum.TryFormat(value, destination, out int charsWritten, format));
@@ -2336,7 +2344,7 @@ namespace System.Tests
 
         private static void TryFormat_WithDestinationSpanLargerThanExpected_ReturnsTrueWithExpectedAndExtraSpaceNotFilled<TEnum>(TEnum value, ReadOnlySpan<char> format, string expected) where TEnum : struct, Enum
         {
-            var oneMoreThanExpectedLength = expected.Length + 1;
+            int oneMoreThanExpectedLength = expected.Length + 1;
             Span<char> destination = new char[oneMoreThanExpectedLength];
 
             Assert.True(Enum.TryFormat(value, destination, out int charsWritten, format));
@@ -2355,8 +2363,6 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
         [InlineData(" ")]
         [InlineData("  ")]
         [InlineData("   \t")]
@@ -2367,14 +2373,15 @@ namespace System.Tests
         [InlineData("dd")]
         [InlineData("xx")]
         [InlineData("ff")]
-        private static void TryFormat_WithInvalidFormat_ReturnsFalseWithNoCharsWritten(string format)
+        private static void TryFormat_WithInvalidFormat_ThrowsWithNoCharsWritten(string format)
         {
-            var expecedEnum = SimpleEnum.Green;
+            SimpleEnum expecedEnum = SimpleEnum.Green;
             string expected = nameof(expecedEnum);
-            Span<char> destination = new char[expected.Length];
+            int charsWritten = 0;
+            char[] destination = new char[expected.Length];
 
-            Assert.False(Enum.TryFormat(expecedEnum, destination, out int charsWritten, format));
-            Assert.Equal(new string('\0', expected.Length), destination.ToString());
+            Assert.Throws<FormatException>(() => Enum.TryFormat(expecedEnum, destination, out charsWritten, format));
+            Assert.Equal(new string('\0', expected.Length), new string(destination));
             Assert.Equal(0, charsWritten);
         }
 

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
@@ -977,7 +977,7 @@ namespace System.ServiceProcess
         /// <param name="timeout">Wait for specific timeout</param>
         public void WaitForStatus(ServiceControllerStatus desiredStatus, TimeSpan timeout)
         {
-            if (!Enum.IsDefined(typeof(ServiceControllerStatus), desiredStatus))
+            if (!Enum.IsDefined(desiredStatus))
                 throw new ArgumentException(SR.Format(SR.InvalidEnumArgument, nameof(desiredStatus), (int)desiredStatus, typeof(ServiceControllerStatus)));
 
             DateTime start = DateTime.UtcNow;


### PR DESCRIPTION
Partial implementation of #57881 

### Benchmarks

Code: https://gist.github.com/heathbm/59783b3d9e08d9556d7a86fa6ee2cd20

Before implementation:  

|      Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Allocated |
|------------ |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
|     FormatG | 33.96 ns | 0.722 ns | 0.676 ns | 33.80 ns | 33.07 ns | 35.16 ns | 0.0019 |      24 B |
|     FormatD | 27.03 ns | 0.149 ns | 0.132 ns | 27.00 ns | 26.84 ns | 27.29 ns | 0.0019 |      24 B |
|     FormatX | 35.46 ns | 0.737 ns | 0.789 ns | 35.42 ns | 33.99 ns | 36.74 ns | 0.0050 |      64 B |
|     FormatF | 33.69 ns | 0.270 ns | 0.225 ns | 33.73 ns | 33.17 ns | 33.95 ns | 0.0018 |      24 B |

After implementation:  

|      Method |      Mean |     Error |    StdDev |    Median |       Min |      Max |  Gen 0 | Allocated |
|------------ |----------:|----------:|----------:|----------:|----------:|---------:|-------:|----------:|
|     FormatG | 32.983 ns | 0.2221 ns | 0.1969 ns | 32.980 ns | 32.588 ns | 33.40 ns | 0.0018 |      24 B |
|  TryFormatG | 14.332 ns | 0.1794 ns | 0.1678 ns | 14.412 ns | 13.943 ns | 14.51 ns |      - |         - |
|     FormatD | 26.751 ns | 0.8298 ns | 0.9556 ns | 26.348 ns | 25.166 ns | 28.47 ns | 0.0019 |      24 B |
| TryFormatD |  9.906 ns | 0.1853 ns | 0.1734 ns |  9.862 ns |  9.747 ns | 10.35 ns |      - |         - |
|     FormatX | 34.408 ns | 0.2204 ns | 0.1954 ns | 34.430 ns | 33.866 ns | 34.63 ns | 0.0050 |      64 B |
|  TryFormatX | 17.993 ns | 0.0465 ns | 0.0435 ns | 17.998 ns | 17.913 ns | 18.08 ns |      - |         - |
|     FormatF | 34.604 ns | 0.2278 ns | 0.2131 ns | 34.486 ns | 34.385 ns | 34.99 ns | 0.0018 |      24 B |
|  TryFormatF | 17.251 ns | 0.0471 ns | 0.0368 ns | 17.247 ns | 17.172 ns | 17.31 ns |      - |         - |

No visible regression.  

### Profiling:
Profiling code: https://gist.github.com/heathbm/079c4bea1dc541ffc12c91f283892875
Tested with:
- Visual Studio Performance Profiler (.NET Object Allocation Tracking)
- DotMemory (Full, Entire process tree)

Only allocations appear in the first run from:
- System.Enum.GetEnumInfo
- System.RuntimeType.GetTypeCodeImpl
I believe there is nothing I can do to prevent these allocations on the first run as they generate cache.

![alloc1](https://user-images.githubusercontent.com/13576170/177027167-99c8d868-f498-4dbf-a8a3-bf5420e0bfed.png)
![alloc2](https://user-images.githubusercontent.com/13576170/177027198-c66e11ff-9905-42c4-92b4-40aed96f5ad5.png)


