### PR TITLE
[wasm] fix Debug configuration compilation

### DIFF
--- a/src/mono/wasm/runtime/buffers.ts
+++ b/src/mono/wasm/runtime/buffers.ts
@@ -61,8 +61,8 @@ function typedarray_copy_to(typed_array: TypedArray, pinned_array: MonoArray, be
     // split the implementation into buffers and views. A buffer (implemented by the ArrayBuffer object)
     //  is an object representing a chunk of data; it has no format to speak of, and offers no
     // mechanism for accessing its contents. In order to access the memory contained in a buffer,
-    // you need to use a view. A view provides a context — that is, a data type, starting offset,
-    // and number of elements — that turns the data into an actual typed array.
+    // you need to use a view. A view provides a context - that is, a data type, starting offset,
+    // and number of elements - that turns the data into an actual typed array.
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays
     if (has_backing_array_buffer(typed_array) && typed_array.BYTES_PER_ELEMENT) {
         // Some sanity checks of what is being asked of us
@@ -104,8 +104,8 @@ function typedarray_copy_from(typed_array: TypedArray, pinned_array: MonoArray, 
     // split the implementation into buffers and views. A buffer (implemented by the ArrayBuffer object)
     //  is an object representing a chunk of data; it has no format to speak of, and offers no
     // mechanism for accessing its contents. In order to access the memory contained in a buffer,
-    // you need to use a view. A view provides a context — that is, a data type, starting offset,
-    // and number of elements — that turns the data into an actual typed array.
+    // you need to use a view. A view provides a context - that is, a data type, starting offset,
+    // and number of elements - that turns the data into an actual typed array.
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays
     if (has_backing_array_buffer(typed_array) && typed_array.BYTES_PER_ELEMENT) {
         // Some sanity checks of what is being asked of us

--- a/src/mono/wasm/runtime/js-to-cs.ts
+++ b/src/mono/wasm/runtime/js-to-cs.ts
@@ -168,8 +168,8 @@ export function js_typed_array_to_array_root(js_obj: any, result: WasmRoot<MonoA
     // split the implementation into buffers and views. A buffer (implemented by the ArrayBuffer object)
     //  is an object representing a chunk of data; it has no format to speak of, and offers no
     // mechanism for accessing its contents. In order to access the memory contained in a buffer,
-    // you need to use a view. A view provides a context — that is, a data type, starting offset,
-    // and number of elements — that turns the data into an actual typed array.
+    // you need to use a view. A view provides a context - that is, a data type, starting offset,
+    // and number of elements - that turns the data into an actual typed array.
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays
     if (has_backing_array_buffer(js_obj) && js_obj.BYTES_PER_ELEMENT) {
         const arrayType = js_obj[wasm_type_symbol];

--- a/src/mono/wasm/runtime/polyfills.ts
+++ b/src/mono/wasm/runtime/polyfills.ts
@@ -118,7 +118,7 @@ export async function fetch_like(url: string): Promise<Response> {
             return globalThis.fetch(url, { credentials: "same-origin" });
         }
         else if (typeof (read) === "function") {
-            // note that it can't open files with unicode names, like Straße.xml
+            // note that it can't open files with unicode names, like Stra<unicode char - Latin Small Letter Sharp S>e.xml
             // https://bugs.chromium.org/p/v8/issues/detail?id=12541
             const arrayBuffer = new Uint8Array(read(url, "binary"));
             return <Response><any>{


### PR DESCRIPTION
Current emcc compiler has problems with unicode chars in JS comments.
Update our sources as workaround, before we have better solution.