### PR TITLE
Refactor Rfc2898DeriveBytes to support spans

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Browser.cs
@@ -65,14 +65,12 @@ namespace System.Security.Cryptography
             Span<byte> destination)
         {
             using (Rfc2898DeriveBytes deriveBytes = new Rfc2898DeriveBytes(
-                password.ToArray(),
-                salt.ToArray(),
+                password,
+                salt,
                 iterations,
-                hashAlgorithmName,
-                clearPassword: true))
+                hashAlgorithmName))
             {
-                byte[] result = deriveBytes.GetBytes(destination.Length);
-                result.AsSpan().CopyTo(destination);
+                deriveBytes.GetBytes(destination);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Managed.cs
@@ -19,14 +19,12 @@ namespace System.Security.Cryptography
             Debug.Assert(hashAlgorithmName.Name is not null);
 
             using (Rfc2898DeriveBytes deriveBytes = new Rfc2898DeriveBytes(
-                password.ToArray(),
-                salt.ToArray(),
+                password,
+                salt,
                 iterations,
-                hashAlgorithmName,
-                clearPassword: true))
+                hashAlgorithmName))
             {
-                byte[] result = deriveBytes.GetBytes(destination.Length);
-                result.AsSpan().CopyTo(destination);
+                deriveBytes.GetBytes(destination);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography
     {
         private byte[] _salt;
         private uint _iterations;
-        private HMAC _hmac;
+        private IncrementalHash _hmac;
         private readonly int _blockSize;
 
         private byte[] _buffer;
@@ -84,34 +84,36 @@ namespace System.Security.Cryptography
             HashAlgorithm = hashAlgorithm;
             _hmac = OpenHmac(passwordBytes);
             CryptographicOperations.ZeroMemory(passwordBytes);
-            // _blockSize is in bytes, HashSize is in bits.
-            _blockSize = _hmac.HashSize >> 3;
+            _blockSize = _hmac.HashLengthInBytes;
 
             Initialize();
         }
 
-        internal Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm, bool clearPassword)
+        internal Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm, bool clearPassword) :
+            this(
+                new ReadOnlySpan<byte>(password ?? throw new NullReferenceException()), // This "should" be ArgumentNullException but for compat, we throw NullReferenceException.
+                new ReadOnlySpan<byte>(salt ?? throw new ArgumentNullException(nameof(salt))),
+                iterations,
+                hashAlgorithm)
         {
-            ArgumentNullException.ThrowIfNull(salt);
-
-            if (iterations <= 0)
-                throw new ArgumentOutOfRangeException(nameof(iterations), SR.ArgumentOutOfRange_NeedPosNum);
-            if (password is null)
-                throw new NullReferenceException();  // This "should" be ArgumentNullException but for compat, we throw NullReferenceException.
-
-            _salt = new byte[salt.Length + sizeof(uint)];
-            salt.AsSpan().CopyTo(_salt);
-            _iterations = (uint)iterations;
-            HashAlgorithm = hashAlgorithm;
-            _hmac = OpenHmac(password);
-
             if (clearPassword)
             {
                 CryptographicOperations.ZeroMemory(password);
             }
+        }
 
-            // _blockSize is in bytes, HashSize is in bits.
-            _blockSize = _hmac.HashSize >> 3;
+        internal Rfc2898DeriveBytes(ReadOnlySpan<byte> password, ReadOnlySpan<byte> salt, int iterations, HashAlgorithmName hashAlgorithm)
+        {
+            if (iterations <= 0)
+                throw new ArgumentOutOfRangeException(nameof(iterations), SR.ArgumentOutOfRange_NeedPosNum);
+
+            _salt = new byte[salt.Length + sizeof(uint)];
+            salt.CopyTo(_salt);
+            _iterations = (uint)iterations;
+            HashAlgorithm = hashAlgorithm;
+            _hmac = OpenHmac(password);
+
+            _blockSize = _hmac.HashLengthInBytes;
             Initialize();
         }
 
@@ -167,27 +169,35 @@ namespace System.Security.Cryptography
 
         public override byte[] GetBytes(int cb)
         {
-            Debug.Assert(_blockSize > 0);
-
             if (cb <= 0)
                 throw new ArgumentOutOfRangeException(nameof(cb), SR.ArgumentOutOfRange_NeedPosNum);
-            byte[] password = new byte[cb];
 
+            byte[] password = new byte[cb];
+            GetBytes(password);
+            return password;
+        }
+
+        internal void GetBytes(Span<byte> password)
+        {
+            Debug.Assert(_blockSize > 0);
+            int cb = password.Length;
             int offset = 0;
             int size = _endIndex - _startIndex;
+            ReadOnlySpan<byte> bufferSpan = _buffer;
+
             if (size > 0)
             {
                 if (cb >= size)
                 {
-                    Buffer.BlockCopy(_buffer, _startIndex, password, 0, size);
+                    bufferSpan.Slice(_startIndex, size).CopyTo(password);
                     _startIndex = _endIndex = 0;
                     offset += size;
                 }
                 else
                 {
-                    Buffer.BlockCopy(_buffer, _startIndex, password, 0, cb);
+                    bufferSpan.Slice(_startIndex, cb).CopyTo(password);
                     _startIndex += cb;
-                    return password;
+                    return;
                 }
             }
 
@@ -199,18 +209,17 @@ namespace System.Security.Cryptography
                 int remainder = cb - offset;
                 if (remainder >= _blockSize)
                 {
-                    Buffer.BlockCopy(_buffer, 0, password, offset, _blockSize);
+                    bufferSpan.Slice(0, _blockSize).CopyTo(password.Slice(offset));
                     offset += _blockSize;
                 }
                 else
                 {
-                    Buffer.BlockCopy(_buffer, 0, password, offset, remainder);
+                    bufferSpan.Slice(0, remainder).CopyTo(password.Slice(offset));
                     _startIndex = remainder;
                     _endIndex = _buffer.Length;
-                    return password;
+                    return;
                 }
             }
-            return password;
         }
 
         [Obsolete(Obsoletions.Rfc2898CryptDeriveKeyMessage, DiagnosticId = Obsoletions.Rfc2898CryptDeriveKeyDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
@@ -230,26 +239,25 @@ namespace System.Security.Cryptography
             Initialize();
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "HMACSHA1 is needed for compat. (https://github.com/dotnet/runtime/issues/17618)")]
-        private HMAC OpenHmac(byte[] password)
+        private IncrementalHash OpenHmac(ReadOnlySpan<byte> password)
         {
-            Debug.Assert(password != null);
-
             HashAlgorithmName hashAlgorithm = HashAlgorithm;
 
             if (string.IsNullOrEmpty(hashAlgorithm.Name))
+            {
                 throw new CryptographicException(SR.Cryptography_HashAlgorithmNameNullOrEmpty);
+            }
 
-            if (hashAlgorithm == HashAlgorithmName.SHA1)
-                return new HMACSHA1(password);
-            if (hashAlgorithm == HashAlgorithmName.SHA256)
-                return new HMACSHA256(password);
-            if (hashAlgorithm == HashAlgorithmName.SHA384)
-                return new HMACSHA384(password);
-            if (hashAlgorithm == HashAlgorithmName.SHA512)
-                return new HMACSHA512(password);
+            // Restrict the HashAlgorithmName to known hashes, particularly excluding MD5.
+            if (hashAlgorithm != HashAlgorithmName.SHA1 &&
+                hashAlgorithm != HashAlgorithmName.SHA256 &&
+                hashAlgorithm != HashAlgorithmName.SHA384 &&
+                hashAlgorithm != HashAlgorithmName.SHA512)
+            {
+                throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name));
+            }
 
-            throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name));
+            return IncrementalHash.CreateHMAC(hashAlgorithm, password);
         }
 
         [MemberNotNull(nameof(_buffer))]
@@ -281,20 +289,17 @@ namespace System.Security.Cryptography
             //
             Span<byte> uiSpan = stackalloc byte[64];
             uiSpan = uiSpan.Slice(0, _blockSize);
-
-            if (!_hmac.TryComputeHash(_salt, uiSpan, out int bytesWritten) || bytesWritten != _blockSize)
-            {
-                throw new CryptographicException();
-            }
+            _hmac.AppendData(_salt);
+            int bytesWritten = _hmac.GetHashAndReset(uiSpan);
+            Debug.Assert(bytesWritten == _blockSize);
 
             uiSpan.CopyTo(_buffer);
 
             for (int i = 2; i <= _iterations; i++)
             {
-                if (!_hmac.TryComputeHash(uiSpan, uiSpan, out bytesWritten) || bytesWritten != _blockSize)
-                {
-                    throw new CryptographicException();
-                }
+                _hmac.AppendData(uiSpan);
+                bytesWritten = _hmac.GetHashAndReset(uiSpan);
+                Debug.Assert(bytesWritten == _blockSize);
 
                 for (int j = _buffer.Length - 1; j >= 0; j--)
                 {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
@@ -172,15 +172,15 @@ namespace System.Security.Cryptography
             if (cb <= 0)
                 throw new ArgumentOutOfRangeException(nameof(cb), SR.ArgumentOutOfRange_NeedPosNum);
 
-            byte[] password = new byte[cb];
-            GetBytes(password);
-            return password;
+            byte[] ret = new byte[cb];
+            GetBytes(ret);
+            return ret;
         }
 
-        internal void GetBytes(Span<byte> password)
+        internal void GetBytes(Span<byte> destination)
         {
             Debug.Assert(_blockSize > 0);
-            int cb = password.Length;
+            int cb = destination.Length;
             int offset = 0;
             int size = _endIndex - _startIndex;
             ReadOnlySpan<byte> bufferSpan = _buffer;
@@ -189,13 +189,13 @@ namespace System.Security.Cryptography
             {
                 if (cb >= size)
                 {
-                    bufferSpan.Slice(_startIndex, size).CopyTo(password);
+                    bufferSpan.Slice(_startIndex, size).CopyTo(destination);
                     _startIndex = _endIndex = 0;
                     offset += size;
                 }
                 else
                 {
-                    bufferSpan.Slice(_startIndex, cb).CopyTo(password);
+                    bufferSpan.Slice(_startIndex, cb).CopyTo(destination);
                     _startIndex += cb;
                     return;
                 }
@@ -209,12 +209,12 @@ namespace System.Security.Cryptography
                 int remainder = cb - offset;
                 if (remainder >= _blockSize)
                 {
-                    bufferSpan.Slice(0, _blockSize).CopyTo(password.Slice(offset));
+                    bufferSpan.Slice(0, _blockSize).CopyTo(destination.Slice(offset));
                     offset += _blockSize;
                 }
                 else
                 {
-                    bufferSpan.Slice(0, remainder).CopyTo(password.Slice(offset));
+                    bufferSpan.Slice(0, remainder).CopyTo(destination.Slice(offset));
                     _startIndex = remainder;
                     _endIndex = _buffer.Length;
                     return;


### PR DESCRIPTION
Since the managed `Rfc2898DeriveBytes` is used to implement the one-shots on some platforms, this changes the internals of it to better support spans.

I took this approach as an alternative to a pure one-shot managed PBKDF2 implementation to use as much existing, battle tested code as possible to increase the chances that it will be taken in time for .NET 7.

----

I investigated using the native PBKDF2 capabilities for Android and determined that unfortunately Android's APIs are not suitable for our needs for two reasons. First, it requires API Level 26 for SHA2 PBKDF2, which means we would still need the managed fallback since we support older Android versions. Second, it operates entirely on `Char[]` passwords, not `Byte[]`. We can't feed arbitrary bytes in to Java character arrays.