### PR TITLE
PropertyVisibilityTests.cs: Fix invalid change in tests merged earlier

### DIFF
--- a/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.cs
@@ -1191,7 +1191,7 @@ namespace System.Text.Json.Serialization.Tests
 
             var dictionary = new Dictionary<object, object>();
             // Uri is an unsupported dictionary key.
-            dictionary.Add(new Uri("http://typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]"), "bar");
+            dictionary.Add(new Uri("http://foo"), "bar");
 
             var concurrentDictionary = new ConcurrentDictionary<object, object>(dictionary);
 


### PR DESCRIPTION
Prompted by https://github.com/dotnet/runtime/pull/71875/files#r919266335