### PR TITLE
ILASM - Allow EntryPoint methods to be on interfaces

### DIFF
--- a/src/coreclr/ilasm/assem.cpp
+++ b/src/coreclr/ilasm/assem.cpp
@@ -725,8 +725,6 @@ BOOL Assembler::EmitMethod(Method *pMethod)
     //--------------------------------------------------------------------------------
     if (pMethod->m_fEntryPoint)
     {
-        if(fIsInterface) report->error("Entrypoint in Interface: Method '%s'\n",pszMethodName);
-
         if (FAILED(m_pCeeFileGen->SetEntryPoint(m_pCeeFile, MethodToken)))
         {
             report->error("Failed to set entry point for method '%s'\n",pszMethodName);

--- a/src/tests/Regressions/coreclr/Runtime_49998/Runtime_49998.cs
+++ b/src/tests/Regressions/coreclr/Runtime_49998/Runtime_49998.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace InterfaceMain
+{
+    interface Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/tests/Regressions/coreclr/Runtime_49998/Runtime_49998.cs
+++ b/src/tests/Regressions/coreclr/Runtime_49998/Runtime_49998.cs
@@ -4,9 +4,9 @@ namespace InterfaceMain
 {
     interface Program
     {
-        static void Main(string[] args)
+        static int Main(string[] args)
         {
-            Console.WriteLine("Hello World!");
+            return 100;
         }
     }
 }

--- a/src/tests/Regressions/coreclr/Runtime_49998/Runtime_49998.csproj
+++ b/src/tests/Regressions/coreclr/Runtime_49998/Runtime_49998.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Runtime_49998.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Should resolve: https://github.com/dotnet/runtime/issues/49998

**Description**

ILASM would error if an `EntryPoint` was on an interface. This PR should fix that as it is legal to do now.

**Acceptance Criteria**

- [x] Tests