### PR TITLE
Always poison arrays allocated with GC_ALLOC_ZEROING_OPTIONAL

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -677,15 +677,6 @@ namespace System
                 {
                     return new T[length];
                 }
-
-                // for debug builds we always want to call AllocateNewArray to detect AllocateNewArray bugs
-#if !DEBUG
-                // small arrays are allocated using `new[]` as that is generally faster.
-                if (length < 2048 / Unsafe.SizeOf<T>())
-                {
-                    return new T[length];
-                }
-#endif
             }
             else if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -480,6 +480,13 @@ OBJECTREF AllocateSzArray(MethodTable* pArrayMT, INT32 cElements, GC_ALLOC_FLAGS
         orArray->SetMethodTable(pArrayMT);
     }
 
+#if DEBUG
+    if (flags & GC_ALLOC_ZEROING_OPTIONAL)
+    {
+        memset(orArray->GetDataPtr(), 0xFF, cElements);
+    }
+#endif
+
     // Initialize Object
     orArray->m_NumComponents = cElements;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -145,16 +145,19 @@ namespace System.Buffers
                 haveBucket = true;
 
                 // Clear the array if the user requested it.
-#if DEBUG
-                if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+                if (clearArray)
                 {
-                    // Only clear arrays with GC handles in Debug mode to keep other types of array
-                    // "uninitialized" for debug purposes
-                    Array.Clear(array);
-                }
+#if DEBUG
+                    if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+                    {
+                        // Only clear arrays with GC handles in Debug mode to keep other types of array
+                        // "uninitialized" for debug purposes
+                        Array.Clear(array);
+                    }
 #else
-                Array.Clear(array);
+                    Array.Clear(array);
 #endif
+                }
 
                 // Check to see if the buffer is the correct size for this bucket.
                 if (array.Length != Utilities.GetMaxSizeForBucket(bucketIndex))

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -68,7 +68,7 @@ namespace System.Buffers
             ArrayPoolEventSource log = ArrayPoolEventSource.Log;
             T[]? buffer;
 
-            if (minimumLength > 64 && minimumLength < 2000000000) 
+            if (minimumLength > 64 && minimumLength < 2000000000)
                 minimumLength += 100;
 
             // Get the bucket number for the array length. The result may be out of range of buckets,

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -68,6 +68,8 @@ namespace System.Buffers
             ArrayPoolEventSource log = ArrayPoolEventSource.Log;
             T[]? buffer;
 
+            minimumLength += Random.Shared.Next(1, 1000);
+
             // Get the bucket number for the array length. The result may be out of range of buckets,
             // either for too large a value or for 0 and negative values.
             int bucketIndex = Utilities.SelectBucketIndex(minimumLength);
@@ -160,16 +162,7 @@ namespace System.Buffers
                 // Clear the array if the user requested it.
                 if (clearArray)
                 {
-#if DEBUG
-                    if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                    {
-                        // Only clear arrays with GC handles in Debug mode to keep other types of array
-                        // "uninitialized" for debug purposes
-                        Array.Clear(array);
-                    }
-#else
                     Array.Clear(array);
-#endif
                 }
 
                 // Check to see if the buffer is the correct size for this bucket.

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -68,8 +68,8 @@ namespace System.Buffers
             ArrayPoolEventSource log = ArrayPoolEventSource.Log;
             T[]? buffer;
 
-            //if (minimumLength > 64 && minimumLength < 2000000000)
-            //    minimumLength += 100;
+            if (minimumLength > 64 && minimumLength < 2000000000)
+                minimumLength += 100;
 
             // Get the bucket number for the array length. The result may be out of range of buckets,
             // either for too large a value or for 0 and negative values.

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -144,11 +144,13 @@ namespace System.Buffers
             {
                 haveBucket = true;
 
+#if !DEBUG
                 // Clear the array if the user requested it.
                 if (clearArray)
                 {
                     Array.Clear(array);
                 }
+#endif
 
                 // Check to see if the buffer is the correct size for this bucket.
                 if (array.Length != Utilities.GetMaxSizeForBucket(bucketIndex))

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -68,7 +68,8 @@ namespace System.Buffers
             ArrayPoolEventSource log = ArrayPoolEventSource.Log;
             T[]? buffer;
 
-            minimumLength += Random.Shared.Next(1, 1000);
+            if (minimumLength > 64 && minimumLength < 2000000000) 
+                minimumLength += 100;
 
             // Get the bucket number for the array length. The result may be out of range of buckets,
             // either for too large a value or for 0 and negative values.

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -144,12 +144,16 @@ namespace System.Buffers
             {
                 haveBucket = true;
 
-#if !DEBUG
                 // Clear the array if the user requested it.
-                if (clearArray)
+#if DEBUG
+                if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                 {
+                    // Only clear arrays with GC handles in Debug mode to keep other types of array
+                    // "uninitialized" for debug purposes
                     Array.Clear(array);
                 }
+#else
+                Array.Clear(array);
 #endif
 
                 // Check to see if the buffer is the correct size for this bucket.

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -68,8 +68,8 @@ namespace System.Buffers
             ArrayPoolEventSource log = ArrayPoolEventSource.Log;
             T[]? buffer;
 
-            if (minimumLength > 64 && minimumLength < 2000000000)
-                minimumLength += 100;
+            //if (minimumLength > 64 && minimumLength < 2000000000)
+            //    minimumLength += 100;
 
             // Get the bucket number for the array length. The result may be out of range of buckets,
             // either for too large a value or for 0 and negative values.


### PR DESCRIPTION
```csharp
byte[] a = ArrayPool<byte>.Shared.Rent(100);
Console.WriteLine(string.Join(',', a));
```
now always print:
```
255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255
```