### PR TITLE
Tweak inline reporting rules to behave as they did before #71271 was merged

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InliningInfoNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InliningInfoNode.cs
@@ -105,7 +105,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         continue;
                     }
 
-                    if (inlinee.IsNonVersionable())
+                    if (inlinee.IsNonVersionable() && !factory.CompilationModuleGroup.VersionsWithMethodBody(inlinee))
                     {
                         // Non-versionable methods don't need to be reported
                         continue;


### PR DESCRIPTION
The issue here is an assumption I made. The issue is the behavior of NonVersionable methods.

- NonVersionable methods can be inlined across version bubbles, and that has been true for a long time.
- We never used to report NonVersionable methods as inlined when the inline crosses a version bubble
- My change extended that lack of reporting to not report inlines even within a version bubble, as we can't reliably do a rejit of the method, as not all implementations will be marked as inlined in any case.

This change returns our behavior to match the previous handling. Its still not reliable to use this api for rejit of a NonVersionable method, but it will be as reliable as before.

Fixes #71774