### PR TITLE
[mono] Update MonoAOTCompiler to provide reference assemblies location

### DIFF
--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -16,6 +16,7 @@
 
     <ItemGroup>
       <AotInputAssemblies Include="$(PublishDir)\*.dll" />
+      <ReferenceAssembliesForPGO Include="$(PublishDir)\*.dll" />
     </ItemGroup>
 
     <MonoAOTCompiler
@@ -29,7 +30,7 @@
       CacheFilePath="$(IntermediateOutputPath)aot_compiler_cache.json"
       NetTracePath="$(NetTracePath)"
       PgoBinaryPath="$(PgoBinaryPath)"
-      ReferenceAssembliesDir="$(PublishDir)"
+      ReferenceAssembliesForPGO="@(ReferenceAssembliesForPGO)"
       MibcProfilePath="$(MibcProfilePath)">
       <Output TaskParameter="CompiledAssemblies" ItemName="BundleAssemblies" />
     </MonoAOTCompiler>

--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -29,6 +29,7 @@
       CacheFilePath="$(IntermediateOutputPath)aot_compiler_cache.json"
       NetTracePath="$(NetTracePath)"
       PgoBinaryPath="$(PgoBinaryPath)"
+      ReferenceAssembliesDir="$(PublishDir)"
       MibcProfilePath="$(MibcProfilePath)">
       <Output TaskParameter="CompiledAssemblies" ItemName="BundleAssemblies" />
     </MonoAOTCompiler>

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -122,9 +122,9 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     public string? NetTracePath { get; set; }
 
     /// <summary>
-    /// Path to assemblies to reference when invoking dotnet-pgo to process a .nettrace collected from a separate device. Necessary for mobile platforms.
+    /// Directory containing all assemblies referenced in a .nettrace collected from a separate device needed by dotnet-pgo. Necessary for mobile platforms.
     /// </summary>
-    public string? ReferenceAssembliesDir { get; set; }
+    public string? ReferenceAssembliesDirForPGO { get; set; }
 
     /// <summary>
     /// File to use for profile-guided optimization, *only* the methods described in the file will be AOT compiled.
@@ -298,9 +298,9 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
                 Log.LogError($"NetTracePath was provided, but {nameof(PgoBinaryPath)}='{PgoBinaryPath}' doesn't exist");
                 return false;
             }
-            if (!Directory.Exists(ReferenceAssembliesDir))
+            if (!Directory.Exists(ReferenceAssembliesDirForPGO))
             {
-                Log.LogError($"NetTracePath was provided, but {nameof(ReferenceAssembliesDir)}='{ReferenceAssembliesDir}' doesn't exist");
+                Log.LogError($"NetTracePath was provided, but {nameof(ReferenceAssembliesDirForPGO)}='{ReferenceAssembliesDirForPGO}' doesn't exist");
                 return false;
             }
         }
@@ -451,7 +451,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
         (int exitCode, string output) = Utils.TryRunProcess(Log,
                                                             PgoBinaryPath!,
-                                                            $"create-mibc --trace {netTraceFile} --reference \"{ReferenceAssembliesDir}*.dll\" --output {outputMibcPath}");
+                                                            $"create-mibc --trace {netTraceFile} --reference \"{ReferenceAssembliesDirForPGO}*.dll\" --output {outputMibcPath}");
 
         if (exitCode != 0)
         {

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -124,7 +124,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     /// <summary>
     /// Directory containing all assemblies referenced in a .nettrace collected from a separate device needed by dotnet-pgo. Necessary for mobile platforms.
     /// </summary>
-    public ITaskItem[]? ReferenceAssembliesForPGO { get; set; }
+    public ITaskItem[] ReferenceAssembliesForPGO { get; set; } = Array.Empty<ITaskItem>();
 
     /// <summary>
     /// File to use for profile-guided optimization, *only* the methods described in the file will be AOT compiled.
@@ -298,7 +298,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
                 Log.LogError($"NetTracePath was provided, but {nameof(PgoBinaryPath)}='{PgoBinaryPath}' doesn't exist");
                 return false;
             }
-            if (ReferenceAssembliesForPGO!.Length == 0)
+            if (ReferenceAssembliesForPGO.Length == 0)
             {
                 Log.LogError($"NetTracePath was provided, but {nameof(ReferenceAssembliesForPGO)} is empty");
                 return false;
@@ -458,7 +458,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         StringBuilder pgoArgsStr = new StringBuilder(string.Empty);
         pgoArgsStr.Append($"create-mibc ");
         pgoArgsStr.Append($"--trace {netTraceFile} ");
-        foreach (var refAsmItem in ReferenceAssembliesForPGO!)
+        foreach (var refAsmItem in ReferenceAssembliesForPGO)
         {
             string? fullPath = refAsmItem.GetMetadata("FullPath");
             pgoArgsStr.Append($"--reference \"{fullPath}\" ");

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -124,7 +124,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     /// <summary>
     /// Directory containing all assemblies referenced in a .nettrace collected from a separate device needed by dotnet-pgo. Necessary for mobile platforms.
     /// </summary>
-    public ITaskItem[] ReferenceAssembliesForPGO { get; set; } = Array.Empty<ITaskItem>();
+    public ITaskItem[] ReferenceAssemblyPathsForPGO { get; set; } = Array.Empty<ITaskItem>();
 
     /// <summary>
     /// File to use for profile-guided optimization, *only* the methods described in the file will be AOT compiled.
@@ -298,12 +298,12 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
                 Log.LogError($"NetTracePath was provided, but {nameof(PgoBinaryPath)}='{PgoBinaryPath}' doesn't exist");
                 return false;
             }
-            if (ReferenceAssembliesForPGO.Length == 0)
+            if (ReferenceAssemblyPathsForPGO.Length == 0)
             {
-                Log.LogError($"NetTracePath was provided, but {nameof(ReferenceAssembliesForPGO)} is empty");
+                Log.LogError($"NetTracePath was provided, but {nameof(ReferenceAssemblyPathsForPGO)} is empty");
                 return false;
             }
-            foreach (var refAsmItem in ReferenceAssembliesForPGO)
+            foreach (var refAsmItem in ReferenceAssemblyPathsForPGO)
             {
                 string? fullPath = refAsmItem.GetMetadata("FullPath");
                 if (!File.Exists(fullPath))
@@ -456,14 +456,14 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         }
 
         StringBuilder pgoArgsStr = new StringBuilder(string.Empty);
-        pgoArgsStr.Append($"create-mibc ");
-        pgoArgsStr.Append($"--trace {netTraceFile} ");
-        foreach (var refAsmItem in ReferenceAssembliesForPGO)
+        pgoArgsStr.Append($"create-mibc");
+        pgoArgsStr.Append($" --trace {netTraceFile} ");
+        foreach (var refAsmItem in ReferenceAssemblyPathsForPGO)
         {
             string? fullPath = refAsmItem.GetMetadata("FullPath");
-            pgoArgsStr.Append($"--reference \"{fullPath}\" ");
+            pgoArgsStr.Append($" --reference \"{fullPath}\" ");
         }
-        pgoArgsStr.Append($"--output {outputMibcPath} ");
+        pgoArgsStr.Append($" --output {outputMibcPath} ");
         (int exitCode, string output) = Utils.TryRunProcess(Log,
                                                             PgoBinaryPath!,
                                                             pgoArgsStr.ToString());

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -122,6 +122,11 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     public string? NetTracePath { get; set; }
 
     /// <summary>
+    /// Path to assemblies to reference when invoking dotnet-pgo to process a .nettrace collected from a separate device. Necessary for mobile platforms.
+    /// </summary>
+    public string? ReferenceAssembliesDir { get; set; }
+
+    /// <summary>
     /// File to use for profile-guided optimization, *only* the methods described in the file will be AOT compiled.
     /// </summary>
     public string[]? AotProfilePath { get; set; }
@@ -285,12 +290,17 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         {
             if (!File.Exists(NetTracePath))
             {
-                Log.LogError($"NetTracePath={nameof(NetTracePath)} doesn't exist");
+                Log.LogError($"{nameof(NetTracePath)}='{NetTracePath}' doesn't exist");
                 return false;
             }
             if (!File.Exists(PgoBinaryPath))
             {
                 Log.LogError($"NetTracePath was provided, but {nameof(PgoBinaryPath)}='{PgoBinaryPath}' doesn't exist");
+                return false;
+            }
+            if (!Directory.Exists(ReferenceAssembliesDir))
+            {
+                Log.LogError($"NetTracePath was provided, but {nameof(ReferenceAssembliesDir)}='{ReferenceAssembliesDir}' doesn't exist");
                 return false;
             }
         }
@@ -441,7 +451,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
         (int exitCode, string output) = Utils.TryRunProcess(Log,
                                                             PgoBinaryPath!,
-                                                            $"create-mibc --trace {netTraceFile} --output {outputMibcPath}");
+                                                            $"create-mibc --trace {netTraceFile} --reference \"{ReferenceAssembliesDir}*.dll\" --output {outputMibcPath}");
 
         if (exitCode != 0)
         {


### PR DESCRIPTION
Profiled AOT on mobile platforms leads to `.nettrace` files referencing assemblies on the mobile device. When invoking dotnet-pgo, this would lead to problems when finding the assembly.

`/Users/mihw/runtime_droid/src/mono/sample/Android/AndroidSampleApp.csproj(64,5): error : dotnet-pgo(/Users/mihw/runtime_coreclr/artifacts/bin/coreclr/OSX.arm64.Release/dotnet-pgo/dotnet-pgo) failed for /Users/mihw/runtime_droid/android_debug.nettrace:Creating ETLX file /Users/mihw/runtime_droid/android_debug.etlx from /Users/mihw/runtime_droid/android_debug.nettrace
/Users/mihw/runtime_droid/src/mono/sample/Android/AndroidSampleApp.csproj(64,5): error : Error: Failed to load assembly 'System.Private.CoreLib' from '/data/data/net.dot.HelloAndroid/files/System.Private.CoreLib.dll'`

Note the `/data/data/net.dot.HelloAndroid/files/System.Private.CoreLib.dll` path expected by the dotnet-pgo tool.

This PR enables the MonoAOTCompiler to pass the referenced assemblies needed by dotnet-pgo.\

---------

### Testing

Tested on Android with AndroidSampleApp

1. Build mono - `./build.sh -s mono+libs+libs.pretest -os Android -arch arm64 -c Debug`
2. Build AndroidSampleApp with diagnostic ports enabled without AOT, llvm, or trimming. (`cd src/mono/sample/Android`) - `make run` (after making relevant changes to the makefile and csproj)
3. Trace app - 
```
~/android-sdk/platform-tools/adb reverse tcp:9000 tcp:9001
./dotnet-dsrouter client-server -tcps 127.0.0.1:9001 -ipcc ~/myport --verbose debug
dotnet-trace collect --diagnostic-port ~/myport --providers Microsoft-Windows-DotNETRuntime:0x1F000080018:5 --output ~/runtime_droid/android_debug.nettrace
```
4. Build AndroidSampleApp with diagnostic ports disabled with AOT (no llvm or trimming) and provide .nettrace

Binlog: [AndroidSampleApp.binlog.zip](https://github.com/dotnet/runtime/files/9067689/AndroidSampleApp.binlog.zip)
Snippet: 
```
Added 1 methods from mibc profile.
Mono: Requesting loading reference 1 (of 2) of /Users/mihw/runtime_droid/artifacts/bin/AndroidSampleApp/arm64/Debug/android-arm64/publish/AndroidSampleApp.dll
Mono: Loading reference 1 of /Users/mihw/runtime_droid/artifacts/bin/AndroidSampleApp/arm64/Debug/android-arm64/publish/AndroidSampleApp.dll (default ALC), looking for System.Console, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
Mono: Request to load System.Console in alc 0x600000828000
Mono: Assembly already loaded in the active ALC: 'System.Console'.
Mono: Assembly Ref addref AndroidSampleApp[0x600000624000] -> System.Console[0x600000624090]: 3
Compiled: 1/1
```
