### PR TITLE
Remove unused property

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.csproj
@@ -19,7 +19,6 @@
     <PackageProjectUrl>https://github.com/dotnet/runtime/tree/main/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator</PackageProjectUrl>
     <Description>JSImportGenerator</Description>
     <PackageTags>JSImportGenerator, analyzers</PackageTags>
-    <IsNETCoreAppAnalyzer>true</IsNETCoreAppAnalyzer>
     <DefineConstants>$(DefineConstants);JSIMPORTGENERATOR</DefineConstants>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
   </PropertyGroup>


### PR DESCRIPTION
IsNETCoreAppAnalyzer is automatically calculated based on the NetCoreAppLibrary.props file. Setting this in the project file doesn't have any impact.