### PR TITLE
[wasm][debugger][firefox] Added exception handling for Firefox onEval

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxMonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxMonoProxy.cs
@@ -601,11 +601,7 @@ internal sealed class FirefoxMonoProxy : MonoProxy
                         await SendEvent(sessionId, "", o, token);
 
                         Frame scope = context.CallStack.First<Frame>();
-
-                        var resolver = new MemberReferenceResolver(this, context, sessionId, scope.Id, logger);
-                        JObject retValue = await resolver.Resolve(args?["text"]?.Value<string>(), token);
-                        if (retValue == null)
-                            retValue = await ExpressionEvaluator.CompileAndRunTheExpression(args?["text"]?.Value<string>(), resolver, logger, token);
+                        string expression = args?["text"]?.Value<string>();
                         var osend = JObject.FromObject(new
                         {
                             type = "evaluationResult",
@@ -614,23 +610,67 @@ internal sealed class FirefoxMonoProxy : MonoProxy
                             input = args?["text"],
                             from = args["to"].Value<string>()
                         });
-                        if (retValue["type"].Value<string>() == "object")
+                        try
                         {
-                            osend["result"] = JObject.FromObject(new
+                            var resolver = new MemberReferenceResolver(this, context, sessionId, scope.Id, logger);
+                            JObject retValue = await resolver.Resolve(expression, token);
+                            if (retValue == null)
+                                retValue = await ExpressionEvaluator.CompileAndRunTheExpression(expression, resolver, logger, token);
+                            if (retValue["type"].Value<string>() == "object")
                             {
-                                type = retValue["type"],
-                                @class = retValue["className"],
-                                description = retValue["description"],
-                                actor = retValue["objectId"],
-                            });
+                                osend["result"] = JObject.FromObject(new
+                                {
+                                    type = retValue["type"],
+                                    @class = retValue["className"],
+                                    description = retValue["description"],
+                                    actor = retValue["objectId"],
+                                });
+                            }
+                            else
+                            {
+                                osend["result"] = retValue["value"];
+                                osend["resultType"] = retValue["type"];
+                                osend["resultDescription"] = retValue["description"];
+                            }
+                            await SendEvent(sessionId, "", osend, token);
                         }
-                        else
+                        catch (ReturnAsErrorException ree)
                         {
-                            osend["result"] = retValue["value"];
-                            osend["resultType"] = retValue["type"];
-                            osend["resultDescription"] = retValue["description"];
+                            osend["hasException"] = true;
+                            osend.Add("exception", JObject.FromObject(new
+                            {
+                                type = "object",
+                                @class = ree.Error.Value["result"]["className"],
+                                isError = true,
+                                preview = JObject.FromObject(new
+                                {
+                                    kind = "Error",
+                                    name = ree.Error.Value["result"]["className"],
+                                    message = ree.Error.Value["result"]["description"],
+                                    isError = true
+                                })
+                            }));
+                            await SendEvent(sessionId, "", osend, token);
                         }
-                        await SendEvent(sessionId, "", osend, token);
+                        catch (Exception e)
+                        {
+                            logger.LogDebug($"Error in EvaluateOnCallFrame for expression '{expression}' with '{e}.");
+                            osend["hasException"] = true;
+                            osend.Add("exception", JObject.FromObject(new
+                            {
+                                type = "object",
+                                @class = "InternalError",
+                                isError = true,
+                                preview = JObject.FromObject(new
+                                {
+                                    kind = "Error",
+                                    name = "InternalError",
+                                    message = e.Message,
+                                    isError = true
+                                })
+                            }));
+                            await SendEvent(sessionId, "", osend, token);
+                        }
                     }
                     else
                     {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1421,8 +1421,10 @@ namespace DebuggerTests
         {
             foreach (var arg in args)
             {
-                (_, Result _res) = await EvaluateOnCallFrame(id, arg.expression, expect_ok: false).ConfigureAwait(false);;
-                AssertEqual(arg.message, _res.Error["result"]?["description"]?.Value<string>(), $"Expression '{arg.expression}' - wrong error message");
+                (_, Result _res) = await EvaluateOnCallFrame(id, arg.expression, expect_ok: false).ConfigureAwait(false);
+                // different response structure for Chrome and Firefox:
+                string errorMessage = _res.Error["preview"] == null ? _res.Error["result"]?["description"]?.Value<string>() : _res.Error["preview"]?["message"]?.Value<string>();
+                AssertEqual(arg.message, errorMessage, $"Expression '{arg.expression}' - wrong error message");
             }
         }
     }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -825,7 +825,7 @@ namespace DebuggerTests
                    ("NoNamespaceClass.NestedClass1.NestedClass2.NestedClass3.StaticPropertyWithError", TString("System.Exception: not implemented 30")));
            });
 
-        [ConditionalFact(nameof(RunningOnChrome))]
+        [Fact]
         public async Task EvaluateStaticClassesNestedWithSameNames() => await CheckInspectLocalsAtBreakpointSite(
             "NestedWithSameNames.B.NestedWithSameNames.B", "Run", 1, "Run",
             "window.setTimeout(function() { invoke_static_method ('[debugger-test] NestedWithSameNames:Evaluate'); })",
@@ -1281,7 +1281,7 @@ namespace DebuggerTests
                    ("tcNull?.MemberListNull?.Count", TObject("DebuggerTests.EvaluateNullableProperties.TestClass", is_null: true)));
             });
 
-        [ConditionalFact(nameof(RunningOnChrome))]
+        [Fact]
         public async Task EvaluateNullObjectPropertiesNegative() => await CheckInspectLocalsAtBreakpointSite(
             $"DebuggerTests.EvaluateNullableProperties", "Evaluate", 6, "Evaluate",
             $"window.setTimeout(function() {{ invoke_static_method ('[debugger-test] DebuggerTests.EvaluateNullableProperties:Evaluate'); 1 }})",
@@ -1292,7 +1292,7 @@ namespace DebuggerTests
                     ("list.Count.x", "Cannot find member 'x' on a primitive type"),
                     ("listNull.Count", GetNullReferenceErrorOn("\"Count\"")),
                     ("listNull!.Count", GetNullReferenceErrorOn("\"Count\"")),
-                    ( "tcNull.MemberListNull.Count", GetNullReferenceErrorOn("\"MemberListNull\"")),
+                    ("tcNull.MemberListNull.Count", GetNullReferenceErrorOn("\"MemberListNull\"")),
                     ("tc.MemberListNull.Count", GetNullReferenceErrorOn("\"Count\"")),
                     ("tcNull?.MemberListNull.Count", GetNullReferenceErrorOn("\"Count\"")),
                     ("listNull?.Count.NonExistingProperty", GetNullReferenceErrorOn("\"NonExistingProperty\"")),


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/70819.

Added try/catch the same way we have it for Chrome because `evaluateJSAsync` throws when expression is invalid or internal error happens.