### PR TITLE
PeriodicTimer add missing XML documentation

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PeriodicTimer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PeriodicTimer.cs
@@ -43,6 +43,9 @@ namespace System.Threading
         /// the underlying timer continues firing.
         /// </param>
         /// <returns>A task that will be completed due to the timer firing, <see cref="Dispose"/> being called to stop the timer, or cancellation being requested.</returns>
+        /// <exception cref="System.InvalidOperationException">
+        /// A call to <see cref="WaitForNextTickAsync" /> is currently in flight.
+        /// </exception>        
         /// <remarks>
         /// The <see cref="PeriodicTimer"/> behaves like an auto-reset event, in that multiple ticks are coalesced into a single tick if they occur between
         /// calls to <see cref="WaitForNextTickAsync"/>.  Similarly, a call to <see cref="Dispose"/> will void any tick not yet consumed. <see cref="WaitForNextTickAsync"/>


### PR DESCRIPTION
The method [`WaitForNextTickAsync`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.periodictimer.waitfornexttickasync) of the [`PeriodicTimer`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.periodictimer) class can throw synchronously an `InvalidOperationException`, when there is another similar operation in-flight. This PR adds the relevant XML documentation in the source code of this method.

Minimal demonstration:

```C#
using System;
using System.Threading;

public class Program
{
    public static void Main()
    {
        PeriodicTimer timer = new(TimeSpan.FromSeconds(1.0));
        timer.WaitForNextTickAsync();
        timer.WaitForNextTickAsync();
    }
}
```

Output:

```none
Unhandled exception. System.InvalidOperationException: Operation is not valid due to the current state of the object.
```

[Online demo](https://dotnetfiddle.net/bkeEka).