### PR TITLE
Add support for int keyed dictionaries to configuration binder

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -491,10 +491,19 @@ namespace Microsoft.Extensions.Configuration
             Type keyType = dictionaryType.GenericTypeArguments[0];
             Type valueType = dictionaryType.GenericTypeArguments[1];
             bool keyTypeIsEnum = keyType.IsEnum;
+            bool keyTypeIsInteger =
+                keyType == typeof(sbyte) ||
+                keyType == typeof(byte) ||
+                keyType == typeof(short) ||
+                keyType == typeof(ushort) ||
+                keyType == typeof(int) ||
+                keyType == typeof(uint) ||
+                keyType == typeof(long) ||
+                keyType == typeof(ulong);
 
-            if (keyType != typeof(string) && !keyTypeIsEnum)
+            if (keyType != typeof(string) && !keyTypeIsEnum && !keyTypeIsInteger)
             {
-                // We only support string and enum keys
+                // We only support string, enum and integer (except nint-IntPtr and nuint-UIntPtr) keys
                 return null;
             }
 
@@ -543,10 +552,19 @@ namespace Microsoft.Extensions.Configuration
             Type keyType = dictionaryType.GenericTypeArguments[0];
             Type valueType = dictionaryType.GenericTypeArguments[1];
             bool keyTypeIsEnum = keyType.IsEnum;
+            bool keyTypeIsInteger =
+                keyType == typeof(sbyte) ||
+                keyType == typeof(byte) ||
+                keyType == typeof(short) ||
+                keyType == typeof(ushort) ||
+                keyType == typeof(int) ||
+                keyType == typeof(uint) ||
+                keyType == typeof(long) ||
+                keyType == typeof(ulong);
 
-            if (keyType != typeof(string) && !keyTypeIsEnum)
+            if (keyType != typeof(string) && !keyTypeIsEnum && !keyTypeIsInteger)
             {
-                // We only support string and enum keys
+                // We only support string, enum and integer (except nint-IntPtr and nuint-UIntPtr) keys
                 return;
             }
 
@@ -558,7 +576,9 @@ namespace Microsoft.Extensions.Configuration
             {
                 try
                 {
-                    object key = keyTypeIsEnum ? Enum.Parse(keyType, child.Key) : child.Key;
+                    object key = keyTypeIsEnum ? Enum.Parse(keyType, child.Key) :
+                        keyTypeIsInteger ? Convert.ChangeType(child.Key, keyType) :
+                        child.Key;
                     var valueBindingPoint = new BindingPoint(
                         initialValueProvider: () =>
                         {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -216,41 +216,49 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         {
             GetIntDictionaryT<sbyte>(0, 1, 2);
         }
+
         [Fact]
         public void GetByteDictionary()
         {
             GetIntDictionaryT<byte>(0, 1, 2);
         }
+
         [Fact]
         public void GetShortDictionary()
         {
             GetIntDictionaryT<short>(0, 1, 2);
         }
+
         [Fact]
         public void GetUShortDictionary()
         {
             GetIntDictionaryT<ushort>(0, 1, 2);
         }
+
         [Fact]
         public void GetIntDictionary()
         {
             GetIntDictionaryT<int>(0, 1, 2);
         }
+
         [Fact]
         public void GetUIntDictionary()
         {
             GetIntDictionaryT<uint>(0, 1, 2);
         }
+
         [Fact]
         public void GetLongDictionary()
         {
             GetIntDictionaryT<long>(0, 1, 2);
         }
+
         [Fact]
         public void GetULongDictionary()
         {
             GetIntDictionaryT<ulong>(0, 1, 2);
         }
+
         private void GetIntDictionaryT<T>(T k1, T k2, T k3)
         {
             var input = new Dictionary<string, string>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -212,6 +212,69 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         }
 
         [Fact]
+        public void GetSByteDictionary()
+        {
+            GetIntDictionaryT<sbyte>(0, 1, 2);
+        }
+        [Fact]
+        public void GetByteDictionary()
+        {
+            GetIntDictionaryT<byte>(0, 1, 2);
+        }
+        [Fact]
+        public void GetShortDictionary()
+        {
+            GetIntDictionaryT<short>(0, 1, 2);
+        }
+        [Fact]
+        public void GetUShortDictionary()
+        {
+            GetIntDictionaryT<ushort>(0, 1, 2);
+        }
+        [Fact]
+        public void GetIntDictionary()
+        {
+            GetIntDictionaryT<int>(0, 1, 2);
+        }
+        [Fact]
+        public void GetUIntDictionary()
+        {
+            GetIntDictionaryT<uint>(0, 1, 2);
+        }
+        [Fact]
+        public void GetLongDictionary()
+        {
+            GetIntDictionaryT<long>(0, 1, 2);
+        }
+        [Fact]
+        public void GetULongDictionary()
+        {
+            GetIntDictionaryT<ulong>(0, 1, 2);
+        }
+        private void GetIntDictionaryT<T>(T k1, T k2, T k3)
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"IntegerKeyDictionary:0", "val_0"},
+                {"IntegerKeyDictionary:1", "val_1"},
+                {"IntegerKeyDictionary:2", "val_2"}
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(input);
+            var config = configurationBuilder.Build();
+
+            var options = new Dictionary<T, string>();
+            config.GetSection("IntegerKeyDictionary").Bind(options);
+
+            Assert.Equal(3, options.Count);
+
+            Assert.Equal("val_0", options[k1]);
+            Assert.Equal("val_1", options[k2]);
+            Assert.Equal("val_2", options[k3]);
+        }
+
+        [Fact]
         public void GetStringList()
         {
             var input = new Dictionary<string, string>


### PR DESCRIPTION
Up to now, only string or enum keys are supported for dictionaries in ConfigurationBinder.
This simple proposal adds support for "integeral typed" keys:

- sbyte
- byte
- short
- ushort
- int
- uint
- long
- ulong

I previously submitted a similar PR  dotnet/extensions/pull/3063 but it was closed due to the repo migration exensions&#8594;runtime.
Many others are interested in this simple, obvious feature. Look here: #36044
Please consider and review this!!!!

