### PR TITLE
Mark `Assembly.GetCallingAssembly` with `[RequiresDynamicCode]`.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -71,6 +72,7 @@ namespace System.Reflection
         }
 
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
+        [RequiresDynamicCode("Assembly.GetCallingAssembly is not supported in AOT environments.")]
         public static Assembly GetCallingAssembly()
         {
             // LookForMyCallersCaller is not guaranteed to return the correct stack frame

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
@@ -17,7 +17,7 @@ namespace System.Reflection
 
         [System.Runtime.CompilerServices.Intrinsic]
         public static Assembly GetExecutingAssembly() { throw NotImplemented.ByDesign; } //Implemented by toolchain.
-        
+
         [RequiresDynamicCode("Assembly.GetCallingAssembly is not supported in AOT environments.")]
         public static Assembly GetCallingAssembly()
         {
@@ -56,5 +56,5 @@ namespace System.Reflection
                 return null;
             }
         }
-   }
+    }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Configuration.Assemblies;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.IO;
 
@@ -16,7 +17,8 @@ namespace System.Reflection
 
         [System.Runtime.CompilerServices.Intrinsic]
         public static Assembly GetExecutingAssembly() { throw NotImplemented.ByDesign; } //Implemented by toolchain.
-
+        
+        [RequiresDynamicCode("Assembly.GetCallingAssembly is not supported in AOT environments.")]
         public static Assembly GetCallingAssembly()
         {
             if (AppContext.TryGetSwitch("Switch.System.Reflection.Assembly.SimulatedCallingAssembly", out bool isSimulated) && isSimulated)

--- a/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
@@ -316,6 +316,7 @@ namespace Microsoft.VisualBasic
         public string Source { get { throw null; } set { } }
         public void Clear() { }
         public System.Exception? GetException() { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("ErrObject.Raise is not supported in AOT environments. Throw exceptions with the Throw keyword instead.")]
         public void Raise(int Number, object? Source = null, object? Description = null, object? HelpFile = null, object? HelpContext = null) { }
     }
     [System.FlagsAttribute]
@@ -329,6 +330,7 @@ namespace Microsoft.VisualBasic
         Directory = 16,
         Archive = 32,
     }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("The FileSystem module is not supported in AOT environments. Use members of the System.IO namespace instead.")]
     [Microsoft.VisualBasic.CompilerServices.StandardModuleAttribute]
     public sealed partial class FileSystem
     {
@@ -1146,6 +1148,7 @@ namespace Microsoft.VisualBasic.CompilerServices
         internal ProjectData() { }
         public static void ClearProjectError() { }
         public static System.Exception CreateProjectError(int hr) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("ProjectData.EndApp is not supported in AOT environments. Use System.Environment.Exit(0) instead.")]
         public static void EndApp() { }
         public static void SetProjectError(System.Exception? ex) { }
         public static void SetProjectError(System.Exception? ex, int lErl) { }

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/ProjectData.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/ProjectData.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 
 Imports System
+Imports System.Diagnostics.CodeAnalysis
 
 Namespace Global.Microsoft.VisualBasic.CompilerServices
 
@@ -177,6 +178,7 @@ Namespace Global.Microsoft.VisualBasic.CompilerServices
             Err.Clear()
         End Sub
 
+        <RequiresDynamicCode("ProjectData.EndApp is not supported in AOT environments. Use System.Environment.Exit(0) instead.")>
         Public Shared Sub EndApp()
             FileSystem.CloseAllFiles(System.Reflection.Assembly.GetCallingAssembly())
             System.Environment.Exit(0) 'System.Environment.Exit will cause finalizers to be run at shutdown

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/ErrObject.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/ErrObject.vb
@@ -5,6 +5,7 @@ Imports Microsoft.VisualBasic.CompilerServices
 Imports Microsoft.VisualBasic.CompilerServices.Utils
 
 Imports System
+Imports System.Diagnostics.CodeAnalysis
 Imports System.Runtime.InteropServices
 
 Namespace Microsoft.VisualBasic
@@ -269,6 +270,7 @@ Namespace Microsoft.VisualBasic
         ''' <param name="Description">If not supplied, we try to look one up based on the error code being raised</param>
         ''' <param name="HelpFile"></param>
         ''' <param name="HelpContext"></param>
+        <RequiresDynamicCode("ErrObject.Raise is not supported in AOT environments. Throw exceptions with the Throw keyword instead.")>
         Public Sub Raise(ByVal Number As Integer,
                          Optional ByVal Source As Object = Nothing,
                          Optional ByVal Description As Object = Nothing,

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileSystem.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileSystem.vb
@@ -16,6 +16,7 @@ Imports Microsoft.VisualBasic.CompilerServices.Utils
 
 Namespace Microsoft.VisualBasic
 
+    <RequiresDynamicCode("The FileSystem module is not supported in AOT environments. Use members of the System.IO namespace instead.")>
     Public Module FileSystem
 
         Private Const ERROR_FILE_NOT_FOUND As Integer = 2

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10731,6 +10731,7 @@ namespace System.Reflection
         public static string CreateQualifiedName(string? assemblyName, string? typeName) { throw null; }
         public override bool Equals(object? o) { throw null; }
         public static System.Reflection.Assembly? GetAssembly(System.Type type) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("Assembly.GetCallingAssembly is not supported in AOT environments.")]
         public static System.Reflection.Assembly GetCallingAssembly() { throw null; }
         public virtual object[] GetCustomAttributes(bool inherit) { throw null; }
         public virtual object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Assembly.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Assembly.Mono.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -42,6 +43,7 @@ namespace System.Reflection
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern RuntimeAssembly GetExecutingAssembly(ref StackCrawlMark stackMark);
 
+        [RequiresDynamicCode("Assembly.GetCallingAssembly is not supported in AOT environments.")]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public static extern Assembly GetCallingAssembly();
 


### PR DESCRIPTION
Fixes #71290
Fixes #53825

I added `[RequiresDynamicCode]` to `Assembly.GetDynamicAssembly` across all runtimes, and also marked all APIs that use it. The only uses of it in non-test code are `AssemblyBuilder.DefineDynamicAssembly` which obviously is already marked, and some APIs in `Microsoft.VisualBasic.Core` (c.c. @cston).