### PR TITLE
Delete the custom gitignore file

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/.gitignore
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/.gitignore
@@ -1,5 +1,0 @@
-.vs/
-**/bin
-**/obj
-*.binlog
-BenchmarkDotNet.Artifacts

--- a/src/libraries/System.Runtime.InteropServices/gen/.gitignore
+++ b/src/libraries/System.Runtime.InteropServices/gen/.gitignore
@@ -1,5 +1,0 @@
-.vs/
-**/bin
-**/obj
-*.binlog
-BenchmarkDotNet.Artifacts


### PR DESCRIPTION
The root gitignore file already contains most of these settings and should be preferred.