### PR TITLE
Moved call to TryLoadGenericMetaTypeNullability

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -325,7 +325,14 @@ namespace System.Reflection
         private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser)
         {
             int index = 0;
-            return GetNullabilityInfo(memberInfo, type, parser, ref index);
+            NullabilityInfo nullability = GetNullabilityInfo(memberInfo, type, parser, ref index);
+
+            if (!type.IsValueType && nullability.ReadState != NullabilityState.Unknown)
+            {
+                TryLoadGenericMetaTypeNullability(memberInfo, nullability);
+            }
+
+            return nullability;
         }
 
         private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser, ref int index)
@@ -379,14 +386,7 @@ namespace System.Reflection
                 }
             }
 
-            NullabilityInfo nullability = new NullabilityInfo(type, state, state, elementState, genericArgumentsState);
-
-            if (!type.IsValueType && state != NullabilityState.Unknown)
-            {
-                TryLoadGenericMetaTypeNullability(memberInfo, nullability);
-            }
-
-            return nullability;
+            return new NullabilityInfo(type, state, state, elementState, genericArgumentsState);
         }
 
         private static NullableAttributeStateParser CreateParser(IList<CustomAttributeData> customAttributes)

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -1096,12 +1096,59 @@ namespace System.Reflection.Tests
         {
             Type type = typeof(TypeWithPropertiesNestingItsGenericTypeArgument<int>);
 
-            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Shallow1")!));
-            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Deep1")!));
-            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Deep2")!));
-            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Deep3")!));
-            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Deep4")!));
-            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Deep5")!));
+            NullabilityInfo shallow1Info = nullabilityContext.Create(type.GetProperty("Shallow1")!);
+            NullabilityInfo deep1Info = nullabilityContext.Create(type.GetProperty("Deep1")!);
+            NullabilityInfo deep2Info = nullabilityContext.Create(type.GetProperty("Deep2")!);
+            NullabilityInfo deep3Info = nullabilityContext.Create(type.GetProperty("Deep3")!);
+            NullabilityInfo deep4Info = nullabilityContext.Create(type.GetProperty("Deep4")!);
+            NullabilityInfo deep5Info = nullabilityContext.Create(type.GetProperty("Deep5")!);
+
+            //public Tuple<T>? Shallow1 { get; set; }
+            NullabilityInfo info = shallow1Info;
+            Assert.Equal(1, info.GenericTypeArguments.Length);
+            Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[0].ReadState);
+
+            //public Tuple<Tuple<T>>? Deep1 { get; set; }
+            info = deep1Info;
+            Assert.Equal(1, info.GenericTypeArguments.Length);
+            Assert.Equal(1, info.GenericTypeArguments[0].GenericTypeArguments.Length);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
+            Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[0].GenericTypeArguments[0].ReadState);
+
+            //public Tuple<Tuple<T>, int>? Deep2 { get; set; }
+            info = deep2Info;
+            Assert.Equal(2, info.GenericTypeArguments.Length);
+            Assert.Equal(1, info.GenericTypeArguments[0].GenericTypeArguments.Length);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[1].ReadState);
+            Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[0].GenericTypeArguments[0].ReadState);
+
+            //public Tuple<int, Tuple<T>>? Deep3 { get; set; }
+            info = deep3Info;
+            Assert.Equal(2, info.GenericTypeArguments.Length);
+            Assert.Equal(1, info.GenericTypeArguments[1].GenericTypeArguments.Length);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[1].ReadState);
+            Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[1].GenericTypeArguments[0].ReadState);
+
+            //public Tuple<int, int, Tuple<T>>? Deep4 { get; set; }
+            info = deep4Info;
+            Assert.Equal(3, info.GenericTypeArguments.Length);
+            Assert.Equal(1, info.GenericTypeArguments[2].GenericTypeArguments.Length);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[1].ReadState);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[2].ReadState);
+            Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[2].GenericTypeArguments[0].ReadState);
+
+            //public Tuple<int, int, Tuple<T, T>>? Deep5 { get; set; }
+            info = deep5Info;
+            Assert.Equal(3, info.GenericTypeArguments.Length);
+            Assert.Equal(2, info.GenericTypeArguments[2].GenericTypeArguments.Length);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[1].ReadState);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[2].ReadState);
+            Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[2].GenericTypeArguments[0].ReadState);
+            Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[2].GenericTypeArguments[1].ReadState);
         }
     }
 

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -1123,32 +1123,32 @@ namespace System.Reflection.Tests
             Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[1].ReadState);
             Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[0].GenericTypeArguments[0].ReadState);
 
-            //public Tuple<int, Tuple<T>>? Deep3 { get; set; }
+            //public Tuple<int?, Tuple<T>>? Deep3 { get; set; }
             info = deep3Info;
             Assert.Equal(2, info.GenericTypeArguments.Length);
             Assert.Equal(1, info.GenericTypeArguments[1].GenericTypeArguments.Length);
-            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
+            Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[0].ReadState);
             Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[1].ReadState);
             Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[1].GenericTypeArguments[0].ReadState);
 
-            //public Tuple<int, int, Tuple<T>>? Deep4 { get; set; }
+            //public Tuple<int, int?, Tuple<T>>? Deep4 { get; set; }
             info = deep4Info;
             Assert.Equal(3, info.GenericTypeArguments.Length);
             Assert.Equal(1, info.GenericTypeArguments[2].GenericTypeArguments.Length);
             Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
-            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[1].ReadState);
+            Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[1].ReadState);
             Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[2].ReadState);
             Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[2].GenericTypeArguments[0].ReadState);
 
-            //public Tuple<int, int, Tuple<T, T>>? Deep5 { get; set; }
+            //public Tuple<int, int, Tuple<T, int>?>? Deep5 { get; set; }
             info = deep5Info;
             Assert.Equal(3, info.GenericTypeArguments.Length);
             Assert.Equal(2, info.GenericTypeArguments[2].GenericTypeArguments.Length);
             Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
             Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[1].ReadState);
-            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[2].ReadState);
+            Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[2].ReadState);
             Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[2].GenericTypeArguments[0].ReadState);
-            Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[2].GenericTypeArguments[1].ReadState);
+            Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[2].GenericTypeArguments[1].ReadState);
         }
     }
 
@@ -1415,8 +1415,8 @@ namespace System.Reflection.Tests
         public Tuple<T>? Shallow1 { get; set; }
         public Tuple<Tuple<T>>? Deep1 { get; set; }
         public Tuple<Tuple<T>, int>? Deep2 { get; set; }
-        public Tuple<int, Tuple<T>>? Deep3 { get; set; }
-        public Tuple<int, int, Tuple<T>>? Deep4 { get; set; }
-        public Tuple<int, int, Tuple<T, T>>? Deep5 { get; set; }
+        public Tuple<int?, Tuple<T>>? Deep3 { get; set; }
+        public Tuple<int, int?, Tuple<T?>>? Deep4 { get; set; }
+        public Tuple<int, int, Tuple<T, int>?>? Deep5 { get; set; }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -1089,6 +1089,20 @@ namespace System.Reflection.Tests
             Assert.Equal(NullabilityState.NotNull, item3Info.ElementType!.ReadState);
             Assert.Equal(NullabilityState.NotNull, item3Info.ElementType.WriteState);
         }
+
+        [Fact]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
+        public void TestNullabilityInfoCreationOnPropertiesWithNestedGenericTypeArguments()
+        {
+            Type type = typeof(TypeWithPropertiesNestingItsGenericTypeArgument<int>);
+
+            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Shallow1")!));
+            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Deep1")!));
+            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Deep2")!));
+            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Deep3")!));
+            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Deep4")!));
+            Assert.NotNull(nullabilityContext.Create(type.GetProperty("Deep5")!));
+        }
     }
 
 #pragma warning disable CS0649, CS0067, CS0414
@@ -1347,5 +1361,15 @@ namespace System.Reflection.Tests
             : base(item1, item2, item3)
         {
         }
+    }
+
+    public class TypeWithPropertiesNestingItsGenericTypeArgument<T>
+    {
+        public Tuple<T>? Shallow1 { get; set; }
+        public Tuple<Tuple<T>>? Deep1 { get; set; }
+        public Tuple<Tuple<T>, int>? Deep2 { get; set; }
+        public Tuple<int, Tuple<T>>? Deep3 { get; set; }
+        public Tuple<int, int, Tuple<T>>? Deep4 { get; set; }
+        public Tuple<int, int, Tuple<T, T>>? Deep5 { get; set; }
     }
 }


### PR DESCRIPTION
The TryLoadGenericMetaTypeNullability method was called with the same
member info but varying nullability across the entire nullability
hierarchy. Moved it one level up where nullability and member info are
aligned.

Added a test to cover this issue.

Fix #68461