### PR TITLE
Fixing PhysicalFilesWatcher path maintenance (Issue #71386)

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PathUtils.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PathUtils.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Primitives;
@@ -67,5 +68,6 @@ namespace Microsoft.Extensions.FileProviders.Physical.Internal
 
             return false;
         }
+
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PathUtils.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PathUtils.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Primitives;

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PathUtils.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PathUtils.cs
@@ -67,6 +67,5 @@ namespace Microsoft.Extensions.FileProviders.Physical.Internal
 
             return false;
         }
-
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
 
             IChangeToken changeToken = GetOrAddChangeToken(filter);
-            // We made sure that browser/iOS/tvOS never uses FileSystemWatcher.
+// We made sure that browser/iOS/tvOS never uses FileSystemWatcher.
 #pragma warning disable CA1416 // Validate platform compatibility
             TryEnableFileSystemWatcher();
 #pragma warning restore CA1416 // Validate platform compatibility

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
 
             IChangeToken changeToken = GetOrAddChangeToken(filter);
-// We made sure that browser/iOS/tvOS never uses FileSystemWatcher.
+            // We made sure that browser/iOS/tvOS never uses FileSystemWatcher.
 #pragma warning disable CA1416 // Validate platform compatibility
             TryEnableFileSystemWatcher();
 #pragma warning restore CA1416 // Validate platform compatibility
@@ -175,6 +175,10 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
         internal IChangeToken GetOrAddFilePathChangeToken(string filePath)
         {
+#if NET5_0_OR_GREATER
+            var absolutePath = Path.GetFullPath(filePath, _root);
+            filePath = absolutePath.Substring(_root.Length);
+#endif
             if (!_filePathTokenLookup.TryGetValue(filePath, out ChangeTokenInfo tokenInfo))
             {
                 var cancellationTokenSource = new CancellationTokenSource();

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
         internal IChangeToken GetOrAddFilePathChangeToken(string filePath)
         {
-#if NET5_0_OR_GREATER
+#if NETCOREAPP
             var absolutePath = Path.GetFullPath(filePath, _root);
             filePath = absolutePath.Substring(_root.Length);
 #endif


### PR DESCRIPTION
#if NET5_0_OR_GREATER is needed beacuse the project is targeting .net framwork for some reason (analyzers maybe).
All project should be refactored at this lib some point in my opinion.
fixes #71386