### PR TITLE
Don't set CORINFO_FLG_CUSTOMLAYOUT for auto-layout structs

### DIFF
--- a/src/coreclr/vm/classlayoutinfo.cpp
+++ b/src/coreclr/vm/classlayoutinfo.cpp
@@ -301,7 +301,8 @@ namespace
 
     BOOL TypeHasGCPointers(CorElementType corElemType, TypeHandle pNestedType)
     {
-        if (CorTypeInfo::IsPrimitiveType(corElemType) || corElemType == ELEMENT_TYPE_PTR || corElemType == ELEMENT_TYPE_FNPTR)
+        if (CorTypeInfo::IsPrimitiveType(corElemType) || corElemType == ELEMENT_TYPE_PTR || corElemType == ELEMENT_TYPE_FNPTR ||
+            corElemType == ELEMENT_TYPE_BYREF)
         {
             return FALSE;
         }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -3624,10 +3624,12 @@ uint32_t CEEInfo::getClassAttribsInternal (CORINFO_CLASS_HANDLE clsHnd)
             if (pMT->IsByRefLike())
                 ret |= CORINFO_FLG_BYREF_LIKE;
 
-            if ((pClass->IsNotTightlyPacked() && (!pClass->IsManagedSequential() || pClass->HasExplicitSize())) ||
+            if ((pClass->IsNotTightlyPacked() && (pClass->HasExplicitSize())) ||
                 pMT == g_TypedReferenceMT ||
                 VMClsHnd.IsNativeValueType())
             {
+                // All kinds of structs with Size=.., Pack=... will be marked as "Explicit Size"
+                // and end up as "custom layout". We consider "Auto-layout" as non-custom one
                 ret |= CORINFO_FLG_CUSTOMLAYOUT;
             }
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -3624,12 +3624,10 @@ uint32_t CEEInfo::getClassAttribsInternal (CORINFO_CLASS_HANDLE clsHnd)
             if (pMT->IsByRefLike())
                 ret |= CORINFO_FLG_BYREF_LIKE;
 
-            if ((pClass->IsNotTightlyPacked() && (pClass->HasExplicitSize())) ||
+            if ((pClass->IsNotTightlyPacked() && (!pClass->IsManagedSequential() || pClass->HasExplicitSize())) ||
                 pMT == g_TypedReferenceMT ||
                 VMClsHnd.IsNativeValueType())
             {
-                // All kinds of structs with Size=.., Pack=... will be marked as "Explicit Size"
-                // and end up as "custom layout". We consider "Auto-layout" as non-custom one
                 ret |= CORINFO_FLG_CUSTOMLAYOUT;
             }
 


### PR DESCRIPTION
Close https://github.com/dotnet/runtime/issues/71667

Apply @SingleAccretion's suggestion in https://github.com/dotnet/runtime/issues/71667#issuecomment-1175457905 to see if it works (works locally, also I tested various kinds of structs to see when "ExplicitSize" is reported and when not) - if it passes the tests I will run jit-diff tools locally to estimate impact.