### PR TITLE
Remove GeneratePackageOnBuild missed on branding PR

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -16,11 +16,10 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5128</NoWarn> <!-- No Dependencies-->
     <PackageDescription>Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages.</PackageDescription>
-    
+
     <!-- When building from source, ensure the RID we're building for is part of the RID graph -->
     <AdditionalRuntimeIdentifiers Condition="'$(DotNetBuildFromSource)' == 'true'">$(AdditionalRuntimeIdentifiers);$(OutputRID)</AdditionalRuntimeIdentifiers>
     <ServicingVersion>5</ServicingVersion>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
@@ -58,6 +57,6 @@
                           RuntimeJson="$(IntermediateOutputPath)runtime.json"
                           UpdateRuntimeFiles="True" />
   </Target>
-  
+
   <Import Project="runtimeGroups.props" />
 </Project>


### PR DESCRIPTION
Branding PR: https://github.com/dotnet/runtime/pull/71668

@ViktorHofer AFAIK the Microsoft.NetCore.Platforms.csproj line always needs to be removed like all others, judging by the blame history of

- the ServicingVersion line: https://github.com/dotnet/runtime/blame/da14e9fc6a8c44be40fde90b93dec7ab046ce2a6/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj#L22

- and the GeneratePackageOnBuild line: https://github.com/dotnet/runtime/blame/da14e9fc6a8c44be40fde90b93dec7ab046ce2a6/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj#L23