### PR TITLE
add CertificateChainPolicy to ssl options

### DIFF
--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -196,6 +196,7 @@ namespace System.Net.Security
         public System.Net.Security.LocalCertificateSelectionCallback? LocalCertificateSelectionCallback { get { throw null; } set { } }
         public System.Net.Security.RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get { throw null; } set { } }
         public string? TargetHost { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509ChainPolicy? ValidationPolicy { get { throw null; } set { } }
     }
     public readonly partial struct SslClientHelloInfo
     {
@@ -218,6 +219,7 @@ namespace System.Net.Security
         public System.Security.Cryptography.X509Certificates.X509Certificate? ServerCertificate { get { throw null; } set { } }
         public System.Net.Security.SslStreamCertificateContext? ServerCertificateContext { get { throw null; } set { } }
         public System.Net.Security.ServerCertificateSelectionCallback? ServerCertificateSelectionCallback { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509ChainPolicy? ValidationPolicy { get { throw null; } set { } }
     }
     public partial class SslStream : System.Net.Security.AuthenticatedStream
     {

--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -196,7 +196,7 @@ namespace System.Net.Security
         public System.Net.Security.LocalCertificateSelectionCallback? LocalCertificateSelectionCallback { get { throw null; } set { } }
         public System.Net.Security.RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get { throw null; } set { } }
         public string? TargetHost { get { throw null; } set { } }
-        public System.Security.Cryptography.X509Certificates.X509ChainPolicy? ValidationPolicy { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509ChainPolicy? CertificateChainPolicy { get { throw null; } set { } }
     }
     public readonly partial struct SslClientHelloInfo
     {
@@ -219,7 +219,7 @@ namespace System.Net.Security
         public System.Security.Cryptography.X509Certificates.X509Certificate? ServerCertificate { get { throw null; } set { } }
         public System.Net.Security.SslStreamCertificateContext? ServerCertificateContext { get { throw null; } set { } }
         public System.Net.Security.ServerCertificateSelectionCallback? ServerCertificateSelectionCallback { get { throw null; } set { } }
-        public System.Security.Cryptography.X509Certificates.X509ChainPolicy? ValidationPolicy { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509ChainPolicy? CertificateChainPolicy { get { throw null; } set { } }
     }
     public partial class SslStream : System.Net.Security.AuthenticatedStream
     {

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
@@ -44,7 +44,8 @@ namespace System.Net
         private static X509Certificate2? GetRemoteCertificate(
             SafeDeleteContext? securityContext,
             bool retrieveChainCertificates,
-            ref X509Chain? chain)
+            ref X509Chain? chain,
+            X509ChainPolicy? chainPolicy)
         {
             SafeSslHandle? sslContext = ((SafeDeleteSslContext?)securityContext)?.SslContext;
             if (sslContext == null)
@@ -65,6 +66,10 @@ namespace System.Net
             else
             {
                 chain ??= new X509Chain();
+                if (chainPolicy != null)
+                {
+                    chain.ChainPolicy = chainPolicy;
+                }
                 IntPtr[]? ptrs = Interop.AndroidCrypto.SSLStreamGetPeerCertificates(sslContext);
                 if (ptrs != null && ptrs.Length > 0)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
@@ -50,7 +50,8 @@ namespace System.Net
         private static X509Certificate2? GetRemoteCertificate(
             SafeDeleteContext? securityContext,
             bool retrieveChainCertificates,
-            ref X509Chain? chain)
+            ref X509Chain? chain,
+            X509ChainPolicy? chainPolicy)
         {
             if (securityContext == null)
             {
@@ -73,6 +74,10 @@ namespace System.Net
                 if (retrieveChainCertificates)
                 {
                     chain ??= new X509Chain();
+                    if (chainPolicy != null)
+                    {
+                        chain.ChainPolicy = chainPolicy;
+                    }
 
                     for (int i = 0; i < chainSize; i++)
                     {

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -24,7 +24,11 @@ namespace System.Net
         //
         // Extracts a remote certificate upon request.
         //
-        private static X509Certificate2? GetRemoteCertificate(SafeDeleteContext? securityContext, bool retrieveChainCertificates, ref X509Chain? chain)
+        private static X509Certificate2? GetRemoteCertificate(
+            SafeDeleteContext? securityContext,
+            bool retrieveChainCertificates,
+            ref X509Chain? chain,
+            X509ChainPolicy? chainPolicy)
         {
             bool gotReference = false;
 
@@ -48,6 +52,10 @@ namespace System.Net
                 if (retrieveChainCertificates)
                 {
                     chain ??= new X509Chain();
+                    if (chainPolicy != null)
+                    {
+                        chain.ChainPolicy = chainPolicy;
+                    }
 
                     using (SafeSharedX509StackHandle chainStack =
                         Interop.OpenSsl.GetPeerCertificateChain(((SafeDeleteSslContext)securityContext).SslContext))

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -29,7 +29,10 @@ namespace System.Net
         //
 
         private static X509Certificate2? GetRemoteCertificate(
-            SafeDeleteContext? securityContext, bool retrieveChainCertificates, ref X509Chain? chain)
+            SafeDeleteContext? securityContext,
+            bool retrieveChainCertificates,
+            ref X509Chain? chain,
+            X509ChainPolicy? chainPolicy)
         {
             if (securityContext == null)
             {
@@ -67,6 +70,10 @@ namespace System.Net
                     if (retrieveChainCertificates)
                     {
                         chain ??= new X509Chain();
+                        if (chainPolicy != null)
+                        {
+                            chain.ChainPolicy = chainPolicy;
+                        }
 
                         UnmanagedCertificateContext.GetRemoteCertificatesFromStoreContext(remoteContext, chain.ChainPolicy.ExtraStore);
                     }

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
@@ -19,10 +19,10 @@ namespace System.Net
         private static X509Chain? s_chain;
 
         internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext? securityContext) =>
-            GetRemoteCertificate(securityContext, retrieveChainCertificates: false, ref s_chain);
+            GetRemoteCertificate(securityContext, retrieveChainCertificates: false, ref s_chain, null);
 
-        internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext? securityContext, ref X509Chain? chain) =>
-            GetRemoteCertificate(securityContext, retrieveChainCertificates: true, ref chain);
+        internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext? securityContext, ref X509Chain? chain, X509ChainPolicy? chainPolicy) =>
+            GetRemoteCertificate(securityContext, retrieveChainCertificates: true, ref chain, chainPolicy);
 
         static partial void CheckSupportsStore(StoreLocation storeLocation, ref bool hasSupport);
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -56,6 +56,11 @@ namespace System.Net.Security
             CertificateRevocationCheckMode = sslClientAuthenticationOptions.CertificateRevocationCheckMode;
             ClientCertificates = sslClientAuthenticationOptions.ClientCertificates;
             CipherSuitesPolicy = sslClientAuthenticationOptions.CipherSuitesPolicy;
+
+            if (sslClientAuthenticationOptions.ValidationPolicy != null)
+            {
+                ValidationPolicy = sslClientAuthenticationOptions.ValidationPolicy.Clone();
+            }
         }
 
         internal void UpdateOptions(ServerOptionsSelectionCallback optionCallback, object? state)
@@ -135,6 +140,11 @@ namespace System.Net.Security
             {
                 ServerCertSelectionDelegate = sslServerAuthenticationOptions.ServerCertificateSelectionCallback;
             }
+
+            if (sslServerAuthenticationOptions.ValidationPolicy != null)
+            {
+                ValidationPolicy = sslServerAuthenticationOptions.ValidationPolicy.Clone();
+            }
         }
 
         private static SslProtocols FilterOutIncompatibleSslProtocols(SslProtocols protocols)
@@ -170,5 +180,6 @@ namespace System.Net.Security
         internal CipherSuitesPolicy? CipherSuitesPolicy { get; set; }
         internal object? UserState { get; set; }
         internal ServerOptionsSelectionCallback? ServerOptionDelegate { get; set; }
+        internal X509ChainPolicy? ValidationPolicy { get; set; }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -57,9 +57,9 @@ namespace System.Net.Security
             ClientCertificates = sslClientAuthenticationOptions.ClientCertificates;
             CipherSuitesPolicy = sslClientAuthenticationOptions.CipherSuitesPolicy;
 
-            if (sslClientAuthenticationOptions.ValidationPolicy != null)
+            if (sslClientAuthenticationOptions.CertificateChainPolicy != null)
             {
-                ValidationPolicy = sslClientAuthenticationOptions.ValidationPolicy.Clone();
+                CertificateChainPolicy = sslClientAuthenticationOptions.CertificateChainPolicy.Clone();
             }
         }
 
@@ -141,9 +141,9 @@ namespace System.Net.Security
                 ServerCertSelectionDelegate = sslServerAuthenticationOptions.ServerCertificateSelectionCallback;
             }
 
-            if (sslServerAuthenticationOptions.ValidationPolicy != null)
+            if (sslServerAuthenticationOptions.CertificateChainPolicy != null)
             {
-                ValidationPolicy = sslServerAuthenticationOptions.ValidationPolicy.Clone();
+                CertificateChainPolicy = sslServerAuthenticationOptions.CertificateChainPolicy.Clone();
             }
         }
 
@@ -180,6 +180,6 @@ namespace System.Net.Security
         internal CipherSuitesPolicy? CipherSuitesPolicy { get; set; }
         internal object? UserState { get; set; }
         internal ServerOptionsSelectionCallback? ServerOptionDelegate { get; set; }
-        internal X509ChainPolicy? ValidationPolicy { get; set; }
+        internal X509ChainPolicy? CertificateChainPolicy { get; set; }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
@@ -76,7 +76,9 @@ namespace System.Net.Security
 
         /// <summary>
         /// Specifies X509ChainPolicy to use for remote certificate
-        /// validation. If set, CertificateRevocationCheckMode and SslCertificateTrust is ignored.
+        /// validation. If not <see langword="null"/>,
+        /// <see cref="CertificateRevocationCheckMode"/> and <see cref="SslCertificateTrust"/>
+        /// are ignored.
         /// </summary>
         public X509ChainPolicy? ValidationPolicy { get; set; }
     }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
@@ -75,7 +75,7 @@ namespace System.Net.Security
         public CipherSuitesPolicy? CipherSuitesPolicy { get; set; }
 
         /// <summary>
-        /// Specifies X509ChainPolicy to use for remote certificate
+        /// Gets or sets an optional customized policy for remote certificate
         /// validation. If not <see langword="null"/>,
         /// <see cref="CertificateRevocationCheckMode"/> and <see cref="SslCertificateTrust"/>
         /// are ignored.

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
@@ -80,6 +80,6 @@ namespace System.Net.Security
         /// <see cref="CertificateRevocationCheckMode"/> and <see cref="SslCertificateTrust"/>
         /// are ignored.
         /// </summary>
-        public X509ChainPolicy? ValidationPolicy { get; set; }
+        public X509ChainPolicy? CertificateChainPolicy { get; set; }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
@@ -73,5 +73,11 @@ namespace System.Net.Security
         /// Use extreme caution when changing this setting.
         /// </summary>
         public CipherSuitesPolicy? CipherSuitesPolicy { get; set; }
+
+        /// <summary>
+        /// Specifies X509ChainPolicy to use for remote certificate
+        /// validation. If set, CertificateRevocationCheckMode and SslCertificateTrust is ignored.
+        /// </summary>
+        public X509ChainPolicy? ValidationPolicy { get; set; }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
@@ -76,9 +76,11 @@ namespace System.Net.Security
         public CipherSuitesPolicy? CipherSuitesPolicy { get; set; }
 
         /// <summary>
-        /// Specifies X509ChainPolicy to use for remote certificate
-        /// validation. If set, CertificateRevocationCheckMode and SslCertificateTrust is ignored.
+        /// Gets or sets an optional customized policy for remote certificate
+        /// validation. If not <see langword="null"/>,
+        /// <see cref="CertificateRevocationCheckMode"/> and <see cref="SslCertificateTrust"/>
+        /// are ignored.
         /// </summary>
-        public X509ChainPolicy? ValidationPolicy { get; set; }
+        public X509ChainPolicy? CertificateChainPolicy { get; set; }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
@@ -74,5 +74,11 @@ namespace System.Net.Security
         /// Use extreme caution when changing this setting.
         /// </summary>
         public CipherSuitesPolicy? CipherSuitesPolicy { get; set; }
+
+        /// <summary>
+        /// Specifies X509ChainPolicy to use for remote certificate
+        /// validation. If set, CertificateRevocationCheckMode and SslCertificateTrust is ignored.
+        /// </summary>
+        public X509ChainPolicy? ValidationPolicy { get; set; }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -925,7 +925,7 @@ namespace System.Net.Security
 
             try
             {
-                X509Certificate2? certificate = CertificateValidationPal.GetRemoteCertificate(_securityContext, ref chain, _sslAuthenticationOptions.ValidationPolicy);
+                X509Certificate2? certificate = CertificateValidationPal.GetRemoteCertificate(_securityContext, ref chain, _sslAuthenticationOptions.CertificateChainPolicy);
                 if (_remoteCertificate != null && certificate != null &&
                     certificate.RawDataMemory.Span.SequenceEqual(_remoteCertificate.RawDataMemory.Span))
                 {
@@ -945,14 +945,9 @@ namespace System.Net.Security
                 {
                     chain ??= new X509Chain();
 
-                    if (_sslAuthenticationOptions.ValidationPolicy != null)
+                    if (_sslAuthenticationOptions.CertificateChainPolicy != null)
                     {
-                        chain.ChainPolicy = _sslAuthenticationOptions.ValidationPolicy;
-                        if (_sslAuthenticationOptions.ValidationPolicy.VerificationTimeIgnored)
-                        {
-                            // Update VerificationTime to 'Now' unless explicitly set for whatever reason.
-                            chain.ChainPolicy.VerificationTime = DateTime.Now;
-                        }
+                        chain.ChainPolicy = _sslAuthenticationOptions.CertificateChainPolicy;
                     }
                     else
                     {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
@@ -67,7 +67,7 @@ namespace System.Net.Security.Tests
                         LocalCertificateSelectionCallback = clientLocalCallback,
                         RemoteCertificateValidationCallback = clientRemoteCallback,
                         TargetHost = clientHost,
-                        ValidationPolicy = policy
+                        CertificateChainPolicy = policy,
                     };
 
                     // Create server options
@@ -82,7 +82,7 @@ namespace System.Net.Security.Tests
                         RemoteCertificateValidationCallback = serverRemoteCallback,
                         ServerCertificate = serverCert,
                         ServerCertificateContext = certificateContext,
-                        ValidationPolicy = policy
+                        CertificateChainPolicy = policy,
                     };
 
                     // Authenticate
@@ -103,7 +103,7 @@ namespace System.Net.Security.Tests
                     Assert.Same(clientRemoteCallback, clientOptions.RemoteCertificateValidationCallback);
                     Assert.Same(clientHost, clientOptions.TargetHost);
                     Assert.Same(clientHost, clientOptions.TargetHost);
-                    Assert.Same(policy, clientOptions.ValidationPolicy);
+                    Assert.Same(policy, clientOptions.CertificateChainPolicy);
 
                     // Validate that server options are unchanged
                     Assert.Equal(serverAllowRenegotiation, serverOptions.AllowRenegotiation);
@@ -116,7 +116,7 @@ namespace System.Net.Security.Tests
                     Assert.Same(serverRemoteCallback, serverOptions.RemoteCertificateValidationCallback);
                     Assert.Same(serverCert, serverOptions.ServerCertificate);
                     Assert.Same(certificateContext, serverOptions.ServerCertificateContext);
-                    Assert.Same(policy, serverOptions.ValidationPolicy);
+                    Assert.Same(policy, serverOptions.CertificateChainPolicy);
                 }
             }
         }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
@@ -49,6 +49,7 @@ namespace System.Net.Security.Tests
 #pragma warning restore SYSLIB0040
                 RemoteCertificateValidationCallback serverRemoteCallback = new RemoteCertificateValidationCallback(delegate { return true; });
                 SslStreamCertificateContext certificateContext = SslStreamCertificateContext.Create(serverCert, null, false);
+                X509ChainPolicy policy = new X509ChainPolicy();
 
                 (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
                 using (var client = new SslStream(stream1))
@@ -65,7 +66,8 @@ namespace System.Net.Security.Tests
                         EncryptionPolicy = clientEncryption,
                         LocalCertificateSelectionCallback = clientLocalCallback,
                         RemoteCertificateValidationCallback = clientRemoteCallback,
-                        TargetHost = clientHost
+                        TargetHost = clientHost,
+                        ValidationPolicy = policy
                     };
 
                     // Create server options
@@ -80,6 +82,7 @@ namespace System.Net.Security.Tests
                         RemoteCertificateValidationCallback = serverRemoteCallback,
                         ServerCertificate = serverCert,
                         ServerCertificateContext = certificateContext,
+                        ValidationPolicy = policy
                     };
 
                     // Authenticate
@@ -99,6 +102,8 @@ namespace System.Net.Security.Tests
                     Assert.Same(clientLocalCallback, clientOptions.LocalCertificateSelectionCallback);
                     Assert.Same(clientRemoteCallback, clientOptions.RemoteCertificateValidationCallback);
                     Assert.Same(clientHost, clientOptions.TargetHost);
+                    Assert.Same(clientHost, clientOptions.TargetHost);
+                    Assert.Same(policy, clientOptions.ValidationPolicy);
 
                     // Validate that server options are unchanged
                     Assert.Equal(serverAllowRenegotiation, serverOptions.AllowRenegotiation);
@@ -111,6 +116,7 @@ namespace System.Net.Security.Tests
                     Assert.Same(serverRemoteCallback, serverOptions.RemoteCertificateValidationCallback);
                     Assert.Same(serverCert, serverOptions.ServerCertificate);
                     Assert.Same(certificateContext, serverOptions.ServerCertificateContext);
+                    Assert.Same(policy, serverOptions.ValidationPolicy);
                 }
             }
         }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -750,16 +750,16 @@ namespace System.Net.Security.Tests
             int split = Random.Shared.Next(0, certificates.serverChain.Count - 1);
 
             var clientOptions = new SslClientAuthenticationOptions() { TargetHost = "localhost" };
-            clientOptions.ValidationPolicy = new X509ChainPolicy() { RevocationMode = X509RevocationMode.NoCheck,
+            clientOptions.CertificateChainPolicy = new X509ChainPolicy() { RevocationMode = X509RevocationMode.NoCheck,
                                                                      TrustMode = X509ChainTrustMode.CustomRootTrust };
-            clientOptions.ValidationPolicy.CustomTrustStore.Add(certificates.serverChain[certificates.serverChain.Count - 1]);
+            clientOptions.CertificateChainPolicy.CustomTrustStore.Add(certificates.serverChain[certificates.serverChain.Count - 1]);
             // Add only one CA to verify that peer did send intermediate CA cert.
             // In case of partial chain, we need to make missing certs available.
             if (usePartialChain)
             {
                 for (int i = split; i < certificates.serverChain.Count - 1; i++)
                 {
-                    clientOptions.ValidationPolicy.ExtraStore.Add(certificates.serverChain[i]);
+                    clientOptions.CertificateChainPolicy.ExtraStore.Add(certificates.serverChain[i]);
                 }
             }
 

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -2916,6 +2916,8 @@ namespace System.Security.Cryptography.X509Certificates
         public System.TimeSpan UrlRetrievalTimeout { get { throw null; } set { } }
         public System.Security.Cryptography.X509Certificates.X509VerificationFlags VerificationFlags { get { throw null; } set { } }
         public System.DateTime VerificationTime { get { throw null; } set { } }
+        public bool VerificationTimeIgnored { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509ChainPolicy Clone() { throw null; }
         public void Reset() { }
     }
     public partial struct X509ChainStatus

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
@@ -133,7 +133,7 @@ namespace System.Security.Cryptography.X509Certificates
                     chainPolicy.RevocationFlag,
                     chainPolicy._customTrustStore,
                     chainPolicy.TrustMode,
-                    chainPolicy.VerificationTime,
+                    chainPolicy.VerificationTimeIgnored ? DateTime.Now : chainPolicy.VerificationTime,
                     chainPolicy.UrlRetrievalTimeout,
                     chainPolicy.DisableCertificateDownloads);
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.X509Certificates
         private X509RevocationFlag _revocationFlag;
         private X509VerificationFlags _verificationFlags;
         private X509ChainTrustMode _trustMode;
+        private DateTime _verificationTime;
         internal OidCollection? _applicationPolicy;
         internal OidCollection? _certificatePolicy;
         internal X509Certificate2Collection? _extraStore;
@@ -29,6 +30,16 @@ namespace System.Security.Cryptography.X509Certificates
         ///   The default is <see langword="false" />.
         /// </value>
         public bool DisableCertificateDownloads { get; set; }
+
+        /// <summary>
+        ///   Gets or sets a value that indicates if VerificationTime was set and should be used or if it defaults to DateTime.Now from object creation.
+        /// </summary>
+        /// <value>
+        ///   <see langword="false" /> if VerificationTime was explicitly set and shall be used
+        ///   otherwise, <see langword="false" />.
+        ///   The default is <see langword="true" />.
+        /// </value>
+        public bool VerificationTimeIgnored { get; set; } = true;
 
         public OidCollection ApplicationPolicy => _applicationPolicy ??= new OidCollection();
 
@@ -94,7 +105,15 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        public DateTime VerificationTime { get; set; }
+        public DateTime VerificationTime
+        {
+            get => _verificationTime;
+            set
+            {
+                _verificationTime = value;
+                VerificationTimeIgnored = false;
+            }
+        }
 
         public TimeSpan UrlRetrievalTimeout { get; set; }
 
@@ -109,8 +128,15 @@ namespace System.Security.Cryptography.X509Certificates
             _revocationFlag = X509RevocationFlag.ExcludeRoot;
             _verificationFlags = X509VerificationFlags.NoFlag;
             _trustMode = X509ChainTrustMode.System;
-            VerificationTime = DateTime.Now;
+            _verificationTime = DateTime.Now;
+            VerificationTimeIgnored = true;
+
             UrlRetrievalTimeout = TimeSpan.Zero; // default timeout
+        }
+
+        public X509ChainPolicy Clone()
+        {
+            return (X509ChainPolicy)MemberwiseClone();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
@@ -32,14 +32,15 @@ namespace System.Security.Cryptography.X509Certificates
         public bool DisableCertificateDownloads { get; set; }
 
         /// <summary>
-        ///   Gets or sets a value that indicates if VerificationTime was set and should be used or if it defaults to DateTime.Now from object creation.
+        ///   Gets or sets a value that indicates whether the chain validation should use
+        ///   <see cref="VerificationTime" /> or the current system time when building
+        ///   an X.509 certificate chain.
         /// </summary>
         /// <value>
-        ///   <see langword="false" /> if VerificationTime was explicitly set and shall be used
-        ///   otherwise, <see langword="false" />.
+        ///   <see langword="true" /> to ignore <see cref="VerificationTime"/> and use the current system time; otherwise <see langword="false"/>.
         ///   The default is <see langword="true" />.
         /// </value>
-        public bool VerificationTimeIgnored { get; set; } = true;
+        public bool VerificationTimeIgnored { get; set; }
 
         public OidCollection ApplicationPolicy => _applicationPolicy ??= new OidCollection();
 
@@ -130,7 +131,6 @@ namespace System.Security.Cryptography.X509Certificates
             _trustMode = X509ChainTrustMode.System;
             _verificationTime = DateTime.Now;
             VerificationTimeIgnored = true;
-
             UrlRetrievalTimeout = TimeSpan.Zero; // default timeout
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
@@ -136,7 +136,45 @@ namespace System.Security.Cryptography.X509Certificates
 
         public X509ChainPolicy Clone()
         {
-            return (X509ChainPolicy)MemberwiseClone();
+            X509ChainPolicy clone = new X509ChainPolicy
+            {
+                DisableCertificateDownloads = DisableCertificateDownloads,
+                _revocationMode = _revocationMode,
+                _revocationFlag = _revocationFlag,
+                _verificationFlags = _verificationFlags,
+                _trustMode = _trustMode,
+                _verificationTime = _verificationTime,
+                VerificationTimeIgnored = VerificationTimeIgnored,
+                UrlRetrievalTimeout = UrlRetrievalTimeout,
+            };
+
+            if (_applicationPolicy?.Count > 0)
+            {
+                foreach (var item in _applicationPolicy)
+                {
+                    clone.ApplicationPolicy.Add(item);
+                }
+            }
+
+            if (_certificatePolicy?.Count > 0)
+            {
+                foreach (var item in _certificatePolicy)
+                {
+                    clone.CertificatePolicy.Add(item);
+                }
+            }
+
+            if (_customTrustStore?.Count > 0)
+            {
+               clone.CustomTrustStore.AddRange(_customTrustStore);
+            }
+
+            if (_extraStore?.Count > 0)
+            {
+               clone.ExtraStore.AddRange(_extraStore);
+            }
+
+            return clone;
         }
     }
 }


### PR DESCRIPTION
This is replacement for #69908
fixes #71191 #59979 #35839 #59944 #40423  

This adds API approved in  #71191 so callers of SslStream can specify custom X509ChainPolicy to specify custom trust, AIA download behavior or other options available in X509ChainPolicy.

Unlike original PoC there is no attempt to enforce consistency with other validation fragments. When custom policy is specified it will be used exclusively instead of fragments we currently use to construct it it internally. 

TODO: This changes only SslStream. I will follow-up with PR for QUIC once the code there is stable. (#71783 done)