### PR TITLE
Fix leak caused by IsCertInKeychain

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_keychain_ios.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_keychain_ios.c
@@ -45,12 +45,10 @@ static int32_t EnumerateKeychain(CFStringRef matchType, CFArrayRef* pCertsOut)
         assert(result == NULL);
         status = noErr;
     }
-    else
+
+    if (result != NULL)
     {
-        if (result != NULL)
-        {
-            CFRelease(result);
-        }
+        CFRelease(result);
     }
 
     return status;

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_keychain_macos.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_keychain_macos.c
@@ -263,7 +263,7 @@ static bool IsCertInKeychain(CFTypeRef needle, SecKeychainRef haystack)
         ret = false;
     }
     
-    if (result != null)
+    if (result != NULL)
     {
         CFRelease(result);
     }

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_keychain_macos.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_keychain_macos.c
@@ -262,6 +262,11 @@ static bool IsCertInKeychain(CFTypeRef needle, SecKeychainRef haystack)
     {
         ret = false;
     }
+    
+    if (result != null)
+    {
+        CFRelease(result);
+    }
 
     CFRelease(itemMatch);
     CFRelease(searchList);


### PR DESCRIPTION
SecItemCopyMatching result parameter is caller owned