### PR TITLE
Implement ControlledExecution API

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -100,6 +100,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0043`__ | ECDiffieHellmanPublicKey.ToByteArray() and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo() instead. |
 |  __`SYSLIB0044`__ | AssemblyName.CodeBase and AssemblyName.EscapedCodeBase are obsolete. Using them for loading an assembly is not supported. |
 |  __`SYSLIB0045`__ | Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead. |
+|  __`SYSLIB0046`__ | ControlledExecution.Run method may corrupt the process and should not be used in production code. |
 
 ## Analyzer Warnings
 

--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -208,6 +208,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\RuntimeFeature.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\RuntimeHelpers.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\TypeDependencyAttribute.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Runtime\ControlledExecution.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\DependentHandle.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\GCSettings.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\JitInfo.CoreCLR.cs" />

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
@@ -1,0 +1,173 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace System.Runtime
+{
+    /// <summary>
+    /// Allows to run code and abort it asynchronously.
+    /// </summary>
+    public static partial class ControlledExecution
+    {
+        /// <summary>
+        /// Runs code that may be aborted asynchronously.
+        /// </summary>
+        /// <param name="action">The delegate that represents the code to execute.</param>
+        /// <param name="cancellationToken">The cancellation token that may be used to abort execution.</param>
+        /// <exception cref="System.ArgumentNullException">The <paramref name="action"/> argument is null.</exception>
+        /// <exception cref="System.InvalidOperationException">
+        /// The current thread is already running the <see cref="ControlledExecution.Run"/> method.
+        /// </exception>
+        /// <exception cref="System.OperationCanceledException">The execution was aborted.</exception>
+        [Obsolete(Obsoletions.ControlledExecutionRunMessage, DiagnosticId = Obsoletions.ControlledExecutionRunDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+        public static void Run(Action action, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(action);
+            var execution = new Execution(action, cancellationToken);
+            cancellationToken.Register(execution.Abort, useSynchronizationContext: false);
+            execution.Run();
+        }
+
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_Abort")]
+        private static partial void AbortThread(ThreadHandle thread);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern bool ResetAbortThread();
+
+        private sealed partial class Execution
+        {
+            // The state transition diagram (S means the Started flag and so on):
+            // N ⟶  S  ⟶ SF
+            // ↓     ↓
+            // AR   SAR ⟶ SFAR
+            // ↓     ↓       ↓
+            // A    SA  ⟶ SFA
+            private enum State : int
+            {
+                None = 0,
+                Started = 1,
+                Finished = 2,
+                AbortRequested = 4,
+                RunningAbort = 8
+            }
+
+            [ThreadStatic]
+            private static Execution? t_execution;
+
+            // Interpreted as a value of the State enumeration type
+            private int _state;
+            private readonly Action _action;
+            private readonly CancellationToken _cancellationToken;
+            private Thread? _thread;
+
+            public Execution(Action action, CancellationToken cancellationToken)
+            {
+                _action = action;
+                _cancellationToken = cancellationToken;
+            }
+
+            public void Run()
+            {
+                Debug.Assert((_state & (int)State.Started) == 0 && _thread == null);
+
+                // Nested ControlledExecution.Run methods are not supported
+                if (t_execution != null)
+                    throw new InvalidOperationException(SR.InvalidOperation_NestedControlledExecutionRun);
+
+                _thread = Thread.CurrentThread;
+
+                try
+                {
+                    try
+                    {
+                        // As soon as the Started flag is set, this thread may be aborted asynchronously
+                        if (Interlocked.CompareExchange(ref _state, (int)State.Started, (int)State.None) == (int)State.None)
+                        {
+                            t_execution = this;
+                            _action();
+                        }
+                    }
+                    finally
+                    {
+                        if ((_state & (int)State.Started) != 0)
+                        {
+                            // Set the Finished flag to prevent a potential subsequent AbortThread call
+                            State oldState = (State)Interlocked.Or(ref _state, (int)State.Finished);
+
+                            if ((oldState & State.AbortRequested) != 0)
+                            {
+                                // Either in SFAR or SFA state
+                                while (true)
+                                {
+                                    // The enclosing finally may be cloned by the JIT for the non-exceptional code flow.
+                                    // In that case this code is not guarded against a thread abort, so make this FCall as
+                                    // soon as possible.
+                                    bool resetAbortRequest = ResetAbortThread();
+
+                                    // If there is an Abort in progress, we need to wait until it sets the TS_AbortRequested
+                                    // flag on this thread, then we can reset the flag and safely exit this frame.
+                                    if (((oldState & State.RunningAbort) == 0) || resetAbortRequest)
+                                    {
+                                        break;
+                                    }
+
+                                    // It should take very short time for AbortThread to set the TS_AbortRequested flag
+                                    Thread.Sleep(0);
+                                    oldState = (State)Volatile.Read(ref _state);
+                                }
+                            }
+
+                            t_execution = null;
+                        }
+                    }
+                }
+                catch (ThreadAbortException) when (_cancellationToken.IsCancellationRequested)
+                {
+                    throw new OperationCanceledException(_cancellationToken);
+                }
+            }
+
+            public void Abort()
+            {
+                // Prevent potential refetching of _state from shared memory
+                State curState = (State)Volatile.Read(ref _state);
+                State oldState;
+
+                do
+                {
+                    Debug.Assert((curState & (State.AbortRequested | State.RunningAbort)) == 0);
+
+                    // If the execution has finished, there is nothing to do
+                    if ((curState & State.Finished) != 0)
+                        return;
+
+                    // Try to set the AbortRequested and RunningAbort flags
+                    oldState = curState;
+                    curState = (State)Interlocked.CompareExchange(ref _state,
+                        (int)(oldState | State.AbortRequested | State.RunningAbort), (int)oldState);
+                }
+                while (curState != oldState);
+
+                try
+                {
+                    // If the execution has not started yet, we are done
+                    if ((curState & State.Started) == 0)
+                        return;
+
+                    // Must be in SAR or SFAR state now
+                    Debug.Assert(_thread != null);
+                    AbortThread(_thread.GetNativeHandle());
+                }
+                finally
+                {
+                    // Reset the RunningAbort flag to signal the executing thread it is safe to exit
+                    Interlocked.And(ref _state, (int)~State.RunningAbort);
+                }
+            }
+        }
+    }
+}

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
@@ -74,7 +74,7 @@ namespace System.Runtime
             {
                 Debug.Assert((_state & (int)State.Started) == 0 && _thread == null);
 
-                // Nested ControlledExecution.Run methods are not supported
+                // Recursive ControlledExecution.Run calls are not supported
                 if (t_execution != null)
                     throw new InvalidOperationException(SR.InvalidOperation_NestedControlledExecutionRun);
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
@@ -35,6 +35,9 @@ namespace System.Runtime
         [Obsolete(Obsoletions.ControlledExecutionRunMessage, DiagnosticId = Obsoletions.ControlledExecutionRunDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void Run(Action action, CancellationToken cancellationToken)
         {
+            if (!OperatingSystem.IsWindows())
+                throw new PlatformNotSupportedException();
+
             ArgumentNullException.ThrowIfNull(action);
 
             // Recursive ControlledExecution.Run calls are not supported

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
@@ -35,9 +35,6 @@ namespace System.Runtime
         [Obsolete(Obsoletions.ControlledExecutionRunMessage, DiagnosticId = Obsoletions.ControlledExecutionRunDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void Run(Action action, CancellationToken cancellationToken)
         {
-            if (!OperatingSystem.IsWindows())
-                throw new PlatformNotSupportedException();
-
             ArgumentNullException.ThrowIfNull(action);
 
             // Recursive ControlledExecution.Run calls are not supported

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
@@ -21,15 +21,23 @@ namespace System.Runtime
         /// </summary>
         /// <param name="action">The delegate that represents the code to execute.</param>
         /// <param name="cancellationToken">The cancellation token that may be used to abort execution.</param>
+        /// <exception cref="System.PlatformNotSupportedException">The method is not supported on this platform.</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="action"/> argument is null.</exception>
         /// <exception cref="System.InvalidOperationException">
         /// The current thread is already running the <see cref="ControlledExecution.Run"/> method.
         /// </exception>
         /// <exception cref="System.OperationCanceledException">The execution was aborted.</exception>
         /// <remarks>
-        /// <see cref="ControlledExecution"/> enables aborting arbitrary code in a non-cooperative manner.
-        /// Doing so may corrupt the process.  This method is not recommended for use in production code
-        /// in which reliability is important.
+        /// <para>This method enables aborting arbitrary managed code in a non-cooperative manner by throwing an exception
+        /// in the thread executing that code.  While the exception may be caught by the code, it is re-thrown at the end
+        /// of `catch` blocks until the execution flow returns to the `ControlledExecution.Run` method.</para>
+        /// <para>Execution of the code is not guaranteed to abort immediately, or at all.  This situation can occur, for
+        /// example, if a thread is stuck executing unmanaged code or the `catch` and `finally` blocks that are called as
+        /// part of the abort procedure, thereby indefinitely delaying the abort.  Furthermore, execution may not be
+        /// aborted immediately if the thread is currently executing a `catch` or `finally` block.</para>
+        /// <para>Aborting code at an unexpected location may corrupt the state of data structures in the process and lead
+        /// to unpredictable results.  For that reason, this method should not be used in production code and calling it
+        /// produces a compile-time warning.</para>
         /// </remarks>
         [Obsolete(Obsoletions.ControlledExecutionRunMessage, DiagnosticId = Obsoletions.ControlledExecutionRunDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void Run(Action action, CancellationToken cancellationToken)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ControlledExecution.CoreCLR.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
@@ -14,6 +13,9 @@ namespace System.Runtime
     /// </summary>
     public static partial class ControlledExecution
     {
+        [ThreadStatic]
+        private static bool t_executing;
+
         /// <summary>
         /// Runs code that may be aborted asynchronously.
         /// </summary>
@@ -33,149 +35,117 @@ namespace System.Runtime
         public static void Run(Action action, CancellationToken cancellationToken)
         {
             if (!OperatingSystem.IsWindows())
+            {
                 throw new PlatformNotSupportedException();
+            }
 
             ArgumentNullException.ThrowIfNull(action);
 
-            // Recursive ControlledExecution.Run calls are not supported
-            if (Execution.t_executing)
+            // ControlledExecution.Run does not support nested invocations.  If there's one already in flight
+            // on this thread, fail.
+            if (t_executing)
+            {
                 throw new InvalidOperationException(SR.InvalidOperation_NestedControlledExecutionRun);
-
-            new Execution(action, cancellationToken).Run();
-        }
-
-        private sealed partial class Execution
-        {
-            // The state transition diagram (F means the Finished flag and so on):
-            // N  ⟶ F
-            // ↓
-            // AR ⟶ FAR
-            // ↓      ↓
-            // A  ⟶ FA
-            private enum State : int
-            {
-                None = 0,
-                Finished = 1,
-                AbortRequested = 2,
-                RunningAbort = 4
             }
 
-            [ThreadStatic]
-            internal static bool t_executing;
+            // Store the current thread so that it may be referenced by the Canceler.Cancel callback if one occurs.
+            Canceler canceler = new(Thread.CurrentThread);
 
-            // Interpreted as a value of the State enumeration type
-            private int _state;
-            private readonly Action _action;
-            private readonly CancellationToken _cancellationToken;
-            private Thread? _thread;
-
-            public Execution(Action action, CancellationToken cancellationToken)
+            try
             {
-                _action = action;
-                _cancellationToken = cancellationToken;
-            }
+                // Mark this thread as now running a ControlledExecution.Run to prevent recursive usage.
+                t_executing = true;
 
-            public void Run()
-            {
-                Debug.Assert(_state == (int)State.None && _thread == null);
-                _thread = Thread.CurrentThread;
-
+                // Register for aborting.  From this moment until ctr.Unregister is called, this thread is subject to being
+                // interrupted at any moment.  This could happen during the call to UnsafeRegister if cancellation has
+                // already been requested at the time of the registration.
+                CancellationTokenRegistration ctr = cancellationToken.UnsafeRegister(e => ((Canceler)e!).Cancel(), canceler);
                 try
                 {
-                    try
-                    {
-                        t_executing = true;
-                        // Cannot Dispose this registration in a finally or a catch block as that may deadlock with AbortThread
-                        _cancellationToken.UnsafeRegister(e => ((Execution)e!).Abort(), this);
-                        _action();
-                    }
-                    finally
-                    {
-                        t_executing = false;
+                    // Invoke the caller's code.
+                    action();
+                }
+                finally
+                {
+                    // This finally block may be cloned by JIT for the non-exceptional code flow.  In that case the code
+                    // below is not guarded against aborting.  That is OK as the outer try block will catch the
+                    // ThreadAbortException and call ResetAbortThread.
 
-                        // Set the Finished flag to prevent a potential subsequent AbortThread call
-                        State oldState = (State)Interlocked.Or(ref _state, (int)State.Finished);
-
-                        if ((oldState & State.AbortRequested) != 0)
+                    // Unregister the callback.  Unlike Dispose, Unregister will not block waiting for an callback in flight
+                    // to complete, and will instead return false if the callback has already been invoked or is currently
+                    // in flight.
+                    if (!ctr.Unregister())
+                    {
+                        // Wait until the callback has completed.  Either the callback is already invoked and completed
+                        // (in which case IsCancelCompleted will be true), or it may still be in flight.  If it's in flight,
+                        // the AbortThread call may be waiting for this thread to exit this finally block to exit, so while
+                        // spinning waiting for the callback to complete, we also need to call ResetAbortThread in order to
+                        // reset the flag the AbortThread call is polling in its waiting loop.
+                        SpinWait sw = default;
+                        while (!canceler.IsCancelCompleted)
                         {
-                            // Either in FAR or FA state
-                            while (true)
-                            {
-                                // The enclosing finally may be cloned by the JIT for the non-exceptional code flow.
-                                // In that case this code is not guarded against a thread abort. In particular, any
-                                // QCall may be aborted. That is OK as we will catch the ThreadAbortException and call
-                                // ResetAbortThread again below. The only downside is that a successfully executed
-                                // action may be reported as canceled.
-                                bool resetAbortRequest = ResetAbortThread() != Interop.BOOL.FALSE;
-
-                                // If there is an Abort in progress, we need to wait until it sets the TS_AbortRequested
-                                // flag on this thread, then we can reset the flag and safely exit this frame.
-                                if (((oldState & State.RunningAbort) == 0) || resetAbortRequest)
-                                {
-                                    break;
-                                }
-
-                                // It should take very short time for AbortThread to set the TS_AbortRequested flag
-                                Thread.Sleep(0);
-                                oldState = (State)Volatile.Read(ref _state);
-                            }
+                            ResetAbortThread();
+                            sw.SpinOnce();
                         }
                     }
                 }
-                catch (ThreadAbortException tae) when (_cancellationToken.IsCancellationRequested)
+            }
+            catch (ThreadAbortException tae)
+            {
+                // We don't want to leak ThreadAbortExceptions to user code.  Instead, translate the exception into
+                // an OperationCanceledException, preserving stack trace details from the ThreadAbortException in
+                // order to aid in diagnostics and debugging.
+                OperationCanceledException e = cancellationToken.IsCancellationRequested ? new(cancellationToken) : new();
+                if (tae.StackTrace is string stackTrace)
                 {
-                    t_executing = false;
-                    ResetAbortThread();
+                    ExceptionDispatchInfo.SetRemoteStackTrace(e, stackTrace);
+                }
+                throw e;
+            }
+            finally
+            {
+                // Unmark this thread for recursion detection.
+                t_executing = false;
 
-                    var e = new OperationCanceledException(_cancellationToken);
-                    if (tae.StackTrace is string stackTrace)
-                    {
-                        ExceptionDispatchInfo.SetRemoteStackTrace(e, stackTrace);
-                    }
-                    throw e;
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    // Reset an abort request that may still be pending on this thread.
+                    ResetAbortThread();
                 }
             }
+        }
 
-            public void Abort()
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_Abort")]
+        private static partial void AbortThread(ThreadHandle thread);
+
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_ResetAbort")]
+        [SuppressGCTransition]
+        private static partial void ResetAbortThread();
+
+        private sealed class Canceler
+        {
+            private readonly Thread _thread;
+            private volatile bool _cancelCompleted;
+
+            public Canceler(Thread thread)
             {
-                // Prevent potential refetching of _state from shared memory
-                State curState = (State)Volatile.Read(ref _state);
-                State oldState;
+                _thread = thread;
+            }
 
-                do
-                {
-                    Debug.Assert((curState & (State.AbortRequested | State.RunningAbort)) == 0);
+            public bool IsCancelCompleted => _cancelCompleted;
 
-                    // If the execution has finished, there is nothing to do
-                    if ((curState & State.Finished) != 0)
-                        return;
-
-                    // Try to set the AbortRequested and RunningAbort flags
-                    oldState = curState;
-                    curState = (State)Interlocked.CompareExchange(ref _state,
-                        (int)(oldState | State.AbortRequested | State.RunningAbort), (int)oldState);
-                }
-                while (curState != oldState);
-
+            public void Cancel()
+            {
                 try
                 {
-                    // Must be in AR or FAR state now
-                    Debug.Assert(_thread != null);
+                    // Abort the thread executing the action (which may be the current thread).
                     AbortThread(_thread.GetNativeHandle());
                 }
                 finally
                 {
-                    // Reset the RunningAbort flag to signal the executing thread it is safe to exit
-                    Interlocked.And(ref _state, (int)~State.RunningAbort);
+                    _cancelCompleted = true;
                 }
             }
-
-            [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_Abort")]
-            private static partial void AbortThread(ThreadHandle thread);
-
-            [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_ResetAbort")]
-            [SuppressGCTransition]
-            private static partial Interop.BOOL ResetAbortThread();
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -189,6 +189,7 @@
     <Compile Include="System\Resources\ManifestBasedResourceGroveler.NativeAot.cs" />
     <Compile Include="System\RuntimeArgumentHandle.cs" />
     <Compile Include="System\RuntimeType.cs" />
+    <Compile Include="System\Runtime\ControlledExecution.NativeAot.cs" />
     <Compile Include="System\Runtime\DependentHandle.cs" />
     <Compile Include="System\Runtime\CompilerServices\ForceLazyDictionaryAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\EagerStaticClassConstructionAttribute.cs" />

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ControlledExecution.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ControlledExecution.NativeAot.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+
+namespace System.Runtime
+{
+    public static class ControlledExecution
+    {
+        public static void Run(Action action, CancellationToken cancellationToken)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ControlledExecution.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ControlledExecution.NativeAot.cs
@@ -7,6 +7,7 @@ namespace System.Runtime
 {
     public static class ControlledExecution
     {
+        [Obsolete("ControlledExecution.Run method may corrupt the process and should not be used in production code.", DiagnosticId = "SYSLIB0046", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static void Run(Action action, CancellationToken cancellationToken)
         {
             throw new PlatformNotSupportedException();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ControlledExecution.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ControlledExecution.NativeAot.cs
@@ -7,7 +7,7 @@ namespace System.Runtime
 {
     public static class ControlledExecution
     {
-        [Obsolete("ControlledExecution.Run method may corrupt the process and should not be used in production code.", DiagnosticId = "SYSLIB0046", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [Obsolete(Obsoletions.ControlledExecutionRunMessage, DiagnosticId = Obsoletions.ControlledExecutionRunDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void Run(Action action, CancellationToken cancellationToken)
         {
             throw new PlatformNotSupportedException();

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -20,6 +20,8 @@
 #ifdef FEATURE_READYTORUN
     IMPORT DynamicHelperWorker
 #endif
+    IMPORT HijackHandler
+    IMPORT ThrowControlForThread
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
     IMPORT  g_sw_ww_table
@@ -1027,6 +1029,31 @@ FaultingExceptionFrame_FrameOffset        SETA  SIZEOF__GSCookie
 
         MEND
 
+
+; ------------------------------------------------------------------
+;
+; Helpers for ThreadAbort exceptions
+;
+
+        NESTED_ENTRY RedirectForThreadAbort2,,HijackHandler
+        PROLOG_SAVE_REG_PAIR fp,lr, #-16!
+
+        ; stack must be 16 byte aligned
+        CHECK_STACK_ALIGNMENT
+
+        ; On entry:
+        ;
+        ; x0 = address of FaultingExceptionFrame
+        ;
+        ; Invoke the helper to setup the FaultingExceptionFrame and raise the exception
+        bl              ThrowControlForThread
+
+        ; ThrowControlForThread doesn't return.
+        EMIT_BREAKPOINT
+
+        NESTED_END RedirectForThreadAbort2
+
+        GenerateRedirectedStubWithFrame RedirectForThreadAbort, RedirectForThreadAbort2
 
 ; ------------------------------------------------------------------
 ; ResolveWorkerChainLookupAsmStub

--- a/src/coreclr/vm/arm64/asmmacros.h
+++ b/src/coreclr/vm/arm64/asmmacros.h
@@ -155,6 +155,24 @@ $FuncName
     MEND
 
 ;-----------------------------------------------------------------------------
+; Macro used to check (in debug builds only) whether the stack is 16-bytes aligned (a requirement before calling
+; out into C++/OS code). Invoke this directly after your prolog (if the stack frame size is fixed) or directly
+; before a call (if you have a frame pointer and a dynamic stack). A breakpoint will be invoked if the stack
+; is misaligned.
+;
+    MACRO
+        CHECK_STACK_ALIGNMENT
+
+#ifdef _DEBUG
+        add     x9, sp, xzr
+        tst     x9, #15
+        beq     %F0
+        EMIT_BREAKPOINT
+0
+#endif
+    MEND
+
+;-----------------------------------------------------------------------------
 ; The Following sets of SAVE_*_REGISTERS expect the memory to be reserved and
 ; base address to be passed in $reg
 ;

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -918,12 +918,6 @@ PTR_CONTEXT GetCONTEXTFromRedirectedStubStackFrame(T_CONTEXT * pContext)
     return *ppContext;
 }
 
-void RedirectForThreadAbort()
-{
-    // ThreadAbort is not supported in .net core
-    throw "NYI";
-}
-
 #if !defined(DACCESS_COMPILE)
 FaultingExceptionFrame *GetFrameFromRedirectedStubStackFrame (DISPATCHER_CONTEXT *pDispatcherContext)
 {

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -918,13 +918,6 @@ PTR_CONTEXT GetCONTEXTFromRedirectedStubStackFrame(T_CONTEXT * pContext)
     return *ppContext;
 }
 
-#ifndef TARGET_WINDOWS
-void RedirectForThreadAbort()
-{
-    throw "NYI";
-}
-#endif // TARGET_WINDOWS
-
 #if !defined(DACCESS_COMPILE)
 FaultingExceptionFrame *GetFrameFromRedirectedStubStackFrame (DISPATCHER_CONTEXT *pDispatcherContext)
 {

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -918,6 +918,13 @@ PTR_CONTEXT GetCONTEXTFromRedirectedStubStackFrame(T_CONTEXT * pContext)
     return *ppContext;
 }
 
+#ifndef TARGET_WINDOWS
+void RedirectForThreadAbort()
+{
+    throw "NYI";
+}
+#endif // TARGET_WINDOWS
+
 #if !defined(DACCESS_COMPILE)
 FaultingExceptionFrame *GetFrameFromRedirectedStubStackFrame (DISPATCHER_CONTEXT *pDispatcherContext)
 {

--- a/src/coreclr/vm/arm64/unixstubs.cpp
+++ b/src/coreclr/vm/arm64/unixstubs.cpp
@@ -9,4 +9,9 @@ extern "C"
     {
         PORTABILITY_ASSERT("Implement for PAL");
     }
+
+    void RedirectForThreadAbort()
+    {
+        PORTABILITY_ASSERT("Implement for PAL");
+    }
 };

--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -1149,6 +1149,36 @@ extern "C" BOOL QCALLTYPE ThreadNative_YieldThread()
     return ret;
 }
 
+extern "C" void QCALLTYPE ThreadNative_Abort(QCall::ThreadHandle thread)
+{
+    QCALL_CONTRACT;
+
+    BEGIN_QCALL
+
+    thread->UserAbort(EEPolicy::TA_Safe, INFINITE);
+
+    END_QCALL
+}
+
+// Unmarks the current thread for abort.
+// Returns true if the thread had the TS_AbortRequested flag set.
+FCIMPL0(FC_BOOL_RET, ThreadNative::ResetAbort)
+{
+    FCALL_CONTRACT;
+
+    BOOL ret = FALSE;
+
+    Thread *pThread = GetThreadNULLOk();
+    if (pThread != NULL && pThread->IsAbortRequested())
+    {
+        pThread->UnmarkThreadForAbort();
+        ret = TRUE;
+    }
+
+    FC_RETURN_BOOL(ret);
+}
+FCIMPLEND
+
 FCIMPL0(INT32, ThreadNative::GetCurrentProcessorNumber)
 {
     FCALL_CONTRACT;

--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -1160,22 +1160,16 @@ extern "C" void QCALLTYPE ThreadNative_Abort(QCall::ThreadHandle thread)
     END_QCALL;
 }
 
-// Unmarks the current thread for abort.
-// Returns TRUE if the thread had the TS_AbortRequested flag set.
-extern "C" BOOL QCALLTYPE ThreadNative_ResetAbort()
+// Unmark the current thread for a safe abort.
+extern "C" void QCALLTYPE ThreadNative_ResetAbort()
 {
     QCALL_CONTRACT_NO_GC_TRANSITION;
-
-    BOOL ret = FALSE;
 
     Thread *pThread = GetThread();
     if (pThread->IsAbortRequested())
     {
-        pThread->UnmarkThreadForAbort();
-        ret = TRUE;
+        pThread->UnmarkThreadForAbort(EEPolicy::TA_Safe);
     }
-
-    return ret;
 }
 
 FCIMPL0(INT32, ThreadNative::GetCurrentProcessorNumber)

--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -1140,11 +1140,11 @@ extern "C" BOOL QCALLTYPE ThreadNative_YieldThread()
 
     BOOL ret = FALSE;
 
-    BEGIN_QCALL
+    BEGIN_QCALL;
 
     ret = __SwitchToThread(0, CALLER_LIMITS_SPINNING);
 
-    END_QCALL
+    END_QCALL;
 
     return ret;
 }
@@ -1153,31 +1153,30 @@ extern "C" void QCALLTYPE ThreadNative_Abort(QCall::ThreadHandle thread)
 {
     QCALL_CONTRACT;
 
-    BEGIN_QCALL
+    BEGIN_QCALL;
 
     thread->UserAbort(EEPolicy::TA_Safe, INFINITE);
 
-    END_QCALL
+    END_QCALL;
 }
 
 // Unmarks the current thread for abort.
-// Returns true if the thread had the TS_AbortRequested flag set.
-FCIMPL0(FC_BOOL_RET, ThreadNative::ResetAbort)
+// Returns TRUE if the thread had the TS_AbortRequested flag set.
+extern "C" BOOL QCALLTYPE ThreadNative_ResetAbort()
 {
-    FCALL_CONTRACT;
+    QCALL_CONTRACT_NO_GC_TRANSITION;
 
     BOOL ret = FALSE;
 
-    Thread *pThread = GetThreadNULLOk();
-    if (pThread != NULL && pThread->IsAbortRequested())
+    Thread *pThread = GetThread();
+    if (pThread->IsAbortRequested())
     {
         pThread->UnmarkThreadForAbort();
         ret = TRUE;
     }
 
-    FC_RETURN_BOOL(ret);
+    return ret;
 }
-FCIMPLEND
 
 FCIMPL0(INT32, ThreadNative::GetCurrentProcessorNumber)
 {

--- a/src/coreclr/vm/comsynchronizable.h
+++ b/src/coreclr/vm/comsynchronizable.h
@@ -62,6 +62,7 @@ public:
     static FCDECL1(INT32,   GetPriority,       ThreadBaseObject* pThisUNSAFE);
     static FCDECL2(void,    SetPriority,       ThreadBaseObject* pThisUNSAFE, INT32 iPriority);
     static FCDECL1(void,    Interrupt,         ThreadBaseObject* pThisUNSAFE);
+    static FCDECL0(FC_BOOL_RET, ResetAbort);
     static FCDECL1(FC_BOOL_RET, IsAlive,       ThreadBaseObject* pThisUNSAFE);
     static FCDECL2(FC_BOOL_RET, Join,          ThreadBaseObject* pThisUNSAFE, INT32 Timeout);
     static FCDECL1(void,    Sleep,             INT32 iTime);
@@ -110,6 +111,7 @@ extern "C" void QCALLTYPE ThreadNative_InformThreadNameChange(QCall::ThreadHandl
 extern "C" UINT64 QCALLTYPE ThreadNative_GetProcessDefaultStackSize();
 extern "C" BOOL QCALLTYPE ThreadNative_YieldThread();
 extern "C" UINT64 QCALLTYPE ThreadNative_GetCurrentOSThreadId();
+extern "C" void QCALLTYPE ThreadNative_Abort(QCall::ThreadHandle thread);
 
 #endif // _COMSYNCHRONIZABLE_H
 

--- a/src/coreclr/vm/comsynchronizable.h
+++ b/src/coreclr/vm/comsynchronizable.h
@@ -111,7 +111,7 @@ extern "C" UINT64 QCALLTYPE ThreadNative_GetProcessDefaultStackSize();
 extern "C" BOOL QCALLTYPE ThreadNative_YieldThread();
 extern "C" UINT64 QCALLTYPE ThreadNative_GetCurrentOSThreadId();
 extern "C" void QCALLTYPE ThreadNative_Abort(QCall::ThreadHandle thread);
-extern "C" BOOL QCALLTYPE ThreadNative_ResetAbort();
+extern "C" void QCALLTYPE ThreadNative_ResetAbort();
 
 #endif // _COMSYNCHRONIZABLE_H
 

--- a/src/coreclr/vm/comsynchronizable.h
+++ b/src/coreclr/vm/comsynchronizable.h
@@ -62,7 +62,6 @@ public:
     static FCDECL1(INT32,   GetPriority,       ThreadBaseObject* pThisUNSAFE);
     static FCDECL2(void,    SetPriority,       ThreadBaseObject* pThisUNSAFE, INT32 iPriority);
     static FCDECL1(void,    Interrupt,         ThreadBaseObject* pThisUNSAFE);
-    static FCDECL0(FC_BOOL_RET, ResetAbort);
     static FCDECL1(FC_BOOL_RET, IsAlive,       ThreadBaseObject* pThisUNSAFE);
     static FCDECL2(FC_BOOL_RET, Join,          ThreadBaseObject* pThisUNSAFE, INT32 Timeout);
     static FCDECL1(void,    Sleep,             INT32 iTime);
@@ -112,6 +111,7 @@ extern "C" UINT64 QCALLTYPE ThreadNative_GetProcessDefaultStackSize();
 extern "C" BOOL QCALLTYPE ThreadNative_YieldThread();
 extern "C" UINT64 QCALLTYPE ThreadNative_GetCurrentOSThreadId();
 extern "C" void QCALLTYPE ThreadNative_Abort(QCall::ThreadHandle thread);
+extern "C" BOOL QCALLTYPE ThreadNative_ResetAbort();
 
 #endif // _COMSYNCHRONIZABLE_H
 

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -715,6 +715,10 @@ FCFuncStart(gWeakReferenceOfTFuncs)
     FCFuncElement("IsTrackResurrection", WeakReferenceOfTNative::IsTrackResurrection)
 FCFuncEnd()
 
+FCFuncStart(gControlledExecutionFuncs)
+    FCFuncElement("ResetAbortThread", ThreadNative::ResetAbort)
+FCFuncEnd()
+
 #ifdef FEATURE_COMINTEROP
 
 //
@@ -753,6 +757,7 @@ FCClassElement("AssemblyLoadContext", "System.Runtime.Loader", gAssemblyLoadCont
 FCClassElement("Buffer", "System", gBufferFuncs)
 FCClassElement("CastHelpers", "System.Runtime.CompilerServices", gCastHelpers)
 FCClassElement("CompatibilitySwitch", "System.Runtime.Versioning", gCompatibilitySwitchFuncs)
+FCClassElement("ControlledExecution", "System.Runtime", gControlledExecutionFuncs)
 FCClassElement("CustomAttribute", "System.Reflection", gCOMCustomAttributeFuncs)
 FCClassElement("CustomAttributeEncodedArgument", "System.Reflection", gCustomAttributeEncodedArgument)
 FCClassElement("Debugger", "System.Diagnostics", gDiagnosticsDebugger)

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -715,10 +715,6 @@ FCFuncStart(gWeakReferenceOfTFuncs)
     FCFuncElement("IsTrackResurrection", WeakReferenceOfTNative::IsTrackResurrection)
 FCFuncEnd()
 
-FCFuncStart(gControlledExecutionFuncs)
-    FCFuncElement("ResetAbortThread", ThreadNative::ResetAbort)
-FCFuncEnd()
-
 #ifdef FEATURE_COMINTEROP
 
 //
@@ -757,7 +753,6 @@ FCClassElement("AssemblyLoadContext", "System.Runtime.Loader", gAssemblyLoadCont
 FCClassElement("Buffer", "System", gBufferFuncs)
 FCClassElement("CastHelpers", "System.Runtime.CompilerServices", gCastHelpers)
 FCClassElement("CompatibilitySwitch", "System.Runtime.Versioning", gCompatibilitySwitchFuncs)
-FCClassElement("ControlledExecution", "System.Runtime", gControlledExecutionFuncs)
 FCClassElement("CustomAttribute", "System.Reflection", gCOMCustomAttributeFuncs)
 FCClassElement("CustomAttributeEncodedArgument", "System.Reflection", gCustomAttributeEncodedArgument)
 FCClassElement("Debugger", "System.Diagnostics", gDiagnosticsDebugger)

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -775,16 +775,14 @@ UINT_PTR ExceptionTracker::FinishSecondPass(
 
 #if defined(DEBUGGING_SUPPORTED)
     // Don't honour thread abort requests at this time for intercepted exceptions.
-    if (fIntercepted)
-    {
-        uAbortAddr = 0;
-    }
-    else
-#endif // !DEBUGGING_SUPPORTED
+    if (!fIntercepted)
+#endif // DEBUGGING_SUPPORTED
     {
         CopyOSContext(pThread->m_OSContext, pContextRecord);
         SetIP(pThread->m_OSContext, (PCODE)uResumePC);
+#ifndef TARGET_UNIX
         uAbortAddr = (UINT_PTR)COMPlusCheckForAbort(uResumePC);
+#endif // TARGET_UNIX
     }
 
     if (uAbortAddr)

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -775,14 +775,16 @@ UINT_PTR ExceptionTracker::FinishSecondPass(
 
 #if defined(DEBUGGING_SUPPORTED)
     // Don't honour thread abort requests at this time for intercepted exceptions.
-    if (!fIntercepted)
-#endif // DEBUGGING_SUPPORTED
+    if (fIntercepted)
+    {
+        uAbortAddr = 0;
+    }
+    else
+#endif // !DEBUGGING_SUPPORTED
     {
         CopyOSContext(pThread->m_OSContext, pContextRecord);
         SetIP(pThread->m_OSContext, (PCODE)uResumePC);
-#ifndef TARGET_UNIX
         uAbortAddr = (UINT_PTR)COMPlusCheckForAbort(uResumePC);
-#endif // TARGET_UNIX
     }
 
     if (uAbortAddr)

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -209,6 +209,7 @@ static const Entry s_QCall[] =
     DllImportEntry(ThreadNative_InformThreadNameChange)
     DllImportEntry(ThreadNative_YieldThread)
     DllImportEntry(ThreadNative_GetCurrentOSThreadId)
+    DllImportEntry(ThreadNative_Abort)
     DllImportEntry(ThreadPool_GetCompletedWorkItemCount)
     DllImportEntry(ThreadPool_RequestWorkerThread)
     DllImportEntry(ThreadPool_PerformGateActivities)

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -210,6 +210,7 @@ static const Entry s_QCall[] =
     DllImportEntry(ThreadNative_YieldThread)
     DllImportEntry(ThreadNative_GetCurrentOSThreadId)
     DllImportEntry(ThreadNative_Abort)
+    DllImportEntry(ThreadNative_ResetAbort)
     DllImportEntry(ThreadPool_GetCompletedWorkItemCount)
     DllImportEntry(ThreadPool_RequestWorkerThread)
     DllImportEntry(ThreadPool_PerformGateActivities)

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -2496,7 +2496,7 @@ private:
 
 public:
     void MarkThreadForAbort(EEPolicy::ThreadAbortTypes abortType);
-    void UnmarkThreadForAbort();
+    void UnmarkThreadForAbort(EEPolicy::ThreadAbortTypes abortType = EEPolicy::TA_Rude);
 
     static ULONGLONG GetNextSelfAbortEndTime()
     {

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -1785,7 +1785,7 @@ void Thread::RemoveAbortRequestBit()
 }
 
 // Make sure that when AbortRequest bit is cleared, we also dec TrapReturningThreads count.
-void Thread::UnmarkThreadForAbort()
+void Thread::UnmarkThreadForAbort(EEPolicy::ThreadAbortTypes abortType /* = EEPolicy::TA_Rude */)
 {
     CONTRACTL
     {
@@ -1794,10 +1794,13 @@ void Thread::UnmarkThreadForAbort()
     }
     CONTRACTL_END;
 
-    // Switch to COOP (for ClearAbortReason) before acquiring AbortRequestLock
-    GCX_COOP();
-
     AbortRequestLockHolder lh(this);
+
+    if (m_AbortType > (DWORD)abortType)
+    {
+        // Aborting at a higher level
+        return;
+    }
 
     m_AbortType = EEPolicy::TA_None;
     m_AbortEndTime = MAXULONGLONG;

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -147,5 +147,8 @@ namespace System
 
         internal const string CryptoStringFactoryMessage = "Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.";
         internal const string CryptoStringFactoryDiagId = "SYSLIB0045";
+
+        internal const string ControlledExecutionRunMessage = "ControlledExecution.Run method may corrupt the process and should not be used in production code.";
+        internal const string ControlledExecutionRunDiagId = "SYSLIB0046";
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2500,6 +2500,10 @@
   <data name="InvalidOperation_NativeOverlappedReused" xml:space="preserve">
     <value>NativeOverlapped cannot be reused for multiple operations.</value>
   </data>
+  <data name="InvalidOperation_NestedControlledExecutionRun" xml:space="preserve">
+    <value>The thread is already executing the ControlledExecution.Run method.</value>
+    <comment>{Locked="ControlledExecution.Run"}</comment>
+  </data>
   <data name="InvalidOperation_NoMultiModuleAssembly" xml:space="preserve">
     <value>You cannot have more than one dynamic module in each dynamic assembly in this version of the runtime.</value>
   </data>

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12131,6 +12131,11 @@ namespace System.Runtime
         public AssemblyTargetedPatchBandAttribute(string targetedPatchBand) { }
         public string TargetedPatchBand { get { throw null; } }
     }
+    public static partial class ControlledExecution
+    {
+        [System.ObsoleteAttribute("ControlledExecution.Run method may corrupt the process and should not be used in production code.", DiagnosticId = "SYSLIB0046", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static void Run(System.Action action, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
     public partial struct DependentHandle : System.IDisposable
     {
         private object _dummy;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -226,6 +226,7 @@
     <Compile Include="System\Reflection\TypeDelegatorTests.cs" />
     <Compile Include="System\Reflection\TypeTests.Get.CornerCases.cs" />
     <Compile Include="System\Reflection\TypeTests.GetMember.cs" />
+    <Compile Include="System\Runtime\ControlledExecutionTests.cs" />
     <Compile Include="System\Runtime\DependentHandleTests.cs" />
     <Compile Include="System\Runtime\JitInfoTests.cs" />
     <Compile Include="System\Runtime\MemoryFailPointTests.cs" />

--- a/src/libraries/System.Runtime/tests/System/Runtime/ControlledExecutionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/ControlledExecutionTests.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using Xunit;
+
+// Disable warnings for ControlledExecution.Run
+#pragma warning disable SYSLIB0046
+
+namespace System.Runtime.Tests
+{
+    public class ControlledExecutionTests
+    {
+        private bool _startedExecution, _caughtException, _finishedExecution;
+        private Exception _exception;
+        private volatile int _counter;
+
+        // Tests cancellation on timeout. The ThreadAbortException must be mapped to OperationCanceledException.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetFramework), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+        public void CancelOnTimeout()
+        {
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(200);
+            RunTest(LengthyAction, cts.Token);
+
+            Assert.True(_startedExecution);
+            Assert.True(_caughtException);
+            Assert.False(_finishedExecution);
+            Assert.IsType<OperationCanceledException>(_exception);
+        }
+
+        // Tests that catch blocks are not aborted. The action catches the ThreadAbortException and throws an exception of a different type.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetFramework), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+        public void CancelOnTimeout_ThrowFromCatch()
+        {
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(200);
+            RunTest(LengthyAction_ThrowFromCatch, cts.Token);
+
+            Assert.True(_startedExecution);
+            Assert.True(_caughtException);
+            Assert.False(_finishedExecution);
+            Assert.IsType<TimeoutException>(_exception);
+        }
+
+        // Tests that finally blocks are not aborted. The action catches the ThreadAbortException and throws an exception of a different type.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetFramework), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+        public void CancelOnTimeout_ThrowFromFinally()
+        {
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(200);
+            RunTest(LengthyAction_ThrowFromFinally, cts.Token);
+
+            Assert.True(_startedExecution);
+            Assert.IsType<TimeoutException>(_exception);
+        }
+
+        // Tests that finally blocks are not aborted. The action throws an exception of a different type.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetFramework), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+        public void CancelOnTimeout_Finally()
+        {
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(200);
+            RunTest(LengthyAction_Finally, cts.Token);
+
+            Assert.True(_startedExecution);
+            Assert.True(_finishedExecution);
+            Assert.IsType<TimeoutException>(_exception);
+        }
+
+        // Tests cancellation before calling the Run method
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetFramework), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+        public void CancelBeforeRun()
+        {
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            Thread.Sleep(100);
+            RunTest(LengthyAction, cts.Token);
+
+            Assert.False(_startedExecution);
+            Assert.Null(_exception);
+        }
+
+        private void RunTest(Action action, CancellationToken cancellationToken)
+        {
+            _startedExecution = _caughtException = _finishedExecution = false;
+            _exception = null;
+
+            try
+            {
+                ControlledExecution.Run(action, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                _exception = e;
+            }
+        }
+
+        private void LengthyAction()
+        {
+            _startedExecution = true;
+
+            try
+            {
+                for (_counter = 0; _counter < int.MaxValue; _counter++) { }
+            }
+            catch
+            {
+                // Swallow all exceptions to verify that the exception is automatically rethrown
+                _caughtException = true;
+            }
+
+            _finishedExecution = true;
+        }
+
+        private void LengthyAction_ThrowFromCatch()
+        {
+            _startedExecution = true;
+
+            try
+            {
+                for (_counter = 0; _counter < int.MaxValue; _counter++) { }
+            }
+            catch
+            {
+                _caughtException = true;
+                // Catch blocks must not be aborted
+                Thread.Sleep(100);
+                throw new TimeoutException();
+            }
+
+            _finishedExecution = true;
+        }
+
+        private void LengthyAction_ThrowFromFinally()
+        {
+            _startedExecution = true;
+
+            try
+            {
+                // Make sure to run the non-inlined finally
+                throw new Exception();
+            }
+            finally
+            {
+                // Finally blocks must not be aborted
+                Thread.Sleep(400);
+                throw new TimeoutException();
+            }
+        }
+
+        private void LengthyAction_Finally()
+        {
+            _startedExecution = true;
+
+            try
+            {
+                // Make sure to run the non-inlined finally
+                throw new TimeoutException();
+            }
+            finally
+            {
+                // Finally blocks must not be aborted
+                Thread.Sleep(400);
+                _finishedExecution = true;
+            }
+
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System/Runtime/ControlledExecutionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/ControlledExecutionTests.cs
@@ -33,6 +33,7 @@ namespace System.Runtime.Tests
 
         // Tests that catch blocks are not aborted. The action catches the ThreadAbortException and throws an exception of a different type.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72703", TestPlatforms.AnyUnix)]
         public void CancelOnTimeout_ThrowFromCatch()
         {
             var cts = new CancellationTokenSource();
@@ -47,6 +48,7 @@ namespace System.Runtime.Tests
 
         // Tests that finally blocks are not aborted. The action throws an exception from a finally block.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72703", TestPlatforms.AnyUnix)]
         public void CancelOnTimeout_ThrowFromFinally()
         {
             var cts = new CancellationTokenSource();
@@ -59,6 +61,7 @@ namespace System.Runtime.Tests
 
         // Tests that finally blocks are not aborted. The action throws an exception from a try block.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72703", TestPlatforms.AnyUnix)]
         public void CancelOnTimeout_Finally()
         {
             var cts = new CancellationTokenSource();
@@ -72,6 +75,7 @@ namespace System.Runtime.Tests
 
         // Tests cancellation before calling the Run method
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72703", TestPlatforms.AnyUnix)]
         public void CancelBeforeRun()
         {
             var cts = new CancellationTokenSource();
@@ -84,6 +88,7 @@ namespace System.Runtime.Tests
 
         // Tests cancellation by the action itself
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72703", TestPlatforms.AnyUnix)]
         public void CancelItself()
         {
             _cts = new CancellationTokenSource();

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -254,6 +254,7 @@
       <Compile Include="$(BclSourcesRoot)\System\Reflection\Metadata\AssemblyExtensions.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Reflection\Metadata\MetadataUpdater.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Resources\ManifestBasedResourceGroveler.Mono.cs" />
+      <Compile Include="$(BclSourcesRoot)\System\Runtime\ControlledExecution.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Runtime\DependentHandle.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Runtime\GCSettings.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Runtime\JitInfo.Mono.cs" />

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/ControlledExecution.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/ControlledExecution.Mono.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+
+namespace System.Runtime
+{
+    public static class ControlledExecution
+    {
+        public static void Run(Action action, CancellationToken cancellationToken)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/ControlledExecution.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/ControlledExecution.Mono.cs
@@ -7,6 +7,7 @@ namespace System.Runtime
 {
     public static class ControlledExecution
     {
+        [Obsolete("ControlledExecution.Run method may corrupt the process and should not be used in production code.", DiagnosticId = "SYSLIB0046", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static void Run(Action action, CancellationToken cancellationToken)
         {
             throw new PlatformNotSupportedException();

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/ControlledExecution.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/ControlledExecution.Mono.cs
@@ -7,7 +7,7 @@ namespace System.Runtime
 {
     public static class ControlledExecution
     {
-        [Obsolete("ControlledExecution.Run method may corrupt the process and should not be used in production code.", DiagnosticId = "SYSLIB0046", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [Obsolete(Obsoletions.ControlledExecutionRunMessage, DiagnosticId = Obsoletions.ControlledExecutionRunDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void Run(Action action, CancellationToken cancellationToken)
         {
             throw new PlatformNotSupportedException();


### PR DESCRIPTION
Implementation for API proposal [#69622](https://github.com/dotnet/runtime/issues/69622#issuecomment-1178000827):

```C#
namespace System.Runtime;

// Allows to run code and abort it asynchronously
public static class ControlledExecution
{
    // Runs code that may be aborted asynchronously
    public static void Run(Action action, CancellationToken cancellationToken);
}
```

The `Run` method runs the specified action and allows to abort it asynchronously using the provided cancellation token.  When cancellation is requested, the registered `Execution.Abort` callback calls the `Thread::UserAbort` runtime function, which is currently employed by the debugger to abort function evaluation.  That function sets the `TS_AbortRequested` flag on the thread to abort, which causes the runtime to throw an asynchronous `ThreadAbortException`.  This exception may be caught by the code being executed; however, it is automatically rethrown at the end of `catch` blocks.  However, the code may catch it and throw an exception of a different type. 
 The `Run` method resets the `TS_AbortRequested` flag on the current thread if execution of the action has been aborted, which stops rethrowing the exception.  It also catches the `ThreadAbortException` and normalizes it to an `OperationCancelledException`.

Recursive `ControlledExecution.Run` calls are not supported at present — we can support them if there is a valid scenario.

An example of using this API:
```C#
var cts = new CancellationTokenSource();
cts.CancelAfter(300); // timeout
ControlledExecution.Run(SomeAction, cts.Token);
```
FYI: @mangod9 @janvorli