### PR TITLE
[mono] Build mono logging profiler on s390x

### DIFF
--- a/src/mono/mono/profiler/CMakeLists.txt
+++ b/src/mono/mono/profiler/CMakeLists.txt
@@ -10,9 +10,10 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/../sgen)
 
 if(NOT DISABLE_LIBS)
-  if(HOST_ANDROID OR HOST_IOS OR HOST_TVOS)
-    # Build the logging profiler only for mobile platforms
+  if(HOST_ANDROID OR HOST_IOS OR HOST_TVOS OR HOST_S390X)
+    # Build the logging profiler only for certain platforms
     add_library(mono-profiler-log SHARED helper.c log.c log-args.c ${ZLIB_SOURCES})
+    target_compile_definitions(mono-profiler-log PRIVATE -DMONO_DLL_EXPORT)
     target_link_libraries(mono-profiler-log monosgen-shared eglib_objects monoapi)
     if(HOST_ANDROID)
       target_link_libraries(mono-profiler-log log)


### PR DESCRIPTION
At the moment we don't have too many profiling options on s390x, and
the logging profiler comes in handy. Enable building it on s390x and
define MONO_DLL_EXPORT in order to unhide mono_profiler_init_log().