### PR TITLE
Get rid of hardcoded sleep in tracing/runtimeeventsource/nativeruntimeeventsource

### DIFF
--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeEventSourceTest.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeEventSourceTest.cs
@@ -45,7 +45,7 @@ namespace Tracing.Tests
                         Thread.Sleep(100);
 
                         if ((OperatingSystem.IsWindows() && listener.SeenProvidersAndEvents.Contains("Microsoft-Windows-DotNETRuntime/EVENTID(65)"))
-                             || (listener.EventCount > 0))
+                             || (!OperatingSystem.IsWindows() && listener.EventCount > 0))
                         {
                             break;
                         }

--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeEventSourceTest.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeEventSourceTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
@@ -31,14 +32,19 @@ namespace Tracing.Tests
                     if (OperatingSystem.IsWindows())
                         DoOverlappedIO();
 
-                    // Wait for events.
-                    Thread.Sleep(1000);
-
                     // Generate some GC events.
                     GC.Collect(2, GCCollectionMode.Forced);
 
-                    // Wait for more events.
-                    Thread.Sleep(1000);
+                    Stopwatch sw = Stopwatch.StartNew();
+
+                    while (sw.Elapsed <= TimeSpan.FromMinutes(1))
+                    {
+                        Thread.Sleep(100);
+                        if (listener.SeenProvidersAndEvents.Contains("Microsoft-Windows-DotNETRuntime/EVENTID(65)"))
+                        {
+                            break;
+                        }
+                    }
 
                     // Ensure that we've seen some events.
                     foreach (string s in listener.SeenProvidersAndEvents)


### PR DESCRIPTION
Fixes #71331

This test was failing because in some runs the event would take longer than 2 seconds to get all the way through the eventing pipeline.