### PR TITLE
Fix ConsoleStream.Flush to not throw for stdin

### DIFF
--- a/src/libraries/System.Console/src/System/IO/ConsoleStream.cs
+++ b/src/libraries/System.Console/src/System/IO/ConsoleStream.cs
@@ -142,10 +142,7 @@ namespace System.IO
             set => throw Error.GetSeekNotSupported();
         }
 
-        public override void Flush()
-        {
-            if (!CanWrite) throw Error.GetWriteNotSupported();
-        }
+        public override void Flush() { }
 
         public sealed override void SetLength(long value) => throw Error.GetSeekNotSupported();
 

--- a/src/libraries/System.Console/tests/ReadAndWrite.cs
+++ b/src/libraries/System.Console/tests/ReadAndWrite.cs
@@ -429,6 +429,7 @@ public class ReadAndWrite
     }
 
     [Fact]
+    [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on Browser, iOS, MacCatalyst, or tvOS.")]
     public static async Task FlushOnStreams_Nop()
     {
         using Stream input = Console.OpenStandardInput();

--- a/src/libraries/System.Console/tests/ReadAndWrite.cs
+++ b/src/libraries/System.Console/tests/ReadAndWrite.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -425,5 +426,20 @@ public class ReadAndWrite
     public static void OpenStandardError_NegativeBufferSize_ThrowsArgumentOutOfRangeException()
     {
         AssertExtensions.Throws<ArgumentOutOfRangeException>("bufferSize", () => Console.OpenStandardError(-1));
+    }
+
+    [Fact]
+    public static async Task FlushOnStreams_Nop()
+    {
+        using Stream input = Console.OpenStandardInput();
+        using Stream output = Console.OpenStandardOutput();
+        using Stream error = Console.OpenStandardError();
+
+        foreach (Stream s in new[] { input, output, error })
+        {
+            s.Flush();
+            await s.FlushAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await s.FlushAsync(new CancellationToken(canceled: true)));
+        }
     }
 }


### PR DESCRIPTION
Stream.Flush{Async} is supposed be a nop on a read-only stream.