### PR TITLE
Add clrgc binary to sharedFx

### DIFF
--- a/src/coreclr/gc/CMakeLists.txt
+++ b/src/coreclr/gc/CMakeLists.txt
@@ -130,3 +130,5 @@ endif(CLR_CMAKE_HOST_OSX)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/env)
+
+install_clr(TARGETS clrgc DESTINATIONS . sharedFramework COMPONENT runtime)

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -102,6 +102,9 @@
     <PlatformManifestFileEntry Include="coreclr.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libcoreclr.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libcoreclr.dylib" IsNative="true" />
+    <PlatformManifestFileEntry Include="clrgc.dll" IsNative="true" />
+    <PlatformManifestFileEntry Include="libclrgc.so" IsNative="true" />
+    <PlatformManifestFileEntry Include="libclrgc.dylib" IsNative="true" />
     <PlatformManifestFileEntry Include="clretwrc.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="clrjit.dll" IsNative="true" />
     <PlatformManifestFileEntry Condition="'$(PgoInstrument)' != ''" Include="pgort140.dll" IsNative="true" />


### PR DESCRIPTION
Adding clrgc.dll (.so/dylib) to the sharedFx build so we could fallback to GC segments if required. 

We dont plan to update sdk to copy things over for "Self-contained" unless it would get copied since its in the right place. 