### PR TITLE
Temporarily exclude NativeAOT from source-build until we figure out how to handle it

### DIFF
--- a/src/coreclr/tools/aot/Directory.Build.props
+++ b/src/coreclr/tools/aot/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="../Directory.Build.props" />
   <PropertyGroup>
     <IsTrimmable>true</IsTrimmable>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
As-is, we don't believe NativeAOT will work in source-build anyway.  Removing it from the build while we decide what to do removes a prebuilt.

See https://github.com/dotnet/runtime/issues/69611 for further discussion.