### PR TITLE
Release global lock before throwing exceptions from the Unix WaitSystem

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
@@ -125,7 +125,7 @@ namespace System.Threading
         // around and keep track of whether the lock still needs to be released.
         public struct LockHolder
         {
-            LowLevelLock? _lock;
+            private LowLevelLock? _lock;
 
             public LockHolder(LowLevelLock l)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
@@ -120,9 +120,44 @@ namespace System.Threading
     {
         private static readonly LowLevelLock s_lock = new LowLevelLock();
 
+        // Exception handling may use the WaitSubsystem. It means that we need to release the WaitSubsystem
+        // lock before throwing any exceptions to avoid deadlocks. LockHolder allows us to pass the lock state
+        // around and keep track of whether the lock still needs to be released.
+        public struct LockHolder
+        {
+            LowLevelLock? _lock;
+
+            public LockHolder(LowLevelLock l)
+            {
+                l.Acquire();
+                _lock = l;
+            }
+
+            public void Dispose()
+            {
+                if (_lock != null)
+                {
+                    _lock.Release();
+                    _lock = null;
+                }
+            }
+        }
+
         private static SafeWaitHandle NewHandle(WaitableObject waitableObject)
         {
-            IntPtr handle = HandleManager.NewHandle(waitableObject);
+            IntPtr handle = IntPtr.Zero;
+            try
+            {
+                handle = HandleManager.NewHandle(waitableObject);
+            }
+            finally
+            {
+                if (handle == IntPtr.Zero)
+                {
+                    waitableObject.OnDeleteHandle();
+                }
+            }
+
             SafeWaitHandle? safeWaitHandle = null;
             try
             {
@@ -172,8 +207,7 @@ namespace System.Threading
             // between adding the mutex to the named object table and initially acquiring it.
             // To avoid the possibility of another thread retrieving the mutex via its name
             // before we managed to acquire it, we perform both steps while holding s_lock.
-            s_lock.Acquire();
-            bool holdingLock = true;
+            LockHolder lockHolder = new LockHolder(s_lock);
             try
             {
                 WaitableObject? waitableObject = WaitableObject.CreateNamedMutex_Locked(name, out createdNew);
@@ -191,18 +225,13 @@ namespace System.Threading
                 // by the thread. See <see cref="ThreadWaitInfo.LockedMutexesHead"/>. So, acquire the lock only after all
                 // possibilities for exceptions have been exhausted.
                 ThreadWaitInfo waitInfo = Thread.CurrentThread.WaitInfo;
-                int status = waitableObject.Wait_Locked(waitInfo, timeoutMilliseconds: 0, interruptible: false, prioritize: false);
+                int status = waitableObject.Wait_Locked(waitInfo, timeoutMilliseconds: 0, interruptible: false, prioritize: false, ref lockHolder);
                 Debug.Assert(status == 0);
-                // Wait_Locked has already released s_lock, so we no longer hold it here.
-                holdingLock = false;
                 return safeWaitHandle;
             }
             finally
             {
-                if (holdingLock)
-                {
-                    s_lock.Release();
-                }
+                lockHolder.Dispose();
             }
         }
 
@@ -227,14 +256,14 @@ namespace System.Threading
         {
             Debug.Assert(waitableObject != null);
 
-            s_lock.Acquire();
+            LockHolder lockHolder = new LockHolder(s_lock);
             try
             {
-                waitableObject.SignalEvent();
+                waitableObject.SignalEvent(ref lockHolder);
             }
             finally
             {
-                s_lock.Release();
+                lockHolder.Dispose();
             }
         }
 
@@ -247,14 +276,14 @@ namespace System.Threading
         {
             Debug.Assert(waitableObject != null);
 
-            s_lock.Acquire();
+            LockHolder lockHolder = new LockHolder(s_lock);
             try
             {
-                waitableObject.UnsignalEvent();
+                waitableObject.UnsignalEvent(ref lockHolder);
             }
             finally
             {
-                s_lock.Release();
+                lockHolder.Dispose();
             }
         }
 
@@ -269,14 +298,14 @@ namespace System.Threading
             Debug.Assert(waitableObject != null);
             Debug.Assert(count > 0);
 
-            s_lock.Acquire();
+            LockHolder lockHolder = new LockHolder(s_lock);
             try
             {
-                return waitableObject.SignalSemaphore(count);
+                return waitableObject.SignalSemaphore(count, ref lockHolder);
             }
             finally
             {
-                s_lock.Release();
+                lockHolder.Dispose();
             }
         }
 
@@ -289,14 +318,14 @@ namespace System.Threading
         {
             Debug.Assert(waitableObject != null);
 
-            s_lock.Acquire();
+            LockHolder lockHolder = new LockHolder(s_lock);
             try
             {
-                waitableObject.SignalMutex();
+                waitableObject.SignalMutex(ref lockHolder);
             }
             finally
             {
-                s_lock.Release();
+                lockHolder.Dispose();
             }
         }
 
@@ -412,38 +441,30 @@ namespace System.Threading
             Debug.Assert(timeoutMilliseconds >= -1);
 
             ThreadWaitInfo waitInfo = Thread.CurrentThread.WaitInfo;
-            bool waitCalled = false;
-            s_lock.Acquire();
+            LockHolder lockHolder = new LockHolder(s_lock);
             try
             {
                 // A pending interrupt does not signal the specified handle
                 if (interruptible && waitInfo.CheckAndResetPendingInterrupt)
                 {
+                    lockHolder.Dispose();
                     throw new ThreadInterruptedException();
                 }
 
                 try
                 {
-                    waitableObjectToSignal.Signal(1);
+                    waitableObjectToSignal.Signal(1, ref lockHolder);
                 }
                 catch (SemaphoreFullException ex)
                 {
+                    s_lock.VerifyIsNotLocked();
                     throw new InvalidOperationException(SR.Threading_WaitHandleTooManyPosts, ex);
                 }
-                waitCalled = true;
-                return waitableObjectToWaitOn.Wait_Locked(waitInfo, timeoutMilliseconds, interruptible, prioritize);
+                return waitableObjectToWaitOn.Wait_Locked(waitInfo, timeoutMilliseconds, interruptible, prioritize, ref lockHolder);
             }
             finally
             {
-                // Once the wait function is called, it will release the lock
-                if (waitCalled)
-                {
-                    s_lock.VerifyIsNotLocked();
-                }
-                else
-                {
-                    s_lock.Release();
-                }
+                lockHolder.Dispose();
             }
         }
 


### PR DESCRIPTION
The exception throwing and handling can enter wait system recursively that will lead to deadlock.

Fixes #70010