### PR TITLE
Re-enable test now that the msbuild fix has propagated

### DIFF
--- a/src/tests/reflection/GenericAttribute/GenericAttributeMetadata.il
+++ b/src/tests/reflection/GenericAttribute/GenericAttributeMetadata.il
@@ -10,14 +10,13 @@
 
   // --- The following custom attribute is added automatically, do not uncomment -------
   //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 07 01 00 00 00 00 ) 
-/*  Re-enable once the fix to https://github.com/dotnet/msbuild/issues/6734 propagates to this repo.
   .custom instance void class SingleAttribute`1<int32>::.ctor() = ( 01 00 00 00 ) 
   .custom instance void class SingleAttribute`1<bool>::.ctor() = ( 01 00 00 00 ) 
   .custom instance void class MultiAttribute`1<int32>::.ctor() = ( 01 00 00 00 ) 
   .custom instance void class MultiAttribute`1<int32>::.ctor(!0) = ( 01 00 01 00 00 00 00 00 ) 
   .custom instance void class MultiAttribute`1<int32>::.ctor() = ( 01 00 01 00 54 08 05 56 61 6C 75 65 02 00 00 00 ) // ....T..Value....
   .custom instance void class MultiAttribute`1<bool>::.ctor() = ( 01 00 00 00 ) 
-  .custom instance void class MultiAttribute`1<bool>::.ctor(!0) = ( 01 00 01 00 00 ) */
+  .custom instance void class MultiAttribute`1<bool>::.ctor(!0) = ( 01 00 01 00 00 )
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }

--- a/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
+++ b/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
@@ -8,7 +8,6 @@ class Program
 {
     static int Main(string[] args)
     {
-/* Re-enable once the fix to https://github.com/dotnet/msbuild/issues/6734 propagates to this repo.
         Assembly assembly = typeof(Class).GetTypeInfo().Assembly;
         Assert(CustomAttributeExtensions.GetCustomAttribute<SingleAttribute<int>>(assembly) != null);
         Assert(((ICustomAttributeProvider)assembly).GetCustomAttributes(typeof(SingleAttribute<int>), true) != null);
@@ -20,7 +19,6 @@ class Program
         Assert(((ICustomAttributeProvider)assembly).IsDefined(typeof(SingleAttribute<bool>), true));
         Assert(CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
         Assert(CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
-*/
 
         // Uncomment when https://github.com/dotnet/runtime/issues/66168 is resolved
         // Module module = programTypeInfo.Module;


### PR DESCRIPTION
These tests were disabled due to an msbuild bug that made the test not compileable. That has been fixed, and the fix has now propagated to our repo.

Fix #56880