### PR TITLE
Tar: for directories, use a default mask that has the 'x' bit.

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -46,7 +46,7 @@ namespace System.Formats.Tar
 
             // Default values for fields shared by all supported formats
             _header._name = entryName;
-            _header._mode = (int)TarHelpers.DefaultMode;
+            _header._mode = TarHelpers.GetDefaultMode(entryType);
             _header._mTime = DateTimeOffset.UtcNow;
             _header._typeFlag = entryType;
             _header._linkName = string.Empty;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -258,7 +258,7 @@ namespace System.Formats.Tar
             TarHeader longMetadataHeader = default;
 
             longMetadataHeader._name = GnuLongMetadataName; // Same name for both longpath or longlink
-            longMetadataHeader._mode = (int)TarHelpers.DefaultMode;
+            longMetadataHeader._mode = TarHelpers.GetDefaultMode(entryType);
             longMetadataHeader._uid = 0;
             longMetadataHeader._gid = 0;
             longMetadataHeader._mTime = DateTimeOffset.MinValue; // 0
@@ -317,7 +317,7 @@ namespace System.Formats.Tar
             // The ustar fields (uid, gid, linkName, uname, gname, devmajor, devminor) do not get written.
             // The mode gets the default value.
             _name = GenerateExtendedAttributeName();
-            _mode = (int)TarHelpers.DefaultMode;
+            _mode = TarHelpers.GetDefaultMode(_typeFlag);
             _typeFlag = isGea ? TarEntryType.GlobalExtendedAttributes : TarEntryType.ExtendedAttributes;
             _linkName = string.Empty;
             _magic = string.Empty;
@@ -338,7 +338,7 @@ namespace System.Formats.Tar
             // The ustar fields (uid, gid, linkName, uname, gname, devmajor, devminor) do not get written.
             // The mode gets the default value.
             _name = GenerateExtendedAttributeName();
-            _mode = (int)TarHelpers.DefaultMode;
+            _mode = TarHelpers.GetDefaultMode(_typeFlag);
             _typeFlag = isGea ? TarEntryType.GlobalExtendedAttributes : TarEntryType.ExtendedAttributes;
             _linkName = string.Empty;
             _magic = string.Empty;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -22,8 +22,18 @@ namespace System.Formats.Tar
         internal const byte EqualsChar = 0x3d;
         internal const byte NewLineChar = 0xa;
 
-        internal const UnixFileMode DefaultMode = // 644 in octal
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+        private const UnixFileMode DefaultFileMode =
+            UnixFileMode.UserRead | UnixFileMode.UserWrite |
+            UnixFileMode.GroupRead |
+            UnixFileMode.OtherRead;
+
+        private const UnixFileMode DefaultDirectoryMode =
+            UnixFileMode.UserExecute | UnixFileMode.UserRead | UnixFileMode.UserWrite |
+            UnixFileMode.GroupExecute | UnixFileMode.GroupRead |
+            UnixFileMode.OtherExecute | UnixFileMode.OtherRead;
+
+        internal static int GetDefaultMode(TarEntryType type)
+            => type is TarEntryType.Directory or TarEntryType.DirectoryList ? (int)DefaultDirectoryMode : (int)DefaultFileMode;
 
         // Helps advance the stream a total number of bytes larger than int.MaxValue.
         internal static void AdvanceStream(Stream archiveStream, long bytesToDiscard)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -28,9 +28,8 @@ namespace System.Formats.Tar
             UnixFileMode.OtherRead;
 
         private const UnixFileMode DefaultDirectoryMode =
-            UnixFileMode.UserExecute | UnixFileMode.UserRead | UnixFileMode.UserWrite |
-            UnixFileMode.GroupExecute | UnixFileMode.GroupRead |
-            UnixFileMode.OtherExecute | UnixFileMode.OtherRead;
+            DefaultFileMode |
+            UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
 
         internal static int GetDefaultMode(TarEntryType type)
             => type is TarEntryType.Directory or TarEntryType.DirectoryList ? (int)DefaultDirectoryMode : (int)DefaultFileMode;

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -14,7 +14,8 @@ namespace System.Formats.Tar.Tests
         protected readonly string ModifiedEntryName = "ModifiedEntryName.ext";
 
         // Default values are what a TarEntry created with its constructor will set
-        protected const UnixFileMode DefaultMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead; // 644 in octal, internally used as default
+        protected const UnixFileMode DefaultFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead; // 644 in octal, internally used as default
+        private const UnixFileMode DefaultDirectoryMode = UnixFileMode.UserExecute | UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupExecute | UnixFileMode.GroupRead | UnixFileMode.OtherExecute | UnixFileMode.OtherRead;
         protected const UnixFileMode DefaultWindowsMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.UserExecute; // Creating archives in Windows always sets the mode to 777
         protected const int DefaultGid = 0;
         protected const int DefaultUid = 0;
@@ -152,7 +153,7 @@ namespace System.Formats.Tar.Tests
         {
             Assert.NotNull(directory);
             Assert.Equal(TarEntryType.Directory, directory.EntryType);
-            SetCommonProperties(directory);
+            SetCommonProperties(directory, isDirectory: true);
         }
 
         protected void SetCommonHardLink(TarEntry hardLink)
@@ -177,7 +178,7 @@ namespace System.Formats.Tar.Tests
             symbolicLink.LinkName = TestLinkName;
         }
 
-        protected void SetCommonProperties(TarEntry entry)
+        protected void SetCommonProperties(TarEntry entry, bool isDirectory = false)
         {
             // Length (Data is checked outside this method)
             Assert.Equal(0, entry.Length);
@@ -190,7 +191,7 @@ namespace System.Formats.Tar.Tests
             entry.Gid = TestGid;
 
             // Mode
-            Assert.Equal(DefaultMode, entry.Mode);
+            Assert.Equal(isDirectory ? DefaultDirectoryMode : DefaultFileMode, entry.Mode);
             entry.Mode = TestMode;
 
             // MTime: Verify the default value was approximately "now" by default

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -15,7 +15,7 @@ namespace System.Formats.Tar.Tests
 
         // Default values are what a TarEntry created with its constructor will set
         protected const UnixFileMode DefaultFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead; // 644 in octal, internally used as default
-        private const UnixFileMode DefaultDirectoryMode = UnixFileMode.UserExecute | UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupExecute | UnixFileMode.GroupRead | UnixFileMode.OtherExecute | UnixFileMode.OtherRead;
+        private const UnixFileMode DefaultDirectoryMode = DefaultFileMode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute; // 755 in octal, internall used as default
         protected const UnixFileMode DefaultWindowsMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.UserExecute; // Creating archives in Windows always sets the mode to 777
         protected const int DefaultGid = 0;
         protected const int DefaultUid = 0;

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -15,7 +15,7 @@ namespace System.Formats.Tar.Tests
 
         // Default values are what a TarEntry created with its constructor will set
         protected const UnixFileMode DefaultFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead; // 644 in octal, internally used as default
-        private const UnixFileMode DefaultDirectoryMode = DefaultFileMode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute; // 755 in octal, internall used as default
+        private const UnixFileMode DefaultDirectoryMode = DefaultFileMode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute; // 755 in octal, internally used as default
         protected const UnixFileMode DefaultWindowsMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.UserExecute; // Creating archives in Windows always sets the mode to 777
         protected const int DefaultGid = 0;
         protected const int DefaultUid = 0;

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
@@ -23,7 +23,7 @@ namespace System.Formats.Tar.Tests
                 string fifoName = "fifofile";
                 string fifoPath = Path.Join(root.Path, fifoName);
 
-                Interop.CheckIo(Interop.Sys.MkFifo(fifoPath, (int)DefaultMode));
+                Interop.CheckIo(Interop.Sys.MkFifo(fifoPath, (int)DefaultFileMode));
 
                 using MemoryStream archive = new MemoryStream();
                 using (TarWriter writer = new TarWriter(archive, expectedFormat, leaveOpen: true))
@@ -65,7 +65,7 @@ namespace System.Formats.Tar.Tests
                 string blockDevicePath = Path.Join(root.Path, AssetBlockDeviceFileName);
 
                 // Creating device files needs elevation
-                Interop.CheckIo(Interop.Sys.CreateBlockDevice(blockDevicePath, (int)DefaultMode, TestBlockDeviceMajor, TestBlockDeviceMinor));
+                Interop.CheckIo(Interop.Sys.CreateBlockDevice(blockDevicePath, (int)DefaultFileMode, TestBlockDeviceMajor, TestBlockDeviceMinor));
 
                 using MemoryStream archive = new MemoryStream();
                 using (TarWriter writer = new TarWriter(archive, expectedFormat, leaveOpen: true))
@@ -109,7 +109,7 @@ namespace System.Formats.Tar.Tests
                 string characterDevicePath = Path.Join(root.Path, AssetCharacterDeviceFileName);
 
                 // Creating device files needs elevation
-                Interop.CheckIo(Interop.Sys.CreateCharacterDevice(characterDevicePath, (int)DefaultMode, TestCharacterDeviceMajor, TestCharacterDeviceMinor));
+                Interop.CheckIo(Interop.Sys.CreateCharacterDevice(characterDevicePath, (int)DefaultFileMode, TestCharacterDeviceMajor, TestCharacterDeviceMinor));
 
                 using MemoryStream archive = new MemoryStream();
                 using (TarWriter writer = new TarWriter(archive, expectedFormat, leaveOpen: true))

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.Unix.cs
@@ -25,7 +25,7 @@ namespace System.Formats.Tar.Tests
                     string fifoName = "fifofile";
                     string fifoPath = Path.Join(root.Path, fifoName);
 
-                    Interop.CheckIo(Interop.Sys.MkFifo(fifoPath, (int)DefaultMode));
+                    Interop.CheckIo(Interop.Sys.MkFifo(fifoPath, (int)DefaultFileMode));
 
                     await using (MemoryStream archive = new MemoryStream())
                     {
@@ -70,7 +70,7 @@ namespace System.Formats.Tar.Tests
                     string blockDevicePath = Path.Join(root.Path, AssetBlockDeviceFileName);
 
                     // Creating device files needs elevation
-                    Interop.CheckIo(Interop.Sys.CreateBlockDevice(blockDevicePath, (int)DefaultMode, TestBlockDeviceMajor, TestBlockDeviceMinor));
+                    Interop.CheckIo(Interop.Sys.CreateBlockDevice(blockDevicePath, (int)DefaultFileMode, TestBlockDeviceMajor, TestBlockDeviceMinor));
 
                     await using (MemoryStream archive = new MemoryStream())
                     {
@@ -117,7 +117,7 @@ namespace System.Formats.Tar.Tests
                     string characterDevicePath = Path.Join(root.Path, AssetCharacterDeviceFileName);
 
                     // Creating device files needs elevation
-                    Interop.CheckIo(Interop.Sys.CreateCharacterDevice(characterDevicePath, (int)DefaultMode, TestCharacterDeviceMajor, TestCharacterDeviceMinor));
+                    Interop.CheckIo(Interop.Sys.CreateCharacterDevice(characterDevicePath, (int)DefaultFileMode, TestCharacterDeviceMajor, TestCharacterDeviceMinor));
 
                     await using (MemoryStream archive = new MemoryStream())
                     {


### PR DESCRIPTION
Without the 'x'-bit, the directories that get created are not accessible.

@eerhardt @carlossanlop  @dotnet/area-system-io ptal.