### PR TITLE
Override ReadAsync and WriteAsync methods on ConsoleStream.

### DIFF
--- a/src/libraries/System.Console/src/System/IO/ConsoleStream.cs
+++ b/src/libraries/System.Console/src/System/IO/ConsoleStream.cs
@@ -32,28 +32,42 @@ namespace System.IO
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
+            ValidateWrite(buffer, offset, count);
+
             if (cancellationToken.IsCancellationRequested)
             {
                 return Task.FromCanceled(cancellationToken);
             }
 
-            ValidateWrite(buffer, offset, count);
-            Write(new ReadOnlySpan<byte>(buffer, offset, count));
-
-            return Task.CompletedTask;
+            try
+            {
+                Write(new ReadOnlySpan<byte>(buffer, offset, count));
+                return Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException(ex);
+            }
         }
 
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
+            ValidateCanWrite();
+
             if (cancellationToken.IsCancellationRequested)
             {
                 return ValueTask.FromCanceled(cancellationToken);
             }
 
-            ValidateCanWrite();
-            Write(buffer.Span);
-
-            return ValueTask.CompletedTask;
+            try
+            {
+                Write(buffer.Span);
+                return ValueTask.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                return ValueTask.FromException(ex);
+            }
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -71,24 +85,40 @@ namespace System.IO
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
+            ValidateRead(buffer, offset, count);
+
             if (cancellationToken.IsCancellationRequested)
             {
                 return Task.FromCanceled<int>(cancellationToken);
             }
 
-            ValidateRead(buffer, offset, count);
-            return Task.FromResult(Read(new Span<byte>(buffer, offset, count)));
+            try
+            {
+                return Task.FromResult(Read(new Span<byte>(buffer, offset, count)));
+            }
+            catch (Exception exception)
+            {
+                return Task.FromException<int>(exception);
+            }
         }
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
+            ValidateCanRead();
+
             if (cancellationToken.IsCancellationRequested)
             {
                 return ValueTask.FromCanceled<int>(cancellationToken);
             }
 
-            ValidateCanRead();
-            return ValueTask.FromResult(Read(buffer.Span));
+            try
+            {
+                return ValueTask.FromResult(Read(buffer.Span));
+            }
+            catch (Exception exception)
+            {
+                return ValueTask.FromException<int>(exception);
+            }
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Console/tests/ConsoleStreamTests.cs
+++ b/src/libraries/System.Console/tests/ConsoleStreamTests.cs
@@ -17,7 +17,7 @@ public class ConsoleStreamTests
         outStream.Write(new byte[] { }, 0, 0);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(Helpers), nameof(Helpers.IsConsoleInSupported))]
     public void ReadAsyncRespectsCancellation()
     {
         Stream inStream = Console.OpenStandardInput();
@@ -32,7 +32,7 @@ public class ConsoleStreamTests
         Assert.True(valueTaskResult.IsCanceled);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(Helpers), nameof(Helpers.IsConsoleInSupported))]
     public void ReadAsyncHandlesInvalidParams()
     {
         Stream inStream = Console.OpenStandardInput();
@@ -69,7 +69,7 @@ public class ConsoleStreamTests
         Assert.Throws<ArgumentOutOfRangeException>(() => { outStream.WriteAsync(bytes, 0, bytes.Length + 1); });
     }
 
-    [Fact]
+    [ConditionalFact(typeof(Helpers), nameof(Helpers.IsConsoleInSupported))]
     public void InputCannotWriteAsync()
     {
         Stream inStream = Console.OpenStandardInput();

--- a/src/libraries/System.Console/tests/ConsoleStreamTests.cs
+++ b/src/libraries/System.Console/tests/ConsoleStreamTests.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+public class ConsoleStreamTests
+{
+    [Fact]
+    public void WriteToOutputStream_EmptyArray()
+    {
+        Stream outStream = Console.OpenStandardOutput();
+        outStream.Write(new byte[] { }, 0, 0);
+    }
+
+    [Fact]
+    public void ReadAsyncRespectsCancellation()
+    {
+        Stream inStream = Console.OpenStandardInput();
+        CancellationTokenSource cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        byte[] buffer = new byte[1024];
+        Task result = inStream.ReadAsync(buffer, 0, buffer.Length, cts.Token);
+        Assert.True(result.IsCanceled);
+
+        ValueTask<int> valueTaskResult = inStream.ReadAsync(buffer.AsMemory(), cts.Token);
+        Assert.True(valueTaskResult.IsCanceled);
+    }
+
+    [Fact]
+    public void ReadAsyncHandlesInvalidParams()
+    {
+        Stream inStream = Console.OpenStandardInput();
+
+        byte[] buffer = new byte[1024];
+        Assert.Throws<ArgumentNullException>(() => { inStream.ReadAsync(null, 0, buffer.Length); });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { inStream.ReadAsync(buffer, -1, buffer.Length); });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { inStream.ReadAsync(buffer, 0, buffer.Length + 1); });
+    }
+
+    [Fact]
+    public void WriteAsyncRespectsCancellation()
+    {
+        Stream outStream = Console.OpenStandardOutput();
+        CancellationTokenSource cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        byte[] bytes = Encoding.ASCII.GetBytes("Hi");
+        Task result = outStream.WriteAsync(bytes, 0, bytes.Length, cts.Token);
+        Assert.True(result.IsCanceled);
+
+        ValueTask valueTaskResult = outStream.WriteAsync(bytes.AsMemory(), cts.Token);
+        Assert.True(valueTaskResult.IsCanceled);
+    }
+
+    [Fact]
+    public void WriteAsyncHandlesInvalidParams()
+    {
+        Stream outStream = Console.OpenStandardOutput();
+
+        byte[] bytes = Encoding.ASCII.GetBytes("Hi");
+        Assert.Throws<ArgumentNullException>(() => { outStream.WriteAsync(null, 0, bytes.Length); });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { outStream.WriteAsync(bytes, -1, bytes.Length); });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { outStream.WriteAsync(bytes, 0, bytes.Length + 1); });
+    }
+
+    [Fact]
+    public void InputCannotWriteAsync()
+    {
+        Stream inStream = Console.OpenStandardInput();
+
+        byte[] bytes = Encoding.ASCII.GetBytes("Hi");
+        Assert.Throws<NotSupportedException>(() => { inStream.WriteAsync(bytes, 0, bytes.Length); });
+
+        Assert.Throws<NotSupportedException>(() => { inStream.WriteAsync(bytes.AsMemory()); });
+    }
+
+    [Fact]
+    public void OutputCannotReadAsync()
+    {
+        Stream outStream = Console.OpenStandardOutput();
+
+        byte[] buffer = new byte[1024];
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            outStream.ReadAsync(buffer, 0, buffer.Length);
+        });
+
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            outStream.ReadAsync(buffer.AsMemory());
+        });
+    }
+}

--- a/src/libraries/System.Console/tests/Helpers.cs
+++ b/src/libraries/System.Console/tests/Helpers.cs
@@ -6,8 +6,11 @@ using System.IO;
 using System.Text;
 using Xunit;
 
-class Helpers
+static class Helpers
 {
+    public static bool IsConsoleInSupported =>
+        !PlatformDetection.IsAndroid && !PlatformDetection.IsiOS && !PlatformDetection.IsMacCatalyst && !PlatformDetection.IstvOS && !PlatformDetection.IsBrowser;
+
     public static void SetAndReadHelper(Action<TextWriter> setHelper, Func<TextWriter> getHelper, Func<StreamReader, string> readHelper)
     {
         const string TestString = "Test";

--- a/src/libraries/System.Console/tests/ReadAndWrite.cs
+++ b/src/libraries/System.Console/tests/ReadAndWrite.cs
@@ -31,13 +31,6 @@ public class ReadAndWrite
     }
 
     [Fact]
-    public static void WriteToOutputStream_EmptyArray()
-    {
-        Stream outStream = Console.OpenStandardOutput();
-        outStream.Write(new byte[] { }, 0, 0);
-    }
-
-    [Fact]
     [OuterLoop]
     public static void WriteOverloadsToRealConsole()
     {

--- a/src/libraries/System.Console/tests/SetIn.cs
+++ b/src/libraries/System.Console/tests/SetIn.cs
@@ -10,8 +10,7 @@ using Xunit;
 //
 public class SetIn
 {
-    [Fact]
-    [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on Browser, iOS, MacCatalyst, or tvOS.")]
+    [ConditionalFact(typeof(Helpers), nameof(Helpers.IsConsoleInSupported))]
     public static void SetInThrowsOnNull()
     {
         TextReader savedIn = Console.In;
@@ -25,8 +24,7 @@ public class SetIn
         }
     }
 
-    [Fact]
-    [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on Browser, iOS, MacCatalyst, or tvOS.")]
+    [ConditionalFact(typeof(Helpers), nameof(Helpers.IsConsoleInSupported))]
     public static void SetInReadLine()
     {
         const string TextStringFormat = "Test {0}";

--- a/src/libraries/System.Console/tests/System.Console.Tests.csproj
+++ b/src/libraries/System.Console/tests/System.Console.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CancelKeyPress.cs" />
+    <Compile Include="ConsoleStreamTests.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="ReadAndWrite.cs" />
     <Compile Include="ConsoleKeyInfoTests.cs" />
@@ -36,8 +37,8 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(MSBuildThisFileDirectory)TestData\**\*"
-          Link="%(RecursiveDir)%(Filename)%(Extension)"
-          CopyToOutputDirectory="PreserveNewest" />
+             Link="%(RecursiveDir)%(Filename)%(Extension)"
+             CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
     <Compile Include="ConsoleEncoding.Windows.cs" />


### PR DESCRIPTION
The base Stream class implements these overloads by renting a buffer,
creating a ReadWriteTask, and copying data as necessary.

Instead, ConsoleStreams can just override these Async methods and synchronously
call the underlying OS API.


### Benchmark
```C#
public class ConsoleStreamsBenchmark
{
    static byte[] _bytes = Encoding.ASCII.GetBytes("Hello, World!");
    static Stream _stream = Console.OpenStandardOutput();

    static NativeMemoryManager _nativeMemoryManager = CreateNativeMemory();

    private unsafe static NativeMemoryManager CreateNativeMemory()
    {
        byte* mem = (byte*)NativeMemory.Alloc((nuint)_bytes.Length);
        _bytes.AsSpan().CopyTo(new Span<byte>(mem, _bytes.Length));
        return new NativeMemoryManager(mem, _bytes.Length);
    }

    [Benchmark]
    public async Task WriteToStream()
    {
        await _stream.WriteAsync(_bytes);
    }

    [Benchmark]
    public async Task WriteNativeMemoryToStream()
    {
        await _stream.WriteAsync(_nativeMemoryManager.Memory);
    }

    unsafe class NativeMemoryManager : MemoryManager<byte>
    {
        private byte* _pointer;
        private int _length;
        internal NativeMemoryManager(byte* pointer, int length)
        {
            _pointer = pointer;
            _length = length;
        }

        public override Span<byte> GetSpan() => new Span<byte>(_pointer, _length);
        public override MemoryHandle Pin(int elementIndex = 0) => default;
        public override void Unpin() { }
        protected override void Dispose(bool disposing) { }
    }
}
```

Results

|                    Method |        Job |         Toolchain |     Mean |     Error |    StdDev | Ratio | RatioSD |
|-------------------------- |----------- |------------------ |---------:|----------:|----------:|------:|--------:|
|             WriteToStream | Job-AMXSLA | \main\corerun.exe | 6.221 us | 0.6849 us | 0.7888 us |  1.00 |    0.00 |
|             WriteToStream | Job-CRTAYW |   \pr\corerun.exe | 4.602 us | 0.6634 us | 0.7374 us |  0.74 |    0.08 |
|                           |            |                   |          |           |           |       |         |
| WriteNativeMemoryToStream | Job-AMXSLA | \main\corerun.exe | 6.549 us | 0.8117 us | 0.8685 us |  1.00 |    0.00 |
| WriteNativeMemoryToStream | Job-CRTAYW |   \pr\corerun.exe | 4.575 us | 0.6448 us | 0.7426 us |  0.69 |    0.07 |