### PR TITLE
[wasm-mt] Fixup after Emscripten 3.1.12 bump

### DIFF
--- a/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
+++ b/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
@@ -21,7 +21,7 @@ const DotnetSupportLib = {
 let __dotnet_replacement_PThread = ${usePThreads} ? {} : undefined;
 if (${usePThreads}) {
     __dotnet_replacement_PThread.loadWasmModuleToWorker = PThread.loadWasmModuleToWorker;
-    __dotnet_replacement_PThread.threadInit = PThread.threadInit;
+    __dotnet_replacement_PThread.threadInitTLS = PThread.threadInitTLS;
 }
 let __dotnet_replacements = {readAsync, fetch: globalThis.fetch, require, updateGlobalBufferAndViews, pthreadReplacements: __dotnet_replacement_PThread};
 let __dotnet_exportedAPI = __dotnet_runtime.__initializeImportsAndExports(
@@ -35,7 +35,7 @@ require = __dotnet_replacements.requireOut;
 var noExitRuntime = __dotnet_replacements.noExitRuntime;
 if (${usePThreads}) {
     PThread.loadWasmModuleToWorker = __dotnet_replacements.pthreadReplacements.loadWasmModuleToWorker;
-    PThread.threadInit = __dotnet_replacements.pthreadReplacements.threadInit;
+    PThread.threadInitTLS = __dotnet_replacements.pthreadReplacements.threadInitTS;
 }
 `,
 };

--- a/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
+++ b/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
@@ -25,7 +25,7 @@ const DotnetSupportLib = {
 let __dotnet_replacement_PThread = ${usePThreads} ? {} : undefined;
 if (${usePThreads}) {
     __dotnet_replacement_PThread.loadWasmModuleToWorker = PThread.loadWasmModuleToWorker;
-    __dotnet_replacement_PThread.threadInit = PThread.threadInit;
+    __dotnet_replacement_PThread.threadInitTLS = PThread.threadInitTLS;
 }
 let __dotnet_replacements = {readAsync, fetch: globalThis.fetch, require, updateGlobalBufferAndViews, pthreadReplacements: __dotnet_replacement_PThread};
 if (ENVIRONMENT_IS_NODE) {
@@ -72,7 +72,7 @@ require = __dotnet_replacements.requireOut;
 var noExitRuntime = __dotnet_replacements.noExitRuntime;
 if (${usePThreads}) {
     PThread.loadWasmModuleToWorker = __dotnet_replacements.pthreadReplacements.loadWasmModuleToWorker;
-    PThread.threadInit = __dotnet_replacements.pthreadReplacements.threadInit;
+    PThread.threadInitTLS = __dotnet_replacements.pthreadReplacements.threadInitTLS;
 }
 `,
 };

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -77,7 +77,7 @@ import {
 } from "./crypto-worker";
 import { mono_wasm_cancel_promise_ref } from "./cancelable-promise";
 import { mono_wasm_web_socket_open_ref, mono_wasm_web_socket_send, mono_wasm_web_socket_receive, mono_wasm_web_socket_close_ref, mono_wasm_web_socket_abort } from "./web-socket";
-import { mono_wasm_pthread_on_pthread_attached, afterThreadInit } from "./pthreads/worker";
+import { mono_wasm_pthread_on_pthread_attached, afterThreadInitTLS } from "./pthreads/worker";
 import { afterLoadWasmModuleToWorker } from "./pthreads/browser";
 
 const MONO = {
@@ -192,7 +192,7 @@ let exportedAPI: DotnetPublicAPI;
 // We need to replace some of the methods in the Emscripten PThreads support with our own
 type PThreadReplacements = {
     loadWasmModuleToWorker: Function,
-    threadInit: Function
+    threadInitTLS: Function
 }
 
 // this is executed early during load of emscripten runtime
@@ -275,10 +275,10 @@ function initializeImportsAndExports(
             originalLoadWasmModuleToWorker(worker, onFinishedLoading);
             afterLoadWasmModuleToWorker(worker);
         };
-        const originalThreadInit = replacements.pthreadReplacements.threadInit;
-        replacements.pthreadReplacements.threadInit = (): void => {
-            originalThreadInit();
-            afterThreadInit();
+        const originalThreadInitTLS = replacements.pthreadReplacements.threadInitTLS;
+        replacements.pthreadReplacements.threadInitTLS = (): void => {
+            originalThreadInitTLS();
+            afterThreadInitTLS();
         };
     }
 

--- a/src/mono/wasm/runtime/pthreads/worker/index.ts
+++ b/src/mono/wasm/runtime/pthreads/worker/index.ts
@@ -62,7 +62,7 @@ export function mono_wasm_pthread_on_pthread_attached(pthread_id: pthread_ptr): 
 /// This is an implementation detail function.
 /// Called by emscripten when a pthread is setup to run on a worker.  Can be called multiple times
 /// for the same worker, since emscripten can reuse workers.  This is an implementation detail, that shouldn't be used directly.
-export function afterThreadInit(): void {
+export function afterThreadInitTLS(): void {
     // don't do this callback for the main thread
     if (ENVIRONMENT_IS_PTHREAD) {
         const pthread_ptr = (<any>Module)["_pthread_self"]();


### PR DESCRIPTION
Emscripten 3.1.12 library_pthread.js renamed `PThread["threadInit"]` to `PThread["threadInitTLS"]`

Follow-up to https://github.com/dotnet/runtime/pull/70693