### PR TITLE
Make sure the struct field offset matches with that of parent during morphing

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11528,8 +11528,9 @@ DONE_MORPHING_CHILDREN:
                                 LclVarDsc* fieldVarDsc = lvaGetDesc(lclNumFld);
 
                                 // Also make sure that the tree type matches the fieldVarType and that it's lvFldOffset
-                                // is zero
-                                if (fieldVarDsc->TypeGet() == typ && (fieldVarDsc->lvFldOffset == 0))
+                                // is same as that of tree's offset.
+                                if (fieldVarDsc->TypeGet() == typ &&
+                                    (fieldVarDsc->lvFldOffset == temp->AsLclVarCommon()->GetLclOffs()))
                                 {
                                     // We can just use the existing promoted field LclNum
                                     temp->AsLclVarCommon()->SetLclNum(lclNumFld);


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/70170 exposed an issue because we started folding `ADDR(LCL_FLD <original struct>)`  and removed the information about the fields.

![image](https://user-images.githubusercontent.com/12488060/177884323-1a362b76-14a0-42c5-8a80-5b3d8abde527.png)

There is a similar field access for parent struct and we think that the current field's zero-init is redundant and can be safely removed.

```
STMT00010 ( INL02 @ 0x000[E-] ... ??? ) <- INL01 @ 0x000[E-] <- INLRT @ 0x000[E-]
N003 (  5,  4) [000043] -A--G---R--                         *  ASG       int   
N002 (  3,  2) [000040] D---G--N---                         +--*  LCL_VAR   int   (AX) V07 tmp3         
N001 (  1,  1) [000041] -----------                         \--*  CNS_INT   int    0

***** BB01
STMT00009 ( INL01 @ 0x007[E-] ... ??? ) <- INLRT @ 0x000[E-]
N003 (  5,  6) [000035] -A--G---R--                         *  ASG       int   
N002 (  3,  4) [000029] D---G--N---                         +--*  LCL_FLD   int    V07 tmp3         [+4]
N001 (  1,  1) [000033] -----------                         \--*  CNS_INT   int    0
```

The fix is to before making it `LCL_FLD` make sure that the offsets are same too.

Fixes: https://github.com/dotnet/runtime/issues/70791