### PR TITLE
Enable Rfc2898DeriveBytes on Browser WASM

### DIFF
--- a/src/libraries/Common/src/Interop/Browser/System.Security.Cryptography.Native.Browser/Interop.SubtleCrypto.cs
+++ b/src/libraries/Common/src/Interop/Browser/System.Security.Cryptography.Native.Browser/Interop.SubtleCrypto.cs
@@ -52,5 +52,16 @@ internal static partial class Interop
             int input_len,
             byte* output_buffer,
             int output_len);
+
+        [LibraryImport(Libraries.CryptoNative, EntryPoint = "SystemCryptoNativeBrowser_DeriveBits")]
+        internal static unsafe partial int DeriveBits(
+            byte* password_buffer,
+            int password_len,
+            byte* salt_buffer,
+            int salt_len,
+            int iterations,
+            SimpleDigest hashAlgorithm,
+            byte* output_buffer,
+            int output_len);
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/HashOneShotHelpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/HashOneShotHelpers.cs
@@ -114,11 +114,9 @@ namespace System.Security.Cryptography
             {
                 return HMACSHA384.HashData(key, source, destination);
             }
-            else if (hashAlgorithm == HashAlgorithmName.MD5)
+            else if (Helpers.HasMD5 && hashAlgorithm == HashAlgorithmName.MD5)
             {
-#pragma warning disable CA1416 // HMACMD5 is unsupported on browser, caller will get PNSE
                 return HMACMD5.HashData(key, source, destination);
-#pragma warning restore CA1416
             }
 
             throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name));

--- a/src/libraries/Common/src/System/Security/Cryptography/HashOneShotHelpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/HashOneShotHelpers.cs
@@ -98,28 +98,27 @@ namespace System.Security.Cryptography
             ReadOnlySpan<byte> source,
             Span<byte> destination)
         {
-            if (Helpers.HasHMAC)
+            if (hashAlgorithm == HashAlgorithmName.SHA256)
             {
-                if (hashAlgorithm == HashAlgorithmName.SHA256)
-                {
-                    return HMACSHA256.HashData(key, source, destination);
-                }
-                else if (hashAlgorithm == HashAlgorithmName.SHA1)
-                {
-                    return HMACSHA1.HashData(key, source, destination);
-                }
-                else if (hashAlgorithm == HashAlgorithmName.SHA512)
-                {
-                    return HMACSHA512.HashData(key, source, destination);
-                }
-                else if (hashAlgorithm == HashAlgorithmName.SHA384)
-                {
-                    return HMACSHA384.HashData(key, source, destination);
-                }
-                else if (hashAlgorithm == HashAlgorithmName.MD5)
-                {
-                    return HMACMD5.HashData(key, source, destination);
-                }
+                return HMACSHA256.HashData(key, source, destination);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA1)
+            {
+                return HMACSHA1.HashData(key, source, destination);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA512)
+            {
+                return HMACSHA512.HashData(key, source, destination);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA384)
+            {
+                return HMACSHA384.HashData(key, source, destination);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.MD5)
+            {
+#pragma warning disable CA1416 // HMACMD5 is unsupported on browser, caller will get PNSE
+                return HMACMD5.HashData(key, source, destination);
+#pragma warning restore CA1416
             }
 
             throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name));

--- a/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
@@ -10,6 +10,14 @@ namespace Internal.Cryptography
 {
     internal static partial class Helpers
     {
+        [UnsupportedOSPlatformGuard("browser")]
+        internal static bool HasNonAesSymmetricEncryption =>
+#if NETCOREAPP
+            !OperatingSystem.IsBrowser();
+#else
+            true;
+#endif
+
 #if NETCOREAPP
         [UnsupportedOSPlatformGuard("ios")]
         [UnsupportedOSPlatformGuard("tvos")]
@@ -21,7 +29,7 @@ namespace Internal.Cryptography
 #if NETCOREAPP
         [UnsupportedOSPlatformGuard("android")]
         [UnsupportedOSPlatformGuard("browser")]
-        public static bool IsRC2Supported => !OperatingSystem.IsAndroid();
+        public static bool IsRC2Supported => !OperatingSystem.IsAndroid() && !OperatingSystem.IsBrowser();
 #else
         public static bool IsRC2Supported => true;
 #endif

--- a/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
@@ -10,22 +10,6 @@ namespace Internal.Cryptography
 {
     internal static partial class Helpers
     {
-        [UnsupportedOSPlatformGuard("browser")]
-        internal static bool HasSymmetricEncryption { get; } =
-#if NETCOREAPP
-            !OperatingSystem.IsBrowser();
-#else
-            true;
-#endif
-
-        [UnsupportedOSPlatformGuard("browser")]
-        internal static bool HasHMAC { get; } =
-#if NETCOREAPP
-            !OperatingSystem.IsBrowser();
-#else
-            true;
-#endif
-
 #if NETCOREAPP
         [UnsupportedOSPlatformGuard("ios")]
         [UnsupportedOSPlatformGuard("tvos")]

--- a/src/libraries/Common/src/System/Security/Cryptography/PasswordBasedEncryption.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/PasswordBasedEncryption.cs
@@ -74,14 +74,6 @@ namespace System.Security.Cryptography
         {
             Debug.Assert(destination.Length >= encryptedData.Length);
 
-            if (!Helpers.HasSymmetricEncryption)
-            {
-                throw new CryptographicException(
-                    SR.Format(
-                        SR.Cryptography_UnknownAlgorithmIdentifier,
-                        algorithmIdentifier.Algorithm));
-            }
-
             // Don't check that algorithmIdentifier.Parameters is set here.
             // Maybe some future PBES3 will have one with a default.
 
@@ -94,7 +86,9 @@ namespace System.Security.Cryptography
             {
                 case Oids.PbeWithMD5AndDESCBC:
                     digestAlgorithmName = HashAlgorithmName.MD5;
+#pragma warning disable CA1416 // DES is unsupported on browser, caller will get PNSE
                     cipher = DES.Create();
+#pragma warning restore CA1416
                     break;
                 case Oids.PbeWithMD5AndRC2CBC:
                     digestAlgorithmName = HashAlgorithmName.MD5;
@@ -102,7 +96,9 @@ namespace System.Security.Cryptography
                     break;
                 case Oids.PbeWithSha1AndDESCBC:
                     digestAlgorithmName = HashAlgorithmName.SHA1;
+#pragma warning disable CA1416 // DES is unsupported on browser, caller will get PNSE
                     cipher = DES.Create();
+#pragma warning restore CA1416
                     break;
                 case Oids.PbeWithSha1AndRC2CBC:
                     digestAlgorithmName = HashAlgorithmName.SHA1;
@@ -110,12 +106,16 @@ namespace System.Security.Cryptography
                     break;
                 case Oids.Pkcs12PbeWithShaAnd3Key3Des:
                     digestAlgorithmName = HashAlgorithmName.SHA1;
+#pragma warning disable CA1416 // TripleDES is unsupported on browser, caller will get PNSE
                     cipher = TripleDES.Create();
+#pragma warning restore CA1416
                     pkcs12 = true;
                     break;
                 case Oids.Pkcs12PbeWithShaAnd2Key3Des:
                     digestAlgorithmName = HashAlgorithmName.SHA1;
+#pragma warning disable CA1416 // TripleDES is unsupported on browser, caller will get PNSE
                     cipher = TripleDES.Create();
+#pragma warning restore CA1416
                     cipher.KeySize = 128;
                     pkcs12 = true;
                     break;
@@ -237,14 +237,6 @@ namespace System.Security.Cryptography
         {
             Debug.Assert(pbeParameters != null);
 
-            if (!Helpers.HasSymmetricEncryption)
-            {
-                throw new CryptographicException(
-                    SR.Format(
-                        SR.Cryptography_UnknownAlgorithmIdentifier,
-                        pbeParameters.EncryptionAlgorithm));
-            }
-
             isPkcs12 = false;
 
             switch (pbeParameters.EncryptionAlgorithm)
@@ -265,7 +257,9 @@ namespace System.Security.Cryptography
                     encryptionAlgorithmOid = Oids.Aes256Cbc;
                     break;
                 case PbeEncryptionAlgorithm.TripleDes3KeyPkcs12:
+#pragma warning disable CA1416 // TripleDES is unsupported on browser, caller will get PNSE
                     cipher = TripleDES.Create();
+#pragma warning restore CA1416
                     cipher.KeySize = 192;
                     encryptionAlgorithmOid = Oids.Pkcs12PbeWithShaAnd3Key3Des;
                     isPkcs12 = true;
@@ -391,12 +385,6 @@ namespace System.Security.Cryptography
                     else
                     {
                         Debug.Assert(pwdTmpBytes!.Length == 0);
-                    }
-
-                    if (!Helpers.HasHMAC)
-                    {
-                        throw new CryptographicException(
-                            SR.Format(SR.Cryptography_AlgorithmNotSupported, "HMAC" + prf.Name));
                     }
 
                     using (var pbkdf2 = new Rfc2898DeriveBytes(pwdTmpBytes, salt.ToArray(), iterationCount, prf))
@@ -540,8 +528,6 @@ namespace System.Security.Cryptography
             Rfc2898DeriveBytes pbkdf2 =
                 OpenPbkdf2(password, pbes2Params.KeyDerivationFunc.Parameters, out int? requestedKeyLength);
 
-            Debug.Assert(Helpers.HasHMAC);
-
             using (pbkdf2)
             {
                 // The biggest block size (for IV) we support is AES (128-bit / 16 byte)
@@ -579,12 +565,6 @@ namespace System.Security.Cryptography
             ref Span<byte> iv)
         {
             string? algId = encryptionScheme.Algorithm;
-
-            if (!Helpers.HasSymmetricEncryption)
-            {
-                throw new CryptographicException(
-                    SR.Format(SR.Cryptography_AlgorithmNotSupported, algId));
-            }
 
             if (algId == Oids.Aes128Cbc ||
                 algId == Oids.Aes192Cbc ||
@@ -637,7 +617,9 @@ namespace System.Security.Cryptography
                 // The parameters field associated with this OID ... shall have type
                 // OCTET STRING (SIZE(8)) specifying the initialization vector ...
                 ReadIvParameter(encryptionScheme.Parameters, 8, ref iv);
+#pragma warning disable CA1416 // TripleDES is unsupported on browser, caller will get PNSE
                 return TripleDES.Create();
+#pragma warning restore CA1416
             }
 
             if (algId == Oids.Rc2Cbc)
@@ -688,7 +670,9 @@ namespace System.Security.Cryptography
                 // The parameters field associated with this OID ... shall have type
                 // OCTET STRING (SIZE(8)) specifying the initialization vector ...
                 ReadIvParameter(encryptionScheme.Parameters, 8, ref iv);
+#pragma warning disable CA1416 // DES is unsupported on browser, caller will get PNSE
                 return DES.Create();
+#pragma warning restore CA1416
             }
 
             throw new CryptographicException(SR.Cryptography_UnknownAlgorithmIdentifier, algId);
@@ -775,12 +759,6 @@ namespace System.Security.Cryptography
             if (!pbkdf2Params.Prf.HasNullEquivalentParameters())
             {
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
-            }
-
-            if (!Helpers.HasHMAC)
-            {
-                throw new CryptographicException(
-                    SR.Format(SR.Cryptography_AlgorithmNotSupported, "HMAC" + prf.Name));
             }
 
             int iterationCount = NormalizeIterationCount(pbkdf2Params.IterationCount);

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1708,7 +1708,6 @@ namespace System.Security.Cryptography
         public override void GenerateIV() { }
         public override void GenerateKey() { }
     }
-    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class Rfc2898DeriveBytes : System.Security.Cryptography.DeriveBytes
     {
         [System.ObsoleteAttribute("The default hash algorithm and iteration counts in Rfc2898DeriveBytes constructors are outdated and insecure. Use a constructor that accepts the hash algorithm and the number of iterations.", DiagnosticId="SYSLIB0041", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1297,7 +1297,6 @@ namespace System.Security.Cryptography
         public override string ToString() { throw null; }
         public static bool TryFromOid(string oidValue, out System.Security.Cryptography.HashAlgorithmName value) { throw null; }
     }
-    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public static partial class HKDF
     {
         public static byte[] DeriveKey(System.Security.Cryptography.HashAlgorithmName hashAlgorithmName, byte[] ikm, int outputLength, byte[]? salt = null, byte[]? info = null) { throw null; }

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -566,7 +566,7 @@
     <Compile Include="System\Security\Cryptography\OidLookup.NoFallback.cs" />
     <Compile Include="System\Security\Cryptography\OpenSsl.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\PasswordDeriveBytes.NotSupported.cs" />
-    <Compile Include="System\Security\Cryptography\Pbkdf2Implementation.Managed.cs" />
+    <Compile Include="System\Security\Cryptography\Pbkdf2Implementation.Browser.cs" />
     <Compile Include="System\Security\Cryptography\RandomNumberGeneratorImplementation.Browser.cs" />
     <Compile Include="System\Security\Cryptography\RC2CryptoServiceProvider.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\RC2Implementation.NotSupported.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesSubtleCryptoTransform.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesSubtleCryptoTransform.Browser.cs
@@ -148,7 +148,9 @@ namespace System.Security.Cryptography
                     pOutput, output.Length);
 
                 if (bytesWritten < 0)
+                {
                     throw new CryptographicException(SR.Format(SR.Unknown_SubtleCrypto_Error, bytesWritten));
+                }
 
                 return bytesWritten;
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDF.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDF.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.Versioning;
+using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
@@ -14,7 +15,6 @@ namespace System.Security.Cryptography
     /// phase to be skipped, and the master key to be used directly as the pseudorandom key.
     /// See <a href="https://tools.ietf.org/html/rfc5869">RFC5869</a> for more information.
     /// </remarks>
-    [UnsupportedOSPlatform("browser")]
     public static class HKDF
     {
         /// <summary>
@@ -290,7 +290,9 @@ namespace System.Security.Cryptography
             }
             else if (hashAlgorithmName == HashAlgorithmName.MD5)
             {
+#pragma warning disable CA1416 // HMACMD5 is unsupported on browser, throwing is handled later when making the HMAC call
                 return HMACMD5.HashSizeInBytes;
+#pragma warning restore CA1416
             }
             else
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACHashProvider.Browser.Native.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACHashProvider.Browser.Native.cs
@@ -70,7 +70,9 @@ namespace System.Security.Cryptography
             {
                 int res = Interop.BrowserCrypto.Sign(hashName, k, key.Length, src, data.Length, dest, destination.Length);
                 if (res != 0)
+                {
                     throw new CryptographicException(SR.Format(SR.Unknown_SubtleCrypto_Error, res));
+                }
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Browser.cs
@@ -51,7 +51,9 @@ namespace System.Security.Cryptography
                     pDestination, destination.Length);
 
                 if (result != 0)
+                {
                     throw new CryptographicException(SR.Format(SR.Unknown_SubtleCrypto_Error, result));
+                }
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Browser.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Internal.Cryptography;
+
+using SimpleDigest = Interop.BrowserCrypto.SimpleDigest;
+
+namespace System.Security.Cryptography
+{
+    internal static partial class Pbkdf2Implementation
+    {
+        public static void Fill(
+            ReadOnlySpan<byte> password,
+            ReadOnlySpan<byte> salt,
+            int iterations,
+            HashAlgorithmName hashAlgorithmName,
+            Span<byte> destination)
+        {
+            Debug.Assert(!destination.IsEmpty);
+            Debug.Assert(hashAlgorithmName.Name is not null);
+
+            if (Interop.BrowserCrypto.CanUseSubtleCrypto)
+            {
+                FillSubtleCrypto(password, salt, iterations, hashAlgorithmName, destination);
+            }
+            else
+            {
+                FillManaged(password, salt, iterations, hashAlgorithmName, destination);
+            }
+        }
+
+        private static unsafe void FillSubtleCrypto(
+            ReadOnlySpan<byte> password,
+            ReadOnlySpan<byte> salt,
+            int iterations,
+            HashAlgorithmName hashAlgorithmName,
+            Span<byte> destination)
+        {
+            (SimpleDigest hashName, _) = SHANativeHashProvider.HashAlgorithmToPal(hashAlgorithmName.Name!);
+
+            fixed (byte* pPassword = password)
+            fixed (byte* pSalt = salt)
+            fixed (byte* pDestination = destination)
+            {
+                int result = Interop.BrowserCrypto.DeriveBits(
+                    pPassword, password.Length,
+                    pSalt, salt.Length,
+                    iterations,
+                    hashName,
+                    pDestination, destination.Length);
+
+                if (result != 0)
+                    throw new CryptographicException(SR.Format(SR.Unknown_SubtleCrypto_Error, result));
+            }
+        }
+
+        private static void FillManaged(
+            ReadOnlySpan<byte> password,
+            ReadOnlySpan<byte> salt,
+            int iterations,
+            HashAlgorithmName hashAlgorithmName,
+            Span<byte> destination)
+        {
+            using (Rfc2898DeriveBytes deriveBytes = new Rfc2898DeriveBytes(
+                password.ToArray(),
+                salt.ToArray(),
+                iterations,
+                hashAlgorithmName,
+                clearPassword: true))
+            {
+                byte[] result = deriveBytes.GetBytes(destination.Length);
+                result.AsSpan().CopyTo(destination);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Managed.cs
@@ -18,12 +18,6 @@ namespace System.Security.Cryptography
             Debug.Assert(!destination.IsEmpty);
             Debug.Assert(hashAlgorithmName.Name is not null);
 
-            if (!Helpers.HasHMAC)
-            {
-                throw new CryptographicException(
-                    SR.Format(SR.Cryptography_AlgorithmNotSupported, "HMAC" + hashAlgorithmName.Name));
-            }
-
             using (Rfc2898DeriveBytes deriveBytes = new Rfc2898DeriveBytes(
                 password.ToArray(),
                 salt.ToArray(),

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
@@ -12,7 +12,6 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
-    [UnsupportedOSPlatform("browser")]
     public partial class Rfc2898DeriveBytes : DeriveBytes
     {
         private byte[] _salt;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Native.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Native.cs
@@ -66,7 +66,9 @@ namespace System.Security.Cryptography
             {
                 int res = Interop.BrowserCrypto.SimpleDigestHash(hashName, src, data.Length, dest, destination.Length);
                 if (res != 0)
+                {
                     throw new CryptographicException(SR.Format(SR.Unknown_SubtleCrypto_Error, res));
+                }
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace System.Security.Cryptography.Tests
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public abstract class HKDFTests
     {
         protected abstract byte[] Extract(HashAlgorithmName hash, int prkLength, byte[] ikm, byte[] salt);

--- a/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
@@ -24,6 +24,7 @@ namespace System.Security.Cryptography.Tests
 
         [Theory]
         [MemberData(nameof(GetRfc5869TestCases))]
+        [SkipOnPlatform(TestPlatforms.Browser, "MD5 is not supported on Browser")]
         public void Rfc5869ExtractTamperHashTests(Rfc5869TestCase test)
         {
             byte[] prk = Extract(HashAlgorithmName.MD5, 128 / 8, test.Ikm, test.Salt);
@@ -239,7 +240,11 @@ namespace System.Security.Cryptography.Tests
             yield return new object[] { HashAlgorithmName.SHA1, 160 / 8 - 1 };
             yield return new object[] { HashAlgorithmName.SHA256, 256 / 8 - 1 };
             yield return new object[] { HashAlgorithmName.SHA512, 512 / 8 - 1 };
-            yield return new object[] { HashAlgorithmName.MD5, 128 / 8 - 1 };
+
+            if (!PlatformDetection.IsBrowser)
+            {
+                yield return new object[] { HashAlgorithmName.MD5, 128 / 8 - 1 };
+            }
         }
 
         private static Rfc5869TestCase[] Rfc5869TestCases { get; } = new Rfc5869TestCase[7]

--- a/src/libraries/System.Security.Cryptography/tests/Rfc2898OneShotTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/Rfc2898OneShotTests.cs
@@ -8,7 +8,6 @@ using Test.Cryptography;
 
 namespace System.Security.Cryptography
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public static class Rfc2898OneShotTests
     {
         // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Suppression approved. Password for testing.")]

--- a/src/libraries/System.Security.Cryptography/tests/Rfc2898Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/Rfc2898Tests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace System.Security.Cryptography
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public class Rfc2898Tests
     {
         private static readonly byte[] s_testSalt = new byte[] { 9, 5, 5, 5, 1, 2, 1, 2 };

--- a/src/libraries/apicompat/ApiCompatBaseline.NetCoreAppLatestStable.txt
+++ b/src/libraries/apicompat/ApiCompatBaseline.NetCoreAppLatestStable.txt
@@ -13,6 +13,7 @@ CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' on 'System.Security.Cryptography.DSA.Create(System.Security.Cryptography.DSAParameters)' changed from '[UnsupportedOSPlatformAttribute("ios")]' in the contract to '[UnsupportedOSPlatformAttribute("browser")]' in the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.DSASignatureDeformatter' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.DSASignatureFormatter' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HKDF' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA1' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA256' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA384' in the contract but not the implementation.
@@ -72,6 +73,7 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECDiffieHellman' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECDsa' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECParameters' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HKDF' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA1' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA256' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA384' in the contract but not the implementation.
@@ -162,6 +164,7 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECDiffieHellman' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECDsa' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.ECParameters' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HKDF' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA1' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA256' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.HMACSHA384' in the contract but not the implementation.
@@ -189,4 +192,4 @@ Compat issues with assembly System.Security.Cryptography.X509Certificates:
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' on 'System.Security.Cryptography.X509Certificates.PublicKey.GetDSAPublicKey()' changed from '[UnsupportedOSPlatformAttribute("ios")]' in the contract to '[UnsupportedOSPlatformAttribute("browser")]' in the implementation.
 Compat issues with assembly System.Text.Json:
 CannotMakeTypeAbstract : Type 'System.Text.Json.Serialization.Metadata.JsonTypeInfo' is abstract in the implementation but is not abstract in the contract.
-Total Issues: 177
+Total Issues: 180

--- a/src/libraries/apicompat/ApiCompatBaseline.NetCoreAppLatestStable.txt
+++ b/src/libraries/apicompat/ApiCompatBaseline.NetCoreAppLatestStable.txt
@@ -22,6 +22,7 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RandomNumberGenerator.Create(System.String)' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RC2' in the contract but not the implementation.
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' on 'System.Security.Cryptography.RC2.Create()' changed from '[UnsupportedOSPlatformAttribute("android")]' in the contract to '[UnsupportedOSPlatformAttribute("android")]' in the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.Rfc2898DeriveBytes' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.Rijndael' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RijndaelManaged' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RSA' in the contract but not the implementation.
@@ -82,6 +83,7 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RandomNumberGenerator.Create(System.String)' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RC2' in the contract but not the implementation.
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' on 'System.Security.Cryptography.RC2.Create()' changed from '[UnsupportedOSPlatformAttribute("android")]' in the contract to '[UnsupportedOSPlatformAttribute("android")]' in the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.Rfc2898DeriveBytes' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.Rijndael' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RijndaelManaged' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RSA' in the contract but not the implementation.
@@ -171,6 +173,7 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RandomNumberGenerator.Create(System.String)' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RC2' in the contract but not the implementation.
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' on 'System.Security.Cryptography.RC2.Create()' changed from '[UnsupportedOSPlatformAttribute("android")]' in the contract to '[UnsupportedOSPlatformAttribute("android")]' in the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.Rfc2898DeriveBytes' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.Rijndael' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RijndaelManaged' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.RSA' in the contract but not the implementation.
@@ -186,4 +189,4 @@ Compat issues with assembly System.Security.Cryptography.X509Certificates:
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' on 'System.Security.Cryptography.X509Certificates.PublicKey.GetDSAPublicKey()' changed from '[UnsupportedOSPlatformAttribute("ios")]' in the contract to '[UnsupportedOSPlatformAttribute("browser")]' in the implementation.
 Compat issues with assembly System.Text.Json:
 CannotMakeTypeAbstract : Type 'System.Text.Json.Serialization.Metadata.JsonTypeInfo' is abstract in the implementation but is not abstract in the contract.
-Total Issues: 174
+Total Issues: 177

--- a/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
+++ b/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
@@ -91,6 +91,7 @@ const linked_functions = [
     "dotnet_browser_simple_digest_hash",
     "dotnet_browser_sign",
     "dotnet_browser_encrypt_decrypt",
+    "dotnet_browser_derive_bits",
 
     /// mono-threads-wasm.c
     #if USE_PTHREADS

--- a/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
+++ b/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
@@ -128,6 +128,7 @@ const linked_functions = [
     "dotnet_browser_simple_digest_hash",
     "dotnet_browser_sign",
     "dotnet_browser_encrypt_decrypt",
+    "dotnet_browser_derive_bits",
 
     /// mono-threads-wasm.c
     #if USE_PTHREADS

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -72,7 +72,8 @@ import {
     dotnet_browser_can_use_subtle_crypto_impl,
     dotnet_browser_simple_digest_hash,
     dotnet_browser_sign,
-    dotnet_browser_encrypt_decrypt
+    dotnet_browser_encrypt_decrypt,
+    dotnet_browser_derive_bits,
 } from "./crypto-worker";
 import { mono_wasm_cancel_promise_ref } from "./cancelable-promise";
 import { mono_wasm_web_socket_open_ref, mono_wasm_web_socket_send, mono_wasm_web_socket_receive, mono_wasm_web_socket_close_ref, mono_wasm_web_socket_abort } from "./web-socket";
@@ -408,6 +409,7 @@ export const __linker_exports: any = {
     dotnet_browser_simple_digest_hash,
     dotnet_browser_sign,
     dotnet_browser_encrypt_decrypt,
+    dotnet_browser_derive_bits,
 
     // threading exports, if threading is enabled
     ...mono_wasm_threads_exports,

--- a/src/native/libs/System.Security.Cryptography.Native.Browser/pal_crypto_webworker.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Browser/pal_crypto_webworker.c
@@ -32,6 +32,16 @@ extern int32_t dotnet_browser_encrypt_decrypt(
     uint8_t* output_buffer,
     int32_t output_len);
 
+extern int32_t dotnet_browser_derive_bits(
+    uint8_t* password_buffer,
+    int32_t password_len,
+    uint8_t* salt_buffer,
+    int32_t salt_len,
+    int32_t iterations,
+    enum simple_digest hashAlgorithm,
+    uint8_t* output_buffer,
+    int32_t output_len);
+
 extern int32_t dotnet_browser_can_use_subtle_crypto_impl(void);
 
 int32_t SystemCryptoNativeBrowser_SimpleDigestHash(
@@ -68,6 +78,19 @@ int32_t SystemCryptoNativeBrowser_EncryptDecrypt(
     int32_t output_len)
 {
     return dotnet_browser_encrypt_decrypt(encrypting, key_buffer, key_len, iv_buffer, iv_len, input_buffer, input_len, output_buffer, output_len);
+}
+
+int32_t SystemCryptoNativeBrowser_DeriveBits(
+    uint8_t* password_buffer,
+    int32_t password_len,
+    uint8_t* salt_buffer,
+    int32_t salt_len,
+    int32_t iterations,
+    enum simple_digest hashAlgorithm,
+    uint8_t* output_buffer,
+    int32_t output_len)
+{
+    return dotnet_browser_derive_bits(password_buffer, password_len, salt_buffer, salt_len, iterations, hashAlgorithm, output_buffer, output_len);
 }
 
 int32_t SystemCryptoNativeBrowser_CanUseSubtleCryptoImpl(void)

--- a/src/native/libs/System.Security.Cryptography.Native.Browser/pal_crypto_webworker.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Browser/pal_crypto_webworker.h
@@ -42,4 +42,14 @@ PALEXPORT int32_t SystemCryptoNativeBrowser_EncryptDecrypt(
     uint8_t* output_buffer,
     int32_t output_len);
 
+PALEXPORT int32_t SystemCryptoNativeBrowser_DeriveBits(
+    uint8_t* password_buffer,
+    int32_t password_len,
+    uint8_t* salt_buffer,
+    int32_t salt_len,
+    int32_t iterations,
+    enum simple_digest hashAlgorithm,
+    uint8_t* output_buffer,
+    int32_t output_len);
+
 PALEXPORT int32_t SystemCryptoNativeBrowser_CanUseSubtleCryptoImpl(void);


### PR DESCRIPTION
Marks the APIs as supported on Browser, and enables Rfc2898 tests on Browser WASM.
Use SubtleCrypto deriveBits API to implement one shot Pbkdf2.

Also, make HKDF supported on Browser.

Contributes to https://github.com/dotnet/runtime/issues/40074