### PR TITLE
Enabled `System.ComponentModel.TypeConverter.Tests`.

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ILLink.Descriptors.xml
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ILLink.Descriptors.xml
@@ -15,4 +15,7 @@
           <method signature="System.Void .ctor()" />
       </type>
   </assembly>
+  <assembly fullname="System.ComponentModel.TypeConverter">
+      <type fullname="MS.Internal.Xml.Linq.ComponentModel.XDeferredSingleton`1" />
+  </assembly>
 </linker>

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/XTypeDescriptionProviderTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/XTypeDescriptionProviderTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace System.Xml.Linq.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/39709", TestPlatforms.Browser)]
     public class XTypeDescriptionProviderTests
     {
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/39709.
`System.ComponentModel.TypeConverter.Tests` on Browser are passing now. 