### PR TITLE
Adjust weights of blocks with profile inside loops in non-profiled methods

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -247,7 +247,7 @@ void Compiler::optScaleLoopBlocks(BasicBlock* begBlk, BasicBlock* endBlk)
                 // If the block has BB_ZERO_WEIGHT, then it should be marked as rarely run, and skipped, above.
                 noway_assert(curBlk->bbWeight > BB_ZERO_WEIGHT);
 
-                weight_t scale = curBlk->hasProfileWeight() ? curBlk->getCalledCount(this) : BB_LOOP_WEIGHT_SCALE;
+                weight_t scale = BB_LOOP_WEIGHT_SCALE;
 
                 if (!dominates)
                 {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -205,7 +205,7 @@ void Compiler::optScaleLoopBlocks(BasicBlock* begBlk, BasicBlock* endBlk)
     for (BasicBlock* const curBlk : BasicBlockRangeList(begBlk, endBlk))
     {
         // Don't change the block weight if it came from profile data.
-        if (curBlk->hasProfileWeight())
+        if (curBlk->hasProfileWeight() && fgHaveProfileData())
         {
             reportBlockWeight(curBlk, "; unchanged: has profile weight");
             continue;
@@ -247,7 +247,7 @@ void Compiler::optScaleLoopBlocks(BasicBlock* begBlk, BasicBlock* endBlk)
                 // If the block has BB_ZERO_WEIGHT, then it should be marked as rarely run, and skipped, above.
                 noway_assert(curBlk->bbWeight > BB_ZERO_WEIGHT);
 
-                weight_t scale = BB_LOOP_WEIGHT_SCALE;
+                weight_t scale = curBlk->hasProfileWeight() ? curBlk->getCalledCount(this) : BB_LOOP_WEIGHT_SCALE;
 
                 if (!dominates)
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/71649 (and a couple of related performance regressions in dotnet/performance).

Repro:
```csharp
using System;
using System.Linq;
using System.Numerics;
using System.Runtime.CompilerServices;
using System.Threading;

public class Program
{
    public static void Main()
    {
        for (int i = 0; i < 50; i++)
        {
            new Program().Test();
            Thread.Sleep(50);
        }

        Console.WriteLine("Done");
        //Console.ReadKey();
    }

    uint[] input_uint = Enumerable.Range(0, 1000).Select(i => (uint)i).ToArray();

    [MethodImpl(MethodImplOptions.NoInlining |
                MethodImplOptions.AggressiveOptimization)]
    public int Test()
    {
        int sum = 0;
        uint[] input = input_uint;
        for (int i = 0; i < input.Length; i++)
            sum += BitOperations.TrailingZeroCount(input[i]);
        return sum;
    }
}
```

When we run this, `Test` is not profiled, but it imports inside its loop `BitOperations.TrailingZeroCount` which is profiled (static BCL profile). Then `optSetBlockWeiths` divides its weight by 2 because it doesn't dominate all returns and the current method does not have profile data, see [here](https://github.com/dotnet/runtime/blob/05c446760221714de2f433956d2778c4b17b31b7/src/coreclr/jit/optimizer.cpp#L80-L124).
At the same time, `optScaleLoopBlocks` does not touch loop body because it has profile data so it doesn't scale it back to something "hot". My PR changes that - if the root method is not profiled - we try to adjust weights in such loops.

Codegen diff https://www.diffchecker.com/dIVV1Iwy 
Left: ReadyToRun=0, Right: ReadyToRun=1 - take a look at loop body (its weight is 1 in case of static pgo so loop aligner does not think it's profitable to align)

cc @AndyAyersMS 