### PR TITLE
Fix S.R.InteropServices remarks

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/AnsiStringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/AnsiStringMarshaller.cs
@@ -32,8 +32,8 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <remarks>
         /// The <paramref name="buffer"/> must not be movable - that is, it should not be
         /// on the managed heap or it should be pinned.
-        /// <seealso cref="CustomTypeMarshallerFeatures.CallerAllocatedBuffer"/>
         /// </remarks>
+        /// <seealso cref="CustomTypeMarshallerFeatures.CallerAllocatedBuffer"/>
         public AnsiStringMarshaller(string? str, Span<byte> buffer)
         {
             _allocated = false;
@@ -65,18 +65,14 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Returns the native value representing the string.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public byte* ToNativeValue() => _nativeValue;
 
         /// <summary>
         /// Sets the native value representing the string.
         /// </summary>
         /// <param name="value">The native value.</param>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public void FromNativeValue(byte* value)
         {
             _nativeValue = value;
@@ -86,17 +82,13 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Returns the managed string.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
-        /// </remarks>
         public string? ToManaged() => Marshal.PtrToStringAnsi((IntPtr)_nativeValue);
 
         /// <summary>
         /// Frees native resources.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.UnmanagedResources"/>
-        /// </remarks>
         public void FreeNative()
         {
             if (_allocated)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
@@ -50,8 +50,8 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <remarks>
         /// The <paramref name="buffer"/> must not be movable - that is, it should not be
         /// on the managed heap or it should be pinned.
-        /// <seealso cref="CustomTypeMarshallerFeatures.CallerAllocatedBuffer"/>
         /// </remarks>
+        /// <seealso cref="CustomTypeMarshallerFeatures.CallerAllocatedBuffer"/>
         public ArrayMarshaller(T[]? array, Span<byte> buffer, int sizeOfNativeElement)
         {
             _allocatedMemory = default;
@@ -83,9 +83,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Gets a span that points to the memory where the managed values of the array are stored.
         /// </summary>
         /// <returns>Span over managed values of the array.</returns>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.In"/>
-        /// </remarks>
         public ReadOnlySpan<T> GetManagedValuesSource() => _managedArray;
 
         /// <summary>
@@ -93,9 +91,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="length">Length of the array.</param>
         /// <returns>Span where managed values of the array should be stored.</returns>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
-        /// </remarks>
         public Span<T> GetManagedValuesDestination(int length) => _allocatedMemory == IntPtr.Zero ? null : _managedArray = new T[length];
 
         /// <summary>
@@ -103,9 +99,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="length">Length of the array.</param>
         /// <returns>Span over the native values of the array.</returns>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
-        /// </remarks>
         public ReadOnlySpan<byte> GetNativeValuesSource(int length)
         {
             if (_allocatedMemory == IntPtr.Zero)
@@ -120,9 +114,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Returns a span that points to the memory where the native values of the array should be stored.
         /// </summary>
         /// <returns>Span where native values of the array should be stored.</returns>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.In"/>
-        /// </remarks>
         public Span<byte> GetNativeValuesDestination() => _span;
 
         /// <summary>
@@ -133,18 +125,14 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Returns the native value representing the array.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public byte* ToNativeValue() => (byte*)Unsafe.AsPointer(ref GetPinnableReference());
 
         /// <summary>
         /// Sets the native value representing the array.
         /// </summary>
         /// <param name="value">The native value.</param>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public void FromNativeValue(byte* value)
         {
             _allocatedMemory = (IntPtr)value;
@@ -153,17 +141,13 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Returns the managed array.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
-        /// </remarks>
         public T[]? ToManaged() => _managedArray;
 
         /// <summary>
         /// Frees native resources.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.UnmanagedResources"/>
-        /// </remarks>
         public void FreeNative()
         {
             Marshal.FreeCoTaskMem(_allocatedMemory);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/BStrStringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/BStrStringMarshaller.cs
@@ -34,8 +34,8 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <remarks>
         /// The <paramref name="buffer"/> must not be movable - that is, it should not be
         /// on the managed heap or it should be pinned.
-        /// <seealso cref="CustomTypeMarshallerFeatures.CallerAllocatedBuffer"/>
         /// </remarks>
+        /// <seealso cref="CustomTypeMarshallerFeatures.CallerAllocatedBuffer"/>
         public BStrStringMarshaller(string? str, Span<ushort> buffer)
         {
             _allocated = false;
@@ -78,18 +78,14 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Returns the native value representing the string.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public void* ToNativeValue() => _ptrToFirstChar;
 
         /// <summary>
         /// Sets the native value representing the string.
         /// </summary>
         /// <param name="value">The native value.</param>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public void FromNativeValue(void* value)
         {
             _ptrToFirstChar = value;
@@ -99,9 +95,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Returns the managed string.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
-        /// </remarks>
         public string? ToManaged()
         {
             if (_ptrToFirstChar is null)
@@ -113,9 +107,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Frees native resources.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.UnmanagedResources"/>
-        /// </remarks>
         public void FreeNative()
         {
             if (_allocated)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/CustomTypeMarshallerAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/CustomTypeMarshallerAttribute.cs
@@ -9,8 +9,8 @@ namespace System.Runtime.InteropServices.Marshalling
     /// <remarks>
     /// This attribute is recognized by the runtime-provided source generators for source-generated interop scenarios.
     /// It is not used by the interop marshalling system at runtime.
-    /// <seealso cref="LibraryImportAttribute"/>
     /// </remarks>
+    /// <seealso cref="LibraryImportAttribute"/>
     [AttributeUsage(AttributeTargets.Struct)]
     public sealed class CustomTypeMarshallerAttribute : Attribute
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/CustomTypeMarshallerKind.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/CustomTypeMarshallerKind.cs
@@ -10,9 +10,7 @@ namespace System.Runtime.InteropServices.Marshalling
     /// <summary>
     /// The shape of a custom type marshaller for usage in source-generated interop scenarios.
     /// </summary>
-    /// <remarks>
     /// <seealso cref="LibraryImportAttribute"/>
-    /// </remarks>
     public enum CustomTypeMarshallerKind
     {
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
@@ -50,8 +50,8 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <remarks>
         /// The <paramref name="buffer"/> must not be movable - that is, it should not be
         /// on the managed heap or it should be pinned.
-        /// <seealso cref="CustomTypeMarshallerFeatures.CallerAllocatedBuffer"/>
         /// </remarks>
+        /// <seealso cref="CustomTypeMarshallerFeatures.CallerAllocatedBuffer"/>
         public PointerArrayMarshaller(T*[]? array, Span<byte> buffer, int sizeOfNativeElement)
         {
             _allocatedMemory = default;
@@ -83,9 +83,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Gets a span that points to the memory where the managed values of the array are stored.
         /// </summary>
         /// <returns>Span over managed values of the array.</returns>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.In"/>
-        /// </remarks>
         public ReadOnlySpan<IntPtr> GetManagedValuesSource() => Unsafe.As<IntPtr[]>(_managedArray);
 
         /// <summary>
@@ -93,9 +91,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="length">Length of the array.</param>
         /// <returns>Span where managed values of the array should be stored.</returns>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
-        /// </remarks>
         public Span<IntPtr> GetManagedValuesDestination(int length)
         {
             if (_allocatedMemory == IntPtr.Zero)
@@ -110,9 +106,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="length">Length of the array.</param>
         /// <returns>Span over the native values of the array.</returns>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
-        /// </remarks>
         public ReadOnlySpan<byte> GetNativeValuesSource(int length)
         {
             if (_allocatedMemory == IntPtr.Zero)
@@ -127,9 +121,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Returns a span that points to the memory where the native values of the array should be stored.
         /// </summary>
         /// <returns>Span where native values of the array should be stored.</returns>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.In"/>
-        /// </remarks>
         public Span<byte> GetNativeValuesDestination() => _span;
 
         /// <summary>
@@ -140,34 +132,26 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Returns the native value representing the array.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public byte* ToNativeValue() => (byte*)Unsafe.AsPointer(ref GetPinnableReference());
 
         /// <summary>
         /// Sets the native value representing the array.
         /// </summary>
         /// <param name="value">The native value.</param>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public void FromNativeValue(byte* value) => _allocatedMemory = (IntPtr)value;
 
         /// <summary>
         /// Returns the managed array.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
-        /// </remarks>
         public T*[]? ToManaged() => _managedArray;
 
         /// <summary>
         /// Frees native resources.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.UnmanagedResources"/>
-        /// </remarks>
         public void FreeNative()
         {
             Marshal.FreeCoTaskMem(_allocatedMemory);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf16StringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf16StringMarshaller.cs
@@ -31,34 +31,26 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Returns the native value representing the string.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public void* ToNativeValue() => _nativeValue;
 
         /// <summary>
         /// Sets the native value representing the string.
         /// </summary>
         /// <param name="value">The native value.</param>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public void FromNativeValue(void* value) => _nativeValue = value;
 
         /// <summary>
         /// Returns the managed string.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
-        /// </remarks>
         public string? ToManaged() => Marshal.PtrToStringUni((IntPtr)_nativeValue);
 
         /// <summary>
         /// Frees native resources.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.UnmanagedResources"/>
-        /// </remarks>
         public void FreeNative()
         {
             Marshal.FreeCoTaskMem((IntPtr)_nativeValue);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf8StringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf8StringMarshaller.cs
@@ -33,8 +33,8 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <remarks>
         /// The <paramref name="buffer"/> must not be movable - that is, it should not be
         /// on the managed heap or it should be pinned.
-        /// <seealso cref="CustomTypeMarshallerFeatures.CallerAllocatedBuffer"/>
         /// </remarks>
+        /// <seealso cref="CustomTypeMarshallerFeatures.CallerAllocatedBuffer"/>
         public Utf8StringMarshaller(string? str, Span<byte> buffer)
         {
             _allocated = false;
@@ -69,18 +69,14 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Returns the native value representing the string.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public byte* ToNativeValue() => _nativeValue;
 
         /// <summary>
         /// Sets the native value representing the string.
         /// </summary>
         /// <param name="value">The native value.</param>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
-        /// </remarks>
         public void FromNativeValue(byte* value)
         {
             _nativeValue = value;
@@ -90,17 +86,13 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Returns the managed string.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
-        /// </remarks>
         public string? ToManaged() => Marshal.PtrToStringUTF8((IntPtr)_nativeValue);
 
         /// <summary>
         /// Frees native resources.
         /// </summary>
-        /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.UnmanagedResources"/>
-        /// </remarks>
         public void FreeNative()
         {
             if (_allocated)


### PR DESCRIPTION
In the [latest documentation porting PR](https://github.com/dotnet/dotnet-api-docs/pull/8185), I had to manually pull out the isolated `<seealso>` items from the remarks section, otherwise they would show in a confusing way in MS Docs.

The `<seealso>` items can be added without problems at the same level as the rest of the usual comment items.

I am doing this in source too so that the next porting processes do not port the wrong remarks again.