### PR TITLE
[wasm][aot] Avoid making the 'this' variable volatile.

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -6732,7 +6732,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			/* FIXME: Is there a better way to do this?
 			   We need the variable live for the duration
 			   of the whole method. */
-			cfg->args [0]->flags |= MONO_INST_VOLATILE;
+			if (!cfg->llvm_only)
+				cfg->args [0]->flags |= MONO_INST_VOLATILE;
 		}
 	}
 


### PR DESCRIPTION
This is only needed in non-llvmonly mode for computing stack traces in gshared methods.