### PR TITLE
[wasm] fix events for V8

### DIFF
--- a/src/mono/wasm/runtime/pthreads/worker/events.ts
+++ b/src/mono/wasm/runtime/pthreads/worker/events.ts
@@ -19,17 +19,6 @@ export interface WorkerThreadEvent extends Event {
     readonly portToMain: MessagePort;
 }
 
-class WorkerThreadEventImpl extends Event implements WorkerThreadEvent {
-    readonly pthread_ptr: pthread_ptr;
-    readonly portToMain: MessagePort;
-    constructor(type: keyof WorkerThreadEventMap, pthread_ptr: pthread_ptr, portToMain: MessagePort) {
-        super(type);
-        this.pthread_ptr = pthread_ptr;
-        this.portToMain = portToMain;
-    }
-}
-
-
 export interface WorkerThreadEventTarget extends EventTarget {
     dispatchEvent(event: WorkerThreadEvent): boolean;
 
@@ -37,11 +26,18 @@ export interface WorkerThreadEventTarget extends EventTarget {
     addEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
 }
 
-export function makeWorkerThreadEvent(type: keyof WorkerThreadEventMap, pthread_ptr: pthread_ptr, port: MessagePort): WorkerThreadEvent {
-    // this 'if' helps to tree-shake the WorkerThreadEventImpl class if threads are disabled.
-    if (MonoWasmThreads) {
-        return new WorkerThreadEventImpl(type, pthread_ptr, port);
-    } else {
-        throw new Error("threads support disabled");
-    }
-}
+let WorkerThreadEventClassConstructor: new (type: keyof WorkerThreadEventMap, pthread_ptr: pthread_ptr, port: MessagePort) => WorkerThreadEvent;
+export const makeWorkerThreadEvent: (type: keyof WorkerThreadEventMap, pthread_ptr: pthread_ptr, port: MessagePort) => WorkerThreadEvent = !MonoWasmThreads
+    ? (() => { throw new Error("threads support disabled"); })
+    : ((type: keyof WorkerThreadEventMap, pthread_ptr: pthread_ptr, port: MessagePort) => {
+        if (!WorkerThreadEventClassConstructor) WorkerThreadEventClassConstructor = class WorkerThreadEventImpl extends Event implements WorkerThreadEvent {
+            readonly pthread_ptr: pthread_ptr;
+            readonly portToMain: MessagePort;
+            constructor(type: keyof WorkerThreadEventMap, pthread_ptr: pthread_ptr, portToMain: MessagePort) {
+                super(type);
+                this.pthread_ptr = pthread_ptr;
+                this.portToMain = portToMain;
+            }
+        };
+        return new WorkerThreadEventClassConstructor(type, pthread_ptr, port);
+    });


### PR DESCRIPTION
`Event` is not defined on V8 and the class is trying to extend it before polyfills run