### PR TITLE
Add/implement ObsoletedInOSPlatformAttribute.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
@@ -210,6 +210,9 @@
     <type fullname="System.Runtime.Versioning.UnsupportedOSPlatformAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
+    <type fullname="System.Runtime.Versioning.ObsoletedInOSPlatformAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
     <type fullname="System.Runtime.Versioning.SupportedOSPlatformGuardAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/PlatformAttributes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/PlatformAttributes.cs
@@ -102,6 +102,47 @@ namespace System.Runtime.Versioning
         public UnsupportedOSPlatformAttribute(string platformName) : base(platformName)
         {
         }
+        public UnsupportedOSPlatformAttribute(string platformName, string? message) : base(platformName)
+        {
+            Message = message;
+        }
+        public string? Message { get; }
+    }
+
+    /// <summary>
+    /// Marks APIs that were obsoleted in a given operating system version.
+    /// </summary>
+    /// <remarks>
+    /// Primarily used by OS bindings to indicate APIs that should not be used anymore.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Assembly |
+                    AttributeTargets.Class |
+                    AttributeTargets.Constructor |
+                    AttributeTargets.Enum |
+                    AttributeTargets.Event |
+                    AttributeTargets.Field |
+                    AttributeTargets.Interface |
+                    AttributeTargets.Method |
+                    AttributeTargets.Module |
+                    AttributeTargets.Property |
+                    AttributeTargets.Struct,
+                    AllowMultiple = true, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class ObsoletedInOSPlatformAttribute : OSPlatformAttribute
+    {
+        public ObsoletedInOSPlatformAttribute(string platformName) : base(platformName)
+        {
+        }
+        public ObsoletedInOSPlatformAttribute(string platformName, string? message) : base(platformName)
+        {
+            Message = message;
+        }
+        public string? Message { get; }
+        public string? Url { get; set; }
     }
 
     /// <summary>

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13437,6 +13437,14 @@ namespace System.Runtime.Versioning
         public static bool operator !=(System.Runtime.Versioning.FrameworkName? left, System.Runtime.Versioning.FrameworkName? right) { throw null; }
         public override string ToString() { throw null; }
     }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Enum | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
+    public sealed partial class ObsoletedInOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
+    {
+        public ObsoletedInOSPlatformAttribute(string platformName) : base(platformName) { }
+        public ObsoletedInOSPlatformAttribute(string platformName, string? message) : base(platformName) { }
+        public string? Message { get { throw null; } }
+        public string? Url { get { throw null; } set {} }
+    }
     public abstract partial class OSPlatformAttribute : System.Attribute
     {
         private protected OSPlatformAttribute(string platformName) { }
@@ -13503,6 +13511,8 @@ namespace System.Runtime.Versioning
     public sealed partial class UnsupportedOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
     {
         public UnsupportedOSPlatformAttribute(string platformName) : base(platformName) { }
+        public UnsupportedOSPlatformAttribute(string platformName, string? message) : base(platformName) { }
+        public string? Message { get { throw null; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Method | System.AttributeTargets.Property, AllowMultiple=true, Inherited=false)]
     public sealed partial class UnsupportedOSPlatformGuardAttribute : System.Runtime.Versioning.OSPlatformAttribute

--- a/src/libraries/System.Runtime/tests/System/Runtime/Versioning/OSPlatformAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/Versioning/OSPlatformAttributeTests.cs
@@ -58,9 +58,9 @@ namespace System.Runtime.Versioning.Tests
         [InlineData("Windows8.0")]
         [InlineData("Android4.1")]
         [InlineData("")]
-        public void TestObsoletedOSPlatformAttribute(string platformName)
+        public void TestObsoletedInOSPlatformAttribute(string platformName)
         {
-            var tpa = new ObsoletedOSPlatformAttribute(platformName);
+            var tpa = new ObsoletedInOSPlatformAttribute(platformName);
 
             Assert.Equal(platformName, tpa.PlatformName);
         }
@@ -69,9 +69,9 @@ namespace System.Runtime.Versioning.Tests
         [InlineData("Windows8.0", "Message in a bottle")]
         [InlineData("Android4.1", "Message on a pigeon")]
         [InlineData("", null)]
-        public void TestObsoletedOSPlatformAttributeWithMessage(string platformName, string? message)
+        public void TestObsoletedInOSPlatformAttributeWithMessage(string platformName, string? message)
         {
-            var tpa = new ObsoletedOSPlatformAttribute(platformName, message);
+            var tpa = new ObsoletedInOSPlatformAttribute(platformName, message);
 
             Assert.Equal(platformName, tpa.PlatformName);
             Assert.Equal(message, tpa.Message);

--- a/src/libraries/System.Runtime/tests/System/Runtime/Versioning/OSPlatformAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/Versioning/OSPlatformAttributeTests.cs
@@ -28,6 +28,19 @@ namespace System.Runtime.Versioning.Tests
             var tpa = new UnsupportedOSPlatformAttribute(platformName);
 
             Assert.Equal(platformName, tpa.PlatformName);
+            Assert.Null(tpa.Message);
+        }
+
+        [Theory]
+        [InlineData("Windows8.0", "Message in a bottle")]
+        [InlineData("Android4.1", "Message on a pigeon")]
+        [InlineData("", null)]
+        public void TestUnsupportedOSPlatformAttributeWithMessage(string platformName, string? message)
+        {
+            var tpa = new UnsupportedOSPlatformAttribute(platformName, message);
+
+            Assert.Equal(platformName, tpa.PlatformName);
+            Assert.Equal(message, tpa.Message);
         }
 
         [Theory]
@@ -39,6 +52,29 @@ namespace System.Runtime.Versioning.Tests
             var tpa = new SupportedOSPlatformAttribute(platformName);
 
             Assert.Equal(platformName, tpa.PlatformName);
+        }
+
+        [Theory]
+        [InlineData("Windows8.0")]
+        [InlineData("Android4.1")]
+        [InlineData("")]
+        public void TestObsoletedOSPlatformAttribute(string platformName)
+        {
+            var tpa = new ObsoletedOSPlatformAttribute(platformName);
+
+            Assert.Equal(platformName, tpa.PlatformName);
+        }
+
+        [Theory]
+        [InlineData("Windows8.0", "Message in a bottle")]
+        [InlineData("Android4.1", "Message on a pigeon")]
+        [InlineData("", null)]
+        public void TestObsoletedOSPlatformAttributeWithMessage(string platformName, string? message)
+        {
+            var tpa = new ObsoletedOSPlatformAttribute(platformName, message);
+
+            Assert.Equal(platformName, tpa.PlatformName);
+            Assert.Equal(message, tpa.Message);
         }
 
         [Theory]


### PR DESCRIPTION
As described here:

https://github.com/dotnet/runtime/issues/68557#issuecomment-1177934266

@buyaa-n will implement the changes required in the analyzer (target is RC1).

Fixes https://github.com/dotnet/runtime/issues/68557.