### PR TITLE
Implement the ContentLengthReadStream.Length property

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpBaseStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpBaseStream.cs
@@ -28,7 +28,7 @@ namespace System.Net.Http
 
         public sealed override void SetLength(long value) => throw new NotSupportedException();
 
-        public sealed override long Length => throw new NotSupportedException();
+        public override long Length => throw new NotSupportedException();
 
         public sealed override long Position
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -12,13 +12,17 @@ namespace System.Net.Http
     {
         private sealed class ContentLengthReadStream : HttpContentReadStream
         {
+            private ulong _contentLength;
             private ulong _contentBytesRemaining;
 
             public ContentLengthReadStream(HttpConnection connection, ulong contentLength) : base(connection)
             {
                 Debug.Assert(contentLength > 0, "Caller should have checked for 0.");
+                _contentLength = contentLength;
                 _contentBytesRemaining = contentLength;
             }
+
+            public override long Length => (long)_contentLength;
 
             public override int Read(Span<byte> buffer)
             {


### PR DESCRIPTION
Previously, it would throw a `NotSupportedException`.

Fixes #71190