### PR TITLE
[6.0] Re-create MultiCoreJIT profile data on profile-use-only mode

### DIFF
--- a/src/coreclr/vm/multicorejitimpl.h
+++ b/src/coreclr/vm/multicorejitimpl.h
@@ -655,7 +655,7 @@ private:
 
 public:
 
-    MulticoreJitRecorder(AppDomain * pDomain, ICLRPrivBinder * pBinderContext, bool fRecorderActive)
+    MulticoreJitRecorder(AppDomain * pDomain, ICLRPrivBinder * pBinderContext)
         : m_stats(pDomain->GetMulticoreJitManager().GetStats())
         , m_ModuleList(nullptr)
         , m_JitInfoArray(nullptr)
@@ -665,18 +665,10 @@ public:
         m_pDomain           = pDomain;
         m_pBinderContext    = pBinderContext;
 
-        if (fRecorderActive)
-        {
-            m_ModuleList        = new (nothrow) RecorderModuleInfo[MAX_MODULES];
-        }
         m_ModuleCount       = 0;
 
         m_ModuleDepCount    = 0;
 
-        if (fRecorderActive)
-        {
-            m_JitInfoArray      = new (nothrow) RecorderInfo[MAX_METHODS];
-        }
         m_JitInfoCount      = 0;
 
         m_fFirstMethod      = true;
@@ -724,6 +716,14 @@ public:
 
         return (m_JitInfoCount >= (LONG) MAX_METHODS) ||
                (m_ModuleCount  >= MAX_MODULES);
+    }
+
+    void Activate()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        m_ModuleList = new (nothrow) RecorderModuleInfo[MAX_MODULES];
+        m_JitInfoArray = new (nothrow) RecorderInfo[MAX_METHODS];
     }
 
     void RecordMethodJitOrLoad(MethodDesc * pMethod, bool application);


### PR DESCRIPTION
Backport of #71420.

This is a patch to solve the problem that profile data cannot be recreated when profile data is broken on profile-use-only mode.
Please consider backporting this to release/6.0

## Customer Impact

Some apps use `DOTNET_MultiCoreJitNoProfileGather=1`, which only uses the recorded profile data and does not record, to improve flash storage life. The profile data helps to improve startup time. This fix enables an app for which profile data was gathered once, to continue working with profile data across profile data version changes while using the above config switch. When the existing profile data is incompatible, it records profile data once to maintain the startup improvements, and does not record again thereafter to improve storage life. So, the change makes it easier to deploy apps using the above config switch without having to manually recreate profile data by altering the config switch any time the profile version changes.

## Regression?

No

## Testing

Verified that the change behaves as described above

## Risk

Low - The behavior without the config switch is identical to before, and the behavior when the existing profile data is valid is also identical to before.