### PR TITLE
ILASM - Disable `fileversionpreservation` test

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -60,6 +60,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/MonoAPI/**">
             <Issue>CoreCLR does not implement the mono embedding API</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/readytorun/tests/fileversionpreservation">
+            <Issue>https://github.com/dotnet/runtime/issues/11412 ILASM does not support embedding or generating resource data</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets on all runtimes -->

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -60,9 +60,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/MonoAPI/**">
             <Issue>CoreCLR does not implement the mono embedding API</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/readytorun/tests/fileversionpreservation">
-            <Issue>https://github.com/dotnet/runtime/issues/11412 ILASM does not support embedding or generating resource data</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets on all runtimes -->

--- a/src/tests/readytorun/tests/fileversionpreservation/fileversionpreservation.csproj
+++ b/src/tests/readytorun/tests/fileversionpreservation/fileversionpreservation.csproj
@@ -3,6 +3,7 @@
     <OutputType>exe</OutputType>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="fileversionpreservation.cs" />


### PR DESCRIPTION
Should stop this from failing for now: https://github.com/dotnet/runtime/issues/71919

ILASM does not support embedding or generating resource data; we would need to add that functionality. It used to exist, but it depended on `CvtRes.exe` which the dotnet team does not own; which is the reason the resource embedding support was removed. See https://github.com/dotnet/coreclr/pull/20818 and https://github.com/dotnet/runtime/issues/11412