### PR TITLE
Mark JsonSerializerOptions.TypeInfoResolver as nullable and linker-safe

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -339,7 +339,7 @@ namespace System.Text.Json
         public JsonSerializerOptions(System.Text.Json.JsonSerializerOptions options) { }
         public bool AllowTrailingCommas { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Text.Json.Serialization.JsonConverter> Converters { get { throw null; } }
-        public static System.Text.Json.JsonSerializerOptions Default { get { throw null; } }
+        public static System.Text.Json.JsonSerializerOptions Default { [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications."), System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")] get { throw null; } }
         public int DefaultBufferSize { get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }
         public System.Text.Json.JsonNamingPolicy? DictionaryKeyPolicy { get { throw null; } set { } }
@@ -356,16 +356,13 @@ namespace System.Text.Json
         public System.Text.Json.JsonNamingPolicy? PropertyNamingPolicy { get { throw null; } set { } }
         public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
         public System.Text.Json.Serialization.ReferenceHandler? ReferenceHandler { get { throw null; } set { } }
-        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
-        public System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver TypeInfoResolver { [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications."), System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")] get { throw null; } set { } }
+        public System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver? TypeInfoResolver { get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }
         public void AddContext<TContext>() where TContext : System.Text.Json.Serialization.JsonSerializerContext, new() { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("Getting a converter for a type may require reflection which depends on runtime code generation.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Getting a converter for a type may require reflection which depends on unreferenced code.")]
         public System.Text.Json.Serialization.JsonConverter GetConverter(System.Type typeToConvert) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Getting a metadata for a type may require reflection which depends on unreferenced code.")]
-        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Getting a metadata for a type may require reflection which depends on runtime code generation.")]
         public System.Text.Json.Serialization.Metadata.JsonTypeInfo GetTypeInfo(System.Type type) { throw null; }
     }
     public enum JsonTokenType : byte

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -585,7 +585,7 @@
     <value>Built-in type converters have not been initialized. There is no converter available for type '{0}'. To root all built-in converters, use a 'JsonSerializerOptions'-based method of the 'JsonSerializer'.</value>
   </data>
   <data name="NoMetadataForType" xml:space="preserve">
-    <value>Metadata for type '{0}' was not provided to the serializer. The serializer method used does not support reflection-based creation of serialization-related type metadata. If using source generation, ensure that all root types passed to the serializer have been indicated with 'JsonSerializableAttribute', along with any types that might be serialized polymorphically.</value>
+    <value>Metadata for type '{0}' was not provided by TypeInfoResolver of type '{1}'. If using source generation, ensure that all root types passed to the serializer have been indicated with 'JsonSerializableAttribute', along with any types that might be serialized polymorphically.</value>
   </data>
   <data name="CollectionIsReadOnly" xml:space="preserve">
     <value>Collection is read-only.</value>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
@@ -165,7 +165,7 @@ namespace System.Text.Json.Nodes
                 CreateNodes();
                 Debug.Assert(_list != null);
 
-                options ??= JsonSerializerOptions.Default;
+                options ??= JsonSerializerOptions.DefaultInstance;
 
                 writer.WriteStartArray();
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
@@ -165,7 +165,7 @@ namespace System.Text.Json.Nodes
                 CreateNodes();
                 Debug.Assert(_list != null);
 
-                options ??= JsonSerializerOptions.DefaultInstance;
+                options ??= s_defaultOptions;
 
                 writer.WriteStartArray();
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.To.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.To.cs
@@ -5,6 +5,9 @@ namespace System.Text.Json.Nodes
 {
     public abstract partial class JsonNode
     {
+        // linker-safe default JsonSerializerOptions instance used by JsonNode methods.
+        private protected readonly JsonSerializerOptions s_defaultOptions = new();
+
         /// <summary>
         ///   Converts the current instance to string in JSON format.
         /// </summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -96,7 +96,7 @@ namespace System.Text.Json.Nodes
             }
             else
             {
-                options ??= JsonSerializerOptions.Default;
+                options ??= JsonSerializerOptions.DefaultInstance;
 
                 writer.WriteStartObject();
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -96,7 +96,7 @@ namespace System.Text.Json.Nodes
             }
             else
             {
-                options ??= JsonSerializerOptions.DefaultInstance;
+                options ??= s_defaultOptions;
 
                 writer.WriteStartObject();
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueTrimmable.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueTrimmable.cs
@@ -34,7 +34,7 @@ namespace System.Text.Json.Nodes
 
             if (_converter != null)
             {
-                options ??= JsonSerializerOptions.DefaultInstance;
+                options ??= s_defaultOptions;
 
                 if (_converter.IsInternalConverterForNumberType)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueTrimmable.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueTrimmable.cs
@@ -34,7 +34,7 @@ namespace System.Text.Json.Nodes
 
             if (_converter != null)
             {
-                options ??= JsonSerializerOptions.Default;
+                options ??= JsonSerializerOptions.DefaultInstance;
 
                 if (_converter.IsInternalConverterForNumberType)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
@@ -20,7 +20,11 @@ namespace System.Text.Json
             Debug.Assert(runtimeType != null);
 
             options ??= JsonSerializerOptions.Default;
-            options.InitializeForReflectionSerializer();
+
+            if (!options.IsLockedInstance || !DefaultJsonTypeInfoResolver.IsDefaultInstanceRooted)
+            {
+                options.InitializeForReflectionSerializer();
+            }
 
             return options.GetTypeInfoForRootType(runtimeType);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
@@ -33,7 +33,7 @@ namespace System.Text.Json
             JsonTypeInfo? info = context.GetTypeInfo(type);
             if (info is null)
             {
-                ThrowHelper.ThrowInvalidOperationException_NoMetadataForType(type);
+                ThrowHelper.ThrowInvalidOperationException_NoMetadataForType(type, context);
             }
 
             return info;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -33,8 +33,6 @@ namespace System.Text.Json
         ///
         /// If the <see cref="JsonSerializerOptions"/> instance is locked for modification, the method will return a cached instance for the metadata.
         /// </remarks>
-        [RequiresUnreferencedCode("Getting a metadata for a type may require reflection which depends on unreferenced code.")]
-        [RequiresDynamicCode("Getting a metadata for a type may require reflection which depends on runtime code generation.")]
         public JsonTypeInfo GetTypeInfo(Type type)
         {
             if (type is null)
@@ -46,8 +44,6 @@ namespace System.Text.Json
             {
                 ThrowHelper.ThrowArgumentException_CannotSerializeInvalidType(nameof(type), type, null, null);
             }
-
-            _typeInfoResolver ??= DefaultJsonTypeInfoResolver.RootDefaultInstance();
 
             JsonTypeInfo? typeInfo;
             if (IsLockedInstance)
@@ -62,7 +58,7 @@ namespace System.Text.Json
 
             if (typeInfo is null)
             {
-                ThrowHelper.ThrowNotSupportedException_NoMetadataForType(type);
+                ThrowHelper.ThrowNotSupportedException_NoMetadataForType(type, TypeInfoResolver);
             }
 
             return typeInfo;
@@ -82,7 +78,7 @@ namespace System.Text.Json
 
             if (typeInfo == null)
             {
-                ThrowHelper.ThrowNotSupportedException_NoMetadataForType(type);
+                ThrowHelper.ThrowNotSupportedException_NoMetadataForType(type, TypeInfoResolver);
                 return null;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -46,7 +46,13 @@ namespace System.Text.Json
                 ThrowHelper.ThrowArgumentNullException(nameof(typeToConvert));
             }
 
-            _typeInfoResolver ??= DefaultJsonTypeInfoResolver.RootDefaultInstance();
+            if (_typeInfoResolver is null)
+            {
+                // Backward compatibility -- root the default reflection converters
+                // but do not populate the TypeInfoResolver setting.
+                DefaultJsonTypeInfoResolver.RootDefaultInstance();
+            }
+
             return GetConverterFromTypeInfo(typeToConvert);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
@@ -118,7 +118,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
-        internal static DefaultJsonTypeInfoResolver? DefaultInstance => s_defaultInstance;
+        internal static bool IsDefaultInstanceRooted => s_defaultInstance is not null;
         private static DefaultJsonTypeInfoResolver? s_defaultInstance;
 
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -205,7 +205,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             if (ThrowOnDeserialize)
             {
-                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(Options.TypeInfoResolverSafe, Type);
+                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(Options.TypeInfoResolver, Type);
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -434,7 +434,11 @@ namespace System.Text.Json.Serialization.Metadata
         internal virtual void Configure()
         {
             Debug.Assert(Monitor.IsEntered(_configureLock), "Configure called directly, use EnsureConfigured which locks this method");
-            Options.InitializeForMetadataGeneration();
+
+            if (!Options.IsLockedInstance)
+            {
+                Options.InitializeForMetadataGeneration();
+            }
 
             PropertyInfoForTypeInfo.EnsureChildOf(this);
             PropertyInfoForTypeInfo.EnsureConfigured();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
@@ -94,7 +94,7 @@ namespace System.Text.Json.Serialization.Metadata
             JsonParameterInfoValues[] array;
             if (CtorParamInitFunc == null || (array = CtorParamInitFunc()) == null)
             {
-                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeCtorParams(Options.TypeInfoResolverSafe, Type);
+                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeCtorParams(Options.TypeInfoResolver, Type);
                 return null!;
             }
 
@@ -132,7 +132,7 @@ namespace System.Text.Json.Serialization.Metadata
                     return;
                 }
 
-                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(Options.TypeInfoResolverSafe, Type);
+                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(Options.TypeInfoResolver, Type);
                 return;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -651,15 +651,15 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowNotSupportedException_NoMetadataForType(Type type)
+        public static void ThrowNotSupportedException_NoMetadataForType(Type type, IJsonTypeInfoResolver? resolver)
         {
-            throw new NotSupportedException(SR.Format(SR.NoMetadataForType, type));
+            throw new NotSupportedException(SR.Format(SR.NoMetadataForType, type, resolver?.GetType().FullName ?? "<null>"));
         }
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException_NoMetadataForType(Type type)
+        public static void ThrowInvalidOperationException_NoMetadataForType(Type type, IJsonTypeInfoResolver? resolver)
         {
-            throw new InvalidOperationException(SR.Format(SR.NoMetadataForType, type));
+            throw new InvalidOperationException(SR.Format(SR.NoMetadataForType, type, resolver?.GetType().FullName ?? "<null>"));
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoOptionsAreSet()
         {
-            JsonSerializerOptions options = new();
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
             JsonTypeInfo typeInfo = JsonTypeInfo.CreateJsonTypeInfo(typeof(MyClass), options);
             CreatePropertyAndCheckOptions(options, typeInfo);
 
@@ -51,7 +51,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoPropertyTypeIsSet()
         {
-            JsonSerializerOptions options = new();
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
             JsonTypeInfo typeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(MyClass), options);
             Assert.Equal(2, typeInfo.Properties.Count);
             JsonPropertyInfo propertyInfo = typeInfo.Properties[0];
@@ -79,7 +79,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoNameIsSetAndIsMutableForDefaultResolver()
         {
-            JsonSerializerOptions options = new();
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
             JsonTypeInfo typeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(MyClass), options);
             Assert.Equal(2, typeInfo.Properties.Count);
             JsonPropertyInfo propertyInfo = typeInfo.Properties[0];
@@ -95,7 +95,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoForDefaultResolverHasNamingPoliciesRulesApplied()
         {
-            JsonSerializerOptions options = new();
+            JsonSerializerOptions options = new() { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
             options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
             JsonTypeInfo typeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(MyClass), options);
             Assert.Equal(2, typeInfo.Properties.Count);
@@ -111,7 +111,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoCustomConverterIsNullWhenUsingCreateJsonPropertyInfo()
         {
-            JsonSerializerOptions options = new();
+            JsonSerializerOptions options = new() { TypeInfoResolver = JsonSerializerOptions.Default.TypeInfoResolver };
             JsonTypeInfo typeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(TestClassWithCustomConverterOnProperty), options);
             JsonPropertyInfo propertyInfo = typeInfo.CreateJsonPropertyInfo(typeof(MyClass), "test");
 
@@ -121,7 +121,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoCustomConverterIsNotNullForPropertyWithCustomConverter()
         {
-            JsonSerializerOptions options = new();
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
             JsonTypeInfo typeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(TestClassWithCustomConverterOnProperty), options);
             Assert.Equal(1, typeInfo.Properties.Count);
             JsonPropertyInfo propertyInfo = typeInfo.Properties[0];
@@ -259,7 +259,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoGetIsNullAndMutableWhenUsingCreateJsonPropertyInfo()
         {
-            JsonSerializerOptions options = new();
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
             JsonTypeInfo typeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(TestClassWithCustomConverterOnProperty), options);
             JsonPropertyInfo propertyInfo = typeInfo.CreateJsonPropertyInfo(typeof(MyClass), "test");
             Assert.Null(propertyInfo.Get);
@@ -275,7 +275,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoGetIsNotNullForDefaultResolver()
         {
-            JsonSerializerOptions options = new();
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
             JsonTypeInfo typeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(TestClassWithCustomConverterOnProperty), options);
             JsonPropertyInfo propertyInfo = typeInfo.Properties[0];
 
@@ -383,7 +383,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoSetIsNullAndMutableWhenUsingCreateJsonPropertyInfo()
         {
-            JsonSerializerOptions options = new();
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
             JsonTypeInfo typeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(TestClassWithCustomConverterOnProperty), options);
             JsonPropertyInfo propertyInfo = typeInfo.CreateJsonPropertyInfo(typeof(MyClass), "test");
             Assert.Null(propertyInfo.Set);
@@ -399,7 +399,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoSetIsNotNullForDefaultResolver()
         {
-            JsonSerializerOptions options = new();
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
             JsonTypeInfo typeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(TestClassWithCustomConverterOnProperty), options);
             Assert.Equal(1, typeInfo.Properties.Count);
             JsonPropertyInfo propertyInfo = typeInfo.Properties[0];

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -131,7 +131,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void DefaultTypeInfoResolverNull()
+        public static void NewDefaultOptions_TypeInfoResolverIsNull()
         {
             var options = new JsonSerializerOptions();
             Assert.Null(options.TypeInfoResolver);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -37,17 +37,12 @@ namespace System.Text.Json.Serialization.Tests
 
             TestIListNonThrowingOperationsWhenMutable(options.Converters, () => new TestConverter());
 
-            // Verify default TypeInfoResolver throws
-            Action<JsonTypeInfo> tiModifier = (ti) => { };
-            Assert.Throws<InvalidOperationException>(() => (options.TypeInfoResolver as DefaultJsonTypeInfoResolver).Modifiers.Clear());
-            Assert.Throws<InvalidOperationException>(() => (options.TypeInfoResolver as DefaultJsonTypeInfoResolver).Modifiers.Add(tiModifier));
-            Assert.Throws<InvalidOperationException>(() => (options.TypeInfoResolver as DefaultJsonTypeInfoResolver).Modifiers.Insert(0, tiModifier));
-
             // Now set DefaultTypeInfoResolver
             options.TypeInfoResolver = new DefaultJsonTypeInfoResolver();
             TestIListNonThrowingOperationsWhenMutable((options.TypeInfoResolver as DefaultJsonTypeInfoResolver).Modifiers, () => (ti) => { });
 
             // Add one item for later.
+            Action<JsonTypeInfo> tiModifier = (ti) => { };
             TestConverter tc = new TestConverter();
             options.Converters.Add(tc);
             (options.TypeInfoResolver as DefaultJsonTypeInfoResolver).Modifiers.Add(tiModifier);
@@ -136,12 +131,10 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void TypeInfoResolverIsNotNullAndCorrectType()
+        public static void DefaultTypeInfoResolverNull()
         {
             var options = new JsonSerializerOptions();
-            Assert.NotNull(options.TypeInfoResolver);
-            Assert.IsType<DefaultJsonTypeInfoResolver>(options.TypeInfoResolver);
-            Assert.Same(options.TypeInfoResolver, options.TypeInfoResolver);
+            Assert.Null(options.TypeInfoResolver);
         }
 
         [Fact]
@@ -670,7 +663,7 @@ namespace System.Text.Json.Serialization.Tests
 
             // it is possible to reset the resolver
             newOptions.TypeInfoResolver = null;
-            Assert.IsType<DefaultJsonTypeInfoResolver>(newOptions.TypeInfoResolver);
+            Assert.Null(newOptions.TypeInfoResolver);
         }
 
         [Fact]
@@ -681,9 +674,9 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void JsonSerializerOptions_Default_MatchesDefaultConstructor()
+        public static void JsonSerializerOptions_Default_MatchesDefaultConstructorWithDefaultResolver()
         {
-            var options = new JsonSerializerOptions();
+            var options = new JsonSerializerOptions { TypeInfoResolver = JsonSerializerOptions.Default.TypeInfoResolver };
             JsonSerializerOptions optionsSingleton = JsonSerializerOptions.Default;
             VerifyOptionsEqual(options, optionsSingleton);
         }
@@ -702,6 +695,11 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<InvalidOperationException>(() => optionsSingleton.Converters.Add(new JsonStringEnumConverter()));
             Assert.Throws<InvalidOperationException>(() => optionsSingleton.AddContext<JsonContext>());
             Assert.Throws<InvalidOperationException>(() => new JsonContext(optionsSingleton));
+
+            DefaultJsonTypeInfoResolver resolver = Assert.IsType<DefaultJsonTypeInfoResolver>(optionsSingleton.TypeInfoResolver);
+            Assert.Throws<InvalidOperationException>(() => resolver.Modifiers.Clear());
+            Assert.Throws<InvalidOperationException>(() => resolver.Modifiers.Add(ti => { }));
+            Assert.Throws<InvalidOperationException>(() => resolver.Modifiers.Insert(0, ti => { }));
         }
 
         [Fact]
@@ -928,6 +926,11 @@ namespace System.Text.Json.Serialization.Tests
         public static void GetTypeInfo_MutableOptionsInstance(Type type)
         {
             var options = new JsonSerializerOptions();
+
+            // An unset resolver results in NotSupportedException.
+            Assert.Throws<NotSupportedException>(() => options.GetTypeInfo(type));
+
+            options.TypeInfoResolver = new DefaultJsonTypeInfoResolver();
             JsonTypeInfo typeInfo = options.GetTypeInfo(type);
             Assert.Equal(type, typeInfo.Type);
 
@@ -959,7 +962,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void GetTypeInfo_MutableOptions_CanModifyMetadata()
         {
-            var options = new JsonSerializerOptions();
+            var options = new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
             JsonTypeInfo<TestClassForEncoding> jti = (JsonTypeInfo<TestClassForEncoding>)options.GetTypeInfo(typeof(TestClassForEncoding));
 
             Assert.Equal(1, jti.Properties.Count);
@@ -1062,7 +1065,7 @@ namespace System.Text.Json.Serialization.Tests
         [MemberData(nameof(GetTypeInfo_ResultsAreGeneric_Values))]
         public static void GetTypeInfo_ResultsAreGeneric<T>(T value, string expectedJson)
         {
-            var options = new JsonSerializerOptions();
+            var options = new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
             JsonTypeInfo<T> jsonTypeInfo = (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
             string json = JsonSerializer.Serialize(value, jsonTypeInfo);
             Assert.Equal(expectedJson, json);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/TypeInfoResolverFunctionalTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/TypeInfoResolverFunctionalTests.cs
@@ -615,7 +615,7 @@ namespace System.Text.Json.Serialization.Tests
                 return ti;
             });
 
-            JsonSerializerOptions options = new JsonSerializerOptions();
+            JsonSerializerOptions options = new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
             options.IncludeFields = true;
             options.TypeInfoResolver = JsonTypeInfoResolver.Combine(resolver, options.TypeInfoResolver);
 


### PR DESCRIPTION
Fix #71960.