### PR TITLE
Fix BigInteger out-of-bound index during GCD calculation

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.GcdInv.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.GcdInv.cs
@@ -184,11 +184,17 @@ namespace System.Numerics
                 // Euclid's step
                 Reduce(left, right);
 
-                ulong x = ((ulong)right[1] << 32) | right[0];
-                ulong y = ((ulong)left[1] << 32) | left[0];
+                ulong x = right[0];
+                ulong y = left[0];
+
+                if (right.Length > 1)
+                {
+                    x |= (ulong)right[1] << 32;
+                    y |= (ulong)left[1] << 32;
+                }
 
                 left = left.Slice(0, Overwrite(left, Gcd(x, y)));
-                Overwrite(right, 0U);
+                right.Clear();
             }
 
             left.CopyTo(result);
@@ -210,20 +216,6 @@ namespace System.Numerics
             buffer[1] = hi;
             buffer[0] = lo;
             return hi != 0 ? 2 : lo != 0 ? 1 : 0;
-        }
-
-        private static int Overwrite(Span<uint> bits, uint value)
-        {
-            Debug.Assert(bits.Length >= 1);
-
-            if (bits.Length > 1)
-            {
-                // Ensure leading zeros in little-endian
-                bits.Slice(1).Clear();
-            }
-
-            bits[0] = value;
-            return value != 0 ? 1 : 0;
         }
 
         private static void ExtractDigits(ReadOnlySpan<uint> xBuffer,

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/gcd.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/gcd.cs
@@ -63,6 +63,11 @@ namespace System.Numerics.Tests
             tempByteArray1 = new byte[] { 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0 };
             tempByteArray2 = new byte[] { 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 254 };
             VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
+
+            // https://github.com/dotnet/runtime/issues/71641
+            tempByteArray1 = new byte[] { 62, 228, 246, 142, 92, 24, 255, 224, 2 };
+            tempByteArray2 = new byte[] { 0, 0, 230, 83, 69, 20, 2, 220, 1 };
+            VerifyGCDString(Print(tempByteArray1) + Print(tempByteArray2) + "bGCD");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #71641 

A regression was introduced in #35565 that causes out-of-bound index during GCD calculation. That was happened because original `GetBits()` method from .NET 6 didn't take the actual length of the buffer into account. The code was migrated by me in #35565. Now the proper check is added.

As a bonus, `Overwrite` method is no longer needed because it is semantically equivalent to `Span<byte>.Clear()` when argument is `0U`.