### PR TITLE
TypedByReference should be treated as a normal valuetype for calling convention purposes

### DIFF
--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -1186,6 +1186,13 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
     TypeHandle thValueType;
     CorElementType argType = this->GetNextArgumentType(m_argNum++, &thValueType);
 
+    // TypedReference behaves like a valuetype
+    if (argType == ELEMENT_TYPE_TYPEDBYREF)
+    {
+        argType = ELEMENT_TYPE_VALUETYPE;
+        thValueType = TypeHandle(g_TypedReferenceMT);
+    }
+
     int argSize = MetaSig::GetElemSize(argType, thValueType);
 
     m_argType = argType;

--- a/src/tests/Regressions/coreclr/GitHub_42732/test42732.cs
+++ b/src/tests/Regressions/coreclr/GitHub_42732/test42732.cs
@@ -11,14 +11,16 @@ public class Test11611
         public int b;
     }
 
-    delegate void testDelegate(TypedReference tr);
+
+   public delegate void testDelegate(TypedReference tr);
+   public static testDelegate d;
 
     static void test(TypedReference tr)
     {
         Type t = __reftype(tr);
         Console.WriteLine($"tr = {t.Name}");
     }
-    public static void Test(testDelegate d)
+    public static void Test()
     {
         TestStruct s = default;
         var tr = __makeref(s);
@@ -30,7 +32,9 @@ public class Test11611
     public static int Main(string[] args)
     {
         Console.WriteLine("About to run test");
-        Test(test);
+        d = test;
+        Test();
         Console.WriteLine("Test complete run test");
+        return 100;
     }
 }

--- a/src/tests/Regressions/coreclr/GitHub_42732/test42732.cs
+++ b/src/tests/Regressions/coreclr/GitHub_42732/test42732.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Runtime.CompilerServices;
+
+public class Test11611
+{    
+    struct TestStruct
+    {
+        public int a;
+        public int b;
+    }
+
+    delegate void testDelegate(TypedReference tr);
+
+    static void test(TypedReference tr)
+    {
+        Type t = __reftype(tr);
+        Console.WriteLine($"tr = {t.Name}");
+    }
+    public static void Test(testDelegate d)
+    {
+        TestStruct s = default;
+        var tr = __makeref(s);
+        test(tr);
+        d(tr); // this will crash due to __reftype(tr)
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Main(string[] args)
+    {
+        Console.WriteLine("About to run test");
+        Test(test);
+        Console.WriteLine("Test complete run test");
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_42732/test42732.cs
+++ b/src/tests/Regressions/coreclr/GitHub_42732/test42732.cs
@@ -1,5 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+// This test is covering an issue where we would incorrectly compute the
+// argument layout of the static method delegate thunk, due to an issue
+// where we failed to handle ELEMENT_TYPE_TYPEDBYREF like the valuetype it is.
+// This would not reproduce only Windows X64 due to the particular abi of that
+// platform, but was found on Unix X64.
+
 using System;
 using System.Runtime.CompilerServices;
 

--- a/src/tests/Regressions/coreclr/GitHub_42732/test42732.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_42732/test42732.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test42732.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/GitHub_42732/test42732.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_42732/test42732.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>0</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test42732.cs" />


### PR DESCRIPTION
The previous logic would cause the runtime to compute an incorrect size for a TypedByReference argument, and then only shuffle a single register of data instead of two.

Fixes #42732