### PR TITLE
Do not throw BadImageFormat from the type system

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/MethodDesc.Interop.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/MethodDesc.Interop.cs
@@ -168,7 +168,8 @@ namespace Internal.TypeSystem
                     case PInvokeAttributes.None:
                         return MethodSignatureFlags.None;
                     default:
-                        throw new BadImageFormatException();
+                        ThrowHelper.ThrowBadImageFormatException();
+                        return MethodSignatureFlags.None; // unreachable
                 }
             }
             set


### PR DESCRIPTION
This shoots down AOT-usage. Throw whatever is the type system's version of the exception.

Hit in MetadataLoadContext unit tests.

Cc @dotnet/ilc-contrib 