### PR TITLE
Stop throwing when attempting to validate a JObject.

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -518,7 +518,7 @@ namespace System.ComponentModel.DataAnnotations
         private static ICollection<KeyValuePair<ValidationContext, object?>> GetPropertyValues(object instance,
             ValidationContext validationContext)
         {
-            var properties = TypeDescriptor.GetProperties(instance);
+            var properties = TypeDescriptor.GetProperties(instance.GetType());
             var items = new List<KeyValuePair<ValidationContext, object?>>(properties.Count);
             foreach (PropertyDescriptor property in properties)
             {

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace System.ComponentModel.DataAnnotations.Tests
@@ -331,6 +332,16 @@ namespace System.ComponentModel.DataAnnotations.Tests
             Assert.Equal(2, validationResults.Count);
             Assert.Contains(validationResults, x => x.ErrorMessage == "ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value");
             Assert.Contains(validationResults, x => x.ErrorMessage == "The SecondPropertyToBeTested field is not a valid phone number.");
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework has always thrown for this case. See https://github.com/dotnet/runtime/issues/64207")]
+        public static void TryValidateObject_for_JObject_does_not_throw()
+        {
+            var objectToBeValidated = JObject.Parse("{\"Enabled\":true}");
+            var results = new List<ValidationResult>();
+            Assert.True(Validator.TryValidateObject(objectToBeValidated, new ValidationContext(objectToBeValidated), results, true));
+            Assert.Empty(results);
         }
 
         public class RequiredFailure


### PR DESCRIPTION
Fixes #64207

Use the type to get property descriptors, rather than the instance, since the instance can return dynamic property descriptors that are not found on the underlying type, but the rest of validation code does not support this and uses the type.

The case of JObject would always throw on .NET Framework. It stopped throwing when the code diverged in core, and people started relying on this. Once we brought back the Framework code, it started to throw again, which broke people who had been using the Core code in the meantime.