### PR TITLE
Obsolete no-op members on ServicePointManager

### DIFF
--- a/src/libraries/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
+++ b/src/libraries/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
@@ -42,20 +42,31 @@ namespace System.Net
     public partial class ServicePointManager
     {
         internal ServicePointManager() { }
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public const int DefaultNonPersistentConnectionLimit = 4;
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public const int DefaultPersistentConnectionLimit = 2;
         public static bool CheckCertificateRevocationList { get { throw null; } set { } }
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static int DefaultConnectionLimit { get { throw null; } set { } }
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static int DnsRefreshTimeout { get { throw null; } set { } }
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static bool EnableDnsRoundRobin { get { throw null; } set { } }
         [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.Security.EncryptionPolicy EncryptionPolicy { get { throw null; } }
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static bool Expect100Continue { get { throw null; } set { } }
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static int MaxServicePointIdleTime { get { throw null; } set { } }
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static int MaxServicePoints { get { throw null; } set { } }
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static bool ReusePort { get { throw null; } set { } }
         public static System.Net.SecurityProtocolType SecurityProtocol { get { throw null; } set { } }
         public static System.Net.Security.RemoteCertificateValidationCallback? ServerCertificateValidationCallback { get { throw null; } set { } }
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static bool UseNagleAlgorithm { get { throw null; } set { } }
         [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.ServicePoint FindServicePoint(string uriString, System.Net.IWebProxy? proxy) { throw null; }
@@ -63,6 +74,7 @@ namespace System.Net
         public static System.Net.ServicePoint FindServicePoint(System.Uri address) { throw null; }
         [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.ServicePoint FindServicePoint(System.Uri address, System.Net.IWebProxy? proxy) { throw null; }
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval) { }
     }
 }

--- a/src/libraries/System.Net.ServicePoint/src/System/Net/ServicePointManager.cs
+++ b/src/libraries/System.Net.ServicePoint/src/System/Net/ServicePointManager.cs
@@ -11,7 +11,10 @@ namespace System.Net
 {
     public class ServicePointManager
     {
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public const int DefaultNonPersistentConnectionLimit = 4;
+
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public const int DefaultPersistentConnectionLimit = 2;
 
         private static readonly ConcurrentDictionary<string, WeakReference<ServicePoint>> s_servicePointTable = new ConcurrentDictionary<string, WeakReference<ServicePoint>>();
@@ -46,6 +49,7 @@ namespace System.Net
             }
         }
 
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static int MaxServicePoints
         {
             get { return s_maxServicePoints; }
@@ -59,6 +63,7 @@ namespace System.Net
             }
         }
 
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static int DefaultConnectionLimit
         {
             get { return s_connectionLimit; }
@@ -72,6 +77,7 @@ namespace System.Net
             }
         }
 
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static int MaxServicePointIdleTime
         {
             get { return s_maxServicePointIdleTime; }
@@ -85,12 +91,16 @@ namespace System.Net
             }
         }
 
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static bool UseNagleAlgorithm { get; set; } = true;
 
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static bool Expect100Continue { get; set; } = true;
 
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static bool EnableDnsRoundRobin { get; set; }
 
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static int DnsRefreshTimeout
         {
             get { return s_dnsRefreshTimeout; }
@@ -99,11 +109,13 @@ namespace System.Net
 
         public static RemoteCertificateValidationCallback? ServerCertificateValidationCallback { get; set; }
 
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static bool ReusePort { get; set; }
 
         public static bool CheckCertificateRevocationList { get; set; }
 
         [UnsupportedOSPlatform("browser")]
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static EncryptionPolicy EncryptionPolicy { get; } = EncryptionPolicy.RequireEncryption;
 
         [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
@@ -215,6 +227,7 @@ namespace System.Net
             return isProxy ? queryString + "://proxy" : queryString;
         }
 
+        [Obsolete(Obsoletions.WebRequestMessage, DiagnosticId = Obsoletions.WebRequestDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval)
         {
             if (enabled)


### PR DESCRIPTION
Fixes #62770

Most of the public API-s exposed by `ServicePointManager` are unused, having no effect other than being copied to `ServicePoint` properties.

[Team consensus](https://github.com/dotnet/runtime/issues/62770#issuecomment-993830267) was to obsolete the entire `ServicePointManager` class if possible. I encountered some technical problems with that, and it also raises the question if we should stop at `ServicePointManager`, why not to also obsolete `ServicePoint` and other dependent types.

I recommend to do this minimal step for .NET 7, and consider further obsoletions later for .NET 8.