### PR TITLE
PeriodicTimer XML documentation improvement

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PeriodicTimer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PeriodicTimer.cs
@@ -23,7 +23,7 @@ namespace System.Threading
 
         /// <summary>Initializes the timer.</summary>
         /// <param name="period">The time interval between invocations of callback..</param>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="period"/> must be represent a number of milliseconds larger than 0 and smaller than <see cref="uint.MaxValue"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="period"/> must represent a number of milliseconds equal or larger than 1, and smaller than <see cref="uint.MaxValue"/>.</exception>
         public PeriodicTimer(TimeSpan period)
         {
             long ms = (long)period.TotalMilliseconds;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PeriodicTimer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PeriodicTimer.cs
@@ -23,7 +23,7 @@ namespace System.Threading
 
         /// <summary>Initializes the timer.</summary>
         /// <param name="period">The time interval between invocations of callback..</param>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="period"/> must represent a number of milliseconds equal or larger than 1, and smaller than <see cref="uint.MaxValue"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="period"/> must represent a number of milliseconds equal to or larger than 1, and smaller than <see cref="uint.MaxValue"/>.</exception>
         public PeriodicTimer(TimeSpan period)
         {
             long ms = (long)period.TotalMilliseconds;


### PR DESCRIPTION
The XML documentation of the constructor of the class [`PeriodicTimer`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.periodictimer) states that the `period` must represent a number of milliseconds larger than 0, but actually values between 0.0 and 1.0 are invalid. This PR improves the text by stating that the milliseconds must be at least 1.

Minimal demonstration of the actual behavior:

```C#
using System;
using System.Threading;

public class Program
{
    public static void Main()
    {
        PeriodicTimer timer = new(TimeSpan.FromMilliseconds(0.5));
    }
}
```

Output:

```none
Unhandled exception. System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'period')
```

[Online demo](https://dotnetfiddle.net/hxApGr).