### PR TITLE
Handle out-of-bounds access to locals in block morphing

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -192,12 +192,10 @@ void MorphInitBlockHelper::PrepareDst()
     if (m_dst->IsLocal())
     {
         m_dstLclNode   = m_dst->AsLclVarCommon();
-        m_dstVarDsc    = m_comp->lvaGetDesc(m_dstLclNode);
         m_dstLclOffset = m_dstLclNode->GetLclOffs();
 
         if (m_dst->TypeIs(TYP_STRUCT))
         {
-            assert(m_dstVarDsc->GetLayout()->GetSize() == m_dstVarDsc->lvExactSize);
             m_blockLayout = m_dstLclNode->GetLayout(m_comp);
         }
     }
@@ -212,9 +210,19 @@ void MorphInitBlockHelper::PrepareDst()
         ssize_t dstLclOffset = 0;
         if (dstAddr->DefinesLocalAddr(&m_dstLclNode, &dstLclOffset))
         {
-            // Note that lclNode can be a field, like `BLK<4> struct(ADD(ADDR(LCL_FLD int), CNST_INT))`.
-            m_dstVarDsc    = m_comp->lvaGetDesc(m_dstLclNode);
-            m_dstLclOffset = static_cast<unsigned>(dstLclOffset);
+            // Treat out-of-bounds access to locals opaquely to simplify downstream logic.
+            unsigned dstLclSize = m_comp->lvaLclExactSize(m_dstLclNode->GetLclNum());
+
+            if (!FitsIn<unsigned>(dstLclOffset) ||
+                ((static_cast<uint64_t>(dstLclOffset) + m_dst->AsIndir()->Size()) > dstLclSize))
+            {
+                assert(m_comp->lvaGetDesc(m_dstLclNode)->IsAddressExposed());
+                m_dstLclNode = nullptr;
+            }
+            else
+            {
+                m_dstLclOffset = static_cast<unsigned>(dstLclOffset);
+            }
         }
 
         if (m_dst->TypeIs(TYP_STRUCT))
@@ -236,6 +244,10 @@ void MorphInitBlockHelper::PrepareDst()
     if (m_dstLclNode != nullptr)
     {
         m_dstLclNum = m_dstLclNode->GetLclNum();
+        m_dstVarDsc = m_comp->lvaGetDesc(m_dstLclNum);
+
+        assert((m_dstVarDsc->TypeGet() != TYP_STRUCT) ||
+               (m_dstVarDsc->GetLayout()->GetSize() == m_dstVarDsc->lvExactSize));
 
         // Kill everything about m_dstLclNum (and its field locals)
         if (m_comp->optLocalAssertionProp && (m_comp->optAssertionCount > 0))

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71601/Runtime_71601.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71601/Runtime_71601.cs
@@ -13,6 +13,11 @@ public class Runtime_71601
             return 101;
         }
 
+        if (ProblemWithPrimitiveDst())
+        {
+            return 102;
+        }
+
         return 100;
     }
 
@@ -24,6 +29,16 @@ public class Runtime_71601
         Wrap b = WrapTuple.GetFieldTwo(ref p);
 
         return a.Value != b.Value;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ProblemWithPrimitiveDst()
+    {
+        WrapTuple p = new WrapTuple { FieldOne = { Value = 1 }, FieldTwo = { Value = 2 } };
+        Wrap a = p.FieldTwo;
+        WrapTuple.GetFieldTwo(ref p) = a;
+
+        return a.Value == p.FieldOne.Value;
     }
 
     struct WrapTuple

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71601/Runtime_71601.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71601/Runtime_71601.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+public class Runtime_71601
+{
+    public static int Main()
+    {
+        if (ProblemWithPrimitiveSrc())
+        {
+            return 101;
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ProblemWithPrimitiveSrc()
+    {
+        WrapTuple p = new WrapTuple { FieldOne = { Value = 1 }, FieldTwo = { Value = 2 } };
+        Wrap a = p.FieldTwo;
+        Wrap b = WrapTuple.GetFieldTwo(ref p);
+
+        return a.Value != b.Value;
+    }
+
+    struct WrapTuple
+    {
+        public Wrap FieldOne;
+        public Wrap FieldTwo;
+
+        public static ref Wrap GetFieldTwo(ref WrapTuple t) => ref Unsafe.Add(ref t.FieldOne, 1);
+    }
+
+    struct Wrap
+    {
+        public int Value;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71601/Runtime_71601.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71601/Runtime_71601.cs
@@ -28,7 +28,20 @@ public class Runtime_71601
         Wrap a = p.FieldTwo;
         Wrap b = WrapTuple.GetFieldTwo(ref p);
 
-        return a.Value != b.Value;
+        if (a.Value != b.Value)
+        {
+            return true;
+        }
+
+        a = p.FieldOne;
+        b = WrapTuple.GetFieldOne(ref p);
+
+        if (a.Value != b.Value)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -38,7 +51,19 @@ public class Runtime_71601
         Wrap a = p.FieldTwo;
         WrapTuple.GetFieldTwo(ref p) = a;
 
-        return a.Value == p.FieldOne.Value;
+        if (a.Value == p.FieldOne.Value)
+        {
+            return true;
+        }
+
+        WrapTuple.GetFieldOne(ref p) = a;
+
+        if (a.Value != p.FieldOne.Value)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     struct WrapTuple
@@ -46,6 +71,7 @@ public class Runtime_71601
         public Wrap FieldOne;
         public Wrap FieldTwo;
 
+        public static ref Wrap GetFieldOne(ref WrapTuple t) => ref Unsafe.Add(ref t.FieldTwo, -1);
         public static ref Wrap GetFieldTwo(ref WrapTuple t) => ref Unsafe.Add(ref t.FieldOne, 1);
     }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71601/Runtime_71601.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71601/Runtime_71601.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Treat it opaquely.

Fixes #71601.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1860161&view=ms.vss-build-web.run-extensions-tab).