### PR TITLE
[wasm] Fix some failing `System.Runtime.InteropServices.JavaScript.Tests`

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JSImportExportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JSImportExportTest.cs
@@ -253,7 +253,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             yield return new object[] { new object[] { 1.1d, new DateTime(2022, 5, 8, 14, 55, 01, DateTimeKind.Utc), false, true } };
             yield return new object[] { new object[] { new double?(1.1d), new DateTime?(new DateTime(2022, 5, 8, 14, 55, 01, DateTimeKind.Utc)), new bool?(false), new bool?(true) } };
             yield return new object[] { new object[] { null, new object(), new SomethingRef(), new SomethingStruct(), new Exception("test") } };
-            yield return new object[] { new object[] { JavaScriptTestHelper.createData("test"), JavaScriptTestHelper.createException("test") } };
+            yield return new object[] { new object[] { "JSData" } }; // special cased, so we call createData in the test itself
             yield return new object[] { new object[] { new byte[] { }, new int[] { }, new double[] { }, new string[] { }, new object[] { } } };
             yield return new object[] { new object[] { new byte[] { 1, 2, 3 }, new int[] { 1, 2, 3 }, new double[] { 1, 2, 3 }, new string[] { "a", "b", "c" }, new object[] { } } };
             yield return new object[] { new object[] { new object[] { new byte[] { 1, 2, 3 }, new int[] { 1, 2, 3 }, new double[] { 1, 2, 3 }, new string[] { "a", "b", "c" } , new object(), new SomethingRef(), new SomethingStruct(), new Exception("test") } } };
@@ -265,15 +265,18 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [MemberData(nameof(MarshalObjectArrayCases))]
         public unsafe void JsImportObjectArray(object[]? expected)
         {
+            if (expected?.Length == 1 && expected[0] is string s && s == "JSData")
+            {
+                expected = new object[] { new object[] { JavaScriptTestHelper.createData("test"), JavaScriptTestHelper.createException("test") } };
+            }
             var actual = JavaScriptTestHelper.echo1_ObjectArray(expected);
             Assert.Equal(expected, actual);
-            
 
             if (expected != null) for (int i = 0; i < expected.Length; i++)
-                {
-                    var actualI = JavaScriptTestHelper.store_ObjectArray(expected, i);
-                    Assert.Equal(expected[i], actualI);
-                }
+            {
+                var actualI = JavaScriptTestHelper.store_ObjectArray(expected, i);
+                Assert.Equal(expected[i], actualI);
+            }
         }
 
         public static IEnumerable<object[]> MarshalObjectArrayCasesToDouble()

--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -392,7 +392,7 @@ declare class ManagedError extends Error implements IDisposable {
     get isDisposed(): boolean;
     toString(): string;
 }
-declare enum MemoryViewType {
+declare const enum MemoryViewType {
     Byte = 0,
     Int32 = 1,
     Double = 2

--- a/src/mono/wasm/runtime/marshal.ts
+++ b/src/mono/wasm/runtime/marshal.ts
@@ -364,10 +364,10 @@ export function array_element_size(element_type: MarshalerType): number {
                                 : -1;
 }
 
-export enum MemoryViewType {
-    Byte,
-    Int32,
-    Double,
+export const enum MemoryViewType {
+    Byte = 0,
+    Int32 = 1,
+    Double = 2,
 }
 
 abstract class MemoryView implements IMemoryView, IDisposable {

--- a/src/mono/wasm/runtime/rollup.config.js
+++ b/src/mono/wasm/runtime/rollup.config.js
@@ -40,6 +40,7 @@ const terserConfig = {
         // because of stack walk at src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
         // and unit test at src\libraries\System.Private.Runtime.InteropServices.JavaScript\tests\timers.js
         keep_fnames: /(mono_wasm_runtime_ready|mono_wasm_fire_debugger_agent_message|mono_wasm_set_timeout_exec)/,
+        keep_classnames: /(ManagedObject|ManagedError|Span|ArraySegment|WasmRootBuffer|SessionOptionsBuilder)/,
     },
 };
 const plugins = isDebug ? [writeOnChangePlugin()] : [terser(terserConfig), writeOnChangePlugin()];


### PR DESCRIPTION
- protect class names from mangling. Fixes:
   - `System.Runtime.InteropServices.JavaScript.Tests.JSImportExportTest.JSImportException`
   -  `System.Runtime.InteropServices.JavaScript.Tests.JSImportExportTest.JSImportException` 
   - See [log](https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-71932-merge-de34edc2d211483389/WasmTestOnBrowser-System.Runtime.InteropServices.JavaScript.Tests/1/console.075529df.log?helixlogtype=result)
```
[16:44:33] fail: [FAIL] System.Runtime.InteropServices.JavaScript.Tests.JSImportExportTest.JSImportException(value: System.Exception: Test, clazz: "ManagedError")
[16:44:33] info: Assert.Equal() Failure
[16:44:33] info:           ↓ (pos 0)
[16:44:33] info: Expected: ManagedError
[16:44:33] info: Actual:   jr
[16:44:33] info:           ↑ (pos 0)
[16:44:33] info:    at System.Runtime.InteropServices.JavaScript.Tests.JSImportExportTest.JsImportTest[Exception](Exception value, Action`1 store1, Func`1 retrieve1, Func`2 echo1, Func`2 throw1, Func`2 identity1, String jsType, String jsClass)
[16:44:33] info:    at System.Runtime.InteropServices.JavaScript.Tests.JSImportExportTest.JSImportException(Exception value, String clazz)
[16:44:33] info:    at System.Reflection.MethodInvoker.InterpretedInvoke(Object obj, Span`1 args, BindingFlags invokeAttr)
[16:44:33] fail: [FAIL] System.Runtime.InteropServices.JavaScript.Tests.JSImportExportTest.JSImportObject(value: Object { }, clazz: "ManagedObject")
[16:44:33] info: Assert.Equal() Failure
[16:44:33] info:           ↓ (pos 0)
[16:44:33] info: Expected: ManagedObject
[16:44:33] info: Actual:   Rr
[16:44:33] info:           ↑ (pos 0)
[16:44:33] info:    at System.Runtime.InteropServices.JavaScript.Tests.JSImportExportTest.JsImportTest[Object](Object value, Action`1 store1, Func`1 retrieve1, Func`2 echo1, Func`2 throw1, Func`2 identity1, String jsType, String jsClass)
[16:44:33] info:    at System.Runtime.InteropServices.JavaScript.Tests.JSImportExportTest.JSImportObject(Object value, String clazz)
[16:44:33] info:    at System.Reflection.MethodInvoker.InterpretedInvoke(Object obj, Span`1 args, BindingFlags invokeAttr)
```

- Also, fix `JSImportExportTest.JsImportObjectArray` (#71952)

Fixes https://github.com/dotnet/runtime/issues/71952