### PR TITLE
Better error handling in SubtleCrypto workers

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -753,6 +753,9 @@
   <data name="Unknown_Error" xml:space="preserve">
     <value>Unknown error.</value>
   </data>
+  <data name="Unknown_SubtleCrypto_Error" xml:space="preserve">
+    <value>SubtleCrypto returned an unknown error: '{0}'.</value>
+  </data>
   <data name="PlatformNotSupported_CipherModeBrowser" xml:space="preserve">
     <value>Only CipherMode.CBC is supported on this platform.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesSubtleCryptoTransform.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesSubtleCryptoTransform.Browser.cs
@@ -148,7 +148,7 @@ namespace System.Security.Cryptography
                     pOutput, output.Length);
 
                 if (bytesWritten < 0)
-                    throw new Exception(SR.Unknown_Error);
+                    throw new Exception(SR.Format(SR.Unknown_SubtleCrypto_Error, bytesWritten));
 
                 return bytesWritten;
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesSubtleCryptoTransform.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesSubtleCryptoTransform.Browser.cs
@@ -148,7 +148,7 @@ namespace System.Security.Cryptography
                     pOutput, output.Length);
 
                 if (bytesWritten < 0)
-                    throw new Exception(SR.Format(SR.Unknown_SubtleCrypto_Error, bytesWritten));
+                    throw new CryptographicException(SR.Format(SR.Unknown_SubtleCrypto_Error, bytesWritten));
 
                 return bytesWritten;
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACHashProvider.Browser.Native.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACHashProvider.Browser.Native.cs
@@ -43,42 +43,35 @@ namespace System.Security.Cryptography
         {
             Debug.Assert(destination.Length >= _hashSizeInBytes);
 
-            byte[] srcArray = Array.Empty<byte>();
-            int srcLength = 0;
-            if (_buffer != null)
-            {
-                srcArray = _buffer.GetBuffer();
-                srcLength = (int)_buffer.Length;
-            }
+            ReadOnlySpan<byte> source = _buffer != null ?
+                new ReadOnlySpan<byte>(_buffer.GetBuffer(), 0, (int)_buffer.Length) :
+                default;
 
-            unsafe
-            {
-                fixed (byte* key = _key)
-                fixed (byte* src = srcArray)
-                fixed (byte* dest = destination)
-                {
-                    int res = Interop.BrowserCrypto.Sign(_hashAlgorithm, key, _key.Length, src, srcLength, dest, destination.Length);
-                    Debug.Assert(res != 0);
-                }
-            }
+            Sign(_hashAlgorithm, _key, source, destination);
 
             return _hashSizeInBytes;
         }
 
-        public static unsafe int MacDataOneShot(string hashAlgorithmId, ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> destination)
+        public static int MacDataOneShot(string hashAlgorithmId, ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> destination)
         {
             (SimpleDigest hashName, int hashSizeInBytes) = SHANativeHashProvider.HashAlgorithmToPal(hashAlgorithmId);
             Debug.Assert(destination.Length >= hashSizeInBytes);
 
+            Sign(hashName, key, data, destination);
+
+            return hashSizeInBytes;
+        }
+
+        private static unsafe void Sign(SimpleDigest hashName, ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> destination)
+        {
             fixed (byte* k = key)
             fixed (byte* src = data)
             fixed (byte* dest = destination)
             {
                 int res = Interop.BrowserCrypto.Sign(hashName, k, key.Length, src, data.Length, dest, destination.Length);
-                Debug.Assert(res != 0);
+                if (res != 0)
+                    throw new Exception(SR.Format(SR.Unknown_SubtleCrypto_Error, res));
             }
-
-            return hashSizeInBytes;
         }
 
         public override int HashSizeInBytes => _hashSizeInBytes;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACHashProvider.Browser.Native.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACHashProvider.Browser.Native.cs
@@ -70,7 +70,7 @@ namespace System.Security.Cryptography
             {
                 int res = Interop.BrowserCrypto.Sign(hashName, k, key.Length, src, data.Length, dest, destination.Length);
                 if (res != 0)
-                    throw new Exception(SR.Format(SR.Unknown_SubtleCrypto_Error, res));
+                    throw new CryptographicException(SR.Format(SR.Unknown_SubtleCrypto_Error, res));
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Native.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Native.cs
@@ -40,40 +40,34 @@ namespace System.Security.Cryptography
         {
             Debug.Assert(destination.Length >= _hashSizeInBytes);
 
-            byte[] srcArray = Array.Empty<byte>();
-            int srcLength = 0;
-            if (_buffer != null)
-            {
-                srcArray = _buffer.GetBuffer();
-                srcLength = (int)_buffer.Length;
-            }
+            ReadOnlySpan<byte> source = _buffer != null ?
+                new ReadOnlySpan<byte>(_buffer.GetBuffer(), 0, (int)_buffer.Length) :
+                default;
 
-            unsafe
-            {
-                fixed (byte* src = srcArray)
-                fixed (byte* dest = destination)
-                {
-                    int res = Interop.BrowserCrypto.SimpleDigestHash(_impl, src, srcLength, dest, destination.Length);
-                    Debug.Assert(res != 0);
-                }
-            }
+            SimpleDigestHash(_impl, source, destination);
 
             return _hashSizeInBytes;
         }
 
-        public static unsafe int HashOneShot(string hashAlgorithmId, ReadOnlySpan<byte> data, Span<byte> destination)
+        public static int HashOneShot(string hashAlgorithmId, ReadOnlySpan<byte> data, Span<byte> destination)
         {
             (SimpleDigest impl, int hashSizeInBytes) = HashAlgorithmToPal(hashAlgorithmId);
             Debug.Assert(destination.Length >= hashSizeInBytes);
 
+            SimpleDigestHash(impl, data, destination);
+
+            return hashSizeInBytes;
+        }
+
+        private static unsafe void SimpleDigestHash(SimpleDigest hashName, ReadOnlySpan<byte> data, Span<byte> destination)
+        {
             fixed (byte* src = data)
             fixed (byte* dest = destination)
             {
-                int res = Interop.BrowserCrypto.SimpleDigestHash(impl, src, data.Length, dest, destination.Length);
-                Debug.Assert(res != 0);
+                int res = Interop.BrowserCrypto.SimpleDigestHash(hashName, src, data.Length, dest, destination.Length);
+                if (res != 0)
+                    throw new Exception(SR.Format(SR.Unknown_SubtleCrypto_Error, res));
             }
-
-            return hashSizeInBytes;
         }
 
         public override int HashSizeInBytes => _hashSizeInBytes;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Native.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Native.cs
@@ -66,7 +66,7 @@ namespace System.Security.Cryptography
             {
                 int res = Interop.BrowserCrypto.SimpleDigestHash(hashName, src, data.Length, dest, destination.Length);
                 if (res != 0)
-                    throw new Exception(SR.Format(SR.Unknown_SubtleCrypto_Error, res));
+                    throw new CryptographicException(SR.Format(SR.Unknown_SubtleCrypto_Error, res));
             }
         }
 

--- a/src/mono/wasm/runtime/crypto-worker.ts
+++ b/src/mono/wasm/runtime/crypto-worker.ts
@@ -5,7 +5,6 @@ import { Module } from "./imports";
 import { mono_assert } from "./types";
 
 class OperationFailedError extends Error {}
-class ArgumentsError extends Error {}
 
 const ERR_ARGS = -1;
 const ERR_WORKER_FAILED = -2;
@@ -29,7 +28,7 @@ export function dotnet_browser_simple_digest_hash(ver: number, input_buffer: num
     };
 
     const result = _send_msg_worker(msg);
-    if (typeof result === 'number') {
+    if (typeof result === "number") {
         return result;
     }
 
@@ -51,7 +50,7 @@ export function dotnet_browser_sign(hashAlgorithm: number, key_buffer: number, k
     };
 
     const result = _send_msg_worker(msg);
-    if (typeof result === 'number') {
+    if (typeof result === "number") {
         return result;
     }
 
@@ -80,7 +79,7 @@ export function dotnet_browser_encrypt_decrypt(isEncrypting: boolean, key_buffer
     };
 
     const result = _send_msg_worker(msg);
-    if (typeof result === 'number') {
+    if (typeof result === "number") {
         return result;
     }
 

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -514,7 +514,7 @@ export function setup_proxy_console(id: string, originalConsole: Console, origin
         }
     }
 
-    const consoleUrl = `${origin}/console`.replace("http://", "ws://");
+    const consoleUrl = `${origin}/console`.replace("https://", "wss://").replace("http://", "ws://");
 
     const consoleWebSocket = new WebSocket(consoleUrl);
     consoleWebSocket.onopen = function () {

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -472,6 +472,75 @@ export function mono_wasm_trace_logger(log_domain_ptr: CharPtr, log_level_ptr: C
     }
 }
 
+export function setup_proxy_console(id: string, originalConsole: any, origin: string): void {
+    function proxyConsoleMethod(prefix: string, func: any, asJson: boolean) {
+        return function () {
+            try {
+                const args = [...arguments];
+                let payload = args[0];
+                if (payload === undefined) payload = 'undefined';
+                else if (payload === null) payload = 'null';
+                else if (typeof payload === 'function') payload = payload.toString();
+                else if (typeof payload !== 'string') {
+                    try {
+                        payload = JSON.stringify(payload);
+                    } catch (e) {
+                        payload = payload.toString();
+                    }
+                }
+
+                if (typeof payload === "string")
+                    payload = `[${id}] ${payload}`;
+
+                if (asJson) {
+                    func(JSON.stringify({
+                        method: prefix,
+                        payload: payload,
+                        arguments: args
+                    }));
+                } else {
+                    func([prefix + payload, ...args.slice(1)]);
+                }
+            } catch (err) {
+                originalConsole.error(`proxyConsole failed: ${err}`)
+            }
+        };
+    }
+
+    const methods = ["debug", "trace", "warn", "info", "error"];
+    for (let m of methods) {
+        if (typeof (originalConsole[m]) !== "function") {
+            originalConsole[m] = proxyConsoleMethod(`console.${m}: `, originalConsole.log, false);
+        }
+    }
+
+    const consoleUrl = `${origin}/console`.replace('http://', 'ws://');
+
+    const consoleWebSocket = new WebSocket(consoleUrl);
+    consoleWebSocket.onopen = function (event) {
+        originalConsole.log(`browser: [${id}] Console websocket connected.`);
+    };
+    consoleWebSocket.onerror = function (event) {
+        originalConsole.error(`[${id}] websocket error: ${event}`, event);
+    };
+    consoleWebSocket.onclose = function (event) {
+        originalConsole.error(`[${id}] websocket closed: ${event}`, event);
+    };
+
+    const send = (msg: string) => {
+        if (consoleWebSocket.readyState === WebSocket.OPEN) {
+            consoleWebSocket.send(msg);
+        }
+        else {
+            originalConsole.log(msg);
+        }
+    }
+
+    // redirect output early, so that when emscripten starts it's already redirected
+    for (let m of ["log", ...methods])
+        originalConsole[m] = proxyConsoleMethod(`console.${m}`, send, true);
+}
+
 type CallDetails = {
     value: string
 }

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -472,9 +472,9 @@ export function mono_wasm_trace_logger(log_domain_ptr: CharPtr, log_level_ptr: C
     }
 }
 
-export function setup_proxy_console(id: string, originalConsole: Console, origin: string, ...args: any[]): void {
+export function setup_proxy_console(id: string, originalConsole: Console, origin: string): void {
     function proxyConsoleMethod(prefix: string, func: any, asJson: boolean) {
-        return function () {
+        return function (...args: any[]) {
             try {
                 let payload = args[0];
                 if (payload === undefined) payload = "undefined";

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -472,7 +472,7 @@ export function mono_wasm_trace_logger(log_domain_ptr: CharPtr, log_level_ptr: C
     }
 }
 
-export function setup_proxy_console(id: string, originalConsole: any, origin: string, ...args: any[]): void {
+export function setup_proxy_console(id: string, originalConsole: Console, origin: string, ...args: any[]): void {
     function proxyConsoleMethod(prefix: string, func: any, asJson: boolean) {
         return function () {
             try {
@@ -506,10 +506,11 @@ export function setup_proxy_console(id: string, originalConsole: any, origin: st
         };
     }
 
+    const originalConsoleObj : any = originalConsole;
     const methods = ["debug", "trace", "warn", "info", "error"];
     for (const m of methods) {
-        if (typeof (originalConsole[m]) !== "function") {
-            originalConsole[m] = proxyConsoleMethod(`console.${m}: `, originalConsole.log, false);
+        if (typeof (originalConsoleObj[m]) !== "function") {
+            originalConsoleObj[m] = proxyConsoleMethod(`console.${m}: `, originalConsole.log, false);
         }
     }
 
@@ -537,7 +538,7 @@ export function setup_proxy_console(id: string, originalConsole: any, origin: st
 
     // redirect output early, so that when emscripten starts it's already redirected
     for (const m of ["log", ...methods])
-        originalConsole[m] = proxyConsoleMethod(`console.${m}`, send, true);
+        originalConsoleObj[m] = proxyConsoleMethod(`console.${m}`, send, true);
 }
 
 type CallDetails = {

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -472,16 +472,15 @@ export function mono_wasm_trace_logger(log_domain_ptr: CharPtr, log_level_ptr: C
     }
 }
 
-export function setup_proxy_console(id: string, originalConsole: any, origin: string): void {
+export function setup_proxy_console(id: string, originalConsole: any, origin: string, ...args: any[]): void {
     function proxyConsoleMethod(prefix: string, func: any, asJson: boolean) {
         return function () {
             try {
-                const args = [...arguments];
                 let payload = args[0];
-                if (payload === undefined) payload = 'undefined';
-                else if (payload === null) payload = 'null';
-                else if (typeof payload === 'function') payload = payload.toString();
-                else if (typeof payload !== 'string') {
+                if (payload === undefined) payload = "undefined";
+                else if (payload === null) payload = "null";
+                else if (typeof payload === "function") payload = payload.toString();
+                else if (typeof payload !== "string") {
                     try {
                         payload = JSON.stringify(payload);
                     } catch (e) {
@@ -502,22 +501,22 @@ export function setup_proxy_console(id: string, originalConsole: any, origin: st
                     func([prefix + payload, ...args.slice(1)]);
                 }
             } catch (err) {
-                originalConsole.error(`proxyConsole failed: ${err}`)
+                originalConsole.error(`proxyConsole failed: ${err}`);
             }
         };
     }
 
     const methods = ["debug", "trace", "warn", "info", "error"];
-    for (let m of methods) {
+    for (const m of methods) {
         if (typeof (originalConsole[m]) !== "function") {
             originalConsole[m] = proxyConsoleMethod(`console.${m}: `, originalConsole.log, false);
         }
     }
 
-    const consoleUrl = `${origin}/console`.replace('http://', 'ws://');
+    const consoleUrl = `${origin}/console`.replace("http://", "ws://");
 
     const consoleWebSocket = new WebSocket(consoleUrl);
-    consoleWebSocket.onopen = function (event) {
+    consoleWebSocket.onopen = function () {
         originalConsole.log(`browser: [${id}] Console websocket connected.`);
     };
     consoleWebSocket.onerror = function (event) {
@@ -534,10 +533,10 @@ export function setup_proxy_console(id: string, originalConsole: any, origin: st
         else {
             originalConsole.log(msg);
         }
-    }
+    };
 
     // redirect output early, so that when emscripten starts it's already redirected
-    for (let m of ["log", ...methods])
+    for (const m of ["log", ...methods])
         originalConsole[m] = proxyConsoleMethod(`console.${m}`, send, true);
 }
 

--- a/src/mono/wasm/runtime/workers/dotnet-crypto-worker.js
+++ b/src/mono/wasm/runtime/workers/dotnet-crypto-worker.js
@@ -83,7 +83,6 @@ var ChannelWorker = {
                         Atomics.wait(this.comm, this.STATE_IDX, this.STATE_REQ_FAILED);
                         const state = Atomics.load(this.comm, this.STATE_IDX);
                         if (state !== this.STATE_RESET) {
-                            console.error(`aaarghh.. didn't reset`);
                             throw new WorkerFailedError(`expected to RESET, but got ${state}`);
                         }
                     }

--- a/src/mono/wasm/runtime/workers/dotnet-crypto-worker.js
+++ b/src/mono/wasm/runtime/workers/dotnet-crypto-worker.js
@@ -5,6 +5,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+import { setup_proxy_console } from "../debug";
+
+class FailedOrStoppedLoopError extends Error {}
+class ArgumentsError extends Error {}
+class WorkerFailedError extends Error {}
+
 var ChannelWorker = {
     _impl: class {
         // LOCK states
@@ -24,6 +30,8 @@ var ChannelWorker = {
         get STATE_REQ_P() { return 3; } // Request has multiple parts
         get STATE_RESP_P() { return 4; } // Response has multiple parts
         get STATE_AWAIT() { return 5; } // Awaiting the next part
+        get STATE_REQ_FAILED() { return 6; } // The Request failed
+        get STATE_RESET() { return 7; } // Reset to a known state
         // END ChannelOwner contract - shared constants.
 
         constructor(comm_buf, msg_buf, msg_char_len) {
@@ -32,61 +40,103 @@ var ChannelWorker = {
             this.msg_char_len = msg_char_len;
         }
 
-        async await_request(async_call) {
+        async run_message_loop(async_op) {
             for (;;) {
-                // Wait for signal to perform operation
-                Atomics.wait(this.comm, this.STATE_IDX, this.STATE_IDLE);
-
-                // Read in request
-                var req = this._read_request();
-                if (req === this.STATE_SHUTDOWN)
-                    break;
-
-                var resp = null;
                 try {
-                    // Perform async action based on request
-                    resp = await async_call(req);
-                }
-                catch (err) {
-                    console.log("Request error: " + err);
-                    resp = JSON.stringify(err);
+                    // Wait for signal to perform operation
+                    let state;
+                    do {
+                        this._wait(this.STATE_IDLE);
+                        state = Atomics.load(this.comm, this.STATE_IDX);
+                    } while (state !== this.STATE_REQ && state !== this.STATE_REQ_P && state !== this.STATE_SHUTDOWN && state !== this.STATE_REQ_FAILED && state !== this.STATE_RESET);
+
+                    this._throw_if_reset_or_shutdown();
+
+                    // Read in request
+                    var req = this._read_request();
+                    var resp = {};
+                    try {
+                        // Perform async action based on request
+                        resp.result = await async_op(req);
+                    }
+                    catch (err) {
+                        resp.error_type = typeof err;
+                        resp.error = _stringify_err(err);
+                        console.error(`Request error: ${resp.error}. req was: ${req}`);
+                    }
+
+                    // Send response
+                    this._send_response(JSON.stringify(resp));
+                } catch (err) {
+                    if (err instanceof FailedOrStoppedLoopError) {
+                        const state = Atomics.load(this.comm, this.STATE_IDX);
+                        if (state === this.STATE_SHUTDOWN)
+                            break;
+                        if (state === this.STATE_RESET)
+                            console.debug(`caller failed, reseting worker`);
+                    } else {
+                        console.error(`Worker failed to handle the request: ${_stringify_err(err)}`);
+                        this._change_state_locked(this.STATE_REQ_FAILED);
+                        Atomics.store(this.comm, this.LOCK_IDX, this.LOCK_UNLOCKED);
+
+                        console.debug(`set state to failed, now waiting to get RESET`);
+                        Atomics.wait(this.comm, this.STATE_IDX, this.STATE_REQ_FAILED);
+                        const state = Atomics.load(this.comm, this.STATE_IDX);
+                        if (state !== this.STATE_RESET) {
+                            console.error(`aaarghh.. didn't reset`);
+                            throw new WorkerFailedError(`expected to RESET, but got ${state}`);
+                        }
+                    }
+
+                    Atomics.store(this.comm, this.MSG_SIZE_IDX, 0);
+                    Atomics.store(this.comm, this.LOCK_IDX, this.LOCK_UNLOCKED);
+                    this._change_state_locked(this.STATE_IDLE);
                 }
 
-                // Send response
-                this._send_response(resp);
+                const state = Atomics.load(this.comm, this.STATE_IDX);
+                const lock_state = Atomics.load(this.comm, this.LOCK_IDX);
+
+                if (state !== this.STATE_IDLE && state !== this.STATE_REQ && state !== this.STATE_REQ_P)
+                    console.error(`-- state is not idle at the top of the loop: ${state}, and lock_state: ${lock_state}`);
+                if (lock_state !== this.LOCK_UNLOCKED && state !== this.STATE_REQ && state !== this.STATE_REQ_P && state !== this.STATE_IDLE)
+                    console.error(`-- lock is not unlocked at the top of the loop: ${lock_state}, and state: ${state}`);
             }
+
+            Atomics.store(this.comm, this.MSG_SIZE_IDX, 0);
+            this._change_state_locked(this.STATE_SHUTDOWN);
+            console.debug("******* run_message_loop ending");
         }
 
         _read_request() {
             var request = "";
             for (;;) {
                 this._acquire_lock();
+                try {
+                    this._throw_if_reset_or_shutdown();
 
-                // Get the current state and message size
-                var state = Atomics.load(this.comm, this.STATE_IDX);
-                var size_to_read = Atomics.load(this.comm, this.MSG_SIZE_IDX);
+                    // Get the current state and message size
+                    var state = Atomics.load(this.comm, this.STATE_IDX);
+                    var size_to_read = Atomics.load(this.comm, this.MSG_SIZE_IDX);
 
-                // Append the latest part of the message.
-                request += this._read_from_msg(0, size_to_read);
+                    // Append the latest part of the message.
+                    request += this._read_from_msg(0, size_to_read);
 
-                // The request is complete.
-                if (state === this.STATE_REQ) {
+                    // The request is complete.
+                    if (state === this.STATE_REQ) {
+                        break;
+                    }
+
+                    // Shutdown the worker.
+                    this._throw_if_reset_or_shutdown();
+
+                    // Reset the size and transition to await state.
+                    Atomics.store(this.comm, this.MSG_SIZE_IDX, 0);
+                    this._change_state_locked(this.STATE_AWAIT);
+                } finally {
                     this._release_lock();
-                    break;
                 }
 
-                // Shutdown the worker.
-                if (state === this.STATE_SHUTDOWN) {
-                    this._release_lock();
-                    return this.STATE_SHUTDOWN;
-                }
-
-                // Reset the size and transition to await state.
-                Atomics.store(this.comm, this.MSG_SIZE_IDX, 0);
-                Atomics.store(this.comm, this.STATE_IDX, this.STATE_AWAIT);
-                this._release_lock();
-
-                Atomics.wait(this.comm, this.STATE_IDX, this.STATE_AWAIT);
+                this._wait(this.STATE_AWAIT);
             }
 
             return request;
@@ -98,7 +148,7 @@ var ChannelWorker = {
 
         _send_response(msg) {
             if (Atomics.load(this.comm, this.STATE_IDX) !== this.STATE_REQ)
-                throw "WORKER: Invalid sync communication channel state.";
+                throw new WorkerFailedError(`WORKER: Invalid sync communication channel state.`);
 
             var state; // State machine variable
             const msg_len = msg.length;
@@ -107,24 +157,26 @@ var ChannelWorker = {
             for (;;) {
                 this._acquire_lock();
 
-                // Write the message and return how much was written.
-                var wrote = this._write_to_msg(msg, msg_written, msg_len);
-                msg_written += wrote;
+                try {
+                    // Write the message and return how much was written.
+                    var wrote = this._write_to_msg(msg, msg_written, msg_len);
+                    msg_written += wrote;
 
-                // Indicate how much was written to the this.msg buffer.
-                Atomics.store(this.comm, this.MSG_SIZE_IDX, wrote);
+                    // Indicate how much was written to the this.msg buffer.
+                    Atomics.store(this.comm, this.MSG_SIZE_IDX, wrote);
 
-                // Indicate if this was the whole message or part of it.
-                state = msg_written === msg_len ? this.STATE_RESP : this.STATE_RESP_P;
+                    // Indicate if this was the whole message or part of it.
+                    state = msg_written === msg_len ? this.STATE_RESP : this.STATE_RESP_P;
 
-                // Update the state
-                Atomics.store(this.comm, this.STATE_IDX, state);
-
-                this._release_lock();
+                    // Update the state
+                    this._change_state_locked(state);
+                } finally {
+                    this._release_lock();
+                }
 
                 // Wait for the transition to know the main thread has
                 // received the response by moving onto a new state.
-                Atomics.wait(this.comm, this.STATE_IDX, state);
+                this._wait(state);
 
                 // Done sending response.
                 if (state === this.STATE_RESP)
@@ -143,17 +195,36 @@ var ChannelWorker = {
             return ii - start;
         }
 
+        _change_state_locked(newState) {
+            Atomics.store(this.comm, this.STATE_IDX, newState);
+        }
+
         _acquire_lock() {
-            while (Atomics.compareExchange(this.comm, this.LOCK_IDX, this.LOCK_UNLOCKED, this.LOCK_OWNED) !== this.LOCK_UNLOCKED) {
-                // empty
+            for (;;) {
+                const lockState = Atomics.compareExchange(this.comm, this.LOCK_IDX, this.LOCK_UNLOCKED, this.LOCK_OWNED);
+                this._throw_if_reset_or_shutdown();
+
+                if (lockState === this.LOCK_UNLOCKED)
+                    return;
             }
         }
 
         _release_lock() {
             const result = Atomics.compareExchange(this.comm, this.LOCK_IDX, this.LOCK_OWNED, this.LOCK_UNLOCKED);
             if (result !== this.LOCK_OWNED) {
-                throw "CRYPTO: ChannelWorker tried to release a lock that wasn't acquired: " + result;
+                throw new WorkerFailedError("CRYPTO: ChannelWorker tried to release a lock that wasn't acquired: " + result);
             }
+        }
+
+        _wait(expected_state) {
+            Atomics.wait(this.comm, this.STATE_IDX, expected_state);
+            this._throw_if_reset_or_shutdown();
+        }
+
+        _throw_if_reset_or_shutdown() {
+            const state = Atomics.load(this.comm, this.STATE_IDX);
+            if (state === this.STATE_RESET || state === this.STATE_SHUTDOWN)
+                throw new FailedOrStoppedLoopError();
         }
     },
 
@@ -193,7 +264,7 @@ function get_hash_name(type) {
         case 2: return "SHA-384";
         case 3: return "SHA-512";
         default:
-            throw "CRYPTO: Unknown digest: " + type;
+            throw new ArgumentsError("CRYPTO: Unknown digest: " + type);
     }
 }
 
@@ -245,7 +316,7 @@ async function decrypt(algorithm, cryptoKey, data) {
     );
 
     const encryptedPaddingBlock = new Uint8Array(encryptedPaddingBlockResult);
-    for (var i = 0; i < encryptedPaddingBlock.length; i++) {
+    for (let i = 0; i < encryptedPaddingBlock.length; i++) {
         data.push(encryptedPaddingBlock[i]);
     }
 
@@ -267,27 +338,30 @@ function importKey(key, algorithmName, keyUsage) {
 }
 
 // Operation to perform.
-async function async_call(msg) {
+async function handle_req_async(msg) {
     const req = JSON.parse(msg);
 
     if (req.func === "digest") {
-        const digestArr = await call_digest(req.type, new Uint8Array(req.data));
-        return JSON.stringify(digestArr);
+        return await call_digest(req.type, new Uint8Array(req.data));
     } 
     else if (req.func === "sign") {
-        const signResult = await sign(req.type, new Uint8Array(req.key), new Uint8Array(req.data));
-        return JSON.stringify(signResult);
+        return await sign(req.type, new Uint8Array(req.key), new Uint8Array(req.data));
     }
     else if (req.func === "encrypt_decrypt") {
-        const signResult = await encrypt_decrypt(req.isEncrypting, req.key, req.iv, req.data);
-        return JSON.stringify(signResult);
+        return await encrypt_decrypt(req.isEncrypting, req.key, req.iv, req.data);
     }
     else {
-        throw "CRYPTO: Unknown request: " + req.func;
+        throw new ArgumentsError("CRYPTO: Unknown request: " + req.func);
     }
 }
 
+function _stringify_err(err) {
+    return (err instanceof Error && err.stack !== undefined) ? err.stack : err;
+}
+
 var s_channel;
+
+setup_proxy_console("crypto-worker", console, self.location.origin);
 
 // Initialize WebWorker
 onmessage = function (p) {
@@ -296,5 +370,5 @@ onmessage = function (p) {
         data = p.data;
     }
     s_channel = ChannelWorker.create(data.comm_buf, data.msg_buf, data.msg_char_len);
-    s_channel.await_request(async_call);
+    s_channel.run_message_loop(handle_req_async);
 };


### PR DESCRIPTION
Handle exceptions from SubtleCrypto by catching and logging exceptions coming from the crypto stack.

Reset web worker when a request fails.

Also, fix race conditions where the web worker can read its own response as part of the next request.

Contributes to #69740