### PR TITLE
Remove implicit fallback to reflection-based serialization

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -356,6 +356,7 @@ namespace System.Text.Json
         public System.Text.Json.JsonNamingPolicy? PropertyNamingPolicy { get { throw null; } set { } }
         public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
         public System.Text.Json.Serialization.ReferenceHandler? ReferenceHandler { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver TypeInfoResolver { [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications."), System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")] get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -400,10 +400,10 @@
     <value>The converter '{0}' is not compatible with the type '{1}'.</value>
   </data>
   <data name="ResolverTypeNotCompatible" xml:space="preserve">
-    <value>TypeInfoResolver expected to return JsonTypeInfo of type '{0}' but returned JsonTypeInfo of type '{1}'.</value>
+    <value>The IJsonTypeInfoResolver returned an incompatible JsonTypeInfo instance of type '{0}', expected type '{1}'.</value>
   </data>
   <data name="ResolverTypeInfoOptionsNotCompatible" xml:space="preserve">
-    <value>TypeInfoResolver expected to return JsonTypeInfo options bound to the JsonSerializerOptions provided in the argument.</value>
+    <value>The IJsonTypeInfoResolver returned a JsonTypeInfo instance whose JsonSerializerOptions setting does not match the provided argument.</value>
   </data>
   <data name="SerializationConverterWrite" xml:space="preserve">
     <value>The converter '{0}' wrote too much or not enough.</value>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -65,7 +65,7 @@ namespace System.Text.Json.Serialization
                     break;
             }
 
-            return converter!;
+            return converter;
         }
 
         internal sealed override object ReadCoreAsObject(

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -84,6 +84,7 @@ namespace System.Text.Json.Serialization
 
         internal sealed override JsonConverter<TTarget> CreateCastingConverter<TTarget>()
         {
+            JsonSerializerOptions.CheckConverterNullabilityIsSameAsPropertyType(this, typeof(TTarget));
             return new CastingConverter<TTarget, T>(this);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
@@ -20,12 +20,9 @@ namespace System.Text.Json
             Debug.Assert(runtimeType != null);
 
             options ??= JsonSerializerOptions.Default;
-            if (!options.IsInitializedForReflectionSerializer)
-            {
-                options.InitializeForReflectionSerializer();
-            }
+            options.InitializeForReflectionSerializer();
 
-            return options.GetOrAddJsonTypeInfoForRootType(runtimeType);
+            return options.GetJsonTypeInfoForRootType(runtimeType);
         }
 
         private static JsonTypeInfo GetTypeInfo(JsonSerializerContext context, Type type)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -366,13 +366,7 @@ namespace System.Text.Json
                 ThrowHelper.ThrowArgumentNullException(nameof(utf8Json));
             }
 
-            options ??= JsonSerializerOptions.Default;
-            if (!options.IsInitializedForReflectionSerializer)
-            {
-                options.InitializeForReflectionSerializer();
-            }
-
-            JsonTypeInfo jsonTypeInfo = options.GetOrAddJsonTypeInfoForRootType(typeof(TValue));
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
             return CreateAsyncEnumerableDeserializer(utf8Json, CreateQueueTypeInfo<TValue>(jsonTypeInfo), cancellationToken);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -57,11 +57,7 @@ namespace System.Text.Json
         {
             Debug.Assert(writer != null);
 
-            Debug.Assert(!jsonTypeInfo.HasSerialize ||
-                jsonTypeInfo is not JsonTypeInfo<TValue> ||
-                jsonTypeInfo.Options.SerializerContext == null ||
-                !jsonTypeInfo.Options.SerializerContext.CanUseSerializationLogic,
-                "Incorrect method called. WriteUsingGeneratedSerializer() should have been called instead.");
+            // TODO unify method with WriteUsingGeneratedSerializer
 
             WriteStack state = default;
             jsonTypeInfo.EnsureConfigured();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -22,18 +22,8 @@ namespace System.Text.Json.Serialization
         /// <remarks>
         /// The options instance cannot be mutated once it is bound to the context instance.
         /// </remarks>
-        public JsonSerializerOptions Options
-        {
-            get
-            {
-                if (_options is null)
-                {
-                    var options = new JsonSerializerOptions { TypeInfoResolver = this, IsLockedInstance = true };
-                    _options = options;
-                }
-
-                return _options;
-            }
+        public JsonSerializerOptions Options =>
+            _options ??= new JsonSerializerOptions { TypeInfoResolver = this, IsLockedInstance = true };
 
             internal set
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -109,6 +109,11 @@ namespace System.Text.Json.Serialization
 
         JsonTypeInfo? IJsonTypeInfoResolver.GetTypeInfo(Type type, JsonSerializerOptions options)
         {
+            if (options != null && options != _options)
+            {
+                ThrowHelper.ThrowInvalidOperationException_ResolverTypeInfoOptionsNotCompatible();
+            }
+
             return GetTypeInfo(type);
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -22,8 +22,9 @@ namespace System.Text.Json.Serialization
         /// <remarks>
         /// The options instance cannot be mutated once it is bound to the context instance.
         /// </remarks>
-        public JsonSerializerOptions Options =>
-            _options ??= new JsonSerializerOptions { TypeInfoResolver = this, IsLockedInstance = true };
+        public JsonSerializerOptions Options
+        {
+            get => _options ??= new JsonSerializerOptions { TypeInfoResolver = this, IsLockedInstance = true };
 
             internal set
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -37,6 +37,7 @@ namespace System.Text.Json.Serialization
 
             internal set
             {
+                Debug.Assert(!value.IsLockedInstance);
                 value.TypeInfoResolver = this;
                 value.IsLockedInstance = true;
                 _options = value;
@@ -103,6 +104,7 @@ namespace System.Text.Json.Serialization
         {
             if (options != null)
             {
+                options.VerifyMutable();
                 Options = options;
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -4,12 +4,9 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Text.Json.Reflection;
 using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Converters;
 using System.Text.Json.Serialization.Metadata;
-using System.Threading;
 
 namespace System.Text.Json
 {
@@ -25,67 +22,6 @@ namespace System.Text.Json
         /// Once serialization or deserialization occurs, the list cannot be modified.
         /// </remarks>
         public IList<JsonConverter> Converters => _converters;
-
-        // This may return factory converter
-        internal JsonConverter? GetCustomConverterFromMember(Type typeToConvert, MemberInfo memberInfo)
-        {
-            Debug.Assert(memberInfo.DeclaringType != null, "Properties and fields always have a declaring type.");
-            JsonConverter? converter = null;
-
-            JsonConverterAttribute? converterAttribute = memberInfo.GetUniqueCustomAttribute<JsonConverterAttribute>(inherit: false);
-            if (converterAttribute != null)
-            {
-                converter = GetConverterFromAttribute(converterAttribute, typeToConvert, memberInfo);
-            }
-
-            return converter;
-        }
-
-        /// <summary>
-        /// Gets converter for type but does not use TypeInfoResolver
-        /// </summary>
-        internal JsonConverter GetConverterForType(Type typeToConvert)
-        {
-            JsonConverter converter = GetConverterFromOptionsOrReflectionConverter(typeToConvert);
-            Debug.Assert(converter != null);
-
-            converter = ExpandFactoryConverter(converter, typeToConvert);
-
-            CheckConverterNullabilityIsSameAsPropertyType(converter, typeToConvert);
-
-            return converter;
-        }
-
-        [return: NotNullIfNotNull("converter")]
-        internal JsonConverter? ExpandFactoryConverter(JsonConverter? converter, Type typeToConvert)
-        {
-            if (converter is JsonConverterFactory factory)
-            {
-                converter = factory.GetConverterInternal(typeToConvert, this);
-
-                // A factory cannot return null; GetConverterInternal checked for that.
-                Debug.Assert(converter != null);
-            }
-
-            return converter;
-        }
-
-        internal static void CheckConverterNullabilityIsSameAsPropertyType(JsonConverter converter, Type propertyType)
-        {
-            // User has indicated that either:
-            //   a) a non-nullable-struct handling converter should handle a nullable struct type or
-            //   b) a nullable-struct handling converter should handle a non-nullable struct type.
-            // User should implement a custom converter for the underlying struct and remove the unnecessary CanConvert method override.
-            // The serializer will automatically wrap the custom converter with NullableConverter<T>.
-            //
-            // We also throw to avoid passing an invalid argument to setters for nullable struct properties,
-            // which would cause an InvalidProgramException when the generated IL is invoked.
-            if (propertyType.IsValueType && converter.IsValueType &&
-                (propertyType.IsNullableOfT() ^ converter.TypeToConvert.IsNullableOfT()))
-            {
-                ThrowHelper.ThrowInvalidOperationException_ConverterCanConvertMultipleTypes(propertyType, converter);
-            }
-        }
 
         /// <summary>
         /// Returns the converter for the specified type.
@@ -110,7 +46,7 @@ namespace System.Text.Json
                 ThrowHelper.ThrowArgumentNullException(nameof(typeToConvert));
             }
 
-            DefaultJsonTypeInfoResolver.RootDefaultInstance();
+            _typeInfoResolver ??= DefaultJsonTypeInfoResolver.RootDefaultInstance();
             return GetConverterFromTypeInfo(typeToConvert);
         }
 
@@ -119,39 +55,29 @@ namespace System.Text.Json
         /// </summary>
         internal JsonConverter GetConverterFromTypeInfo(Type typeToConvert)
         {
-            if (_cachingContext == null)
-            {
-                if (_isLockedInstance)
-                {
-                    InitializeCachingContext();
-                }
-                else
-                {
-                    // We do not want to lock options instance here but we need to return correct answer
-                    // which means we need to go through TypeInfoResolver but without caching because that's the
-                    // only place which will have correct converter for JsonSerializerContext and reflection
-                    // based resolver. It will also work correctly for combined resolvers.
-                    return GetTypeInfoInternal(typeToConvert)?.Converter
-                        ?? GetConverterFromOptionsOrReflectionConverter(typeToConvert);
+            JsonConverter? converter;
 
-                }
+            if (IsLockedInstance)
+            {
+                InitializeCachingContext();
+                converter = _cachingContext.GetOrAddJsonTypeInfo(typeToConvert)?.Converter;
+            }
+            else
+            {
+                // We do not want to lock options instance here but we need to return correct answer
+                // which means we need to go through TypeInfoResolver but without caching because that's the
+                // only place which will have correct converter for JsonSerializerContext and reflection
+                // based resolver. It will also work correctly for combined resolvers.
+                converter = GetTypeInfoNoCaching(typeToConvert)?.Converter;
             }
 
-            JsonConverter? converter = _cachingContext.GetOrAddJsonTypeInfo(typeToConvert)?.Converter;
-
-            // we can get here if resolver returned null but converter was added for the type
-            converter ??= GetConverterFromOptions(typeToConvert);
-
-            if (converter == null)
-            {
-                ThrowHelper.ThrowNotSupportedException_BuiltInConvertersNotRooted(typeToConvert);
-                return null!;
-            }
-
-            return converter;
+            return converter is null
+                // we can get here if resolver returned null but converter was added for the type
+                ? GetConverterFromListOrBuiltInConverter(typeToConvert)
+                : converter;
         }
 
-        private JsonConverter? GetConverterFromOptions(Type typeToConvert)
+        internal JsonConverter? GetConverterFromList(Type typeToConvert)
         {
             foreach (JsonConverter item in _converters)
             {
@@ -164,93 +90,54 @@ namespace System.Text.Json
             return null;
         }
 
-        private JsonConverter GetConverterFromOptionsOrReflectionConverter(Type typeToConvert)
+        internal JsonConverter GetConverterFromListOrBuiltInConverter(Type typeToConvert)
         {
-            Debug.Assert(typeToConvert != null);
+            JsonConverter? converter = GetConverterFromList(typeToConvert);
+            return GetCustomOrBuiltInConverter(typeToConvert, converter);
+        }
 
-            // Priority 1: Attempt to get custom converter from the Converters list.
-            JsonConverter? converter = GetConverterFromOptions(typeToConvert);
+        internal JsonConverter GetCustomOrBuiltInConverter(Type typeToConvert, JsonConverter? converter)
+        {
+            // Attempt to get built-in converter.
+            converter ??= DefaultJsonTypeInfoResolver.GetBuiltInConverter(typeToConvert);
+            // Expand potential convert converter factory.
+            converter = ExpandConverterFactory(converter, typeToConvert);
 
-            // Priority 2: Attempt to get converter from [JsonConverter] on the type being converted.
-            if (converter == null)
+            if (!converter.TypeToConvert.IsInSubtypeRelationshipWith(typeToConvert))
             {
-                JsonConverterAttribute? converterAttribute = typeToConvert.GetUniqueCustomAttribute<JsonConverterAttribute>(inherit: false);
-                if (converterAttribute != null)
-                {
-                    converter = GetConverterFromAttribute(converterAttribute, typeToConvert: typeToConvert, memberInfo: null);
-                }
+                ThrowHelper.ThrowInvalidOperationException_SerializationConverterNotCompatible(converter.GetType(), converter.TypeToConvert);
             }
 
-            // Priority 3: Attempt to get built-in converter.
-            converter ??= DefaultJsonTypeInfoResolver.GetDefaultConverter(typeToConvert);
+            CheckConverterNullabilityIsSameAsPropertyType(converter, typeToConvert);
+            return converter;
+        }
 
-            // Allow redirection for generic types or the enum converter.
+        [return: NotNullIfNotNull("converter")]
+        internal JsonConverter? ExpandConverterFactory(JsonConverter? converter, Type typeToConvert)
+        {
             if (converter is JsonConverterFactory factory)
             {
                 converter = factory.GetConverterInternal(typeToConvert, this);
-
-                // A factory cannot return null; GetConverterInternal checked for that.
-                Debug.Assert(converter != null);
-            }
-
-            Type converterTypeToConvert = converter.TypeToConvert;
-
-            if (!converterTypeToConvert.IsInSubtypeRelationshipWith(typeToConvert))
-            {
-                ThrowHelper.ThrowInvalidOperationException_SerializationConverterNotCompatible(converter.GetType(), typeToConvert);
             }
 
             return converter;
         }
 
-        // This suppression needs to be removed. https://github.com/dotnet/runtime/issues/68878
-        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "The factory constructors are only invoked in the context of reflection serialization code paths " +
-            "and are marked RequiresDynamicCode")]
-        private JsonConverter GetConverterFromAttribute(JsonConverterAttribute converterAttribute, Type typeToConvert, MemberInfo? memberInfo)
+        internal static void CheckConverterNullabilityIsSameAsPropertyType(JsonConverter converter, Type propertyType)
         {
-            JsonConverter? converter;
-
-            Type declaringType = memberInfo?.DeclaringType ?? typeToConvert;
-            Type? converterType = converterAttribute.ConverterType;
-            if (converterType == null)
+            // User has indicated that either:
+            //   a) a non-nullable-struct handling converter should handle a nullable struct type or
+            //   b) a nullable-struct handling converter should handle a non-nullable struct type.
+            // User should implement a custom converter for the underlying struct and remove the unnecessary CanConvert method override.
+            // The serializer will automatically wrap the custom converter with NullableConverter<T>.
+            //
+            // We also throw to avoid passing an invalid argument to setters for nullable struct properties,
+            // which would cause an InvalidProgramException when the generated IL is invoked.
+            if (propertyType.IsValueType && converter.IsValueType &&
+                (propertyType.IsNullableOfT() ^ converter.TypeToConvert.IsNullableOfT()))
             {
-                // Allow the attribute to create the converter.
-                converter = converterAttribute.CreateConverter(typeToConvert);
-                if (converter == null)
-                {
-                    ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(declaringType, memberInfo, typeToConvert);
-                }
+                ThrowHelper.ThrowInvalidOperationException_ConverterCanConvertMultipleTypes(propertyType, converter);
             }
-            else
-            {
-                ConstructorInfo? ctor = converterType.GetConstructor(Type.EmptyTypes);
-                if (!typeof(JsonConverter).IsAssignableFrom(converterType) || ctor == null || !ctor.IsPublic)
-                {
-                    ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeInvalid(declaringType, memberInfo);
-                }
-
-                converter = (JsonConverter)Activator.CreateInstance(converterType)!;
-            }
-
-            Debug.Assert(converter != null);
-            if (!converter.CanConvert(typeToConvert))
-            {
-                Type? underlyingType = Nullable.GetUnderlyingType(typeToConvert);
-                if (underlyingType != null && converter.CanConvert(underlyingType))
-                {
-                    if (converter is JsonConverterFactory converterFactory)
-                    {
-                        converter = converterFactory.GetConverterInternal(underlyingType, this);
-                    }
-
-                    // Allow nullable handling to forward to the underlying type's converter.
-                    return NullableConverterFactory.CreateValueConverter(underlyingType, converter);
-                }
-
-                ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(declaringType, memberInfo, typeToConvert);
-            }
-
-            return converter;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -59,8 +59,7 @@ namespace System.Text.Json
 
             if (IsLockedInstance)
             {
-                InitializeCachingContext();
-                converter = _cachingContext.GetOrAddJsonTypeInfo(typeToConvert)?.Converter;
+                converter = GetCachingContext()?.GetOrAddJsonTypeInfo(typeToConvert)?.Converter;
             }
             else
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -70,10 +70,7 @@ namespace System.Text.Json
                 converter = GetTypeInfoNoCaching(typeToConvert)?.Converter;
             }
 
-            return converter is null
-                // we can get here if resolver returned null but converter was added for the type
-                ? GetConverterFromListOrBuiltInConverter(typeToConvert)
-                : converter;
+            return converter ?? GetConverterFromListOrBuiltInConverter(typeToConvert);
         }
 
         internal JsonConverter? GetConverterFromList(Type typeToConvert)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -57,7 +57,7 @@ namespace System.Text.Json
         private bool _propertyNameCaseInsensitive;
         private bool _writeIndented;
 
-        private bool _isLockedInstance;
+        private volatile bool _isLockedInstance;
 
         /// <summary>
         /// Constructs a new <see cref="JsonSerializerOptions"/> instance.
@@ -102,9 +102,7 @@ namespace System.Text.Json
             _includeFields = options._includeFields;
             _propertyNameCaseInsensitive = options._propertyNameCaseInsensitive;
             _writeIndented = options._writeIndented;
-            // Preserve backward compatibility with .NET 6
-            // This should almost certainly be changed, cf. https://github.com/dotnet/aspnetcore/issues/38720
-            _typeInfoResolver = options._typeInfoResolver is JsonSerializerContext ? null : options._typeInfoResolver;
+            _typeInfoResolver = options._typeInfoResolver;
             EffectiveMaxDepth = options.EffectiveMaxDepth;
             ReferenceHandlingStrategy = options.ReferenceHandlingStrategy;
 
@@ -149,51 +147,35 @@ namespace System.Text.Json
         /// Binds current <see cref="JsonSerializerOptions"/> instance with a new instance of the specified <see cref="Serialization.JsonSerializerContext"/> type.
         /// </summary>
         /// <typeparam name="TContext">The generic definition of the specified context type.</typeparam>
-        /// <remarks>When serializing and deserializing types using the options
+        /// <remarks>
+        /// When serializing and deserializing types using the options
         /// instance, metadata for the types will be fetched from the context instance.
         /// </remarks>
         public void AddContext<TContext>() where TContext : JsonSerializerContext, new()
         {
             VerifyMutable();
             TContext context = new();
-            _typeInfoResolver = context;
-            _isLockedInstance = true;
-            context._options = this;
+            context.Options = this;
         }
 
         /// <summary>
-        /// Gets or sets JsonTypeInfo resolver.
+        /// Gets or sets a <see cref="JsonTypeInfo"/> contract resolver.
         /// </summary>
-        public IJsonTypeInfoResolver TypeInfoResolver
+        /// <remarks>
+        /// A <see langword="null"/> setting is equivalent to using the reflection-based <see cref="DefaultJsonTypeInfoResolver"/>.
+        /// </remarks>
+        [AllowNull]
+        public IJsonTypeInfoResolver? TypeInfoResolver
         {
             [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
             [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
             get
             {
-                return _typeInfoResolver ?? DefaultJsonTypeInfoResolver.RootDefaultInstance();
+                return _typeInfoResolver ??= DefaultJsonTypeInfoResolver.RootDefaultInstance();
             }
             set
             {
                 VerifyMutable();
-
-                if (value is null)
-                {
-                    ThrowHelper.ThrowArgumentNullException(nameof(value));
-                }
-
-                if (value is JsonSerializerContext ctx)
-                {
-                    if (ctx._options != null && ctx._options != this)
-                    {
-                        // TODO evaluate if this is the appropriate behaviour;
-                        ThrowHelper.ThrowInvalidOperationException_SerializerContextOptionsImmutable();
-                    }
-
-                    // Associate options instance with context and lock for further modification
-                    ctx._options = this;
-                    _isLockedInstance = true;
-                }
-
                 _typeInfoResolver = value;
             }
         }
@@ -616,10 +598,15 @@ namespace System.Text.Json
             }
         }
 
-        internal bool IsInitializedForReflectionSerializer { get; private set; }
-        // Effective resolver, populated when enacting reflection-based fallback
-        // Should not be taken into account when calculating options equality.
-        private IJsonTypeInfoResolver? _effectiveJsonTypeInfoResolver;
+        internal bool IsLockedInstance
+        {
+            get => _isLockedInstance;
+            set
+            {
+                Debug.Assert(value, "cannot unlock options instances");
+                _isLockedInstance = true;
+            }
+        }
 
         /// <summary>
         /// Initializes the converters for the reflection-based serializer.
@@ -628,44 +615,44 @@ namespace System.Text.Json
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
         internal void InitializeForReflectionSerializer()
         {
-            if (_typeInfoResolver is JsonSerializerContext ctx)
+            if (!_isInitializedForReflectionSerializer)
             {
-                // .NET 6 backward compatibility; use fallback to reflection serialization
-                // TODO: Consider removing this behaviour (needs to be filed as a breaking change).
-                _effectiveJsonTypeInfoResolver = JsonTypeInfoResolver.Combine(ctx, DefaultJsonTypeInfoResolver.RootDefaultInstance());
-            }
-            else
-            {
+                IsLockedInstance = true;
                 _typeInfoResolver ??= DefaultJsonTypeInfoResolver.RootDefaultInstance();
-            }
+                InitializeCachingContext();
 
-            if (_cachingContext != null && _cachingContext.Options != this)
-            {
-                // We're using a shared caching context deriving from a different options instance;
-                // for coherence ensure that it has been opted in for reflection-based serialization as well.
-                _cachingContext.Options.InitializeForReflectionSerializer();
-            }
+                if (_cachingContext.Options != this)
+                {
+                    // We're using a shared caching context deriving from a different options instance;
+                    // for coherence ensure that it has been opted in for reflection-based serialization as well.
+                    _cachingContext.Options.InitializeForReflectionSerializer();
+                }
 
-            IsInitializedForReflectionSerializer = true;
+                _isInitializedForReflectionSerializer = true;
+            }
         }
 
-        internal bool IsInitializedForMetadataGeneration { get; private set; }
+        private volatile bool _isInitializedForReflectionSerializer;
+
         internal void InitializeForMetadataGeneration()
         {
-            IJsonTypeInfoResolver? resolver = _effectiveJsonTypeInfoResolver ?? _typeInfoResolver;
-            if (resolver == null)
+            if (!_isInitializedForMetadataGeneration)
             {
-                ThrowHelper.ThrowInvalidOperationException_JsonTypeInfoUsedButTypeInfoResolverNotSet();
-            }
+                if (_typeInfoResolver is null)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_JsonTypeInfoUsedButTypeInfoResolverNotSet();
+                }
 
-            _isLockedInstance = true;
-            IsInitializedForMetadataGeneration = true;
+                IsLockedInstance = true;
+                _isInitializedForMetadataGeneration = true;
+            }
         }
 
-        private JsonTypeInfo? GetTypeInfoInternal(Type type)
+        private volatile bool _isInitializedForMetadataGeneration;
+
+        private JsonTypeInfo? GetTypeInfoNoCaching(Type type)
         {
-            IJsonTypeInfoResolver? resolver = _effectiveJsonTypeInfoResolver ?? _typeInfoResolver;
-            JsonTypeInfo? info = resolver?.GetTypeInfo(type, this);
+            JsonTypeInfo? info = _typeInfoResolver?.GetTypeInfo(type, this);
 
             if (info != null)
             {
@@ -724,7 +711,7 @@ namespace System.Text.Json
             };
         }
 
-        internal void VerifyMutable()
+        private void VerifyMutable()
         {
             if (_isLockedInstance)
             {
@@ -742,13 +729,13 @@ namespace System.Text.Json
                 _options = options;
             }
 
-            protected override bool IsLockedInstance => _options._isLockedInstance;
+            protected override bool IsLockedInstance => _options.IsLockedInstance;
             protected override void VerifyMutable() => _options.VerifyMutable();
         }
 
         private static JsonSerializerOptions CreateDefaultImmutableInstance()
         {
-            var options = new JsonSerializerOptions { _isLockedInstance = true };
+            var options = new JsonSerializerOptions { IsLockedInstance = true };
             return options;
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -165,7 +165,7 @@ namespace System.Text.Json
         /// A <see langword="null"/> setting is equivalent to using the reflection-based <see cref="DefaultJsonTypeInfoResolver"/>.
         /// </remarks>
         [AllowNull]
-        public IJsonTypeInfoResolver? TypeInfoResolver
+        public IJsonTypeInfoResolver TypeInfoResolver
         {
             [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
             [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -620,13 +620,15 @@ namespace System.Text.Json
                 DefaultJsonTypeInfoResolver defaultResolver = DefaultJsonTypeInfoResolver.RootDefaultInstance();
                 _typeInfoResolver ??= defaultResolver;
                 IsLockedInstance = true;
-                InitializeCachingContext();
 
-                if (_cachingContext.Options != this)
+                CachingContext? context = GetCachingContext();
+                Debug.Assert(context != null);
+
+                if (context.Options != this)
                 {
                     // We're using a shared caching context deriving from a different options instance;
                     // for coherence ensure that it has been opted in for reflection-based serialization as well.
-                    _cachingContext.Options.InitializeForReflectionSerializer();
+                    context.Options.InitializeForReflectionSerializer();
                 }
 
                 _isInitializedForReflectionSerializer = true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -617,8 +617,9 @@ namespace System.Text.Json
         {
             if (!_isInitializedForReflectionSerializer)
             {
+                DefaultJsonTypeInfoResolver defaultResolver = DefaultJsonTypeInfoResolver.RootDefaultInstance();
+                _typeInfoResolver ??= defaultResolver;
                 IsLockedInstance = true;
-                _typeInfoResolver ??= DefaultJsonTypeInfoResolver.RootDefaultInstance();
                 InitializeCachingContext();
 
                 if (_cachingContext.Options != this)
@@ -711,7 +712,7 @@ namespace System.Text.Json
             };
         }
 
-        private void VerifyMutable()
+        internal void VerifyMutable()
         {
             if (_isLockedInstance)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// Creates serialization metadata for a type using a simple converter.
         /// </summary>
         internal CustomJsonTypeInfo(JsonSerializerOptions options)
-            : base(options.GetConverterForType(typeof(T)), options)
+            : base(options.GetConverterFromListOrBuiltInConverter(typeof(T)), options)
         {
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text.Json.Reflection;
 using System.Text.Json.Serialization.Converters;
 
 namespace System.Text.Json.Serialization.Metadata
@@ -79,7 +81,7 @@ namespace System.Text.Json.Serialization.Metadata
                 converters.Add(converter.TypeToConvert, converter);
         }
 
-        internal static JsonConverter GetDefaultConverter(Type typeToConvert)
+        internal static JsonConverter GetBuiltInConverter(Type typeToConvert)
         {
             if (s_defaultSimpleConverters == null || s_defaultFactoryConverters == null)
             {
@@ -121,6 +123,100 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             return s_defaultSimpleConverters.TryGetValue(typeToConvert, out converter);
+        }
+
+        // This method gets the runtime information for a given type or property.
+        // The runtime information consists of the following:
+        // - class type,
+        // - element type (if the type is a collection),
+        // - the converter (either native or custom), if one exists.
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        internal static JsonConverter GetConverterForMember(
+            Type typeToConvert,
+            MemberInfo memberInfo,
+            JsonSerializerOptions options,
+            out JsonConverter? customConverter)
+        {
+            Debug.Assert(memberInfo is FieldInfo or PropertyInfo);
+            Debug.Assert(typeToConvert != null);
+
+            JsonConverterAttribute? converterAttribute = memberInfo.GetUniqueCustomAttribute<JsonConverterAttribute>(inherit: false);
+            customConverter = converterAttribute is null ? null : GetConverterFromAttribute(converterAttribute, typeToConvert, memberInfo, options);
+
+            return options.TryGetJsonTypeInfoCached(typeToConvert, out JsonTypeInfo? typeInfo)
+                ? typeInfo.Converter
+                : GetConverterForType(typeToConvert, options);
+        }
+
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        internal static JsonConverter GetConverterForType(Type typeToConvert, JsonSerializerOptions options)
+        {
+            // Priority 1: Attempt to get custom converter from the Converters list.
+            JsonConverter? converter = options.GetConverterFromList(typeToConvert);
+
+            // Priority 2: Attempt to get converter from [JsonConverter] on the type being converted.
+            if (converter == null)
+            {
+                JsonConverterAttribute? converterAttribute = typeToConvert.GetUniqueCustomAttribute<JsonConverterAttribute>(inherit: false);
+                if (converterAttribute != null)
+                {
+                    converter = GetConverterFromAttribute(converterAttribute, typeToConvert: typeToConvert, memberInfo: null, options);
+                }
+            }
+
+            // Priority 3: Fall back to built-in converters and validate result
+            return options.GetCustomOrBuiltInConverter(typeToConvert, converter);
+        }
+
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        private static JsonConverter GetConverterFromAttribute(JsonConverterAttribute converterAttribute, Type typeToConvert, MemberInfo? memberInfo, JsonSerializerOptions options)
+        {
+            JsonConverter? converter;
+
+            Type declaringType = memberInfo?.DeclaringType ?? typeToConvert;
+            Type? converterType = converterAttribute.ConverterType;
+            if (converterType == null)
+            {
+                // Allow the attribute to create the converter.
+                converter = converterAttribute.CreateConverter(typeToConvert);
+                if (converter == null)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(declaringType, memberInfo, typeToConvert);
+                }
+            }
+            else
+            {
+                ConstructorInfo? ctor = converterType.GetConstructor(Type.EmptyTypes);
+                if (!typeof(JsonConverter).IsAssignableFrom(converterType) || ctor == null || !ctor.IsPublic)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeInvalid(declaringType, memberInfo);
+                }
+
+                converter = (JsonConverter)Activator.CreateInstance(converterType)!;
+            }
+
+            Debug.Assert(converter != null);
+            if (!converter.CanConvert(typeToConvert))
+            {
+                Type? underlyingType = Nullable.GetUnderlyingType(typeToConvert);
+                if (underlyingType != null && converter.CanConvert(underlyingType))
+                {
+                    if (converter is JsonConverterFactory converterFactory)
+                    {
+                        converter = converterFactory.GetConverterInternal(underlyingType, options);
+                    }
+
+                    // Allow nullable handling to forward to the underlying type's converter.
+                    return NullableConverterFactory.CreateValueConverter(underlyingType, converter);
+                }
+
+                ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(declaringType, memberInfo, typeToConvert);
+            }
+
+            return converter;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
@@ -39,7 +39,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 Debug.Assert(Options != null);
                 Debug.Assert(ShouldDeserialize);
-                return _jsonTypeInfo ??= Options.GetOrAddJsonTypeInfo(PropertyType);
+                return _jsonTypeInfo ??= Options.GetJsonTypeInfoCached(PropertyType);
             }
             set
             {
@@ -97,7 +97,7 @@ namespace System.Text.Json.Serialization.Metadata
                 Type parameterType = parameterInfo.ParameterType;
 
                 DefaultValueHolder holder;
-                if (matchingProperty.Options.TryGetJsonTypeInfo(parameterType, out JsonTypeInfo? typeInfo))
+                if (matchingProperty.Options.TryGetJsonTypeInfoCached(parameterType, out JsonTypeInfo? typeInfo))
                 {
                     holder = typeInfo.DefaultValueHolder;
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -757,7 +757,7 @@ namespace System.Text.Json.Serialization.Metadata
                 else
                 {
                     // GetOrAddJsonTypeInfo already ensures it's configured.
-                    _jsonTypeInfo = Options.GetOrAddJsonTypeInfo(PropertyType);
+                    _jsonTypeInfo = Options.GetJsonTypeInfoCached(PropertyType);
                 }
 
                 return _jsonTypeInfo;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -184,8 +184,7 @@ namespace System.Text.Json.Serialization.Metadata
             JsonConverter? customConverter = CustomConverter;
             if (customConverter != null)
             {
-                customConverter = Options.ExpandFactoryConverter(customConverter, PropertyType);
-                JsonSerializerOptions.CheckConverterNullabilityIsSameAsPropertyType(customConverter, PropertyType);
+                customConverter = Options.ExpandConverterFactory(customConverter, PropertyType);
             }
 
             JsonConverter converter = customConverter ?? DefaultConverterForType ?? Options.GetConverterFromTypeInfo(PropertyType);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -249,7 +249,7 @@ namespace System.Text.Json.Serialization.Metadata
             public Type DerivedType { get; }
             public object? TypeDiscriminator { get; }
             public JsonTypeInfo GetJsonTypeInfo(JsonSerializerOptions options)
-                => _jsonTypeInfo ??= options.GetOrAddJsonTypeInfo(DerivedType);
+                => _jsonTypeInfo ??= options.GetJsonTypeInfoCached(DerivedType);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json.Reflection;
+using System.Text.Json.Serialization.Converters;
 
 namespace System.Text.Json.Serialization.Metadata
 {
@@ -17,7 +18,7 @@ namespace System.Text.Json.Serialization.Metadata
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
         internal ReflectionJsonTypeInfo(JsonSerializerOptions options)
-            : this(options.GetConverterForType(typeof(T)), options)
+            : this(DefaultJsonTypeInfoResolver.GetConverterForType(typeof(T), options), options)
         {
         }
 
@@ -196,7 +197,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             try
             {
-                converter = GetConverterFromMember(
+                converter = DefaultJsonTypeInfoResolver.GetConverterForMember(
                     typeToConvert,
                     memberInfo,
                     options,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -95,7 +95,7 @@ namespace System.Text.Json
 
         public void Initialize(Type type, JsonSerializerOptions options, bool supportContinuation)
         {
-            JsonTypeInfo jsonTypeInfo = options.GetOrAddJsonTypeInfoForRootType(type);
+            JsonTypeInfo jsonTypeInfo = options.GetJsonTypeInfoForRootType(type);
             Initialize(jsonTypeInfo, supportContinuation);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -138,7 +138,7 @@ namespace System.Text.Json
         /// </summary>
         public JsonConverter Initialize(Type type, JsonSerializerOptions options, bool supportContinuation, bool supportAsync)
         {
-            JsonTypeInfo jsonTypeInfo = options.GetOrAddJsonTypeInfoForRootType(type);
+            JsonTypeInfo jsonTypeInfo = options.GetJsonTypeInfoForRootType(type);
             return Initialize(jsonTypeInfo, supportContinuation, supportAsync);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -126,7 +126,7 @@ namespace System.Text.Json
             // if the current element is the same type as the previous element.
             if (PolymorphicJsonTypeInfo?.PropertyType != runtimeType)
             {
-                JsonTypeInfo typeInfo = options.GetOrAddJsonTypeInfo(runtimeType);
+                JsonTypeInfo typeInfo = options.GetJsonTypeInfoCached(runtimeType);
                 PolymorphicJsonTypeInfo = typeInfo.PropertyInfoForTypeInfo;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -120,7 +120,7 @@ namespace System.Text.Json
         [DoesNotReturn]
         public static void ThrowInvalidOperationException_ResolverTypeNotCompatible(Type requestedType, Type actualType)
         {
-            throw new InvalidOperationException(SR.Format(SR.ResolverTypeNotCompatible, requestedType, actualType));
+            throw new InvalidOperationException(SR.Format(SR.ResolverTypeNotCompatible, actualType, requestedType));
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.cs
@@ -197,6 +197,7 @@ namespace System.Text.Json.Serialization.Tests
                 // since it can't resolve reflection-based metadata.
                 Assert.Throws<NotSupportedException>(() => converter.Write(writer, value, options));
                 Assert.Equal(0, writer.BytesCommitted + writer.BytesPending);
+                options.IncludeFields = false; // options should still be mutable
 
                 JsonSerializer.Serialize(42, options);
 
@@ -204,6 +205,8 @@ namespace System.Text.Json.Serialization.Tests
                 converter.Write(writer, value, options);
                 Assert.NotEqual(0, writer.BytesCommitted + writer.BytesPending);
                 writer.Reset();
+
+                Assert.Throws<InvalidOperationException>(() => options.IncludeFields = false);
 
                 // State change should not leak into unrelated options instances.
                 var options2 = new JsonSerializerOptions();

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
@@ -1101,5 +1101,24 @@ namespace System.Text.Json.Serialization.Tests
             public int Value { get; set; }
             public RecursiveType? Next { get; set; }
         }
+
+        [Fact]
+        public static void CreateJsonTypeInfo_ClassWithConverterAttribute_ShouldNotResolveConverterAttribute()
+        {
+            JsonTypeInfo jsonTypeInfo = JsonTypeInfo.CreateJsonTypeInfo(typeof(ClassWithConverterAttribute), JsonSerializerOptions.Default);
+            Assert.Equal(typeof(ClassWithConverterAttribute), jsonTypeInfo.Type);
+            Assert.IsNotType<ClassWithConverterAttribute.CustomConverter>(jsonTypeInfo.Converter);
+        }
+
+
+        [JsonConverter(typeof(CustomConverter))]
+        public class ClassWithConverterAttribute
+        {
+            public class CustomConverter : JsonConverter<ClassWithConverterAttribute>
+            {
+                public override ClassWithConverterAttribute? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotImplementedException();
+                public override void Write(Utf8JsonWriter writer, ClassWithConverterAttribute value, JsonSerializerOptions options) => throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
@@ -1110,6 +1110,14 @@ namespace System.Text.Json.Serialization.Tests
             Assert.IsNotType<ClassWithConverterAttribute.CustomConverter>(jsonTypeInfo.Converter);
         }
 
+        [Fact]
+        public static void DefaultJsonTypeInfoResolver_ClassWithConverterAttribute_ShouldResolveConverterAttribute()
+        {
+            var options = JsonSerializerOptions.Default;
+            JsonTypeInfo jsonTypeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(ClassWithConverterAttribute), options);
+            Assert.Equal(typeof(ClassWithConverterAttribute), jsonTypeInfo.Type);
+            Assert.IsType<ClassWithConverterAttribute.CustomConverter>(jsonTypeInfo.Converter);
+        }
 
         [JsonConverter(typeof(CustomConverter))]
         public class ClassWithConverterAttribute

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/MetadataTests.Options.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/MetadataTests.Options.cs
@@ -87,6 +87,24 @@ namespace System.Text.Json.Serialization.Tests
             CauseInvalidOperationException(() => options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase);
         }
 
+        [Fact]
+        public void PassingImmutableOptionsThrowsException()
+        {
+            JsonSerializerOptions defaultOptions = JsonSerializerOptions.Default;
+            Assert.Throws<InvalidOperationException>(() => new MyJsonContext(defaultOptions));
+        }
+
+        [Fact]
+        public void PassingWrongOptionsInstanceToResolverThrowsException()
+        {
+            JsonSerializerOptions defaultOptions = JsonSerializerOptions.Default;
+            JsonSerializerOptions contextOptions = new();
+            IJsonTypeInfoResolver context = new EmptyContext(contextOptions);
+
+            Assert.IsAssignableFrom<JsonTypeInfo<int>>(context.GetTypeInfo(typeof(int), contextOptions));
+            Assert.Throws<InvalidOperationException>(() => context.GetTypeInfo(typeof(int), defaultOptions));
+        }
+
         private class MyJsonContext : JsonSerializerContext
         {
             public MyJsonContext() : base(null) { }
@@ -103,6 +121,13 @@ namespace System.Text.Json.Serialization.Tests
             public MyJsonContextThatSetsOptionsInParameterlessCtor() : base(new JsonSerializerOptions()) { }
             public override JsonTypeInfo? GetTypeInfo(Type type) => throw new NotImplementedException();
             protected override JsonSerializerOptions? GeneratedSerializerOptions => null;
+        }
+
+        private class EmptyContext : JsonSerializerContext
+        {
+            public EmptyContext(JsonSerializerOptions options) : base(options) { }
+            protected override JsonSerializerOptions? GeneratedSerializerOptions => null;
+            public override JsonTypeInfo? GetTypeInfo(Type type) => JsonTypeInfo.CreateJsonTypeInfo(type, Options);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/MetadataTests.Options.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/MetadataTests.Options.cs
@@ -102,6 +102,7 @@ namespace System.Text.Json.Serialization.Tests
             IJsonTypeInfoResolver context = new EmptyContext(contextOptions);
 
             Assert.IsAssignableFrom<JsonTypeInfo<int>>(context.GetTypeInfo(typeof(int), contextOptions));
+            Assert.IsAssignableFrom<JsonTypeInfo<int>>(context.GetTypeInfo(typeof(int), null));
             Assert.Throws<InvalidOperationException>(() => context.GetTypeInfo(typeof(int), defaultOptions));
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -444,6 +444,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(unsupportedValue, options));
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static void Options_JsonSerializerContext_GetConverter_FallsBackToReflectionConverter()
         {


### PR DESCRIPTION
Makes the following changes:

* Remove implicit fallback to reflection-based serialization. Fix #71714
* Include JsonSerializerContext in JsonSerializerOptions copy constructor. Fix #71716. Fix https://github.com/dotnet/aspnetcore/issues/38720.
* Move reflection-based converter resolution out of JsonSerializerOptions. Fix #68878
