### PR TITLE
Disable SYSLIB1045 for System.Text.RegularExpressions.Tests

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
@@ -3,7 +3,8 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <!-- xUnit2008 is about regexes and isn't appropriate in the test project for regexes -->
     <!-- SYSLIB0036 is about obsoletion of regex members -->
-    <NoWarn>$(NoWarn);xUnit2008;SYSLIB0036</NoWarn>
+    <!-- SYSLIB1046 is for switching to RegexGenerator -->
+    <NoWarn>$(NoWarn);xUnit2008;SYSLIB0036;SYSLIB1046</NoWarn>
     <TargetFrameworks>$(NetCoreAppCurrent);net48</TargetFrameworks>
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'Browser'">true</DebuggerSupport>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>


### PR DESCRIPTION
We explicitly want to test Regex's ctors and static methods in the Regex tests.