### PR TITLE
Use `-unicode` instead of `/unicode` for linux ildasm roundtrip tests

### DIFF
--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -52,8 +52,8 @@ export RunningIlasmRoundTrip=
 
 if [ -z "$DoLink" -a ! -z "$RunningIlasmRoundTrip" ];
 then
-  echo "$CORE_ROOT/ildasm" -raweh /unicode -out=$(DisassemblyName) $(InputAssemblyName)
-  "$CORE_ROOT/ildasm" -raweh /unicode -out=$(DisassemblyName) $(InputAssemblyName)
+  echo "$CORE_ROOT/ildasm" -raweh -unicode -out=$(DisassemblyName) $(InputAssemblyName)
+  "$CORE_ROOT/ildasm" -raweh -unicode -out=$(DisassemblyName) $(InputAssemblyName)
   ERRORLEVEL=$?
   if [ $ERRORLEVEL -ne 0 ]
   then


### PR DESCRIPTION
Use `-unicode` instead of `/unicode` for linux ildasm roundtrip tests