### PR TITLE
JIT: Fix generating unrepresentable nullchecks on ARM64

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9972,7 +9972,8 @@ bool Compiler::lvaIsOSRLocal(unsigned varNum)
 //
 var_types Compiler::gtTypeForNullCheck(GenTree* tree)
 {
-    static const var_types s_typesBySize[] = { TYP_UNDEF, TYP_BYTE, TYP_SHORT, TYP_UNDEF, TYP_INT, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_LONG };
+    static const var_types s_typesBySize[] = {TYP_UNDEF, TYP_BYTE,  TYP_SHORT, TYP_UNDEF, TYP_INT,
+                                              TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_LONG};
 
     if (!varTypeIsStruct(tree))
     {

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9965,7 +9965,7 @@ bool Compiler::lvaIsOSRLocal(unsigned varNum)
 }
 
 //------------------------------------------------------------------------------
-// gtTypeForNullCheck: helper to get the most optimal type for nullcheck
+// gtTypeForNullCheck: helper to get the most optimal and correct type for nullcheck
 //
 // Arguments:
 //    tree - the node for nullcheck;
@@ -9974,7 +9974,7 @@ var_types Compiler::gtTypeForNullCheck(GenTree* tree)
 {
     static const var_types s_typesBySize[] = { TYP_UNDEF, TYP_BYTE, TYP_SHORT, TYP_UNDEF, TYP_INT, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_LONG };
 
-    if (varTypeIsStruct(tree))
+    if (!varTypeIsStruct(tree))
     {
 #if defined(TARGET_XARCH)
         // Just an optimization for XARCH - smaller mov
@@ -9987,7 +9987,6 @@ var_types Compiler::gtTypeForNullCheck(GenTree* tree)
         assert((genTypeSize(tree) < ARRAY_SIZE(s_typesBySize)) && (s_typesBySize[genTypeSize(tree)] != TYP_UNDEF));
         return s_typesBySize[genTypeSize(tree)];
     }
-
     // for the rest: probe a single byte to avoid potential AVEs
     return TYP_BYTE;
 }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9981,6 +9981,7 @@ var_types Compiler::gtTypeForNullCheck(GenTree* tree)
             return TYP_INT;
         }
 #endif
+
         return tree->TypeGet();
     }
     // for the rest: probe a single byte to avoid potential AVEs

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9965,25 +9965,29 @@ bool Compiler::lvaIsOSRLocal(unsigned varNum)
 }
 
 //------------------------------------------------------------------------------
-// gtTypeForNullCheck: helper to get the most optimal and correct type for nullcheck
+// gtTypeForNullCheck: helper to get the most optimal type for nullcheck
 //
 // Arguments:
 //    tree - the node for nullcheck;
 //
 var_types Compiler::gtTypeForNullCheck(GenTree* tree)
 {
-    if (varTypeIsArithmetic(tree))
+    static const var_types s_typesBySize[] = { TYP_UNDEF, TYP_BYTE, TYP_SHORT, TYP_UNDEF, TYP_INT, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_LONG };
+
+    if (varTypeIsStruct(tree))
     {
 #if defined(TARGET_XARCH)
         // Just an optimization for XARCH - smaller mov
-        if (varTypeIsLong(tree))
+        if (genTypeSize(tree) == 8)
         {
             return TYP_INT;
         }
 #endif
 
-        return tree->TypeGet();
+        assert((genTypeSize(tree) < ARRAY_SIZE(s_typesBySize)) && (s_typesBySize[genTypeSize(tree)] != TYP_UNDEF));
+        return s_typesBySize[genTypeSize(tree)];
     }
+
     // for the rest: probe a single byte to avoid potential AVEs
     return TYP_BYTE;
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71687/Runtime_71687.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71687/Runtime_71687.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+class Runtime_71687
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Test<T>(ref T first, int i)
+    {
+        Consume(Unsafe.Add(ref first, i));
+    }
+
+    // Must be inlined so we end up with null check above
+    private static void Consume<T>(T value) { }
+
+    private static int Main()
+    {
+        Test(ref (new byte[10])[0], 5);
+        Test(ref (new sbyte[10])[0], 5);
+        Test(ref (new ushort[10])[0], 5);
+        Test(ref (new short[10])[0], 5);
+        Test(ref (new uint[10])[0], 5);
+        Test(ref (new int[10])[0], 5);
+        Test(ref (new ulong[10])[0], 5);
+        Test(ref (new long[10])[0], 5);
+        Test(ref (new float[10])[0], 5);
+        Test(ref (new double[10])[0], 5);
+        Test(ref (new object[10])[0], 5);
+        Test(ref (new string[10])[0], 5);
+        Test(ref (new Vector<float>[10])[0], 5);
+        Test(ref (new Vector128<float>[10])[0], 5);
+        Test(ref (new Vector256<float>[10])[0], 5);
+        Test(ref (new Struct1[10])[0], 5);
+        Test(ref (new Struct2[10])[0], 5);
+        Test(ref (new Struct4[10])[0], 5);
+        Test(ref (new Struct8[10])[0], 5);
+        return 100;
+    }
+
+    private struct Struct1 { public byte Field; }
+    private struct Struct2 { public short Field; }
+    private struct Struct4 { public int Field; }
+    private struct Struct8 { public long Field; }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71687/Runtime_71687.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71687/Runtime_71687.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71687/Runtime_71687.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71687/Runtime_71687.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
The logic in lowering could in some struct and primitive type cases
generate an unrepresentable NULLCHECK node for ARM64/LA64 when there
was a contained address mode. We now transform unused indirections and
create address modes in the opposite order on non-xarch to avoid these unrepresentable
nullchecks.

Fix #71684