### PR TITLE
Update Compiles.cs

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -481,7 +481,7 @@ namespace LibraryImportGenerator.UnitTests
 
         public static IEnumerable<object[]> CodeSnippetsToValidateFallbackForwarder()
         {
-            yield return new object[] { CodeSnippets.UserDefinedEntryPoint, TestTargetFramework.Net, true };
+            yield return new object[] { ID(), CodeSnippets.UserDefinedEntryPoint, TestTargetFramework.Net, true };
 
             // Confirm that all unsupported target frameworks can be generated.
             {


### PR DESCRIPTION
Missed passing `ID()` for a test case.

Fixes https://github.com/dotnet/runtime/issues/71810