### PR TITLE
Fix contract customization being silently ignored over pre-existing JsonIgnoreCondition configuration

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -200,7 +200,7 @@ namespace System.Text.Json.Serialization.Converters
 
                     if (state.Current.PropertyState < StackFramePropertyState.ReadValue)
                     {
-                        if (!jsonPropertyInfo.CanDeserialize)
+                        if (!jsonPropertyInfo.HasSetter)
                         {
                             if (!reader.TrySkip())
                             {
@@ -289,7 +289,7 @@ namespace System.Text.Json.Serialization.Converters
                 for (int i = 0; i < properties.Count; i++)
                 {
                     JsonPropertyInfo jsonPropertyInfo = properties[i].Value;
-                    if (jsonPropertyInfo.CanSerialize)
+                    if (jsonPropertyInfo.HasGetter)
                     {
                         // Remember the current property for JsonPath support if an exception is thrown.
                         state.Current.JsonPropertyInfo = jsonPropertyInfo;
@@ -305,7 +305,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 // Write extension data after the normal properties.
                 JsonPropertyInfo? extensionDataProperty = jsonTypeInfo.ExtensionDataProperty;
-                if (extensionDataProperty?.CanSerialize == true)
+                if (extensionDataProperty?.HasGetter == true)
                 {
                     // Remember the current property for JsonPath support if an exception is thrown.
                     state.Current.JsonPropertyInfo = extensionDataProperty;
@@ -339,7 +339,7 @@ namespace System.Text.Json.Serialization.Converters
                 while (state.Current.EnumeratorIndex < propertyList.Count)
                 {
                     JsonPropertyInfo jsonPropertyInfo = propertyList[state.Current.EnumeratorIndex].Value;
-                    if (jsonPropertyInfo.CanSerialize)
+                    if (jsonPropertyInfo.HasGetter)
                     {
                         state.Current.JsonPropertyInfo = jsonPropertyInfo;
                         state.Current.NumberHandling = jsonPropertyInfo.EffectiveNumberHandling;
@@ -368,7 +368,7 @@ namespace System.Text.Json.Serialization.Converters
                 if (state.Current.EnumeratorIndex == propertyList.Count)
                 {
                     JsonPropertyInfo? extensionDataProperty = jsonTypeInfo.ExtensionDataProperty;
-                    if (extensionDataProperty?.CanSerialize == true)
+                    if (extensionDataProperty?.HasGetter == true)
                     {
                         // Remember the current property for JsonPath support if an exception is thrown.
                         state.Current.JsonPropertyInfo = extensionDataProperty;
@@ -415,7 +415,7 @@ namespace System.Text.Json.Serialization.Converters
             bool useExtensionProperty)
         {
             // Skip the property if not found.
-            if (!jsonPropertyInfo.CanDeserialize)
+            if (!jsonPropertyInfo.HasSetter)
             {
                 reader.Skip();
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
@@ -21,7 +21,7 @@ namespace System.Text.Json.Serialization.Converters
 
             bool success = jsonParameterInfo.ConverterBase.TryReadAsObject(ref reader, jsonParameterInfo.Options!, ref state, out object? arg);
 
-            if (success && !(arg == null && jsonParameterInfo.IgnoreDefaultValuesOnRead))
+            if (success && !(arg == null && jsonParameterInfo.IgnoreNullTokensOnRead))
             {
                 ((object[])state.Current.CtorArgumentState!.Arguments)[jsonParameterInfo.ClrInfo.Position] = arg!;
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
@@ -67,7 +67,7 @@ namespace System.Text.Json.Serialization.Converters
 
             bool success = converter.TryRead(ref reader, info.PropertyType, info.Options!, ref state, out TArg? value);
 
-            arg = value == null && jsonParameterInfo.IgnoreDefaultValuesOnRead
+            arg = value == null && jsonParameterInfo.IgnoreNullTokensOnRead
                 ? (TArg?)info.DefaultValue! // Use default value specified on parameter, if any.
                 : value!;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -287,7 +287,7 @@ namespace System.Text.Json.Serialization.Converters
                         out _,
                         createExtensionProperty: false);
 
-                    if (jsonPropertyInfo.CanDeserialize)
+                    if (jsonPropertyInfo.HasSetter)
                     {
                         ArgumentState argumentState = state.Current.CtorArgumentState!;
 
@@ -452,7 +452,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             if (state.Current.PropertyState < StackFramePropertyState.ReadValue)
             {
-                if (!jsonPropertyInfo.CanDeserialize)
+                if (!jsonPropertyInfo.HasSetter)
                 {
                     if (!reader.TrySkip())
                     {
@@ -486,7 +486,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
             }
 
-            Debug.Assert(jsonPropertyInfo.CanDeserialize);
+            Debug.Assert(jsonPropertyInfo.HasSetter);
 
             // Ensure that the cache has enough capacity to add this property.
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
@@ -20,7 +20,7 @@ namespace System.Text.Json.Serialization.Metadata
         // The default value of the parameter. This is `DefaultValue` of the `ParameterInfo`, if specified, or the CLR `default` for the `ParameterType`.
         public object? DefaultValue { get; private protected set; }
 
-        public bool IgnoreDefaultValuesOnRead { get; private set; }
+        public bool IgnoreNullTokensOnRead { get; private set; }
 
         // Options can be referenced here since all JsonPropertyInfos originate from a JsonTypeInfo that is cached on JsonSerializerOptions.
         public JsonSerializerOptions? Options { get; set; } // initialized in Init method
@@ -62,7 +62,7 @@ namespace System.Text.Json.Serialization.Metadata
             PropertyType = matchingProperty.PropertyType;
             NameAsUtf8Bytes = matchingProperty.NameAsUtf8Bytes!;
             ConverterBase = matchingProperty.EffectiveConverter;
-            IgnoreDefaultValuesOnRead = matchingProperty.IgnoreDefaultValuesOnRead;
+            IgnoreNullTokensOnRead = matchingProperty.IgnoreNullTokensOnRead;
             NumberHandling = matchingProperty.EffectiveNumberHandling;
             MatchingPropertyCanBeNull = matchingProperty.PropertyTypeCanBeNull;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -53,6 +53,7 @@ namespace System.Text.Json.Serialization.Metadata
             set
             {
                 VerifyMutable();
+                DetermineEffectiveConverter(value);
                 _customConverter = value;
             }
         }
@@ -68,7 +69,11 @@ namespace System.Text.Json.Serialization.Metadata
         public Func<object, object?>? Get
         {
             get => _untypedGet;
-            set => SetGetter(value);
+            set
+            {
+                VerifyMutable();
+                SetGetter(value);
+            }
         }
 
         /// <summary>
@@ -80,7 +85,14 @@ namespace System.Text.Json.Serialization.Metadata
         public Action<object, object?>? Set
         {
             get => _untypedSet;
-            set => SetSetter(value);
+            set
+            {
+                VerifyMutable();
+                SetSetter(value);
+                // Invalidate any JsonIgnore configuration if delegate set manually by user
+                IgnoreNullTokensOnRead = false;
+                _ignoreCondition = null;
+            }
         }
 
         private protected Func<object, object?>? _untypedGet;
@@ -106,13 +118,15 @@ namespace System.Text.Json.Serialization.Metadata
             set
             {
                 VerifyMutable();
-                _shouldSerialize = value;
-                // By default we will go through faster path (not using delegate) and use IgnoreCondition
-                // If user sets it explicitly we always go through delegate
+                SetShouldSerialize(value);
+                // Invalidate any JsonIgnore configuration if delegate set manually by user
+                IgnoreDefaultValuesOnWrite = false;
                 _ignoreCondition = null;
-                _shouldSerializeIsExplicitlySet = true;
             }
         }
+
+        private protected Func<object, object?, bool>? _shouldSerialize;
+        private protected abstract void SetShouldSerialize(Delegate? predicate);
 
         internal JsonIgnoreCondition? IgnoreCondition
         {
@@ -120,18 +134,13 @@ namespace System.Text.Json.Serialization.Metadata
             set
             {
                 Debug.Assert(!_isConfigured);
-
+                ConfigureIgnoreCondition(value);
                 _ignoreCondition = value;
-                _shouldSerialize = value != null ? GetShouldSerializeForIgnoreCondition(value.Value) : null;
-                _shouldSerializeIsExplicitlySet = false;
             }
         }
 
-        private Func<object, object?, bool>? _shouldSerialize;
-        private bool _shouldSerializeIsExplicitlySet;
         private JsonIgnoreCondition? _ignoreCondition;
-
-        private protected abstract Func<object, object?, bool> GetShouldSerializeForIgnoreCondition(JsonIgnoreCondition condition);
+        private protected abstract void ConfigureIgnoreCondition(JsonIgnoreCondition? ignoreCondition);
 
         /// <summary>
         /// Gets or sets a custom attribute provider for the current property.
@@ -199,8 +208,8 @@ namespace System.Text.Json.Serialization.Metadata
             JsonPropertyInfo info = new JsonPropertyInfo<object>(typeof(object), declaringTypeInfo: null, options: null!);
 
             Debug.Assert(!info.IsForTypeInfo);
-            Debug.Assert(!info.CanDeserialize);
-            Debug.Assert(!info.CanSerialize);
+            Debug.Assert(!info.HasSetter);
+            Debug.Assert(!info.HasGetter);
 
             info.Name = string.Empty;
 
@@ -220,6 +229,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
+        internal bool IsConfigured => _isConfigured;
         private volatile bool _isConfigured;
 
         internal void EnsureConfigured()
@@ -246,12 +256,11 @@ namespace System.Text.Json.Serialization.Metadata
                 CacheNameAsUtf8BytesAndEscapedNameSection();
             }
 
-            if (IsIgnored)
+            if (EffectiveConverter is null)
             {
-                return;
+                Debug.Assert(CustomConverter is null);
+                DetermineEffectiveConverter(customConverter: null);
             }
-
-            DetermineEffectiveConverter();
 
             if (IsForTypeInfo)
             {
@@ -260,17 +269,10 @@ namespace System.Text.Json.Serialization.Metadata
             else
             {
                 DetermineNumberHandlingForProperty();
-
-                if (!IsIgnored)
-                {
-                    DetermineIgnoreCondition(IgnoreCondition);
-                }
-
-                DetermineSerializationCapabilities(IgnoreCondition);
             }
         }
 
-        private protected abstract void DetermineEffectiveConverter();
+        private protected abstract void DetermineEffectiveConverter(JsonConverter? customConverter);
         private protected abstract void DetermineMemberAccessors(MemberInfo memberInfo);
 
         private void DeterminePoliciesFromMember(MemberInfo memberInfo)
@@ -313,118 +315,6 @@ namespace System.Text.Json.Serialization.Metadata
 
             NameAsUtf8Bytes = Encoding.UTF8.GetBytes(Name);
             EscapedNameSection = JsonHelpers.GetEscapedPropertyNameSection(NameAsUtf8Bytes, Options.Encoder);
-        }
-
-        internal void DetermineSerializationCapabilities(JsonIgnoreCondition? ignoreCondition)
-        {
-            if (IsIgnored)
-            {
-                CanSerialize = false;
-                CanDeserialize = false;
-                return;
-            }
-
-            Debug.Assert(MemberType == MemberTypes.Property || MemberType == MemberTypes.Field || MemberType == default);
-
-            if ((ConverterStrategy & (ConverterStrategy.Enumerable | ConverterStrategy.Dictionary)) == 0)
-            {
-                Debug.Assert(ignoreCondition != JsonIgnoreCondition.Always);
-
-                // Three possible values for ignoreCondition:
-                // null = JsonIgnore was not placed on this property, global IgnoreReadOnlyProperties/Fields wins
-                // WhenNull = only ignore when null, global IgnoreReadOnlyProperties/Fields loses
-                // Never = never ignore (always include), global IgnoreReadOnlyProperties/Fields loses
-                bool serializeReadOnlyProperty = ignoreCondition != null || (MemberType == MemberTypes.Property
-                    ? !Options.IgnoreReadOnlyProperties
-                    : !Options.IgnoreReadOnlyFields);
-
-                // We serialize if there is a getter + not ignoring readonly properties.
-                CanSerialize = HasGetter && (HasSetter || serializeReadOnlyProperty || _shouldSerializeIsExplicitlySet);
-
-                // We deserialize if there is a setter.
-                CanDeserialize = HasSetter;
-            }
-            else
-            {
-                if (HasGetter)
-                {
-                    Debug.Assert(EffectiveConverter != null);
-
-                    CanSerialize = true;
-
-                    if (HasSetter)
-                    {
-                        CanDeserialize = true;
-                    }
-                }
-            }
-        }
-
-        internal void DetermineIgnoreCondition(JsonIgnoreCondition? ignoreCondition)
-        {
-            if (_shouldSerializeIsExplicitlySet)
-            {
-                Debug.Assert(ignoreCondition == null);
-#pragma warning disable SYSLIB0020 // JsonSerializerOptions.IgnoreNullValues is obsolete
-                if (Options.IgnoreNullValues)
-#pragma warning restore SYSLIB0020
-                {
-                    Debug.Assert(Options.DefaultIgnoreCondition == JsonIgnoreCondition.Never);
-                    if (PropertyTypeCanBeNull)
-                    {
-                        IgnoreDefaultValuesOnRead = true;
-                    }
-                }
-
-                return;
-            }
-
-            if (ignoreCondition != null)
-            {
-                // This is not true for CodeGen scenarios since we do not cache this as of yet.
-                // Debug.Assert(MemberInfo != null);
-                Debug.Assert(ignoreCondition != JsonIgnoreCondition.Always);
-
-                if (ignoreCondition == JsonIgnoreCondition.WhenWritingDefault)
-                {
-                    IgnoreDefaultValuesOnWrite = true;
-                }
-                else if (ignoreCondition == JsonIgnoreCondition.WhenWritingNull)
-                {
-                    if (PropertyTypeCanBeNull)
-                    {
-                        IgnoreDefaultValuesOnWrite = true;
-                    }
-                    else
-                    {
-                        ThrowHelper.ThrowInvalidOperationException_IgnoreConditionOnValueTypeInvalid(MemberName!, DeclaringType);
-                    }
-                }
-            }
-#pragma warning disable SYSLIB0020 // JsonSerializerOptions.IgnoreNullValues is obsolete
-            else if (Options.IgnoreNullValues)
-            {
-                Debug.Assert(Options.DefaultIgnoreCondition == JsonIgnoreCondition.Never);
-                if (PropertyTypeCanBeNull)
-                {
-                    IgnoreDefaultValuesOnRead = true;
-                    IgnoreDefaultValuesOnWrite = true;
-                }
-            }
-            else if (Options.DefaultIgnoreCondition == JsonIgnoreCondition.WhenWritingNull)
-            {
-                Debug.Assert(!Options.IgnoreNullValues);
-                if (PropertyTypeCanBeNull)
-                {
-                    IgnoreDefaultValuesOnWrite = true;
-                }
-            }
-            else if (Options.DefaultIgnoreCondition == JsonIgnoreCondition.WhenWritingDefault)
-            {
-                Debug.Assert(!Options.IgnoreNullValues);
-                IgnoreDefaultValuesOnWrite = true;
-            }
-#pragma warning restore SYSLIB0020
         }
 
         internal void DetermineNumberHandlingForTypeInfo()
@@ -524,8 +414,8 @@ namespace System.Text.Json.Serialization.Metadata
             sb.AppendLine($"{ind}  NameAsUtf8.Length: {(NameAsUtf8Bytes?.Length ?? -1)},");
             sb.AppendLine($"{ind}  IsConfigured: {_isConfigured},");
             sb.AppendLine($"{ind}  IsIgnored: {IsIgnored},");
-            sb.AppendLine($"{ind}  CanSerialize: {CanSerialize},");
-            sb.AppendLine($"{ind}  CanDeserialize: {CanDeserialize},");
+            sb.AppendLine($"{ind}  HasGetter: {HasGetter},");
+            sb.AppendLine($"{ind}  HasSetter: {HasSetter},");
             sb.AppendLine($"{ind}}}");
 
             return sb.ToString();
@@ -535,7 +425,7 @@ namespace System.Text.Json.Serialization.Metadata
         internal bool HasGetter => _untypedGet is not null;
         internal bool HasSetter => _untypedSet is not null;
 
-        internal void InitializeUsingMemberReflection(MemberInfo memberInfo)
+        internal void InitializeUsingMemberReflection(MemberInfo memberInfo, JsonConverter? customConverter, JsonIgnoreCondition? ignoreCondition)
         {
             Debug.Assert(AttributeProvider == null);
 
@@ -559,19 +449,37 @@ namespace System.Text.Json.Serialization.Metadata
                     break;
             }
 
+            CustomConverter = customConverter;
             DeterminePoliciesFromMember(memberInfo);
             DeterminePropertyNameFromMember(memberInfo);
 
-            if (!IsIgnored)
+            if (ignoreCondition != JsonIgnoreCondition.Always)
             {
                 DetermineMemberAccessors(memberInfo);
             }
 
+            // NB setting the ignore condition must follow converter & getter/setter
+            // configuration in order for access policies to be applied correctly.
+            IgnoreCondition = ignoreCondition;
             IsExtensionData = memberInfo.GetCustomAttribute<JsonExtensionDataAttribute>(inherit: false) != null;
         }
 
-        internal bool IgnoreDefaultValuesOnRead { get; private set; }
-        internal bool IgnoreDefaultValuesOnWrite { get; private set; }
+        internal bool IgnoreNullTokensOnRead { get; private protected set; }
+        internal bool IgnoreDefaultValuesOnWrite { get; private protected set; }
+
+        internal bool IgnoreReadOnlyMember
+        {
+            get
+            {
+                Debug.Assert(MemberType == MemberTypes.Property || MemberType == MemberTypes.Field || MemberType == default);
+                return MemberType switch
+                {
+                    MemberTypes.Property => Options.IgnoreReadOnlyProperties,
+                    MemberTypes.Field => Options.IgnoreReadOnlyFields,
+                    _ => false,
+                };
+            }
+        }
 
         /// <summary>
         /// True if the corresponding cref="JsonTypeInfo.PropertyInfoForTypeInfo"/> is this instance.
@@ -772,10 +680,6 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
         internal abstract void SetExtensionDictionaryAsObject(object obj, object? extensionDict);
-
-        internal bool CanSerialize { get; private set; }
-
-        internal bool CanDeserialize { get; private set; }
 
         internal bool IsIgnored => _ignoreCondition == JsonIgnoreCondition.Always;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -89,8 +89,6 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 VerifyMutable();
                 SetSetter(value);
-                // Invalidate any JsonIgnore configuration if delegate set manually by user
-                IgnoreNullTokensOnRead = false;
                 _isUserSpecifiedSetter = true;
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -37,8 +37,7 @@ namespace System.Text.Json.Serialization.Metadata
         private protected override void SetGetter(Delegate? getter)
         {
             Debug.Assert(getter is null or Func<object, object?> or Func<object, T>);
-
-            VerifyMutable();
+            Debug.Assert(!IsConfigured);
 
             if (getter is null)
             {
@@ -61,8 +60,7 @@ namespace System.Text.Json.Serialization.Metadata
         private protected override void SetSetter(Delegate? setter)
         {
             Debug.Assert(setter is null or Action<object, object?> or Action<object, T>);
-
-            VerifyMutable();
+            Debug.Assert(!IsConfigured);
 
             if (setter is null)
             {
@@ -82,6 +80,37 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
+        internal new Func<object, T?, bool>? ShouldSerialize
+        {
+            get => _shouldSerializeTyped;
+            set => SetShouldSerialize(value);
+        }
+
+        private Func<object, T?, bool>? _shouldSerializeTyped;
+
+        private protected override void SetShouldSerialize(Delegate? predicate)
+        {
+            Debug.Assert(predicate is null or Func<object, object?, bool> or Func<object, T?, bool>);
+            Debug.Assert(!IsConfigured);
+
+            if (predicate is null)
+            {
+                _shouldSerializeTyped = null;
+                _shouldSerialize = null;
+            }
+            else if (predicate is Func<object, T?, bool> typedPredicate)
+            {
+                _shouldSerializeTyped = typedPredicate;
+                _shouldSerialize = typedPredicate is Func<object, object?, bool> untypedPredicate ? untypedPredicate : (obj, value) => typedPredicate(obj, (T)value!);
+            }
+            else
+            {
+                Func<object, object?, bool> untypedPredicate = (Func<object, object?, bool>)predicate;
+                _shouldSerializeTyped = (obj, value) => untypedPredicate(obj, value);
+                _shouldSerialize = untypedPredicate;
+            }
+        }
+
         internal override object? DefaultValue => default(T);
         internal override bool PropertyTypeCanBeNull => default(T) is null;
 
@@ -94,43 +123,37 @@ namespace System.Text.Json.Serialization.Metadata
             switch (memberInfo)
             {
                 case PropertyInfo propertyInfo:
+                    bool useNonPublicAccessors = propertyInfo.GetCustomAttribute<JsonIncludeAttribute>(inherit: false) != null;
+
+                    MethodInfo? getMethod = propertyInfo.GetMethod;
+                    if (getMethod != null && (getMethod.IsPublic || useNonPublicAccessors))
                     {
-                        bool useNonPublicAccessors = propertyInfo.GetCustomAttribute<JsonIncludeAttribute>(inherit: false) != null;
-
-                        MethodInfo? getMethod = propertyInfo.GetMethod;
-                        if (getMethod != null && (getMethod.IsPublic || useNonPublicAccessors))
-                        {
-                            Get = Options.MemberAccessorStrategy.CreatePropertyGetter<T>(propertyInfo);
-                        }
-
-                        MethodInfo? setMethod = propertyInfo.SetMethod;
-                        if (setMethod != null && (setMethod.IsPublic || useNonPublicAccessors))
-                        {
-                            Set = Options.MemberAccessorStrategy.CreatePropertySetter<T>(propertyInfo);
-                        }
-
-                        break;
+                        Get = Options.MemberAccessorStrategy.CreatePropertyGetter<T>(propertyInfo);
                     }
+
+                    MethodInfo? setMethod = propertyInfo.SetMethod;
+                    if (setMethod != null && (setMethod.IsPublic || useNonPublicAccessors))
+                    {
+                        Set = Options.MemberAccessorStrategy.CreatePropertySetter<T>(propertyInfo);
+                    }
+
+                    break;
 
                 case FieldInfo fieldInfo:
+                    Debug.Assert(fieldInfo.IsPublic);
+
+                    Get = Options.MemberAccessorStrategy.CreateFieldGetter<T>(fieldInfo);
+
+                    if (!fieldInfo.IsInitOnly)
                     {
-                        Debug.Assert(fieldInfo.IsPublic);
-
-                        Get = Options.MemberAccessorStrategy.CreateFieldGetter<T>(fieldInfo);
-
-                        if (!fieldInfo.IsInitOnly)
-                        {
-                            Set = Options.MemberAccessorStrategy.CreateFieldSetter<T>(fieldInfo);
-                        }
-
-                        break;
+                        Set = Options.MemberAccessorStrategy.CreateFieldSetter<T>(fieldInfo);
                     }
+
+                    break;
 
                 default:
-                    {
-                        Debug.Fail($"Invalid MemberInfo type: {memberInfo.MemberType}");
-                        break;
-                    }
+                    Debug.Fail($"Invalid MemberInfo type: {memberInfo.MemberType}");
+                    break;
             }
         }
 
@@ -168,20 +191,21 @@ namespace System.Text.Json.Serialization.Metadata
             DefaultConverterForType = propertyInfo.PropertyTypeInfo?.Converter as JsonConverter<T>;
             CustomConverter = propertyInfo.Converter;
 
-            IgnoreCondition = propertyInfo.IgnoreCondition;
-            if (IgnoreCondition != JsonIgnoreCondition.Always)
+            if (propertyInfo.IgnoreCondition != JsonIgnoreCondition.Always)
             {
                 Get = propertyInfo.Getter!;
                 Set = propertyInfo.Setter;
             }
 
+            // NB setting the ignore condition must follow converter & getter/setter
+            // configuration in order for access policies to be applied correctly.
+            IgnoreCondition = propertyInfo.IgnoreCondition;
             JsonTypeInfo = propertyInfo.PropertyTypeInfo;
             NumberHandling = propertyInfo.NumberHandling;
         }
 
-        private protected override void DetermineEffectiveConverter()
+        private protected override void DetermineEffectiveConverter(JsonConverter? customConverter)
         {
-            JsonConverter? customConverter = CustomConverter;
             if (customConverter != null)
             {
                 customConverter = Options.ExpandConverterFactory(customConverter, PropertyType);
@@ -229,23 +253,13 @@ namespace System.Text.Json.Serialization.Metadata
 
             if (IgnoreDefaultValuesOnWrite)
             {
-                if (default(T) is null)
+                // Fast path `ShouldSerialize` check when using JsonIgnoreCondition.WhenWritingNull/Default configuration
+                if (IsDefaultValue(value))
                 {
-                    if (value is null)
-                    {
-                        return true;
-                    }
-                }
-                else
-                {
-                    if (EqualityComparer<T>.Default.Equals(default, value))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
-
-            if (ShouldSerialize?.Invoke(obj, value) == false)
+            else if (ShouldSerialize?.Invoke(obj, value) == false)
             {
                 // We return true here.
                 // False means that there is not enough data.
@@ -326,7 +340,7 @@ namespace System.Text.Json.Serialization.Metadata
                     ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(TypedEffectiveConverter.TypeToConvert);
                 }
 
-                if (!IgnoreDefaultValuesOnRead)
+                if (!IgnoreNullTokensOnRead)
                 {
                     T? value = default;
                     Set!(obj, value!);
@@ -339,7 +353,7 @@ namespace System.Text.Json.Serialization.Metadata
                 // CanUseDirectReadOrWrite == false when using streams
                 Debug.Assert(!state.IsContinuation);
 
-                if (!isNullToken || !IgnoreDefaultValuesOnRead || default(T) is not null)
+                if (!isNullToken || !IgnoreNullTokensOnRead || default(T) is not null)
                 {
                     // Optimize for internal converters by avoiding the extra call to TryRead.
                     T? fastValue = TypedEffectiveConverter.Read(ref reader, PropertyType, Options);
@@ -351,7 +365,7 @@ namespace System.Text.Json.Serialization.Metadata
             else
             {
                 success = true;
-                if (!isNullToken || !IgnoreDefaultValuesOnRead || default(T) is not null || state.IsContinuation)
+                if (!isNullToken || !IgnoreNullTokensOnRead || default(T) is not null || state.IsContinuation)
                 {
                     success = TypedEffectiveConverter.TryRead(ref reader, PropertyType, Options, ref state, out T? value);
                     if (success)
@@ -406,40 +420,115 @@ namespace System.Text.Json.Serialization.Metadata
             Set!(obj, typedValue);
         }
 
-        private protected override Func<object, object?, bool> GetShouldSerializeForIgnoreCondition(JsonIgnoreCondition ignoreCondition)
+        private protected override void ConfigureIgnoreCondition(JsonIgnoreCondition? ignoreCondition)
         {
+            DetermineSerializationCapabilities(ignoreCondition);
+
             switch (ignoreCondition)
             {
-                case JsonIgnoreCondition.Always: return ShouldSerializeIgnoreConditionAlways;
-                case JsonIgnoreCondition.Never: return ShouldSerializeIgnoreConditionNever;
+                case JsonIgnoreCondition.Never:
+                    break;
+
+                case JsonIgnoreCondition.Always:
+                    ShouldSerialize = ShouldSerializeIgnoreConditionAlways;
+                    break;
+
                 case JsonIgnoreCondition.WhenWritingNull:
-                    if (!PropertyTypeCanBeNull)
+                    if (PropertyTypeCanBeNull)
                     {
-                        return ShouldSerializeIgnoreConditionNever;
+                        ShouldSerialize = ShouldSerializeIgnoreWhenWritingDefault;
+                        IgnoreDefaultValuesOnWrite = true;
+                    }
+                    else
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_IgnoreConditionOnValueTypeInvalid(MemberName!, DeclaringType);
+                    }
+                    break;
+
+                case JsonIgnoreCondition.WhenWritingDefault:
+                    ShouldSerialize = ShouldSerializeIgnoreWhenWritingDefault;
+                    IgnoreDefaultValuesOnWrite = true;
+                    break;
+
+                case not null:
+                    Debug.Fail($"Unknown value of JsonIgnoreCondition '{ignoreCondition}'");
+                    break;
+
+                case null:
+#pragma warning disable SYSLIB0020 // JsonSerializerOptions.IgnoreNullValues is obsolete
+                    if (Options.IgnoreNullValues)
+#pragma warning restore SYSLIB0020
+                    {
+                        Debug.Assert(Options.DefaultIgnoreCondition == JsonIgnoreCondition.Never);
+                        if (PropertyTypeCanBeNull)
+                        {
+                            ShouldSerialize = ShouldSerializeIgnoreWhenWritingDefault;
+                            IgnoreDefaultValuesOnWrite = true;
+                            IgnoreNullTokensOnRead = true;
+                        }
+                    }
+                    else if (Options.DefaultIgnoreCondition == JsonIgnoreCondition.WhenWritingNull)
+                    {
+                        if (PropertyTypeCanBeNull)
+                        {
+                            ShouldSerialize = ShouldSerializeIgnoreWhenWritingDefault;
+                            IgnoreDefaultValuesOnWrite = true;
+                        }
+                    }
+                    else if (Options.DefaultIgnoreCondition == JsonIgnoreCondition.WhenWritingDefault)
+                    {
+                        ShouldSerialize = ShouldSerializeIgnoreWhenWritingDefault;
+                        IgnoreDefaultValuesOnWrite = true;
                     }
 
-                    goto case JsonIgnoreCondition.WhenWritingDefault;
-                case JsonIgnoreCondition.WhenWritingDefault:
-                    {
-                        return ShouldSerializeIgnoreConditionWhenWritingDefaultPropertyTypeEqualsTypeToConvert;
-                    }
-                default:
-                    Debug.Fail($"Unknown value of JsonIgnoreCondition '{ignoreCondition}'");
-                    return null!;
+                    break;
+            }
+
+            static bool ShouldSerializeIgnoreConditionAlways(object _, T? value) => false;
+            static bool ShouldSerializeIgnoreWhenWritingDefault(object _, T? value)
+            {
+                return default(T) is null ? value is not null : !EqualityComparer<T>.Default.Equals(default, value);
             }
         }
 
-        private static bool ShouldSerializeIgnoreConditionAlways(object obj, object? value) => false;
-        private static bool ShouldSerializeIgnoreConditionNever(object obj, object? value) => true;
-        private static bool ShouldSerializeIgnoreConditionWhenWritingDefaultPropertyTypeEqualsTypeToConvert(object obj, object? value)
+        private static bool IsDefaultValue(T? value)
         {
-            if (value == null)
+            return default(T) is null ? value is null : EqualityComparer<T>.Default.Equals(default, value);
+        }
+
+        private void DetermineSerializationCapabilities(JsonIgnoreCondition? ignoreCondition)
+        {
+            if (ignoreCondition == JsonIgnoreCondition.Always)
             {
-                return false;
+                Debug.Assert(Get == null && Set == null, "Getters or Setters should not be set when JsonIgnoreCondition.Always is specified.");
+                return;
             }
 
-            T typedValue = (T)value;
-            return !EqualityComparer<T>.Default.Equals(default, typedValue);
+            Debug.Assert(TypedEffectiveConverter != null, "Must have calculated the effective converter strategy.");
+            if ((ConverterStrategy & (ConverterStrategy.Enumerable | ConverterStrategy.Dictionary)) == 0)
+            {
+                // We serialize if there is a getter + not ignoring readonly properties.
+                if (Get != null && Set == null)
+                {
+                    // Three possible values for ignoreCondition:
+                    // null = JsonIgnore was not placed on this property, global IgnoreReadOnlyProperties/Fields wins
+                    // WhenNull = only ignore when null, global IgnoreReadOnlyProperties/Fields loses
+                    // Never = never ignore (always include), global IgnoreReadOnlyProperties/Fields loses
+                    bool serializeReadOnlyProperty = ignoreCondition != null || !IgnoreReadOnlyMember;
+                    if (!serializeReadOnlyProperty)
+                    {
+                        Get = null;
+                    }
+                }
+            }
+            else
+            {
+                if (Get == null && Set != null)
+                {
+                    // Collection properties with setters only are not supported.
+                    Set = null;
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -430,6 +430,7 @@ namespace System.Text.Json.Serialization.Metadata
                     break;
 
                 case JsonIgnoreCondition.Never:
+                    ShouldSerialize = ShouldSerializeIgnoreConditionNever;
                     break;
 
                 case JsonIgnoreCondition.Always:
@@ -458,6 +459,7 @@ namespace System.Text.Json.Serialization.Metadata
                     break;
             }
 
+            static bool ShouldSerializeIgnoreConditionNever(object _, T? value) => true;
             static bool ShouldSerializeIgnoreConditionAlways(object _, T? value) => false;
             static bool ShouldSerializeIgnoreWhenWritingDefault(object _, T? value)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -426,6 +426,9 @@ namespace System.Text.Json.Serialization.Metadata
 
             switch (ignoreCondition)
             {
+                case null:
+                    break;
+
                 case JsonIgnoreCondition.Never:
                     break;
 
@@ -450,37 +453,8 @@ namespace System.Text.Json.Serialization.Metadata
                     IgnoreDefaultValuesOnWrite = true;
                     break;
 
-                case not null:
+                default:
                     Debug.Fail($"Unknown value of JsonIgnoreCondition '{ignoreCondition}'");
-                    break;
-
-                case null:
-#pragma warning disable SYSLIB0020 // JsonSerializerOptions.IgnoreNullValues is obsolete
-                    if (Options.IgnoreNullValues)
-#pragma warning restore SYSLIB0020
-                    {
-                        Debug.Assert(Options.DefaultIgnoreCondition == JsonIgnoreCondition.Never);
-                        if (PropertyTypeCanBeNull)
-                        {
-                            ShouldSerialize = ShouldSerializeIgnoreWhenWritingDefault;
-                            IgnoreDefaultValuesOnWrite = true;
-                            IgnoreNullTokensOnRead = true;
-                        }
-                    }
-                    else if (Options.DefaultIgnoreCondition == JsonIgnoreCondition.WhenWritingNull)
-                    {
-                        if (PropertyTypeCanBeNull)
-                        {
-                            ShouldSerialize = ShouldSerializeIgnoreWhenWritingDefault;
-                            IgnoreDefaultValuesOnWrite = true;
-                        }
-                    }
-                    else if (Options.DefaultIgnoreCondition == JsonIgnoreCondition.WhenWritingDefault)
-                    {
-                        ShouldSerialize = ShouldSerializeIgnoreWhenWritingDefault;
-                        IgnoreDefaultValuesOnWrite = true;
-                    }
-
                     break;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -101,7 +101,7 @@ namespace System.Text.Json.Serialization.Metadata
             else if (predicate is Func<object, T?, bool> typedPredicate)
             {
                 _shouldSerializeTyped = typedPredicate;
-                _shouldSerialize = typedPredicate is Func<object, object?, bool> untypedPredicate ? untypedPredicate : (obj, value) => typedPredicate(obj, (T)value!);
+                _shouldSerialize = typedPredicate is Func<object, object?, bool> untypedPredicate ? untypedPredicate : (obj, value) => typedPredicate(obj, (T?)value);
             }
             else
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -209,9 +209,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             JsonPropertyInfo jsonPropertyInfo = CreatePropertyUsingReflection(typeToConvert, converter);
-            jsonPropertyInfo.IgnoreCondition = ignoreCondition;
-            jsonPropertyInfo.CustomConverter = customConverter;
-            jsonPropertyInfo.InitializeUsingMemberReflection(memberInfo);
+            jsonPropertyInfo.InitializeUsingMemberReflection(memberInfo, customConverter, ignoreCondition);
             return jsonPropertyInfo;
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
@@ -1037,10 +1037,19 @@ namespace System.Text.Json.Serialization.Tests
                         Assert.Null(property.Set);
                         break;
                     case JsonIgnoreCondition.WhenWritingDefault:
-                        TestIntIgnoreWhenWritingDefault();
+                        Assert.NotNull(property.ShouldSerialize);
+                        Assert.False(property.ShouldSerialize(null, 0));
+                        Assert.True(property.ShouldSerialize(null, 1));
+                        Assert.True(property.ShouldSerialize(null, -1));
+                        Assert.Throws<NullReferenceException>(() => property.ShouldSerialize(null, null));
+                        Assert.Throws<InvalidCastException>(() => property.ShouldSerialize(null, "string"));
                         break;
                     case JsonIgnoreCondition.WhenWritingNull:
-                        TestStringIgnoreWhenWritingDefault();
+                        Assert.NotNull(property.ShouldSerialize);
+                        Assert.False(property.ShouldSerialize(null, null));
+                        Assert.True(property.ShouldSerialize(null, ""));
+                        Assert.True(property.ShouldSerialize(null, "asd"));
+                        Assert.Throws<InvalidCastException>(() => property.ShouldSerialize(null, 0));
                         break;
                     case JsonIgnoreCondition.Never:
                         Assert.NotNull(property.ShouldSerialize);
@@ -1049,25 +1058,6 @@ namespace System.Text.Json.Serialization.Tests
                         Assert.True(property.ShouldSerialize(null, "asd"));
                         Assert.Throws<InvalidCastException>(() => property.ShouldSerialize(null, 0));
                         break;
-                }
-
-                void TestIntIgnoreWhenWritingDefault()
-                {
-                    Assert.NotNull(property.ShouldSerialize);
-                    Assert.False(property.ShouldSerialize(null, 0));
-                    Assert.True(property.ShouldSerialize(null, 1));
-                    Assert.True(property.ShouldSerialize(null, -1));
-                    Assert.Throws<NullReferenceException>(() => property.ShouldSerialize(null, null));
-                    Assert.Throws<InvalidCastException>(() => property.ShouldSerialize(null, "string"));
-                }
-
-                void TestStringIgnoreWhenWritingDefault()
-                {
-                    Assert.NotNull(property.ShouldSerialize);
-                    Assert.False(property.ShouldSerialize(null, null));
-                    Assert.True(property.ShouldSerialize(null, ""));
-                    Assert.True(property.ShouldSerialize(null, "asd"));
-                    Assert.Throws<InvalidCastException>(() => property.ShouldSerialize(null, 0));
                 }
 
                 if (modify != ModifyJsonIgnore.DontModify && ignoreConditionOnProperty == JsonIgnoreCondition.Always)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
@@ -1095,8 +1095,6 @@ namespace System.Text.Json.Serialization.Tests
                     Assert.True(property.ShouldSerialize(null, "asd"));
                     Assert.Throws<InvalidCastException>(() => property.ShouldSerialize(null, 0));
                 }
-
-
                 if (modify != ModifyJsonIgnore.DontModify && ignoreConditionOnProperty == JsonIgnoreCondition.Always)
                 {
                     property.Get = (o) => ((TestClassWithEveryPossibleJsonIgnore)o).AlwaysProperty;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
@@ -810,7 +810,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void DefaultIgnoreConditionFromOptionsDoesntFlowToShouldSerializePropertyAndOverrideIsRespected()
+        public static void DefaultIgnoreConditionFromOptionsFlowsToShouldSerializePropertyAndOverrideIsRespected()
         {
             TestClassWithNumber obj = new()
             {
@@ -823,7 +823,8 @@ namespace System.Text.Json.Serialization.Tests
                 if (ti.Type == typeof(TestClassWithNumber))
                 {
                     Assert.Equal(1, ti.Properties.Count);
-                    Assert.Null(ti.Properties[0].ShouldSerialize);
+                    Assert.NotNull(ti.Properties[0].ShouldSerialize);
+                    Assert.False(ti.Properties[0].ShouldSerialize(obj, 0));
                     ti.Properties[0].ShouldSerialize = (o, val) =>
                     {
                         Assert.Same(obj, o);
@@ -1019,40 +1020,82 @@ namespace System.Text.Json.Serialization.Tests
 
             static void TestJsonIgnoreConditionDelegate(JsonIgnoreCondition defaultIgnoreCondition, JsonIgnoreCondition? ignoreConditionOnProperty, JsonPropertyInfo property, ModifyJsonIgnore modify)
             {
-                // defaultIgnoreCondition is not taken into accound, we might expect null if defaultIgnoreCondition == ignoreConditionOnProperty
                 switch (ignoreConditionOnProperty)
                 {
-                    case null:
-                        Assert.Null(property.ShouldSerialize);
-                        break;
                     case JsonIgnoreCondition.Always:
                         Assert.NotNull(property.ShouldSerialize);
                         Assert.False(property.ShouldSerialize(null, null));
                         Assert.False(property.ShouldSerialize(null, ""));
                         Assert.False(property.ShouldSerialize(null, "asd"));
+                        Assert.Throws<InvalidCastException>(() => property.ShouldSerialize(null, 0));
 
                         Assert.Null(property.Get);
                         Assert.Null(property.Set);
                         break;
                     case JsonIgnoreCondition.WhenWritingDefault:
-                        Assert.NotNull(property.ShouldSerialize);
-                        Assert.False(property.ShouldSerialize(null, 0));
-                        Assert.True(property.ShouldSerialize(null, 1));
-                        Assert.True(property.ShouldSerialize(null, -1));
+                        TestIntIgnoreWhenWritingDefault();
                         break;
                     case JsonIgnoreCondition.WhenWritingNull:
-                        Assert.NotNull(property.ShouldSerialize);
-                        Assert.False(property.ShouldSerialize(null, null));
-                        Assert.True(property.ShouldSerialize(null, ""));
-                        Assert.True(property.ShouldSerialize(null, "asd"));
+                        TestStringIgnoreWhenWritingDefault();
                         break;
                     case JsonIgnoreCondition.Never:
-                        Assert.NotNull(property.ShouldSerialize);
-                        Assert.True(property.ShouldSerialize(null, null));
-                        Assert.True(property.ShouldSerialize(null, ""));
-                        Assert.True(property.ShouldSerialize(null, "asd"));
+                        Assert.Null(property.ShouldSerialize);
+                        break;
+
+                    case null:
+                        switch (defaultIgnoreCondition)
+                        {
+                            case JsonIgnoreCondition.WhenWritingDefault:
+                                if (property.PropertyType == typeof(int))
+                                {
+                                    TestIntIgnoreWhenWritingDefault();
+                                }
+                                else
+                                {
+                                    Assert.Equal(typeof(string), property.PropertyType);
+                                    TestStringIgnoreWhenWritingDefault();
+                                }
+                                break;
+
+                            case JsonIgnoreCondition.WhenWritingNull:
+                                if (property.PropertyType == typeof(int))
+                                {
+                                    Assert.Null(property.ShouldSerialize);
+                                }
+                                else
+                                {
+                                    Assert.Equal(typeof(string), property.PropertyType);
+                                    TestStringIgnoreWhenWritingDefault();
+                                }
+                                break;
+
+                            default:
+                                Assert.Null(property.ShouldSerialize);
+                                break;
+                        }
+
                         break;
                 }
+
+                void TestIntIgnoreWhenWritingDefault()
+                {
+                    Assert.NotNull(property.ShouldSerialize);
+                    Assert.False(property.ShouldSerialize(null, 0));
+                    Assert.True(property.ShouldSerialize(null, 1));
+                    Assert.True(property.ShouldSerialize(null, -1));
+                    Assert.Throws<NullReferenceException>(() => property.ShouldSerialize(null, null));
+                    Assert.Throws<InvalidCastException>(() => property.ShouldSerialize(null, "string"));
+                }
+
+                void TestStringIgnoreWhenWritingDefault()
+                {
+                    Assert.NotNull(property.ShouldSerialize);
+                    Assert.False(property.ShouldSerialize(null, null));
+                    Assert.True(property.ShouldSerialize(null, ""));
+                    Assert.True(property.ShouldSerialize(null, "asd"));
+                    Assert.Throws<InvalidCastException>(() => property.ShouldSerialize(null, 0));
+                }
+
 
                 if (modify != ModifyJsonIgnore.DontModify && ignoreConditionOnProperty == JsonIgnoreCondition.Always)
                 {
@@ -1443,6 +1486,246 @@ namespace System.Text.Json.Serialization.Tests
             [JsonInclude]
             public string Field;
             public int Property { get; set; }
+        }
+
+        [Fact]
+        public static void CanEnableDeserializationOnAlwaysIgnoreProperty()
+        {
+            var options = new JsonSerializerOptions
+            {
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
+                {
+                    Modifiers =
+                    {
+                        jsonTypeInfo =>
+                        {
+                            if (jsonTypeInfo.Type != typeof(ClassWithJsonIgnoreAlwaysProperty))
+                            {
+                                return;
+                            }
+
+                            Assert.Equal(1, jsonTypeInfo.Properties.Count);
+                            JsonPropertyInfo jsonPropertyInfo = jsonTypeInfo.Properties[0];
+
+                            Assert.NotNull(jsonPropertyInfo.ShouldSerialize);
+                            Assert.Null(jsonPropertyInfo.Get);
+                            Assert.Null(jsonPropertyInfo.Set);
+
+                            jsonPropertyInfo.Set = (obj, value) => ((ClassWithJsonIgnoreAlwaysProperty)obj).Value = (int)value;
+                        }
+                    }
+                }
+            };
+
+            ClassWithJsonIgnoreAlwaysProperty value = JsonSerializer.Deserialize<ClassWithJsonIgnoreAlwaysProperty>("""{"Value":42}""", options);
+            Assert.Equal(42, value.Value);
+        }
+
+        public class ClassWithJsonIgnoreAlwaysProperty
+        {
+            [JsonIgnore]
+            public int Value { get; set; }
+        }
+
+        [Theory]
+        [MemberData(nameof(ClassWithSetterOnlyCollectionProperty_SupportedWhenSetManually_MemberData))]
+        public static void ClassWithSetterOnlyCollectionProperty_SupportedWhenSetManually<T>(T value, string json)
+        {
+            _ = value; // parameter not used
+
+            string fullJson = $@"{{""Value"":{json}}}";
+
+            // sanity check: deserialization is not supported using the default contract
+            ClassWithSetterOnlyProperty<T> result = JsonSerializer.Deserialize<ClassWithSetterOnlyProperty<T>>(fullJson);
+            Assert.Null(result.GetValue());
+
+            var options = new JsonSerializerOptions
+            {
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
+                {
+                    Modifiers =
+                    {
+                        jsonTypeInfo =>
+                        {
+                            if (jsonTypeInfo.Type != typeof(ClassWithSetterOnlyProperty<T>))
+                            {
+                                return;
+                            }
+
+                            Assert.Equal(1, jsonTypeInfo.Properties.Count);
+
+                            JsonPropertyInfo jpi = jsonTypeInfo.Properties[0];
+                            Assert.Null(jpi.Set);
+                            jpi.Set = (obj, value) => ((ClassWithSetterOnlyProperty<T>)obj)._value = (T)value;
+                        }
+                    }
+                }
+            };
+
+            result = JsonSerializer.Deserialize<ClassWithSetterOnlyProperty<T>>(fullJson, options);
+            Assert.NotNull(result.GetValue());
+        }
+
+        public static IEnumerable<object[]> ClassWithSetterOnlyCollectionProperty_SupportedWhenSetManually_MemberData()
+        {
+            yield return Wrap(new List<int>(), "[1,2,3]");
+            yield return Wrap(new Dictionary<string, string>(), """{"key":"value"}""");
+
+            static object[] Wrap<T>(T value, string json) => new object[] { value, json };
+        }
+
+        public class ClassWithSetterOnlyProperty<T>
+        {
+            internal T _value;
+            public T Value { set => _value = value; }
+            public T GetValue() => _value;
+        }
+
+        [Fact]
+        public static void ClassWithReadOnlyMembers_SupportedWhenSetManually()
+        {
+            var value = new ClassWithReadOnlyMembers();
+
+            // Sanity check -- default contract does not support serialization
+            var options = new JsonSerializerOptions { IgnoreReadOnlyFields = true, IgnoreReadOnlyProperties = true };
+            string json = JsonSerializer.Serialize(value, options);
+            Assert.Equal("{}", json);
+
+            // Use a constract resolver that updates getters manually
+            options = new JsonSerializerOptions
+            {
+                IgnoreReadOnlyFields = true,
+                IgnoreReadOnlyProperties = true,
+
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
+                {
+                    Modifiers =
+                    {
+                        jsonTypeInfo =>
+                        {
+                            if (jsonTypeInfo.Type != typeof(ClassWithReadOnlyMembers))
+                            {
+                                return;
+                            }
+
+                            Assert.Equal(2, jsonTypeInfo.Properties.Count);
+
+                            JsonPropertyInfo jpi = jsonTypeInfo.Properties[0];
+                            Assert.Equal("Field", jpi.Name); // JsonPropertyOrder should ensure correct ordering of properties.
+                            Assert.Null(jpi.Get);
+                            jpi.Get = obj => ((ClassWithReadOnlyMembers)obj).Field;
+
+                            jpi = jsonTypeInfo.Properties[1];
+                            Assert.Equal("Property", jpi.Name); // JsonPropertyOrder should ensure correct ordering of properties.
+                            Assert.Null(jpi.Get);
+                            jpi.Get = obj => ((ClassWithReadOnlyMembers)obj).Property;
+                        }
+                    }
+                }
+            };
+
+            json = JsonSerializer.Serialize(value, options);
+            Assert.Equal("""{"Field":1,"Property":2}""", json);
+        }
+
+        public class ClassWithReadOnlyMembers
+        {
+            [JsonInclude, JsonPropertyOrder(0)]
+            public readonly int Field = 1;
+            [JsonPropertyOrder(1)]
+            public int Property => 2;
+        }
+
+        [Fact]
+        public static void IgnoreNullValues_Serialization_CanBeInvalidatedByCustomContracts()
+        {
+            var value = new ClassWithNullableProperty();
+
+            // Sanity check -- property is ignored using default contract
+            var options = new JsonSerializerOptions { IgnoreNullValues = true };
+            string json = JsonSerializer.Serialize(value, options);
+            Assert.Equal("{}", json);
+
+            // Property can be re-enabled using a custom contract
+            options = new JsonSerializerOptions
+            {
+                IgnoreNullValues = true,
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
+                {
+                    Modifiers =
+                    {
+                        jsonTypeInfo =>
+                        {
+                            if (jsonTypeInfo.Type != typeof(ClassWithNullableProperty))
+                            {
+                                return;
+                            }
+
+                            Assert.Equal(1, jsonTypeInfo.Properties.Count);
+
+                            JsonPropertyInfo jpi = jsonTypeInfo.Properties[0];
+                            Assert.NotNull(jpi.ShouldSerialize);
+                            Assert.False(jpi.ShouldSerialize(value, null));
+                            Assert.NotNull(jpi.Get);
+
+                            jpi.ShouldSerialize = null;
+                        }
+                    }
+                }
+            };
+
+            json = JsonSerializer.Serialize(value, options);
+            Assert.Equal("""{"Value":null}""", json);
+        }
+
+        [Fact]
+        public static void IgnoreNullValues_Deserialization_CanBeInvalidatedByCustomContracts()
+        {
+            string json = """{"Value":null}""";
+
+            // Sanity check -- property is ignored using default contract
+            var options = new JsonSerializerOptions { IgnoreNullValues = true };
+            ClassWithNullableProperty value = JsonSerializer.Deserialize<ClassWithNullableProperty>(json, options);
+            Assert.Null(value.Value);
+
+            // Property can be re-enabled using a custom contract
+            options = new JsonSerializerOptions
+            {
+                IgnoreNullValues = true,
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
+                {
+                    Modifiers =
+                    {
+                        jsonTypeInfo =>
+                        {
+                            if (jsonTypeInfo.Type != typeof(ClassWithNullableProperty))
+                            {
+                                return;
+                            }
+
+                            Assert.Equal(1, jsonTypeInfo.Properties.Count);
+
+                            JsonPropertyInfo jpi = jsonTypeInfo.Properties[0];
+                            Assert.NotNull(jpi.Set);
+                            jpi.Set = (obj, value) => ((ClassWithNullableProperty)obj).Value = (string)value;
+                        }
+                    }
+                }
+            };
+
+            value = JsonSerializer.Deserialize<ClassWithNullableProperty>(json, options);
+            Assert.Equal("NULL", value.Value);
+        }
+
+        public class ClassWithNullableProperty
+        {
+            private string? _value;
+
+            public string? Value
+            {
+                get => _value;
+                set => _value = value ?? "NULL";
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
@@ -1043,7 +1043,11 @@ namespace System.Text.Json.Serialization.Tests
                         TestStringIgnoreWhenWritingDefault();
                         break;
                     case JsonIgnoreCondition.Never:
-                        Assert.Null(property.ShouldSerialize);
+                        Assert.NotNull(property.ShouldSerialize);
+                        Assert.True(property.ShouldSerialize(null, null));
+                        Assert.True(property.ShouldSerialize(null, ""));
+                        Assert.True(property.ShouldSerialize(null, "asd"));
+                        Assert.Throws<InvalidCastException>(() => property.ShouldSerialize(null, 0));
                         break;
                 }
 
@@ -1065,6 +1069,7 @@ namespace System.Text.Json.Serialization.Tests
                     Assert.True(property.ShouldSerialize(null, "asd"));
                     Assert.Throws<InvalidCastException>(() => property.ShouldSerialize(null, 0));
                 }
+
                 if (modify != ModifyJsonIgnore.DontModify && ignoreConditionOnProperty == JsonIgnoreCondition.Always)
                 {
                     property.Get = (o) => ((TestClassWithEveryPossibleJsonIgnore)o).AlwaysProperty;


### PR DESCRIPTION
When populating `JsonPropertyInfo` metadata, the default System.Text.Json contract resolvers will consult the value of the `JsonIgnoreCondition` setting to determine the value of the `Get`, `Set` and `ShouldSerialize` properties in the property metadata. While these values are mapped correctly when surfaced to the user, the `JsonPropertyInfo` implementation will also store a copy of the original `JsonIgnoreCondition` setting and consult it further during the final configuration stage of the metadata. In certain cases, this can result in user configuration being silently discarded (see #71886 for an example). 

This PR:

1. Changes the implementation so that `Get`, `Set` and `ShouldSerialize` delegates become the sole source of truth when determining the ignore policy. Any additional internal state used as performance optimization will get invalidated once the user applies relevant custom delegates.
2. Moves the ignore policy resolution logic to the metadata creation phase, and away from the final `Configure` phase. This includes consultation of `JsonSerializerOptions.DefaultIgnoreCondition` and `IgnoreNullValue` settings which can now be unset by a custom contract on a type-by-type basis. For completeness, the `JsonSerializerOptions.DefaultIgnoreCondition`  and `IgnoreNullValue` settings will now also map to `ShouldSerialize`.
3. Makes the `ShouldSerialize` delegate implementation strongly typed in the style of `Get` and `Set`. This should prevent some unnecessary boxing when serializing properties with value types.
4. `JsonIgnoreCondition.Never` now maps to a `null` value for `ShouldSerialize`, giving it an equivalent representation to a null ignore condition.

Fix #71886.