### PR TITLE
Improve argument validation for Rfc2898DeriveBytes

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
@@ -53,7 +53,12 @@ namespace System.Security.Cryptography
         }
 
         public Rfc2898DeriveBytes(string password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm)
-            : this(Encoding.UTF8.GetBytes(password), salt, iterations, hashAlgorithm, clearPassword: true)
+            : this(
+                Encoding.UTF8.GetBytes(password ?? throw new ArgumentNullException(nameof(password))),
+                salt,
+                iterations,
+                hashAlgorithm,
+                clearPassword: true)
         {
         }
 
@@ -91,7 +96,7 @@ namespace System.Security.Cryptography
 
         internal Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm, bool clearPassword) :
             this(
-                new ReadOnlySpan<byte>(password ?? throw new NullReferenceException()), // This "should" be ArgumentNullException but for compat, we throw NullReferenceException.
+                new ReadOnlySpan<byte>(password ?? throw new ArgumentNullException(nameof(password))),
                 new ReadOnlySpan<byte>(salt ?? throw new ArgumentNullException(nameof(salt))),
                 iterations,
                 hashAlgorithm)

--- a/src/libraries/System.Security.Cryptography/tests/Rfc2898Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/Rfc2898Tests.cs
@@ -20,14 +20,14 @@ namespace System.Security.Cryptography
         [Fact]
         public static void Ctor_NullPasswordBytes()
         {
-            Assert.Throws<NullReferenceException>(() =>
+            Assert.Throws<ArgumentNullException>("password", () =>
                 new Rfc2898DeriveBytes((byte[])null, s_testSalt, DefaultIterationCount, HashAlgorithmName.SHA1));
         }
 
         [Fact]
         public static void Ctor_NullPasswordString()
         {
-            Assert.Throws<ArgumentNullException>(() =>
+            Assert.Throws<ArgumentNullException>("password", () =>
                 new Rfc2898DeriveBytes((string)null, s_testSalt, DefaultIterationCount, HashAlgorithmName.SHA1));
         }
 


### PR DESCRIPTION
Two changes:

1. The `byte[] password` changed from `NullReferenceException` to `ArgumentNullException`.
2. The `string password`'s `ArgumentNullException` paramName changed from `s` to `password`.