### PR TITLE
Disable a test for ilasm roundtripping

### DIFF
--- a/src/tests/profiler/rejit/rejit.csproj
+++ b/src/tests/profiler/rejit/rejit.csproj
@@ -12,6 +12,8 @@
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Different file names after roundtripping causes problems with this test -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Makes #71316 non-blocking. The actual fix requires #71119.

cc @dotnet/jit-contrib 