### PR TITLE
createdump improvements for better VS4Mac Watson bucketing

### DIFF
--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -127,7 +127,7 @@ CrashInfo::EnumerateMemoryRegions()
         }
         else
         {
-            if ((info.protection & (VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE)) != 0)
+            if (info.share_mode != SM_EMPTY && (info.protection & (VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE)) != 0)
             {
                 MemoryRegion memoryRegion(ConvertProtectionFlags(info.protection), address, address + size, info.offset);
                 m_allMemoryRegions.insert(memoryRegion);

--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -23,26 +23,6 @@ CrashInfo::Initialize()
 void
 CrashInfo::CleanupAndResumeProcess()
 {
-    if (g_diagnosticsVerbose)
-    {
-        thread_basic_info_data_t info;
-        mach_msg_type_number_t count;
-        kern_return_t result;
-
-        for (ThreadInfo* thread : m_threads)
-        {
-            count = THREAD_BASIC_INFO_COUNT;
-            result = ::thread_info(thread->Port(), THREAD_BASIC_INFO, (thread_info_t)&info, &count);
-            if (result == KERN_SUCCESS)
-            {
-                TRACE("thread_info(%d) state %d flags %%08x suspend %d\n", thread->Tid(), info.run_state, info.flags, info.suspend_count);
-            }
-            else
-            {
-                TRACE("thread_info(%d) FAILED %x %s\n", thread->Tid(), result, mach_error_string(result));
-            }
-        }
-    }
     // Resume all the threads suspended in EnumerateAndSuspendThreads
     ::task_resume(Task());
 }

--- a/src/coreclr/debug/createdump/crashreportwriter.cpp
+++ b/src/coreclr/debug/createdump/crashreportwriter.cpp
@@ -41,6 +41,7 @@ CrashReportWriter::WriteCrashReport(const std::string& dumpFileName)
         }
         WriteCrashReport();
         CloseWriter();
+        printf_status("Crash report successfully written\n");
     }
     catch (const std::exception& e)
     {

--- a/src/coreclr/debug/createdump/createdumpunix.cpp
+++ b/src/coreclr/debug/createdump/createdumpunix.cpp
@@ -69,6 +69,22 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
     }
     result = true;
 exit:
+    if (kill(pid, 0) == 0)
+    {
+        printf_status("Target process is alive\n");
+    }
+    else
+    {
+        int err = errno;
+        if (err == ESRCH)
+        {
+            printf_error("Target process terminated\n");
+        }
+        else
+        {
+            printf_error("kill(%d, 0) FAILED %s (%d)\n", pid, strerror(err), err);
+        }
+    }
     crashInfo->CleanupAndResumeProcess();
     return result;
 }

--- a/src/coreclr/debug/createdump/dumpwritermacho.cpp
+++ b/src/coreclr/debug/createdump/dumpwritermacho.cpp
@@ -4,6 +4,8 @@
 #include "createdump.h"
 #include "specialthreadinfo.h"
 
+extern int g_readProcessMemoryResult;
+
 //
 // Write the core dump file
 //
@@ -264,13 +266,13 @@ DumpWriter::WriteSegments()
                 size_t read = 0;
 
                 if (!m_crashInfo.ReadProcessMemory((void*)address, m_tempBuffer, bytesToRead, &read)) {
-                    printf_error("ReadProcessMemory(%" PRIA PRIx64 ", %08zx) FAILED\n", address, bytesToRead);
+                    printf_error("ReadProcessMemory(%" PRIA PRIx64 ", %08zx) read %d FAILED %s (%x)\n", address, bytesToRead, read, mach_error_string(g_readProcessMemoryResult), g_readProcessMemoryResult);
                     return false;
                 }
 
                 // This can happen if the target process dies before createdump is finished
                 if (read == 0) {
-                    printf_error("ReadProcessMemory(%" PRIA PRIx64 ", %08zx) returned 0 bytes read\n", address, bytesToRead);
+                    printf_error("ReadProcessMemory(%" PRIA PRIx64 ", %08zx) returned 0 bytes read: %s (%x)\n", address, bytesToRead, mach_error_string(g_readProcessMemoryResult), g_readProcessMemoryResult);
                     return false;
                 }
 

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -746,6 +746,11 @@ static void sigterm_handler(int code, siginfo_t *siginfo, void *context)
 {
     if (PALIsInitialized())
     {
+        char* enable = getenv("COMPlus_EnableDumpOnSigTerm");
+        if (enable != nullptr && strcmp(enable, "1") == 0)
+        {
+            PROCCreateCrashDumpIfEnabled(code);
+        }
         // g_pSynchronizationManager shouldn't be null if PAL is initialized.
         _ASSERTE(g_pSynchronizationManager != nullptr);
 

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -213,8 +213,7 @@ void HandleTerminationRequest(int terminationExitCode)
     {
         SetLatchedExitCode(terminationExitCode);
 
-        DWORD enabled = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EnableDumpOnSigTerm);
-        ForceEEShutdown(enabled == 1 ? SCA_TerminateProcessWhenShutdownComplete : SCA_ExitProcessWhenShutdownComplete);
+        ForceEEShutdown(SCA_ExitProcessWhenShutdownComplete);
     }
 }
 #endif


### PR DESCRIPTION
# Customer Impact

These changes will help improving and diagnose unactionable Watson VS4Mac bucketing and reduce the size of MacOS core dumps.

# Details

Add target process terminated/alive message.

Smaller MacOS dumps. Don't add share_mode == SM_EMPTY regions.

Add crashreport success status message for VS4Mac.

Launch createdump from SIGTERM handler directly to reduce the time it takes to get the crash report/dump for VS4Mac.

# Testing

Verified by the VS4Mac team.

# Risk

Low risk because mostly createdump changes. Minor ones in the runtime.