### PR TITLE
Make things work for arrays of function pointers

### DIFF
--- a/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
@@ -302,6 +302,23 @@ namespace ILCompiler
                 case TypeFlags.Pointer:
                     mangledName = GetMangledTypeName(((PointerType)type).ParameterType) + NestMangledName("Pointer");
                     break;
+                case TypeFlags.FunctionPointer:
+                    // TODO: need to also encode calling convention (or all modopts?)
+                    var fnPtrType = (FunctionPointerType)type;
+                    mangledName = "__FnPtr" + EnterNameScopeSequence;
+                    mangledName += GetMangledTypeName(fnPtrType.Signature.ReturnType);
+
+                    mangledName += EnterNameScopeSequence;
+                    for (int i = 0; i < fnPtrType.Signature.Length; i++)
+                    {
+                        if (i != 0)
+                            mangledName += DelimitNameScopeSequence;
+                        mangledName += GetMangledTypeName(fnPtrType.Signature[i]);
+                    }
+                    mangledName += ExitNameScopeSequence;
+
+                    mangledName += ExitNameScopeSequence;
+                    break;
                 default:
                     // Case of a generic type. If `type' is a type definition we use the type name
                     // for mangling, otherwise we use the mangling of the type and its generic type

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableFieldNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableFieldNode.cs
@@ -85,7 +85,11 @@ namespace ILCompiler.DependencyAnalysis
 
             // Runtime reflection stack needs to obtain the type handle of the field
             // (but there's no type handles for function pointers)
-            if (!_field.FieldType.IsFunctionPointer)
+            TypeDesc fieldTypeToCheck = _field.FieldType;
+            while (fieldTypeToCheck.IsParameterizedType)
+                fieldTypeToCheck = ((ParameterizedType)fieldTypeToCheck).ParameterType;
+
+            if (!fieldTypeToCheck.IsFunctionPointer)
                 dependencies.Add(factory.MaximallyConstructableType(_field.FieldType.NormalizeInstantiation()), "Type of the field");
 
             return dependencies;


### PR DESCRIPTION
* Don't try to obtain type handles for fields of types of function pointer arrays. We don't have type handles for function pointers right now.
* Add function pointer support to name mangler. We still don't make EETypes for these, but debug info generation also needs mangled names. We currently generate debug info for function pointers as debug info for `void*`, but arrays of function pointers only partially go through that handling and still end up needing a mangled name for the function pointer.

Unblocks #71516.

Cc @steveharter @dotnet/ilc-contrib 