### PR TITLE
Make MetadataReader.GetAssemblyName(string assemblyFile) public

### DIFF
--- a/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -1663,6 +1663,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.MetadataStringDecoder UTF8Decoder { get { throw null; } }
         public System.Reflection.Metadata.AssemblyDefinition GetAssemblyDefinition() { throw null; }
         public System.Reflection.Metadata.AssemblyFile GetAssemblyFile(System.Reflection.Metadata.AssemblyFileHandle handle) { throw null; }
+        public static unsafe System.Reflection.AssemblyName GetAssemblyName(string assemblyFile) { throw null; }
         public System.Reflection.Metadata.AssemblyReference GetAssemblyReference(System.Reflection.Metadata.AssemblyReferenceHandle handle) { throw null; }
         public byte[] GetBlobBytes(System.Reflection.Metadata.BlobHandle handle) { throw null; }
         public System.Collections.Immutable.ImmutableArray<byte> GetBlobContent(System.Reflection.Metadata.BlobHandle handle) { throw null; }

--- a/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -1663,7 +1663,7 @@ namespace System.Reflection.Metadata
         public System.Reflection.Metadata.MetadataStringDecoder UTF8Decoder { get { throw null; } }
         public System.Reflection.Metadata.AssemblyDefinition GetAssemblyDefinition() { throw null; }
         public System.Reflection.Metadata.AssemblyFile GetAssemblyFile(System.Reflection.Metadata.AssemblyFileHandle handle) { throw null; }
-        public static unsafe System.Reflection.AssemblyName GetAssemblyName(string assemblyFile) { throw null; }
+        public static System.Reflection.AssemblyName GetAssemblyName(string assemblyFile) { throw null; }
         public System.Reflection.Metadata.AssemblyReference GetAssemblyReference(System.Reflection.Metadata.AssemblyReferenceHandle handle) { throw null; }
         public byte[] GetBlobBytes(System.Reflection.Metadata.BlobHandle handle) { throw null; }
         public System.Collections.Immutable.ImmutableArray<byte> GetBlobContent(System.Reflection.Metadata.BlobHandle handle) { throw null; }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
@@ -45,7 +45,16 @@ namespace System.Reflection.Metadata
             return assemblyName;
         }
 
-        internal static unsafe AssemblyName GetAssemblyName(string assemblyFile)
+        /// <summary>
+        /// Gets the <see cref="AssemblyName"/> for a given file.
+        /// </summary>
+        /// <param name="assemblyFile">The path for the assembly which <see cref="AssemblyName"/> is to be returned.</param>
+        /// <returns>An <see cref="AssemblyName"/> that represents the given <paramref name="assemblyFile"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="assemblyFile"/> is null.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="assemblyFile"/> is invalid.</exception>
+        /// <exception cref="FileNotFoundException">If <paramref name="assemblyFile"/> is not found.</exception>
+        /// <exception cref="BadImageFormatException">If <paramref name="assemblyFile"/> is not a valid assembly.</exception>
+        public static unsafe AssemblyName GetAssemblyName(string assemblyFile)
         {
             if (assemblyFile is null)
             {

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -3070,5 +3070,26 @@ namespace System.Reflection.Metadata.Tests
 
             return obfuscated;
         }
+
+        [Fact]
+        public void GetAssemblyName()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("assemblyFile", () => MetadataReader.GetAssemblyName(null));
+            AssertExtensions.Throws<ArgumentException>("path", null, () => MetadataReader.GetAssemblyName(string.Empty));
+            Assert.Throws<FileNotFoundException>(() => MetadataReader.GetAssemblyName("IDontExist"));
+
+            using (var tempFile = new TempFile(Path.GetTempFileName(), 0)) // Zero-size file
+            {
+                Assert.Throws<BadImageFormatException>(() => MetadataReader.GetAssemblyName(tempFile.Path));
+            }
+
+            using (var tempFile = new TempFile(Path.GetTempFileName(), 42))
+            {
+                Assert.Throws<BadImageFormatException>(() => MetadataReader.GetAssemblyName(tempFile.Path));
+            }
+
+            Assembly a = typeof(MetadataReaderTests).Assembly;
+            Assert.Equal(new AssemblyName(a.FullName).ToString(), MetadataReader.GetAssemblyName(AssemblyPathHelper.GetAssemblyLocation(a)).ToString());
+        }
     }
 }

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -295,20 +295,6 @@ namespace System.Reflection.Tests
         [Fact]
         public static void GetAssemblyName()
         {
-            AssertExtensions.Throws<ArgumentNullException>("assemblyFile", () => AssemblyName.GetAssemblyName(null));
-            AssertExtensions.Throws<ArgumentException>("path", null, () => AssemblyName.GetAssemblyName(string.Empty));
-            Assert.Throws<System.IO.FileNotFoundException>(() => AssemblyName.GetAssemblyName("IDontExist"));
-
-            using (var tempFile = new TempFile(Path.GetTempFileName(), 0)) // Zero-size file
-            {
-                Assert.Throws<System.BadImageFormatException>(() => AssemblyName.GetAssemblyName(tempFile.Path));
-            }
-
-            using (var tempFile = new TempFile(Path.GetTempFileName(), 42))
-            {
-                Assert.Throws<System.BadImageFormatException>(() => AssemblyName.GetAssemblyName(tempFile.Path));
-            }
-
             if (!PlatformDetection.IsNativeAot)
             {
                 Assembly a = typeof(AssemblyNameTests).Assembly;


### PR DESCRIPTION
Update internal API: MetadataReader.GetAssemblyName(string assemblyFile) to public

Fixes https://github.com/dotnet/runtime/issues/63960
Related to https://github.com/dotnet/runtime/pull/63915