### PR TITLE
Fixed the error for missing Debug directory

### DIFF
--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <LibrariesConfiguration>Release</LibrariesConfiguration>
+    <LibrariesConfiguration Condition="'$(LibrariesConfiguration)' == ''">$(Configuration)</LibrariesConfiguration>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\Common\dir.sdkbuild.props" Condition="'$(UsingMicrosoftNETSdk)' == 'true'"  />


### PR DESCRIPTION
Fixed the error for **missing Debug** directory
when building by `./src/tests/build.sh generatelayoutonly -loongarch64` after `./build.sh libs -arch loongarch64` on AMD64-linux.

The error liking
<pre>
/home/qiao/runtime/eng/liveBuilds.targets(137,5): error : The 'libs' subset must be built before building this project. Missing artifacts: /home/qiao/runtime/artifacts/bin/microsoft.netcore.app.runtime.linux-loongarch64/Release/runtimes/linux-loongarch64/lib/net7.0/. Configuration: 'Release'. To use a different configuration, specify the 'LibrariesConfiguration' property. [/home/qiao/runtime/src/tests/Common/test_dependencies/test_dependencies.csproj]

生成失败。

/home/qiao/runtime/eng/liveBuilds.targets(137,5): error : The 'libs' subset must be built before building this project. Missing artifacts: /home/qiao/runtime/artifacts/bin/microsoft.netcore.app.runtime.linux-loongarch64/Release/runtimes/linux-loongarch64/lib/net7.0/. Configuration: 'Release'. To use a different configuration, specify the 'LibrariesConfiguration' property. [/home/qiao/runtime/src/tests/Common/test_dependencies/test_dependencies.csproj]
    0 个警告
    1 个错误

已用时间 00:00:20.48
Build failed with exit code 1. Check errors above.
Failed to build tests. See the build logs:
</pre>