### PR TITLE
Change the CSE heuristics cost

### DIFF
--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -278,11 +278,6 @@ bool Compiler::optCSEcostCmpEx::operator()(const CSEdsc* dsc1, const CSEdsc* dsc
     auto expCost1 = exp1->GetCostEx();
     auto expCost2 = exp2->GetCostEx();
 
-    if (expCost2 != expCost1)
-    {
-        return expCost2 < expCost1;
-    }
-
     // Sort the higher Use Counts toward the top
     if (dsc2->csdUseWtCnt != dsc1->csdUseWtCnt)
     {
@@ -293,6 +288,11 @@ bool Compiler::optCSEcostCmpEx::operator()(const CSEdsc* dsc1, const CSEdsc* dsc
     if (dsc1->csdDefWtCnt != dsc2->csdDefWtCnt)
     {
         return dsc1->csdDefWtCnt < dsc2->csdDefWtCnt;
+    }
+
+    if (expCost2 != expCost1)
+    {
+        return expCost2 < expCost1;
     }
 
     // In order to ensure that we have a stable sort, we break ties using the csdIndex
@@ -314,10 +314,6 @@ bool Compiler::optCSEcostCmpSz::operator()(const CSEdsc* dsc1, const CSEdsc* dsc
     auto expCost1 = exp1->GetCostSz();
     auto expCost2 = exp2->GetCostSz();
 
-    if (expCost2 != expCost1)
-    {
-        return expCost2 < expCost1;
-    }
 
     // Sort the higher Use Counts toward the top
     if (dsc2->csdUseCount != dsc1->csdUseCount)
@@ -329,6 +325,11 @@ bool Compiler::optCSEcostCmpSz::operator()(const CSEdsc* dsc1, const CSEdsc* dsc
     if (dsc1->csdDefCount != dsc2->csdDefCount)
     {
         return dsc1->csdDefCount < dsc2->csdDefCount;
+    }
+
+    if (expCost2 != expCost1)
+    {
+        return expCost2 < expCost1;
     }
 
     // In order to ensure that we have a stable sort, we break ties using the csdIndex


### PR DESCRIPTION
During CSE, I realized that we would give more importance to the individual instructions cost rather than the weighted cost or the number of use.

```c#
    [MethodImpl(MethodImplOptions.NoInlining)]
    public void Method0(int a, int b)
    {
        Console.WriteLine(a * b);

        int result = 4;
        for (int i = 0; i < a; i++)
        {
            result += (a - b);
        }

        Console.WriteLine(a * b);
    }
```

In this example, although both `(a * b)`  and `(a - b)` are CSE candidates, when there is a conflict and we need to chose one, we would give preference to `(a * b)` because multiplication cost is higher. However, `(a - b)` is part of a loop and will execute more times than the multiplication.

As an experiment, I am trying to see what happens when we flip the criteria.