### PR TITLE
Less aggressive `stfld` spilling

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2712,7 +2712,7 @@ public:
 
     GenTree* gtReverseCond(GenTree* tree);
 
-    static bool gtHasRef(GenTree* tree, ssize_t lclNum);
+    static bool gtHasRef(GenTree* tree, unsigned lclNum);
 
     bool gtHasLocalsWithAddrOp(GenTree* tree);
 
@@ -4007,10 +4007,7 @@ private:
     void impSpillSpecialSideEff();
     void impSpillSideEffect(bool spillGlobEffects, unsigned chkLevel DEBUGARG(const char* reason));
     void impSpillSideEffects(bool spillGlobEffects, unsigned chkLevel DEBUGARG(const char* reason));
-    void               impSpillValueClasses();
-    void               impSpillEvalStack();
-    static fgWalkPreFn impFindValueClasses;
-    void impSpillLclRefs(ssize_t lclNum);
+    void impSpillLclRefs(unsigned lclNum);
 
     BasicBlock* impPushCatchArgOnStack(BasicBlock* hndBlk, CORINFO_CLASS_HANDLE clsHnd, bool isSingleBlockFilter);
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2667,20 +2667,19 @@ AGAIN:
 }
 
 //------------------------------------------------------------------------
-// gtHasRef: Find out whether the given tree contains a local/field.
+// gtHasRef: Find out whether the given tree contains a local.
 //
 // Arguments:
 //    tree    - tree to find the local in
-//    lclNum  - the local's number, *or* the handle for the field
+//    lclNum  - the local's number
 //
 // Return Value:
-//    Whether "tree" has any LCL_VAR/LCL_FLD nodes that refer to the
-//    local, LHS or RHS, or FIELD nodes with the specified handle.
+//    Whether "tree" has any LCL_VAR/LCL_FLD nodes that refer to the local.
 //
 // Notes:
 //    Does not pay attention to local address nodes.
 //
-/* static */ bool Compiler::gtHasRef(GenTree* tree, ssize_t lclNum)
+/* static */ bool Compiler::gtHasRef(GenTree* tree, unsigned lclNum)
 {
     if (tree == nullptr)
     {
@@ -2689,7 +2688,7 @@ AGAIN:
 
     if (tree->OperIsLeaf())
     {
-        if (tree->OperIs(GT_LCL_VAR, GT_LCL_FLD) && (tree->AsLclVarCommon()->GetLclNum() == (unsigned)lclNum))
+        if (tree->OperIs(GT_LCL_VAR, GT_LCL_FLD) && (tree->AsLclVarCommon()->GetLclNum() == lclNum))
         {
             return true;
         }
@@ -2703,13 +2702,6 @@ AGAIN:
 
     if (tree->OperIsUnary())
     {
-        // Code in importation (see CEE_STFLD in impImportBlockCode), when
-        // spilling, can pass us "lclNum" that is actually a field handle...
-        if (tree->OperIs(GT_FIELD) && (lclNum == (ssize_t)tree->AsField()->gtFldHnd))
-        {
-            return true;
-        }
-
         return gtHasRef(tree->AsUnOp()->gtGetOp1(), lclNum);
     }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71638/Runtime_71638.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71638/Runtime_71638.il
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Runtime { }
+.assembly extern System.Console { }
+
+.assembly Runtime_71638.dll { }
+
+.class Runtime_71638 extends [System.Runtime]System.Object
+{
+  .method public static int32 Main()
+  {
+    .entrypoint
+
+    ldc.i4 10
+    call int32 Runtime_71638::Problem(int32)
+    ldc.i4 10
+    bne.un FAILURE
+
+    ldc.i4 100
+    ret
+
+  FAILURE:
+    ldc.i4 101
+    ret
+  }
+
+  .method private static int32 Problem(int32 a) noinlining
+  {
+    .locals (int32& aRef)
+
+    ldarga a
+    stloc aRef
+
+    ldarg a
+    ldloc aRef
+    ldc.i4 0
+    stfld int32 StructWithIndex::Index
+    ret
+  }
+}
+
+.class sealed StructWithIndex extends [System.Runtime]System.ValueType
+{
+  .field public int32 Index;
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71638/Runtime_71638.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71638/Runtime_71638.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The spilling logic for `st[s]fld` was quite quite complex, and not complete. Replace it with the simple spilling of side effects and global data accesses, which is all that's needed.

The new logic is less conservative because it doesn't spill invariant nodes when the assign is to a struct field, so we see a good number of positive diffs.

Fixes #71638.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1868040&view=ms.vss-build-web.run-extensions-tab).