### PR TITLE
Use UnrelatedR2RCode flag when --compilebubblegenerics is specified

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -123,7 +123,7 @@ namespace ILCompiler
             {
                 flags |= ReadyToRunFlags.READYTORUN_FLAG_MultiModuleVersionBubble;
             }
-            if (CompileAllPossibleCrossModuleCode)
+            if (CompileAllPossibleCrossModuleCode || CompileGenericDependenciesFromVersionBubbleModuleSet)
             {
                 flags |= ReadyToRunFlags.READYTORUN_FLAG_UnrelatedR2RCode;
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -123,7 +123,7 @@ namespace ILCompiler
             {
                 flags |= ReadyToRunFlags.READYTORUN_FLAG_MultiModuleVersionBubble;
             }
-            if (CompileAllPossibleCrossModuleCode || CompileGenericDependenciesFromVersionBubbleModuleSet)
+            if (CompileAllPossibleCrossModuleCode || _compileGenericDependenciesFromVersionBubbleModuleSet)
             {
                 flags |= ReadyToRunFlags.READYTORUN_FLAG_UnrelatedR2RCode;
             }


### PR DESCRIPTION
Fixes #46160