### PR TITLE
[mono] Avoid calling mono_metadata_type_hash () on the container clas…

### DIFF
--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1920,7 +1920,7 @@ static guint
 mono_generic_class_hash (gconstpointer data)
 {
 	const MonoGenericClass *gclass = (const MonoGenericClass *) data;
-	guint hash = mono_metadata_type_hash (m_class_get_byval_arg (gclass->container_class));
+	guint hash = mono_metadata_str_hash (m_class_get_name (gclass->container_class));
 
 	hash *= 13;
 	hash += gclass->is_tb_open;


### PR DESCRIPTION
…s in mono_generic_class_hash ().

If a class inherits from a generic instance instantiated with itself, then its possible
for mono_generic_class_hash () to be called while the container class is not fully
initialized yet, i.e. byval_arg.type is 0. This would cause the generic class to change
its hash.

Fixes https://github.com/dotnet/runtime/issues/71424.