### PR TITLE
Handle unary operator GT_CNEG_LT in few code paths

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4212,7 +4212,7 @@ void GenTree::VisitOperands(TVisitor visitor)
             }
             FALLTHROUGH;
 
-        // Standard unary operators
+// Standard unary operators
 #ifdef TARGET_ARM64
         case GT_CNEG_LT:
 #endif // TARGET_ARM64

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4213,6 +4213,9 @@ void GenTree::VisitOperands(TVisitor visitor)
             FALLTHROUGH;
 
         // Standard unary operators
+#ifdef TARGET_ARM64
+        case GT_CNEG_LT:
+#endif // TARGET_ARM64
         case GT_STORE_LCL_VAR:
         case GT_STORE_LCL_FLD:
         case GT_NOT:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5970,6 +5970,9 @@ bool GenTree::TryGetUse(GenTree* operand, GenTree*** pUse)
             return false;
 
         // Standard unary operators
+#ifdef TARGET_ARM64
+        case GT_CNEG_LT:
+#endif // TARGET_ARM64
         case GT_STORE_LCL_VAR:
         case GT_STORE_LCL_FLD:
         case GT_NOT:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5969,7 +5969,7 @@ bool GenTree::TryGetUse(GenTree* operand, GenTree*** pUse)
         case GT_IL_OFFSET:
             return false;
 
-        // Standard unary operators
+// Standard unary operators
 #ifdef TARGET_ARM64
         case GT_CNEG_LT:
 #endif // TARGET_ARM64


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/70599 introduced `GT_CNEG_LT` but missed the handling of this unary operator at few places.

Fixes: https://github.com/dotnet/runtime/issues/71655