### PR TITLE
[release/6.0] Fix RSA OAEP decryption in Android with non-power-of-two key lengths

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -217,7 +217,7 @@ namespace System.Security.Cryptography
 
                     if (rsaPaddingProcessor != null)
                     {
-                        return rsaPaddingProcessor.DepadOaep(paddingBuf, destination, out bytesWritten);
+                        return rsaPaddingProcessor.DepadOaep(paddingBuf.AsSpan(0, returnValue), destination, out bytesWritten);
                     }
                     else
                     {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using Test.Cryptography;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
@@ -673,6 +674,23 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(TestData.HelloBytes, output);
         }
 
+        [Theory]
+        [MemberData(nameof(OaepPaddingModes))]
+        public void NonPowerOfTwoKeySizeOaepRoundtrip(RSAEncryptionPadding oaepPaddingMode)
+        {
+            byte[] crypt;
+            byte[] output;
+
+            using (RSA rsa = RSAFactory.Create(3072))
+            {
+                crypt = Encrypt(rsa, TestData.HelloBytes, oaepPaddingMode);
+                output = Decrypt(rsa, crypt, oaepPaddingMode);
+            }
+
+            Assert.NotEqual(crypt, output);
+            Assert.Equal(TestData.HelloBytes, output);
+        }
+
         [Fact]
         public void NotSupportedValueMethods()
         {
@@ -680,6 +698,21 @@ namespace System.Security.Cryptography.Rsa.Tests
             {
                 Assert.Throws<NotSupportedException>(() => rsa.DecryptValue(null));
                 Assert.Throws<NotSupportedException>(() => rsa.EncryptValue(null));
+            }
+        }
+
+        public static IEnumerable<object[]> OaepPaddingModes
+        {
+            get
+            {
+                yield return new object[] { RSAEncryptionPadding.OaepSHA1 };
+
+                if (RSAFactory.SupportsSha2Oaep)
+                {
+                    yield return new object[] { RSAEncryptionPadding.OaepSHA256 };
+                    yield return new object[] { RSAEncryptionPadding.OaepSHA384 };
+                    yield return new object[] { RSAEncryptionPadding.OaepSHA512 };
+                }
             }
         }
     }


### PR DESCRIPTION
## Customer Impact

A customer reported in dotnet/runtime#71607 that decrypting RSA OAEP with SHA2 and a 3072-bit key on Linux resulted in a OAEP de-padding error, while other platforms were able to perform these operations successfully. 

Investigation in to the issue led to uncover that RSA OAEP decryption that uses the managed implementation does not work with non-power-of-two keys because we do not slice a rented buffer accordingly. This issue was also present for Android, in addition to the reported platform, Linux. The current implementation only works because `CryptoPool.Rent` happens to give back power-of-two arrays which are exactly the same size as the key.

The fix is to slice the data to the correct size.

.NET 7 will address this issue differently, by completely removing the managed RSA OEAP depadding in https://github.com/dotnet/runtime/pull/71670, so this is not a back port.

This is a port of https://github.com/dotnet/corefx/pull/43153 for Android for release/6.0.

## Testing

Unit tests were introduced to test RSA OAEP encryption with a 3072-bit RSA key. These tests will be forward-ported to dotnet/runtime@main.

## Risk

Minimal. The change is localized and understood that a `Slice` was missing.