### PR TITLE
Fix stack overflow from start set calculation

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -99,6 +99,12 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         internal readonly Dictionary<(SymbolicRegexNode<TSet>, SymbolicRegexNode<TSet>), bool> _subsumptionCache = new();
 
+        /// <summary>
+        /// Cache for <see cref="SymbolicRegexNode{TSet}.GetStartSet(SymbolicRegexBuilder{TSet})"/> keyed by nodes.
+        /// The values are the sets of characters that can start a match from that node.
+        /// </summary>
+        internal readonly Dictionary<SymbolicRegexNode<TSet>, TSet> _startSetCache = new();
+
         /// <summary>Create a new symbolic regex builder.</summary>
         internal SymbolicRegexBuilder(ISolver<TSet> solver, CharSetSolver charSetSolver)
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -66,7 +66,7 @@ namespace System.Text.RegularExpressions.Symbolic
         internal readonly Dictionary<(SymbolicRegexNodeKind,
             SymbolicRegexNode<TSet>?, // _left
             SymbolicRegexNode<TSet>?, // _right
-            int, int, TSet?,          // _lower, _upper, _set
+            int, int, TSet,          // _lower, _upper, _set
             SymbolicRegexInfo), SymbolicRegexNode<TSet>> _nodeCache = new();
 
         // The following dictionaries are used as caches for operations that recurse over the structure of SymbolicRegexNode.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -99,12 +99,6 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         internal readonly Dictionary<(SymbolicRegexNode<TSet>, SymbolicRegexNode<TSet>), bool> _subsumptionCache = new();
 
-        /// <summary>
-        /// Cache for <see cref="SymbolicRegexNode{TSet}.GetStartSet(SymbolicRegexBuilder{TSet})"/> keyed by nodes.
-        /// The values are the sets of characters that can start a match from that node.
-        /// </summary>
-        internal readonly Dictionary<SymbolicRegexNode<TSet>, TSet> _startSetCache = new();
-
         /// <summary>Create a new symbolic regex builder.</summary>
         internal SymbolicRegexBuilder(ISolver<TSet> solver, CharSetSolver charSetSolver)
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -70,6 +70,9 @@ namespace System.Text.RegularExpressions.Symbolic
             _set = set;
             _info = info;
             _nullabilityCache = info.StartsWithSomeAnchor && info.CanBeNullable ? new byte[CharKind.ContextLimit] : null;
+#if DEBUG
+            _debugBuilder = builder;
+#endif
         }
 
         /// <summary> Create a new node or retrieve one from the builder _nodeCache</summary>
@@ -80,9 +83,6 @@ namespace System.Text.RegularExpressions.Symbolic
             if (!builder._nodeCache.TryGetValue(key, out SymbolicRegexNode<TSet>? node))
             {
                 node = new SymbolicRegexNode<TSet>(builder, kind, left, right, lower, upper, setOrStartSet, info);
-#if DEBUG
-                node._debugBuilder = builder;
-#endif
                 builder._nodeCache[key] = node;
             }
             return node;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -36,10 +36,10 @@ namespace System.Text.RegularExpressions.Symbolic
         internal readonly SymbolicRegexNodeKind _kind;
         internal readonly int _lower;
         internal readonly int _upper;
+        internal readonly TSet _set;
         internal readonly SymbolicRegexNode<TSet>? _left;
         internal readonly SymbolicRegexNode<TSet>? _right;
         internal readonly SymbolicRegexInfo _info;
-        internal readonly TSet _set;
 
         /// <summary>
         /// Caches nullability of this node for any given context (0 &lt;= context &lt; ContextLimit)
@@ -60,25 +60,26 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="upper">upper boubd of a loop</param>
         /// <param name="set">singelton set</param>
         /// <param name="info">misc flags including laziness</param>
-        private SymbolicRegexNode(SymbolicRegexBuilder<TSet> builder, SymbolicRegexNodeKind kind, SymbolicRegexNode<TSet>? left, SymbolicRegexNode<TSet>? right, int lower, int upper, TSet? set, SymbolicRegexInfo info)
+        private SymbolicRegexNode(SymbolicRegexBuilder<TSet> builder, SymbolicRegexNodeKind kind, SymbolicRegexNode<TSet>? left, SymbolicRegexNode<TSet>? right, int lower, int upper, TSet set, SymbolicRegexInfo info)
         {
             _kind = kind;
             _left = left;
             _right = right;
             _lower = lower;
             _upper = upper;
+            _set = set;
             _info = info;
             _nullabilityCache = info.StartsWithSomeAnchor && info.CanBeNullable ? new byte[CharKind.ContextLimit] : null;
-            _set = set ?? ComputeStartSet(builder);
         }
 
         /// <summary> Create a new node or retrieve one from the builder _nodeCache</summary>
         private static SymbolicRegexNode<TSet> Create(SymbolicRegexBuilder<TSet> builder, SymbolicRegexNodeKind kind, SymbolicRegexNode<TSet>? left, SymbolicRegexNode<TSet>? right, int lower, int upper, TSet? set, SymbolicRegexInfo info)
         {
-            var key = (kind, left, right, lower, upper, set, info);
+            TSet setOrStartSet = kind == SymbolicRegexNodeKind.Singleton ? set! : ComputeStartSet(builder, kind, left, right);
+            var key = (kind, left, right, lower, upper, setOrStartSet, info);
             if (!builder._nodeCache.TryGetValue(key, out SymbolicRegexNode<TSet>? node))
             {
-                node = new SymbolicRegexNode<TSet>(builder, kind, left, right, lower, upper, set, info);
+                node = new SymbolicRegexNode<TSet>(builder, kind, left, right, lower, upper, setOrStartSet, info);
 #if DEBUG
                 node._debugBuilder = builder;
 #endif
@@ -1936,13 +1937,13 @@ namespace System.Text.RegularExpressions.Symbolic
         }
 
         /// <summary>Computes the set that includes all elements that can start a match.</summary>
-        private TSet ComputeStartSet(SymbolicRegexBuilder<TSet> builder)
+        private static TSet ComputeStartSet(SymbolicRegexBuilder<TSet> builder, SymbolicRegexNodeKind kind, SymbolicRegexNode<TSet>? left, SymbolicRegexNode<TSet>? right)
         {
             // For singletons the start set is the set the singleton is constructed with,
             // so calling this function would not make sense.
-            Debug.Assert(_kind != SymbolicRegexNodeKind.Singleton);
+            Debug.Assert(kind != SymbolicRegexNodeKind.Singleton);
 
-            switch (_kind)
+            switch (kind)
             {
                 // Anchors and () do not contribute to the startset
                 case SymbolicRegexNodeKind.Epsilon:
@@ -1960,24 +1961,24 @@ namespace System.Text.RegularExpressions.Symbolic
                     return builder._solver.Empty;
 
                 case SymbolicRegexNodeKind.Loop:
-                    Debug.Assert(_left is not null);
-                    return _left._set;
+                    Debug.Assert(left is not null);
+                    return left._set;
 
                 case SymbolicRegexNodeKind.Concat:
-                    Debug.Assert(_left is not null && _right is not null);
-                    return _left.CanBeNullable ? builder._solver.Or(_left._set, _right._set) : _left._set;
+                    Debug.Assert(left is not null && right is not null);
+                    return left.CanBeNullable ? builder._solver.Or(left._set, right._set) : left._set;
 
                 case SymbolicRegexNodeKind.Alternate:
-                    Debug.Assert(_left is not null && _right is not null);
-                    return builder._solver.Or(_left._set, _right._set);
+                    Debug.Assert(left is not null && right is not null);
+                    return builder._solver.Or(left._set, right._set);
 
                 case SymbolicRegexNodeKind.DisableBacktrackingSimulation:
                 case SymbolicRegexNodeKind.Effect:
-                    Debug.Assert(_left is not null);
-                    return _left._set;
+                    Debug.Assert(left is not null);
+                    return left._set;
 
                 default:
-                    Debug.Fail($"{nameof(ComputeStartSet)}:{_kind}");
+                    Debug.Fail($"{nameof(ComputeStartSet)}:{kind}");
                     return builder._solver.Full;
             }
         }
@@ -1997,13 +1998,12 @@ namespace System.Text.RegularExpressions.Symbolic
         {
             //first prune the anchors in the node
             TSet wlbSet = builder._wordLetterForBoundariesSet;
-            TSet startSet = _set;
 
             //true if the startset of the node overlaps with some wordletter or the node can be nullable
-            bool contWithWL = CanBeNullable || !builder._solver.IsEmpty(builder._solver.And(wlbSet, startSet));
+            bool contWithWL = CanBeNullable || !builder._solver.IsEmpty(builder._solver.And(wlbSet, _set));
 
             //true if the startset of the node overlaps with some nonwordletter or the node can be nullable
-            bool contWithNWL = CanBeNullable || !builder._solver.IsEmpty(builder._solver.And(builder._solver.Not(wlbSet), startSet));
+            bool contWithNWL = CanBeNullable || !builder._solver.IsEmpty(builder._solver.And(builder._solver.Not(wlbSet), _set));
 
             return PruneAnchorsImpl(builder, prevKind, contWithWL, contWithNWL);
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -78,6 +78,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary> Create a new node or retrieve one from the builder _nodeCache</summary>
         private static SymbolicRegexNode<TSet> Create(SymbolicRegexBuilder<TSet> builder, SymbolicRegexNodeKind kind, SymbolicRegexNode<TSet>? left, SymbolicRegexNode<TSet>? right, int lower, int upper, TSet? set, SymbolicRegexInfo info)
         {
+            Debug.Assert(kind != SymbolicRegexNodeKind.Singleton || set is not null);
             TSet setOrStartSet = kind == SymbolicRegexNodeKind.Singleton ? set! : ComputeStartSet(builder, kind, left, right);
             var key = (kind, left, right, lower, upper, setOrStartSet, info);
             if (!builder._nodeCache.TryGetValue(key, out SymbolicRegexNode<TSet>? node))
@@ -1594,12 +1595,12 @@ namespace System.Text.RegularExpressions.Symbolic
 
                 case SymbolicRegexNodeKind.Singleton:
                     Debug.Assert(_set is not null);
-                    sb.Append(_debugBuilder!._solver.PrettyPrint(_set, _debugBuilder._charSetSolver));
+                    sb.Append(_debugBuilder._solver.PrettyPrint(_set, _debugBuilder._charSetSolver));
                     return;
 
                 case SymbolicRegexNodeKind.Loop:
                     Debug.Assert(_left is not null);
-                    if (IsAnyStar(_debugBuilder!._solver))
+                    if (IsAnyStar(_debugBuilder._solver))
                     {
                         sb.Append(".*");
                     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -48,7 +48,7 @@ namespace System.Text.RegularExpressions.Symbolic
         private readonly byte[]? _nullabilityCache;
 
 #if DEBUG
-        internal SymbolicRegexBuilder<TSet>? _debugBuilder;
+        private readonly SymbolicRegexBuilder<TSet> _debugBuilder;
 #endif
 
         /// <summary>AST node of a symbolic regex</summary>

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1998,12 +1998,6 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(StressTestDeepNestingOfConcat_TestData))]
         public async Task StressTestDeepNestingOfConcat(RegexEngine engine, string pattern, string anchor, string input, int pattern_repetition, int input_repetition)
         {
-            if (RegexHelpers.IsNonBacktracking(engine))
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/71808")]
-                return;
-            }
-
             string fullpattern = string.Concat(string.Concat(Enumerable.Repeat($"({pattern}", pattern_repetition).Concat(Enumerable.Repeat(")", pattern_repetition))), anchor);
             string fullinput = string.Concat(Enumerable.Repeat(input, input_repetition));
 
@@ -2057,12 +2051,6 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(StressTestDeepNestingOfLoops_TestData))]
         public async Task StressTestDeepNestingOfLoops(RegexEngine engine, string begin, string inner, string end, string input, int pattern_repetition, int input_repetition)
         {
-            if (RegexHelpers.IsNonBacktracking(engine))
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/71808")]
-                return;
-            }
-
             string fullpattern = string.Concat(Enumerable.Repeat(begin, pattern_repetition)) + inner + string.Concat(Enumerable.Repeat(end, pattern_repetition));
             string fullinput = string.Concat(Enumerable.Repeat(input, input_repetition));
 


### PR DESCRIPTION
This fixes https://github.com/dotnet/runtime/issues/71808, which was caused by a change I introduced in https://github.com/dotnet/runtime/pull/71234 making a calculation for the possible starting characters of matches be top-down recursive instead of bottom-up.

The  bottom-up computation is re-introduced with one improvement: instead of a separate field for the start set, the set field for `Singleton` nodes is re-used, since for those the start set coincides with the set. This also allowed making the field non-nullable.