### PR TITLE
Add test which reproduces but in complex framework resolution

### DIFF
--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/ComplexHierarchies.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/ComplexHierarchies.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
+using System;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
+{
+    public class ComplexHierarchies :
+        FrameworkResolutionBase,
+        IClassFixture<ComplexHierarchies.SharedTestState>
+    {
+        private SharedTestState SharedState { get; }
+
+        public ComplexHierarchies(SharedTestState sharedState)
+        {
+            SharedState = sharedState;
+        }
+
+        public class SharedTestState : SharedTestStateBase
+        {
+            public TestApp FrameworkReferenceApp { get; }
+
+            public DotNetCli DotNetWithMultipleFrameworks { get; }
+
+            public SharedTestState()
+            {
+                DotNetWithMultipleFrameworks = DotNet("DotNetWithMultipleFrameworks")
+                    .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("5.1.1")
+                    .AddFramework("MiddleWare", "2.1.2", runtimeConfig =>
+                        runtimeConfig.WithFramework(MicrosoftNETCoreApp, "5.1.1"))
+                    .AddFramework("SerializerWare", "3.0.1", runtimeConfig =>
+                        runtimeConfig
+                            .WithFramework(MicrosoftNETCoreApp, "5.1.0")
+                            .WithFramework("MiddleWare", "2.1.0"))
+                    .AddFramework("OMWare", "7.3.1", runtimeConfig =>
+                        runtimeConfig
+                            .WithFramework(MicrosoftNETCoreApp, "5.1.0")
+                            .WithFramework("MiddleWare", "2.1.0"))
+                    .Build();
+
+                FrameworkReferenceApp = CreateFrameworkReferenceApp();
+            }
+        }
+
+        [Fact]
+        public void TwoAppFrameworksOnTopOfMiddleWare()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.0")
+                    .WithFramework("MiddleWare", "2.1.0")
+                    .WithFramework("SerializerWare", "3.0.1")
+                    .WithFramework("OMWare", "7.3.1"))
+                // https://github.com/dotnet/runtime/issues/71027
+                // This should pass just fine and resolve all frameworks correctly
+                // Currently it fails because it does resolve frameworks, but incorrectly
+                // looks for hostpolicy in MiddleWare, instead of Microsoft.NETCore.App.
+                .Should().Fail().And.HaveStdErrContaining("hostpolicy");
+                //.ShouldHaveResolvedFramework(
+                //    MicrosoftNETCoreApp, "5.1.1")
+                //.And.HaveResolvedFramework("MiddleWare", "2.1.")
+                //.And.HaveResolvedFramework("SerializerWare", "3.0.1")
+                //.And.HaveResolvedFramework("OMWare", "7.3.1");
+        }
+
+        private CommandResult RunTest(
+            Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
+            Action<DotNetCliExtensions.DotNetCliCustomizer> customizeDotNet = null,
+            bool rollForwardToPreRelease = false)
+        {
+            return RunTest(
+                SharedState.DotNetWithMultipleFrameworks,
+                SharedState.FrameworkReferenceApp,
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig)
+                    .WithDotnetCustomizer(customizeDotNet)
+                    .WithEnvironment(Constants.RollForwardToPreRelease.EnvironmentVariable, rollForwardToPreRelease ? "1" : "0"));
+        }
+    }
+}


### PR DESCRIPTION
The problem is if there is a high-level framework which lists its dependencies as for example NETCore.App first and then ASPNET.App. When we reorder the frameworks during resolution we try to put the lowest level last, but the reorder doesn't work if there's a high-level framework which depends on middle one last - as the last resolved framework in that scenario will be the middle one (ASPNET.App) and it will end up last in the list.

The code assumes the last framework is the root (NETCore.App) and thus we look for hostpolicy there.

This test is a repro of https://github.com/dotnet/runtime/issues/71027
I'm adding this as "failing" (the failing part is commented out) so that we have a in-house, simpler repro of the problem.