### PR TITLE
Remove android special case from eng/native/naming.props

### DIFF
--- a/eng/native/naming.props
+++ b/eng/native/naming.props
@@ -21,15 +21,6 @@
         <SymbolsSuffix>.dwarf</SymbolsSuffix>
       </PropertyGroup>
     </When>
-    <When Condition="$(PackageRID.StartsWith('android'))">
-      <PropertyGroup>
-        <LibPrefix>lib</LibPrefix>
-        <LibSuffix>.so</LibSuffix>
-        <StaticLibSuffix>.a</StaticLibSuffix>
-        <!--symbols included in .so, like Linux, but can be generated externally and if so, uses .debug ext-->
-        <SymbolsSuffix>.debug</SymbolsSuffix>
-      </PropertyGroup>
-    </When>
     <Otherwise>
       <PropertyGroup>
         <LibPrefix>lib</LibPrefix>


### PR DESCRIPTION
The only difference between the Android and the "Other" case is the SymbolsSuffix .debug instead of .dbg which was added a long time ago in the old CoreCLR Android port:  https://github.com/dotnet/runtime/commit/239186ae975de5cf735d80540db6fe1907126a5b

We only ever used .dbg extension for the Android symbols (like Linux) in the Mono Android port.