### PR TITLE
Add setter to TransactionManager.DefaultTimeout and MaxTimeout.

### DIFF
--- a/src/libraries/System.Transactions.Local/ref/System.Transactions.Local.cs
+++ b/src/libraries/System.Transactions.Local/ref/System.Transactions.Local.cs
@@ -187,10 +187,10 @@ namespace System.Transactions
     }
     public static partial class TransactionManager
     {
-        public static System.TimeSpan DefaultTimeout { get { throw null; } }
+        public static System.TimeSpan DefaultTimeout { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.DisallowNullAttribute]
         public static System.Transactions.HostCurrentTransactionCallback? HostCurrentCallback { get { throw null; } set { } }
-        public static System.TimeSpan MaximumTimeout { get { throw null; } }
+        public static System.TimeSpan MaximumTimeout { get { throw null; } set { } }
         public static event System.Transactions.TransactionStartedEventHandler? DistributedTransactionStarted { add { } remove { } }
         public static void RecoveryComplete(System.Guid resourceManagerIdentifier) { }
         public static System.Transactions.Enlistment Reenlist(System.Guid resourceManagerIdentifier, byte[] recoveryInformation, System.Transactions.IEnlistmentNotification enlistmentNotification) { throw null; }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
@@ -310,6 +310,31 @@ namespace System.Transactions
                 }
                 return s_defaultTimeout;
             }
+            set
+            {
+                TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
+                if (etwLog.IsEnabled())
+                {
+                    etwLog.MethodEnter(TraceSourceType.TraceSourceBase, "TransactionManager.set_DefaultTimeout");
+                }
+
+                s_defaultTimeout = ValidateTimeout(value);
+
+                if (s_defaultTimeout != DefaultSettingsSection.Timeout)
+                {
+                    if (etwLog.IsEnabled())
+                    {
+                        etwLog.ConfiguredDefaultTimeoutAdjusted();
+                    }
+                }
+
+                s_defaultTimeoutValidated = true;
+
+                if (etwLog.IsEnabled())
+                {
+                    etwLog.MethodExit(TraceSourceType.TraceSourceBase, "TransactionManager.set_DefaultTimeout");
+                }
+            }
         }
 
 
@@ -325,7 +350,7 @@ namespace System.Transactions
                     etwLog.MethodEnter(TraceSourceType.TraceSourceBase, "TransactionManager.get_DefaultMaximumTimeout");
                 }
 
-                LazyInitializer.EnsureInitialized(ref s_maximumTimeout, ref s_cachedMaxTimeout, ref s_classSyncObject, () => DefaultSettingsSection.Timeout);
+                LazyInitializer.EnsureInitialized(ref s_maximumTimeout, ref s_cachedMaxTimeout, ref s_classSyncObject, () => MachineSettingsSection.MaxTimeout);
 
                 if (etwLog.IsEnabled())
                 {
@@ -333,6 +358,27 @@ namespace System.Transactions
                 }
 
                 return s_maximumTimeout;
+            }
+            set
+            {
+                TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
+                if (etwLog.IsEnabled())
+                {
+                    etwLog.MethodEnter(TraceSourceType.TraceSourceBase, "TransactionManager.set_DefaultMaximumTimeout");
+                }
+
+                if(value < TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                s_cachedMaxTimeout = false;
+                LazyInitializer.EnsureInitialized(ref s_maximumTimeout, ref s_cachedMaxTimeout, ref s_classSyncObject, () => value);
+
+                if (etwLog.IsEnabled())
+                {
+                    etwLog.MethodExit(TraceSourceType.TraceSourceBase, "TransactionManager.set_DefaultMaximumTimeout");
+                }
             }
         }
 

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
@@ -374,8 +374,14 @@ namespace System.Transactions
 
                 s_cachedMaxTimeout = true;
                 s_maximumTimeout = value;
-                TimeSpan defaultTimeout = DefaultTimeout;
-                s_defaultTimeout = ValidateTimeout(defaultTimeout);
+
+                if(!s_defaultTimeoutValidated)
+                {
+                    s_defaultTimeout = DefaultSettingsSection.Timeout;
+                }
+
+                TimeSpan defaultTimeout = s_defaultTimeout;
+                s_defaultTimeout = ValidateTimeout(s_defaultTimeout);
                 if (s_defaultTimeout != defaultTimeout)
                 {
                     if (etwLog.IsEnabled())

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
@@ -374,7 +374,16 @@ namespace System.Transactions
 
                 s_cachedMaxTimeout = true;
                 s_maximumTimeout = value;
+                TimeSpan defaultTimeout = s_defaultTimeout;
                 s_defaultTimeout = ValidateTimeout(s_defaultTimeout);
+                if (s_defaultTimeout != defaultTimeout)
+                {
+                    if (etwLog.IsEnabled())
+                    {
+                        etwLog.ConfiguredDefaultTimeoutAdjusted();
+                    }
+                }
+
                 s_defaultTimeoutValidated = true;
 
                 if (etwLog.IsEnabled())

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
@@ -320,7 +320,7 @@ namespace System.Transactions
 
                 s_defaultTimeout = ValidateTimeout(value);
 
-                if (s_defaultTimeout != DefaultSettingsSection.Timeout)
+                if (s_defaultTimeout != value)
                 {
                     if (etwLog.IsEnabled())
                     {
@@ -372,8 +372,10 @@ namespace System.Transactions
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
-                s_cachedMaxTimeout = false;
-                LazyInitializer.EnsureInitialized(ref s_maximumTimeout, ref s_cachedMaxTimeout, ref s_classSyncObject, () => value);
+                s_cachedMaxTimeout = true;
+                s_maximumTimeout = value;
+                s_defaultTimeout = ValidateTimeout(s_defaultTimeout);
+                s_defaultTimeoutValidated = true;
 
                 if (etwLog.IsEnabled())
                 {

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
@@ -367,7 +367,7 @@ namespace System.Transactions
                     etwLog.MethodEnter(TraceSourceType.TraceSourceBase, "TransactionManager.set_DefaultMaximumTimeout");
                 }
 
-                if(value < TimeSpan.Zero)
+                if (value < TimeSpan.Zero)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
@@ -375,7 +375,7 @@ namespace System.Transactions
                 s_cachedMaxTimeout = true;
                 s_maximumTimeout = value;
 
-                if(!s_defaultTimeoutValidated)
+                if (!s_defaultTimeoutValidated)
                 {
                     s_defaultTimeout = DefaultSettingsSection.Timeout;
                 }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
@@ -374,7 +374,7 @@ namespace System.Transactions
                 LazyInitializer.EnsureInitialized(ref s_defaultTimeoutTicks, ref s_defaultTimeoutValidated, ref s_classSyncObject, () => DefaultSettingsSection.Timeout.Ticks);
 
                 long defaultTimeoutTicks = Interlocked.Read(ref s_defaultTimeoutTicks);
-                Interlocked.Exchange(ref s_defaultTimeoutTicks, ValidateTimeout(new TimeSpan(Interlocked.Read(ref s_defaultTimeoutTicks))).Ticks);
+                Interlocked.Exchange(ref s_defaultTimeoutTicks, ValidateTimeout(new TimeSpan(defaultTimeoutTicks)).Ticks);
                 if (Interlocked.Read(ref s_defaultTimeoutTicks) != defaultTimeoutTicks)
                 {
                     if (etwLog.IsEnabled())

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
@@ -374,8 +374,8 @@ namespace System.Transactions
 
                 s_cachedMaxTimeout = true;
                 s_maximumTimeout = value;
-                TimeSpan defaultTimeout = s_defaultTimeout;
-                s_defaultTimeout = ValidateTimeout(s_defaultTimeout);
+                TimeSpan defaultTimeout = DefaultTimeout;
+                s_defaultTimeout = ValidateTimeout(defaultTimeout);
                 if (s_defaultTimeout != defaultTimeout)
                 {
                     if (etwLog.IsEnabled())

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
@@ -373,10 +373,9 @@ namespace System.Transactions
                 s_maximumTimeout = value;
                 LazyInitializer.EnsureInitialized(ref s_defaultTimeoutTicks, ref s_defaultTimeoutValidated, ref s_classSyncObject, () => DefaultSettingsSection.Timeout.Ticks);
 
-                long defaultTimeoutTicks = 0;
-                Interlocked.Exchange(ref defaultTimeoutTicks, Interlocked.Read(ref s_defaultTimeoutTicks));
+                long defaultTimeoutTicks = Interlocked.Read(ref s_defaultTimeoutTicks);
                 Interlocked.Exchange(ref s_defaultTimeoutTicks, ValidateTimeout(new TimeSpan(Interlocked.Read(ref s_defaultTimeoutTicks))).Ticks);
-                if (Interlocked.Read(ref s_defaultTimeoutTicks) != Interlocked.Read(ref defaultTimeoutTicks))
+                if (Interlocked.Read(ref s_defaultTimeoutTicks) != defaultTimeoutTicks)
                 {
                     if (etwLog.IsEnabled())
                     {

--- a/src/libraries/System.Transactions.Local/tests/System.Transactions.Local.Tests.csproj
+++ b/src/libraries/System.Transactions.Local/tests/System.Transactions.Local.Tests.csproj
@@ -7,6 +7,7 @@
     <Compile Include="NonMsdtcPromoterTests.cs" />
     <Compile Include="AsyncTransactionScopeTests.cs" />
     <Compile Include="IntResourceManager.cs" />
+    <Compile Include="TransactionManagerTest.cs" />
     <Compile Include="TransactionScopeTest.cs" />
     <Compile Include="AsyncTest.cs" />
     <Compile Include="EnlistTest.cs" />

--- a/src/libraries/System.Transactions.Local/tests/TransactionManagerTest.cs
+++ b/src/libraries/System.Transactions.Local/tests/TransactionManagerTest.cs
@@ -11,13 +11,12 @@ namespace System.Transactions.Tests
         public void DefaultTimeout_MaxTimeout_Set_Get()
         {
             TimeSpan tsDefault = TimeSpan.Parse("00:02:00");
-            TimeSpan tsMax = TimeSpan.Parse("00:30:00");
-
             TransactionManager.DefaultTimeout = tsDefault;
             Assert.Equal(tsDefault, TransactionManager.DefaultTimeout);
 
-            TransactionManager.MaximumTimeout = tsMax; 
-            Assert.Equal(tsMax, TransactionManager.MaximumTimeout);
+            TimeSpan tsMax = TimeSpan.Parse("00:30:00");            
+            TransactionManager.MaximumTimeout = tsMax;
+            Assert.Equal(tsMax, TransactionManager.MaximumTimeout);            
 
             TimeSpan ts = TransactionManager.MaximumTimeout.Add(TimeSpan.FromMinutes(10));
             TransactionManager.DefaultTimeout = ts;

--- a/src/libraries/System.Transactions.Local/tests/TransactionManagerTest.cs
+++ b/src/libraries/System.Transactions.Local/tests/TransactionManagerTest.cs
@@ -7,7 +7,6 @@ namespace System.Transactions.Tests
 {
     public class TransactionManagerTest
     {
-
         [Fact]
         public void DefaultTimeout_Set_LessThanMaximum()
         {

--- a/src/libraries/System.Transactions.Local/tests/TransactionManagerTest.cs
+++ b/src/libraries/System.Transactions.Local/tests/TransactionManagerTest.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Transactions.Tests
+{
+    public class TransactionManagerTest
+    {
+
+        [Fact]
+        public void DefaultTimeout_Set_LessThanMaximum()
+        {
+            TimeSpan tsDefault = TimeSpan.Parse("00:02:00");
+            TransactionManager.DefaultTimeout = tsDefault;
+
+            Assert.Equal(tsDefault, TransactionManager.DefaultTimeout);
+        }
+
+        [Fact]
+        public void DefaultTimeout_Set_ExceedMaximum()
+        {
+            TimeSpan ts = TransactionManager.MaximumTimeout.Add(TimeSpan.FromMinutes(10));
+            TransactionManager.DefaultTimeout = ts;
+
+            Assert.Equal(TransactionManager.DefaultTimeout, TransactionManager.MaximumTimeout);
+        }
+       
+        [Fact]
+        public void DefaultTimeout_Set_Negative()
+        {
+            TimeSpan ts = TimeSpan.Parse("-00:01:00");
+            Assert.Throws<ArgumentOutOfRangeException>(() => TransactionManager.DefaultTimeout = ts);
+        }
+
+        [Fact]
+        public void MaximumTimeout_Set_Positive()
+        {
+            TimeSpan ts = TimeSpan.Parse("00:30:00");
+            TransactionManager.MaximumTimeout = ts;
+
+            Assert.Equal(ts, TransactionManager.MaximumTimeout);
+        }
+
+        [Fact]
+        public void MaximumTimeout_Set_Negative()
+        {
+            TimeSpan ts = TimeSpan.Parse("-00:10:00");
+            Assert.Throws<ArgumentOutOfRangeException>(() => TransactionManager.MaximumTimeout = ts);
+        }
+    }
+}

--- a/src/libraries/System.Transactions.Local/tests/TransactionManagerTest.cs
+++ b/src/libraries/System.Transactions.Local/tests/TransactionManagerTest.cs
@@ -23,12 +23,8 @@ namespace System.Transactions.Tests
             TransactionManager.DefaultTimeout = ts;
             Assert.Equal(tsMax, TransactionManager.MaximumTimeout);
             Assert.Equal(TransactionManager.DefaultTimeout, TransactionManager.MaximumTimeout);
-        }
-       
-        [Fact]
-        public void DefaultTimeout_MaxTimeout_Set_Negative()
-        {
-            TimeSpan ts = TimeSpan.Parse("-00:01:00");
+
+            ts = TimeSpan.Parse("-00:01:00");
             Assert.Throws<ArgumentOutOfRangeException>(() => TransactionManager.DefaultTimeout = ts);
             Assert.Throws<ArgumentOutOfRangeException>(() => TransactionManager.MaximumTimeout = ts);
         }

--- a/src/libraries/System.Transactions.Local/tests/TransactionManagerTest.cs
+++ b/src/libraries/System.Transactions.Local/tests/TransactionManagerTest.cs
@@ -8,43 +8,28 @@ namespace System.Transactions.Tests
     public class TransactionManagerTest
     {
         [Fact]
-        public void DefaultTimeout_Set_LessThanMaximum()
+        public void DefaultTimeout_MaxTimeout_Set_Get()
         {
             TimeSpan tsDefault = TimeSpan.Parse("00:02:00");
+            TimeSpan tsMax = TimeSpan.Parse("00:30:00");
+
             TransactionManager.DefaultTimeout = tsDefault;
-
             Assert.Equal(tsDefault, TransactionManager.DefaultTimeout);
-        }
 
-        [Fact]
-        public void DefaultTimeout_Set_ExceedMaximum()
-        {
+            TransactionManager.MaximumTimeout = tsMax; 
+            Assert.Equal(tsMax, TransactionManager.MaximumTimeout);
+
             TimeSpan ts = TransactionManager.MaximumTimeout.Add(TimeSpan.FromMinutes(10));
             TransactionManager.DefaultTimeout = ts;
-
+            Assert.Equal(tsMax, TransactionManager.MaximumTimeout);
             Assert.Equal(TransactionManager.DefaultTimeout, TransactionManager.MaximumTimeout);
         }
        
         [Fact]
-        public void DefaultTimeout_Set_Negative()
+        public void DefaultTimeout_MaxTimeout_Set_Negative()
         {
             TimeSpan ts = TimeSpan.Parse("-00:01:00");
             Assert.Throws<ArgumentOutOfRangeException>(() => TransactionManager.DefaultTimeout = ts);
-        }
-
-        [Fact]
-        public void MaximumTimeout_Set_Positive()
-        {
-            TimeSpan ts = TimeSpan.Parse("00:30:00");
-            TransactionManager.MaximumTimeout = ts;
-
-            Assert.Equal(ts, TransactionManager.MaximumTimeout);
-        }
-
-        [Fact]
-        public void MaximumTimeout_Set_Negative()
-        {
-            TimeSpan ts = TimeSpan.Parse("-00:10:00");
             Assert.Throws<ArgumentOutOfRangeException>(() => TransactionManager.MaximumTimeout = ts);
         }
     }


### PR DESCRIPTION
@HongGit , @mconnew , @stephentoub, this is for #71025 and #59282.

Test scenario:
1. set DefaultTimeout and MaxTimeout with value in normal/supported range, get expected value being set
2. set DefaultTimeout with value greater than MaxTimeout, get the MaxTimeout value for DefaultTimeout 
3. set DefaultTimeout and MaxTimeout with negative timespan, throws ArgumentOutOfRangeException
