### PR TITLE
Enable direct decomposition of promoted args on ARM

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3188,14 +3188,6 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                         makeOutArgCopy = true;
                     }
 #endif // defined(TARGET_ARMARCH) || defined(TARGET_LOONGARCH64)
-
-#ifdef TARGET_ARM
-                    if ((lclVar != nullptr) &&
-                        (lvaGetPromotionType(lclVar->AsLclVarCommon()->GetLclNum()) == PROMOTION_TYPE_INDEPENDENT))
-                    {
-                        makeOutArgCopy = true;
-                    }
-#endif // TARGET_ARM
                 }
                 else
                 {


### PR DESCRIPTION
We're expecting pretty nice diffs, with a few regressions because sometimes copying to a temp and then decomposing ends up being better due to the fact the promoted local can stay DNER-less.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1866485&view=results).