### PR TITLE
Make JsonTypeInfo.CreateJsonPropertyInfo linker safe

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -1186,8 +1186,6 @@ namespace System.Text.Json.Serialization.Metadata
         public System.Text.Json.Serialization.Metadata.JsonPolymorphismOptions? PolymorphismOptions { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Text.Json.Serialization.Metadata.JsonPropertyInfo> Properties { get { throw null; } }
         public System.Type Type { get { throw null; } }
-        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
         public System.Text.Json.Serialization.Metadata.JsonPropertyInfo CreateJsonPropertyInfo(System.Type propertyType, string name) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -67,8 +67,6 @@ namespace System.Text.Json.Serialization
             throw new InvalidOperationException(SR.NodeJsonObjectCustomConverterNotAllowedOnExtensionProperty);
         }
 
-        internal abstract JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, JsonSerializerOptions options);
-
         internal abstract JsonParameterInfo CreateJsonParameterInfo();
 
         internal abstract JsonConverter<TTarget> CreateCastingConverter<TTarget>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -32,13 +32,6 @@ namespace System.Text.Json.Serialization
         /// </returns>
         public abstract JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options);
 
-        internal override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, JsonSerializerOptions options)
-        {
-            Debug.Fail("We should never get here.");
-
-            throw new InvalidOperationException();
-        }
-
         internal override JsonParameterInfo CreateJsonParameterInfo()
         {
             Debug.Fail("We should never get here.");

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -69,14 +69,6 @@ namespace System.Text.Json.Serialization
 
         internal override ConverterStrategy ConverterStrategy => ConverterStrategy.Value;
 
-        internal sealed override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, JsonSerializerOptions options)
-        {
-            return new JsonPropertyInfo<T>(declaringTypeInfo.Type, declaringTypeInfo, options)
-            {
-                DefaultConverterForType = this
-            };
-        }
-
         internal sealed override JsonParameterInfo CreateJsonParameterInfo()
         {
             return new JsonParameterInfo<T>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -26,7 +26,7 @@ namespace System.Text.Json
         /// <summary>
         /// This method returns configured non-null JsonTypeInfo
         /// </summary>
-        internal JsonTypeInfo GetOrAddJsonTypeInfo(Type type)
+        internal JsonTypeInfo GetOrAddJsonTypeInfo(Type type, bool configured = true)
         {
             if (_cachingContext == null)
             {
@@ -41,7 +41,10 @@ namespace System.Text.Json
                 return null;
             }
 
-            typeInfo.EnsureConfigured();
+            if (configured)
+            {
+                typeInfo.EnsureConfigured();
+            }
 
             return typeInfo;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -170,7 +170,8 @@ namespace System.Text.Json
             [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
             get
             {
-                return _typeInfoResolver ?? DefaultJsonTypeInfoResolver.RootDefaultInstance();
+                InitializeForReflectionSerializer();
+                return _typeInfoResolver;
             }
             set
             {
@@ -626,6 +627,7 @@ namespace System.Text.Json
         /// </summary>
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        [MemberNotNull(nameof(_typeInfoResolver))]
         internal void InitializeForReflectionSerializer()
         {
             if (_typeInfoResolver is JsonSerializerContext ctx)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
@@ -23,6 +23,11 @@ namespace System.Text.Json.Serialization.Metadata
         {
         }
 
+        private protected sealed override void LateAddProperties()
+        {
+            // no properties by default
+        }
+
         internal override JsonParameterInfoValues[] GetParameterInfoValues()
         {
             // Parametrized constructors not supported yet for custom types

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -188,7 +188,7 @@ namespace System.Text.Json.Serialization.Metadata
                 JsonSerializerOptions.CheckConverterNullabilityIsSameAsPropertyType(customConverter, PropertyType);
             }
 
-            JsonConverter converter = customConverter ?? DefaultConverterForType ?? Options.GetConverterFromTypeInfo(PropertyType);
+            JsonConverter converter = customConverter ?? DefaultConverterForType ?? Options.GetOrAddJsonTypeInfo(PropertyType, configured: false).Converter;
             TypedEffectiveConverter = converter is JsonConverter<T> typedConv ? typedConv : converter.CreateCastingConverter<T>();
             ConverterStrategy = TypedEffectiveConverter.ConverterStrategy;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -102,6 +102,19 @@ namespace System.Text.Json.Serialization.Metadata
             };
         }
 
+        private protected sealed override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, JsonSerializerOptions options)
+        {
+            // Options on this type info might not be the same as the one passed in
+            // This is because we're taking JsonTypeInfo from cache which might end up being equivalent but not same reference
+            return new JsonPropertyInfo<T>(declaringTypeInfo.Type, declaringTypeInfo, options)
+            {
+                DefaultConverterForType = Converter,
+                JsonTypeInfo = this,
+            };
+        }
+
+        private protected abstract override void LateAddProperties();
+
         private protected void MapInterfaceTypesToCallbacks()
         {
             // Callbacks currently only supported in object kinds

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
@@ -89,7 +89,7 @@ namespace System.Text.Json.Serialization.Metadata
 #pragma warning restore CS8714
         }
 
-        internal override void LateAddProperties()
+        private protected sealed override void LateAddProperties()
         {
             AddPropertiesUsingSourceGenInfo();
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/NewtonsoftTests/JsonSerializerTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/NewtonsoftTests/JsonSerializerTests.cs
@@ -129,7 +129,7 @@ namespace System.Text.Json.Tests
 
             p1.Spouse = p2;
             p2.Spouse = p1;
-            Assert.Throws<JsonException> (() => JsonSerializer.Serialize(p1));
+            Assert.Throws<JsonException>(() => JsonSerializer.Serialize(p1));
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
@@ -18,6 +18,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void JsonPropertyInfoOptionsAreSet()
         {
             JsonSerializerOptions options = new();
+
             JsonTypeInfo typeInfo = JsonTypeInfo.CreateJsonTypeInfo(typeof(MyClass), options);
             CreatePropertyAndCheckOptions(options, typeInfo);
 
@@ -30,7 +31,8 @@ namespace System.Text.Json.Serialization.Tests
             static void CreatePropertyAndCheckOptions(JsonSerializerOptions expectedOptions, JsonTypeInfo typeInfo)
             {
                 JsonPropertyInfo propertyInfo = typeInfo.CreateJsonPropertyInfo(typeof(string), "test");
-                Assert.Same(expectedOptions, propertyInfo.Options);
+                Assert.Same(expectedOptions, typeInfo.Options);
+                Assert.Same(typeInfo.Options, propertyInfo.Options);
             }
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
@@ -32,6 +32,7 @@ namespace System.Text.Json.Serialization.Tests
 
             DefaultJsonTypeInfoResolver r = new();
             JsonSerializerOptions o = new();
+            o.TypeInfoResolver = r;
             o.Converters.Add(new CustomThrowingConverter<SomeClass>());
 
             JsonTypeInfo ti = r.GetTypeInfo(type, o);
@@ -225,8 +226,12 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(string), JsonTypeInfoKind.None)]
         public static void AddingPropertyToNonObjectJsonTypeInfoKindThrows(Type type, JsonTypeInfoKind expectedKind)
         {
-            JsonSerializerOptions options = new();
             DefaultJsonTypeInfoResolver resolver = new();
+            JsonSerializerOptions options = new()
+            {
+                TypeInfoResolver = resolver
+            };
+
             JsonTypeInfo typeInfo = resolver.GetTypeInfo(type, options);
             Assert.Equal(expectedKind, typeInfo.Kind);
 


### PR DESCRIPTION
We've correctly marked CreateJsonPropertyInfo as linker unsafe in one of the previous PR, this makes it safe now.

The idea is that JsonPropertyInfo's converter was previously going through reflection path and now it will use JsonTypeInfo's converter.