### PR TITLE
Detect generic recursion pattern in S.Linq.Parallel

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/GraphBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/GraphBuilder.cs
@@ -57,6 +57,9 @@ namespace ILCompiler
                             {
                                 var ecmaMethod = (EcmaMethod)assembly.GetObject(methodHandle);
                                 WalkMethod(ecmaMethod);
+
+                                if (ecmaMethod.IsVirtual)
+                                    LookForVirtualOverrides(ecmaMethod);
                             }
                             catch (TypeSystemException)
                             {
@@ -89,6 +92,61 @@ namespace ILCompiler
                 ForEachEmbeddedGenericFormal(ancestorType, typeContext, Instantiation.Empty);
             }
 
+            private void LookForVirtualOverrides(EcmaMethod method)
+            {
+                // We don't currently attempt to handle this for non-generics.
+                if (!method.HasInstantiation)
+                    return;
+
+                // If this is a generic virtual method, add an edge from each of the generic parameters
+                // of the implementation to the generic parameters of the declaration - any call to the
+                // declaration will be modeled as if the declaration was calling into the implementation.
+
+                var decl = (EcmaMethod)MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method).GetTypicalMethodDefinition();
+                if (decl != method)
+                {
+                    RecordBinding(this, decl.Instantiation, method.Instantiation);
+                }
+                else
+                {
+                    TypeDesc methodOwningType = method.OwningType;
+
+                    // This is the slot definition. Does it implement an interface?
+                    // (This has obvious holes. They haven't show up as issues so far.)
+                    foreach (DefType interfaceType in methodOwningType.RuntimeInterfaces)
+                    {
+                        foreach (MethodDesc interfaceMethod in interfaceType.GetVirtualMethods())
+                        {
+                            // Trivially reject looking at interface methods that for sure can't be implemented by
+                            // the method we're looking at.
+                            if (!interfaceMethod.IsVirtual
+                                || interfaceMethod.Instantiation.Length != method.Instantiation.Length
+                                || interfaceMethod.Signature.Length != method.Signature.Length
+                                || interfaceMethod.Signature.IsStatic != method.Signature.IsStatic)
+                                continue;
+
+                            MethodDesc impl = methodOwningType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod)?.GetMethodDefinition();
+                            if (impl == method)
+                            {
+                                RecordBinding(this, interfaceMethod.Instantiation, method.Instantiation);
+                                // Continue the loop in case this method implements multiple interfaces
+                            }
+                        }
+                    }
+                }
+
+                static void RecordBinding(GraphBuilder builder, Instantiation declInstantiation, Instantiation implInstantiation)
+                {
+                    for (int i = 0; i < declInstantiation.Length; i++)
+                    {
+                        builder.RecordBinding(
+                            (EcmaGenericParameter)implInstantiation[i],
+                            (EcmaGenericParameter)declInstantiation[i],
+                            isProperEmbedding: false);
+                    }
+                }
+            }
+
             private void WalkMethod(EcmaMethod method)
             {
                 Instantiation typeContext = method.OwningType.Instantiation;
@@ -99,56 +157,6 @@ namespace ILCompiler
                 foreach (TypeDesc parameterType in methodSig)
                 {
                     ProcessTypeReference(parameterType, typeContext, methodContext);
-                }
-
-                // If this is a generic virtual method, add an edge from each of the generic parameters
-                // of the implementation to the generic parameters of the declaration - any call to the
-                // declaration will be modeled as if the declaration was calling into the implementation.
-                if (method.IsVirtual && method.HasInstantiation)
-                {
-                    Instantiation declInstantiation = default;
-                    Instantiation implInstantiation = default;
-                    var decl = (EcmaMethod)MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method).GetTypicalMethodDefinition();
-                    if (decl != method)
-                    {
-                        declInstantiation = decl.Instantiation;
-                        implInstantiation = method.Instantiation;
-                    }
-                    else
-                    {
-                        TypeDesc methodOwningType = method.OwningType;
-
-                        // This is the slot definition. Does it implement an interface?
-                        foreach (DefType interfaceType in methodOwningType.RuntimeInterfaces)
-                        {
-                            foreach (MethodDesc interfaceMethod in interfaceType.GetVirtualMethods())
-                            {
-                                // Trivially reject looking at interface methods that for sure can't be implemented by
-                                // the method we're looking at.
-                                if (interfaceMethod.Instantiation.Length != method.Instantiation.Length
-                                    || interfaceMethod.Signature.Length != method.Signature.Length)
-                                    continue;
-
-                                MethodDesc impl = methodOwningType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod)?.GetMethodDefinition();
-                                if (impl == method)
-                                {
-                                    declInstantiation = interfaceMethod.Instantiation;
-                                    implInstantiation = method.Instantiation;
-                                }
-                            }
-                        }
-                    }
-
-                    if (!declInstantiation.IsNull)
-                    {
-                        for (int i = 0; i < declInstantiation.Length; i++)
-                        {
-                            RecordBinding(
-                                (EcmaGenericParameter)implInstantiation[i],
-                                (EcmaGenericParameter)declInstantiation[i],
-                                isProperEmbedding: false);
-                        }
-                    }
                 }
 
                 if (method.IsAbstract)

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -43,6 +43,7 @@ class Generics
         TestSimpleGenericRecursion.Run();
         TestGenericRecursionFromNpgsql.Run();
         TestRecursionInGenericVirtualMethods.Run();
+        TestRecursionInGenericInterfaceMethods.Run();
         TestRecursionThroughGenericLookups.Run();
         TestGvmLookupDependency.Run();
         TestInvokeMemberCornerCaseInGenerics.Run();
@@ -3118,6 +3119,47 @@ class Generics
             // There is a generic recursion in the above hierarchy. This just tests that we can compile.
             // Inspired by https://github.com/dotnet/machinelearning/blob/cc5e6395e0d15e4d3db702b9cb1129e12838b840/src/Microsoft.ML.Transforms/UngroupTransform.cs#L610-L629
             s_derived.Get<object>();
+        }
+    }
+
+    class TestRecursionInGenericInterfaceMethods
+    {
+        interface IFoo
+        {
+            void Recurse<T>(int val);
+        }
+
+        class Foo : IFoo
+        {
+            void IFoo.Recurse<T>(int val)
+            {
+                if (val > 0)
+                    ((IFoo)this).Recurse<S<T>>(val - 1);
+            }
+        }
+
+        struct S<T>
+        {
+            public T Field;
+        }
+
+        public static void Run()
+        {
+            IFoo f = new Foo();
+
+            f.Recurse<int>(2);
+
+            bool thrown = false;
+            try
+            {
+                f.Recurse<int>(100);
+            }
+            catch (TypeLoadException)
+            {
+                thrown = true;
+            }
+            if (!thrown)
+                throw new Exception();
         }
     }
 


### PR DESCRIPTION
System.Linq.Parallel has multiple generic cycles in it. We probably hit them all in the System.Linq.Parallel.Tests assembly. We would be compiling the test forever (or until running out of memory) because we didn't detect one of them.

Add detection for the case where the recursion is entered through a generic interface virtual method call. The compiler terminates the infinite expansion after the user-specifiable cutoff point.

The test shows the pattern and the expected behavior.

Cc @dotnet/ilc-contrib 