### PR TITLE
Update wasm related README

### DIFF
--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -188,7 +188,7 @@ Example use of the `wasmconsole` template:
     > dotnet new wasmconsole
     > dotnet publish
     > cd bin/Debug/net7.0/browser-wasm/AppBundle
-    > node main.cjs
+    > node main.mjs
     mono_wasm_runtime_ready fe00e07a-5519-4dfe-b35a-f867dbaf2e28
     Hello World!
     Args:

--- a/src/mono/wasm/templates/templates/console/README.md
+++ b/src/mono/wasm/templates/templates/console/README.md
@@ -1,7 +1,7 @@
-Node/CommonJS console App
+Node/ES Modules console App
 
 Run the published application like:
 
-    node main.cjs
+    node main.mjs
 
 in `bin/$(Configuration)/net7.0/browser-wasm/AppBundle` directory.


### PR DESCRIPTION
ref: https://github.com/dotnet/runtime/pull/70746

The above mentioned PR changed the default modules to es6.
I have applied its contents to README.

