### PR TITLE
Fix the type check in `fgMorphMultiregStructArg`

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3692,7 +3692,7 @@ GenTree* Compiler::fgMorphMultiregStructArg(CallArg* arg)
 
             if (location->OperIsLocalRead())
             {
-                if (!location->OperIs(GT_LCL_VAR) ||
+                if (!location->OperIs(GT_LCL_VAR) || (location->TypeGet() != argObj->TypeGet()) ||
                     !ClassLayout::AreCompatible(lvaGetDesc(location->AsLclVarCommon())->GetLayout(), layout))
                 {
                     unsigned lclOffset = location->AsLclVarCommon()->GetLclOffs();


### PR DESCRIPTION
We cannot assume the underlying local has a layout.

Fixes #71915.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1871946&view=ms.vss-build-web.run-extensions-tab).