### PR TITLE
[RateLimiting] Rename WaitAsync and RateLimitPartition methods

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
+++ b/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
@@ -14,7 +14,7 @@ namespace System.Threading.RateLimiting
         protected override void Dispose(bool disposing) { }
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public override int GetAvailablePermits() { throw null; }
-        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsyncCore(int permitCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public sealed partial class ConcurrencyLimiterOptions
     {
@@ -34,7 +34,7 @@ namespace System.Threading.RateLimiting
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public override int GetAvailablePermits() { throw null; }
         public override bool TryReplenish() { throw null; }
-        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public sealed partial class FixedWindowRateLimiterOptions
     {
@@ -77,8 +77,8 @@ namespace System.Threading.RateLimiting
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public abstract int GetAvailablePermits(TResource resourceID);
-        public System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsync(TResource resourceID, int permitCount = 1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        protected abstract System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsyncCore(TResource resourceID, int permitCount, System.Threading.CancellationToken cancellationToken);
+        public System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsync(TResource resourceID, int permitCount = 1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected abstract System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(TResource resourceID, int permitCount, System.Threading.CancellationToken cancellationToken);
     }
     public enum QueueProcessingOrder
     {
@@ -96,8 +96,8 @@ namespace System.Threading.RateLimiting
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public abstract int GetAvailablePermits();
-        public System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsync(int permitCount = 1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        protected abstract System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsyncCore(int permitCount, System.Threading.CancellationToken cancellationToken);
+        public System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsync(int permitCount = 1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected abstract System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, System.Threading.CancellationToken cancellationToken);
     }
     public abstract partial class RateLimitLease : System.IDisposable
     {
@@ -112,12 +112,12 @@ namespace System.Threading.RateLimiting
     }
     public static partial class RateLimitPartition
     {
-        public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateConcurrencyLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.ConcurrencyLimiterOptions> factory) { throw null; }
-        public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateFixedWindowLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.FixedWindowRateLimiterOptions> factory) { throw null; }
-        public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateNoLimiter<TKey>(TKey partitionKey) { throw null; }
-        public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateSlidingWindowLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.SlidingWindowRateLimiterOptions> factory) { throw null; }
-        public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateTokenBucketLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.TokenBucketRateLimiterOptions> factory) { throw null; }
-        public static System.Threading.RateLimiting.RateLimitPartition<TKey> Create<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.RateLimiter> factory) { throw null; }
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> GetConcurrencyLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.ConcurrencyLimiterOptions> factory) { throw null; }
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> GetFixedWindowLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.FixedWindowRateLimiterOptions> factory) { throw null; }
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> GetNoLimiter<TKey>(TKey partitionKey) { throw null; }
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> GetSlidingWindowLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.SlidingWindowRateLimiterOptions> factory) { throw null; }
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> GetTokenBucketLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.TokenBucketRateLimiterOptions> factory) { throw null; }
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> Get<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.RateLimiter> factory) { throw null; }
     }
     public partial struct RateLimitPartition<TKey>
     {
@@ -125,8 +125,8 @@ namespace System.Threading.RateLimiting
         private object _dummy;
         private int _dummyPrimitive;
         public RateLimitPartition(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.RateLimiter> factory) { throw null; }
+        public readonly System.Func<TKey, System.Threading.RateLimiting.RateLimiter> Factory { get { throw null; } }
         public readonly TKey PartitionKey { get { throw null; } }
-        public readonly Func<TKey, RateLimiter> Factory { get { throw null; } }
     }
     public abstract partial class ReplenishingRateLimiter : System.Threading.RateLimiting.RateLimiter
     {
@@ -146,7 +146,7 @@ namespace System.Threading.RateLimiting
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public override int GetAvailablePermits() { throw null; }
         public override bool TryReplenish() { throw null; }
-        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public sealed partial class SlidingWindowRateLimiterOptions
     {
@@ -169,7 +169,7 @@ namespace System.Threading.RateLimiting
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public override int GetAvailablePermits() { throw null; }
         public override bool TryReplenish() { throw null; }
-        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsyncCore(int tokenCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(int tokenCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public sealed partial class TokenBucketRateLimiterOptions
     {

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
@@ -66,7 +66,7 @@ namespace System.Threading.RateLimiting
             return new CombinedRateLimitLease(leases!);
         }
 
-        protected override async ValueTask<RateLimitLease> WaitAsyncCore(TResource resourceID, int permitCount, CancellationToken cancellationToken)
+        protected override async ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(TResource resourceID, int permitCount, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
             RateLimitLease[]? leases = null;
@@ -76,7 +76,7 @@ namespace System.Threading.RateLimiting
                 Exception? exception = null;
                 try
                 {
-                    lease = await _limiters[i].WaitAsync(resourceID, permitCount, cancellationToken).ConfigureAwait(false);
+                    lease = await _limiters[i].WaitAndAcquireAsync(resourceID, permitCount, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -78,7 +78,7 @@ namespace System.Threading.RateLimiting
         }
 
         /// <inheritdoc/>
-        protected override ValueTask<RateLimitLease> WaitAsyncCore(int permitCount, CancellationToken cancellationToken = default)
+        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken = default)
         {
             // These amounts of resources can never be acquired
             if (permitCount > _options.PermitLimit)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiterOptions.cs
@@ -12,7 +12,7 @@ namespace System.Threading.RateLimiting
         /// Initializes the <see cref="ConcurrencyLimiterOptions"/>.
         /// </summary>
         /// <param name="permitLimit">Maximum number of permits that can be leased concurrently.</param>
-        /// <param name="queueProcessingOrder">Determines the behaviour of <see cref="RateLimiter.WaitAsync"/> when not enough resources can be leased.</param>
+        /// <param name="queueProcessingOrder">Determines the behaviour of <see cref="RateLimiter.WaitAndAcquireAsync"/> when not enough resources can be leased.</param>
         /// <param name="queueLimit">Maximum number of permits that can be queued concurrently.</param>
         /// <exception cref="ArgumentOutOfRangeException">When <paramref name="permitLimit"/> or <paramref name="queueLimit"/> are less than 0.</exception>
         public ConcurrencyLimiterOptions(int permitLimit, QueueProcessingOrder queueProcessingOrder, int queueLimit)
@@ -36,7 +36,7 @@ namespace System.Threading.RateLimiting
         public int PermitLimit { get; }
 
         /// <summary>
-        /// Determines the behaviour of <see cref="RateLimiter.WaitAsync"/> when not enough resources can be leased.
+        /// Determines the behaviour of <see cref="RateLimiter.WaitAndAcquireAsync"/> when not enough resources can be leased.
         /// </summary>
         /// <value>
         /// <see cref="QueueProcessingOrder.OldestFirst"/> by default.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
@@ -68,9 +68,9 @@ namespace System.Threading.RateLimiting
             return GetRateLimiter(resourceID).Acquire(permitCount);
         }
 
-        protected override ValueTask<RateLimitLease> WaitAsyncCore(TResource resourceID, int permitCount, CancellationToken cancellationToken)
+        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(TResource resourceID, int permitCount, CancellationToken cancellationToken)
         {
-            return GetRateLimiter(resourceID).WaitAsync(permitCount, cancellationToken);
+            return GetRateLimiter(resourceID).WaitAndAcquireAsync(permitCount, cancellationToken);
         }
 
         private RateLimiter GetRateLimiter(TResource resourceID)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -93,7 +93,7 @@ namespace System.Threading.RateLimiting
         }
 
         /// <inheritdoc/>
-        protected override ValueTask<RateLimitLease> WaitAsyncCore(int requestCount, CancellationToken cancellationToken = default)
+        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int requestCount, CancellationToken cancellationToken = default)
         {
             // These amounts of resources can never be acquired
             if (requestCount > _options.PermitLimit)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiterOptions.cs
@@ -13,7 +13,7 @@ namespace System.Threading.RateLimiting
         /// </summary>
         /// <param name="permitLimit">Maximum number of requests that can be served in the window.</param>
         /// <param name="queueProcessingOrder"></param>
-        /// <param name="queueLimit">Maximum number of unprocessed request counters waiting via <see cref="RateLimiter.WaitAsync(int, CancellationToken)"/>.</param>
+        /// <param name="queueLimit">Maximum number of unprocessed request counters waiting via <see cref="RateLimiter.WaitAndAcquireAsync(int, CancellationToken)"/>.</param>
         /// <param name="window">
         /// Specifies how often request counters can be replenished. Replenishing is triggered either by an internal timer if <paramref name="autoReplenishment"/> is true, or by calling <see cref="FixedWindowRateLimiter.TryReplenish"/>.
         /// </param>
@@ -61,7 +61,7 @@ namespace System.Threading.RateLimiting
         public int PermitLimit { get; }
 
         /// <summary>
-        /// Determines the behaviour of <see cref="RateLimiter.WaitAsync"/> when not enough resources can be leased.
+        /// Determines the behaviour of <see cref="RateLimiter.WaitAndAcquireAsync"/> when not enough resources can be leased.
         /// </summary>
         /// <value>
         /// <see cref="QueueProcessingOrder.OldestFirst"/> by default.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
@@ -20,7 +20,7 @@ namespace System.Threading.RateLimiting
 
         protected override RateLimitLease AcquireCore(int permitCount) => _lease;
 
-        protected override ValueTask<RateLimitLease> WaitAsyncCore(int permitCount, CancellationToken cancellationToken)
+        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
             => new ValueTask<RateLimitLease>(_lease);
 
         private sealed class NoopLease : RateLimitLease

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
@@ -56,7 +56,7 @@ namespace System.Threading.RateLimiting
         /// <param name="cancellationToken">Optional token to allow canceling a queued request for permits.</param>
         /// <returns>A task that completes when the requested permits are acquired or when the requested permits are denied.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public ValueTask<RateLimitLease> WaitAsync(TResource resourceID, int permitCount = 1, CancellationToken cancellationToken = default)
+        public ValueTask<RateLimitLease> WaitAndAcquireAsync(TResource resourceID, int permitCount = 1, CancellationToken cancellationToken = default)
         {
             if (permitCount < 0)
             {
@@ -68,17 +68,17 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(Task.FromCanceled<RateLimitLease>(cancellationToken));
             }
 
-            return WaitAsyncCore(resourceID, permitCount, cancellationToken);
+            return WaitAndAcquireAsyncCore(resourceID, permitCount, cancellationToken);
         }
 
         /// <summary>
-        /// Method that <see cref="PartitionedRateLimiter{TResource}"/> implementations implement for <see cref="WaitAsync"/>.
+        /// Method that <see cref="PartitionedRateLimiter{TResource}"/> implementations implement for <see cref="WaitAndAcquireAsync"/>.
         /// </summary>
         /// <param name="resourceID">The resource to limit.</param>
         /// <param name="permitCount">Number of permits to try and acquire.</param>
         /// <param name="cancellationToken">Optional token to allow canceling a queued request for permits.</param>
         /// <returns>A task that completes when the requested permits are acquired or when the requested permits are denied.</returns>
-        protected abstract ValueTask<RateLimitLease> WaitAsyncCore(TResource resourceID, int permitCount, CancellationToken cancellationToken);
+        protected abstract ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(TResource resourceID, int permitCount, CancellationToken cancellationToken);
 
         /// <summary>
         /// Dispose method for implementations to write.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/QueueProcessingOrder.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/QueueProcessingOrder.cs
@@ -4,16 +4,16 @@
 namespace System.Threading.RateLimiting
 {
     /// <summary>
-    /// Controls the behavior of <see cref="RateLimiter.WaitAsync"/> when not enough resources can be leased.
+    /// Controls the behavior of <see cref="RateLimiter.WaitAndAcquireAsync"/> when not enough resources can be leased.
     /// </summary>
     public enum QueueProcessingOrder
     {
         /// <summary>
-        /// Lease the oldest queued <see cref="RateLimiter.WaitAsync"/>.
+        /// Lease the oldest queued <see cref="RateLimiter.WaitAndAcquireAsync"/> call.
         /// </summary>
         OldestFirst,
         /// <summary>
-        /// Lease the newest queued <see cref="RateLimiter.WaitAsync"/>.
+        /// Lease the newest queued <see cref="RateLimiter.WaitAndAcquireAsync"/> call.
         /// </summary>
         NewestFirst
     }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.T.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.T.cs
@@ -4,7 +4,7 @@
 namespace System.Threading.RateLimiting
 {
     /// <summary>
-    /// Type returned by <see cref="RateLimitPartition.Create"/> methods to be used by <see cref="PartitionedRateLimiter.Create"/> to know what partitions are configured.
+    /// Type returned by <see cref="RateLimitPartition.Get"/> methods to be used by <see cref="PartitionedRateLimiter.Create"/> to know what partitions are configured.
     /// </summary>
     /// <typeparam name="TKey">The type to distinguish partitions with.</typeparam>
     public struct RateLimitPartition<TKey>

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.cs
@@ -18,7 +18,7 @@ namespace System.Threading.RateLimiting
         /// <param name="partitionKey">The specific key for this partition. This will be used to check for an existing cached limiter before calling the <paramref name="factory"/>.</param>
         /// <param name="factory">The function called when a rate limiter for the given <paramref name="partitionKey"/> is needed. This should be a new instance of a rate limiter every time it is called.</param>
         /// <returns></returns>
-        public static RateLimitPartition<TKey> Create<TKey>(
+        public static RateLimitPartition<TKey> Get<TKey>(
             TKey partitionKey,
             Func<TKey, RateLimiter> factory)
         {
@@ -32,23 +32,23 @@ namespace System.Threading.RateLimiting
         /// <param name="partitionKey">The specific key for this partition. This will be used to check for an existing cached limiter before calling the <paramref name="factory"/>.</param>
         /// <param name="factory">The function called when a rate limiter for the given <paramref name="partitionKey"/> is needed. This can return the same instance of <see cref="ConcurrencyLimiterOptions"/> across different calls.</param>
         /// <returns></returns>
-        public static RateLimitPartition<TKey> CreateConcurrencyLimiter<TKey>(
+        public static RateLimitPartition<TKey> GetConcurrencyLimiter<TKey>(
             TKey partitionKey,
             Func<TKey, ConcurrencyLimiterOptions> factory)
         {
-            return Create(partitionKey, key => new ConcurrencyLimiter(factory(key)));
+            return Get(partitionKey, key => new ConcurrencyLimiter(factory(key)));
         }
 
         /// <summary>
         /// Defines a partition that will not have a rate limiter.
-        /// This means any calls to <see cref="PartitionedRateLimiter{TResource}.Acquire(TResource, int)"/> or <see cref="PartitionedRateLimiter{TResource}.WaitAsync(TResource, int, CancellationToken)"/> will always succeed for the given <paramref name="partitionKey"/>.
+        /// This means any calls to <see cref="PartitionedRateLimiter{TResource}.Acquire(TResource, int)"/> or <see cref="PartitionedRateLimiter{TResource}.WaitAndAcquireAsync(TResource, int, CancellationToken)"/> will always succeed for the given <paramref name="partitionKey"/>.
         /// </summary>
         /// <typeparam name="TKey">The type to distinguish partitions with.</typeparam>
         /// <param name="partitionKey">The specific key for this partition.</param>
         /// <returns></returns>
-        public static RateLimitPartition<TKey> CreateNoLimiter<TKey>(TKey partitionKey)
+        public static RateLimitPartition<TKey> GetNoLimiter<TKey>(TKey partitionKey)
         {
-            return Create(partitionKey, _ => NoopLimiter.Instance);
+            return Get(partitionKey, _ => NoopLimiter.Instance);
         }
 
         /// <summary>
@@ -61,11 +61,11 @@ namespace System.Threading.RateLimiting
         /// <param name="partitionKey">The specific key for this partition.</param>
         /// <param name="factory">The function called when a rate limiter for the given <paramref name="partitionKey"/> is needed. This can return the same instance of <see cref="TokenBucketRateLimiterOptions"/> across different calls.</param>
         /// <returns></returns>
-        public static RateLimitPartition<TKey> CreateTokenBucketLimiter<TKey>(
+        public static RateLimitPartition<TKey> GetTokenBucketLimiter<TKey>(
             TKey partitionKey,
             Func<TKey, TokenBucketRateLimiterOptions> factory)
         {
-            return Create(partitionKey, key =>
+            return Get(partitionKey, key =>
             {
                 TokenBucketRateLimiterOptions options = factory(key);
                 // We don't want individual TokenBucketRateLimiters to have timers. We will instead have our own internal Timer handling all of them
@@ -88,11 +88,11 @@ namespace System.Threading.RateLimiting
         /// <param name="partitionKey">The specific key for this partition.</param>
         /// <param name="factory">The function called when a rate limiter for the given <paramref name="partitionKey"/> is needed. This can return the same instance of <see cref="SlidingWindowRateLimiterOptions"/> across different calls.</param>
         /// <returns></returns>
-        public static RateLimitPartition<TKey> CreateSlidingWindowLimiter<TKey>(
+        public static RateLimitPartition<TKey> GetSlidingWindowLimiter<TKey>(
             TKey partitionKey,
             Func<TKey, SlidingWindowRateLimiterOptions> factory)
         {
-            return Create(partitionKey, key =>
+            return Get(partitionKey, key =>
             {
                 SlidingWindowRateLimiterOptions options = factory(key);
                 // We don't want individual SlidingWindowRateLimiters to have timers. We will instead have our own internal Timer handling all of them
@@ -115,11 +115,11 @@ namespace System.Threading.RateLimiting
         /// <param name="partitionKey">The specific key for this partition.</param>
         /// <param name="factory">The function called when a rate limiter for the given <paramref name="partitionKey"/> is needed. This can return the same instance of <see cref="FixedWindowRateLimiterOptions"/> across different calls.</param>
         /// <returns></returns>
-        public static RateLimitPartition<TKey> CreateFixedWindowLimiter<TKey>(
+        public static RateLimitPartition<TKey> GetFixedWindowLimiter<TKey>(
             TKey partitionKey,
             Func<TKey, FixedWindowRateLimiterOptions> factory)
         {
-            return Create(partitionKey, key =>
+            return Get(partitionKey, key =>
             {
                 FixedWindowRateLimiterOptions options = factory(key);
                 // We don't want individual FixedWindowRateLimiters to have timers. We will instead have our own internal Timer handling all of them

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
@@ -61,7 +61,7 @@ namespace System.Threading.RateLimiting
         /// <param name="cancellationToken">Optional token to allow canceling a queued request for permits.</param>
         /// <returns>A task that completes when the requested permits are acquired or when the requested permits are denied.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public ValueTask<RateLimitLease> WaitAsync(int permitCount = 1, CancellationToken cancellationToken = default)
+        public ValueTask<RateLimitLease> WaitAndAcquireAsync(int permitCount = 1, CancellationToken cancellationToken = default)
         {
             if (permitCount < 0)
             {
@@ -73,16 +73,16 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(Task.FromCanceled<RateLimitLease>(cancellationToken));
             }
 
-            return WaitAsyncCore(permitCount, cancellationToken);
+            return WaitAndAcquireAsyncCore(permitCount, cancellationToken);
         }
 
         /// <summary>
-        /// Method that <see cref="RateLimiter"/> implementations implement for <see cref="WaitAsync"/>.
+        /// Method that <see cref="RateLimiter"/> implementations implement for <see cref="WaitAndAcquireAsync"/>.
         /// </summary>
         /// <param name="permitCount">Number of permits to try and acquire.</param>
         /// <param name="cancellationToken">Optional token to allow canceling a queued request for permits.</param>
         /// <returns>A task that completes when the requested permits are acquired or when the requested permits are denied.</returns>
-        protected abstract ValueTask<RateLimitLease> WaitAsyncCore(int permitCount, CancellationToken cancellationToken);
+        protected abstract ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken);
 
         /// <summary>
         /// Dispose method for implementations to write.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -98,7 +98,7 @@ namespace System.Threading.RateLimiting
         }
 
         /// <inheritdoc/>
-        protected override ValueTask<RateLimitLease> WaitAsyncCore(int requestCount, CancellationToken cancellationToken = default)
+        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int requestCount, CancellationToken cancellationToken = default)
         {
             // These amounts of resources can never be acquired
             if (requestCount > _options.PermitLimit)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiterOptions.cs
@@ -13,7 +13,7 @@ namespace System.Threading.RateLimiting
         /// </summary>
         /// <param name="permitLimit">Maximum number of request counters that can be served in a window.</param>
         /// <param name="queueProcessingOrder"></param>
-        /// <param name="queueLimit">Maximum number of unprocessed request counters waiting via <see cref="RateLimiter.WaitAsync(int, CancellationToken)"/>.</param>
+        /// <param name="queueLimit">Maximum number of unprocessed request counters waiting via <see cref="RateLimiter.WaitAndAcquireAsync(int, CancellationToken)"/>.</param>
         /// <param name="window">
         /// Specifies how often requests can be replenished. Replenishing is triggered either by an internal timer if <paramref name="autoReplenishment"/> is true, or by calling <see cref="SlidingWindowRateLimiter.TryReplenish"/>.
         /// </param>
@@ -73,7 +73,7 @@ namespace System.Threading.RateLimiting
         public int PermitLimit { get; }
 
         /// <summary>
-        /// Determines the behaviour of <see cref="RateLimiter.WaitAsync"/> when not enough resources can be leased.
+        /// Determines the behaviour of <see cref="RateLimiter.WaitAndAcquireAsync"/> when not enough resources can be leased.
         /// </summary>
         /// <value>
         /// <see cref="QueueProcessingOrder.OldestFirst"/> by default.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -91,7 +91,7 @@ namespace System.Threading.RateLimiting
         }
 
         /// <inheritdoc/>
-        protected override ValueTask<RateLimitLease> WaitAsyncCore(int tokenCount, CancellationToken cancellationToken = default)
+        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int tokenCount, CancellationToken cancellationToken = default)
         {
             // These amounts of resources can never be acquired
             if (tokenCount > _options.TokenLimit)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiterOptions.cs
@@ -13,7 +13,7 @@ namespace System.Threading.RateLimiting
         /// </summary>
         /// <param name="tokenLimit">Maximum number of tokens that can be in the token bucket.</param>
         /// <param name="queueProcessingOrder"></param>
-        /// <param name="queueLimit">Maximum number of unprocessed tokens waiting via <see cref="RateLimiter.WaitAsync(int, CancellationToken)"/>.</param>
+        /// <param name="queueLimit">Maximum number of unprocessed tokens waiting via <see cref="RateLimiter.WaitAndAcquireAsync(int, CancellationToken)"/>.</param>
         /// <param name="replenishmentPeriod">
         /// Specifies how often tokens can be replenished. Replenishing is triggered either by an internal timer if <paramref name="autoReplenishment"/> is true, or by calling <see cref="TokenBucketRateLimiter.TryReplenish"/>.
         /// </param>
@@ -73,7 +73,7 @@ namespace System.Threading.RateLimiting
         public int TokenLimit { get; }
 
         /// <summary>
-        /// Determines the behaviour of <see cref="RateLimiter.WaitAsync"/> when not enough resources can be leased.
+        /// Determines the behaviour of <see cref="RateLimiter.WaitAndAcquireAsync"/> when not enough resources can be leased.
         /// </summary>
         /// <value>
         /// <see cref="QueueProcessingOrder.OldestFirst"/> by default.

--- a/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
@@ -60,25 +60,25 @@ namespace System.Threading.RateLimiting.Test
         public abstract void AcquireZero_WithoutAvailability();
 
         [Fact]
-        public abstract Task WaitAsyncZero_WithAvailability();
+        public abstract Task WaitAndAcquireAsyncZero_WithAvailability();
 
         [Fact]
-        public abstract Task WaitAsyncZero_WithoutAvailabilityWaitsForAvailability();
+        public abstract Task WaitAndAcquireAsyncZero_WithoutAvailabilityWaitsForAvailability();
 
         [Fact]
         public abstract Task CanDequeueMultipleResourcesAtOnce();
 
         [Fact]
-        public abstract Task CanAcquireResourcesWithWaitAsyncWithQueuedItemsIfNewestFirst();
+        public abstract Task CanAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfNewestFirst();
 
         [Fact]
-        public abstract Task CannotAcquireResourcesWithWaitAsyncWithQueuedItemsIfOldestFirst();
+        public abstract Task CannotAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfOldestFirst();
 
         [Fact]
-        public abstract Task CanCancelWaitAsyncAfterQueuing();
+        public abstract Task CanCancelWaitAndAcquireAsyncAfterQueuing();
 
         [Fact]
-        public abstract Task CanCancelWaitAsyncBeforeQueuing();
+        public abstract Task CanCancelWaitAndAcquireAsyncBeforeQueuing();
 
         [Fact]
         public abstract Task CanFillQueueWithNewestFirstAfterCancelingQueuedRequestWithAnotherQueuedRequest();

--- a/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
@@ -30,11 +30,11 @@ namespace System.Threading.RateLimiting.Tests
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.CreateConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 0));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 0));
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.CreateConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 0));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 0));
             });
             var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
@@ -42,7 +42,7 @@ namespace System.Threading.RateLimiting.Tests
 
             Assert.Throws<ObjectDisposedException>(() => chainedLimiter.GetAvailablePermits(""));
             Assert.Throws<ObjectDisposedException>(() => chainedLimiter.Acquire(""));
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await chainedLimiter.WaitAsync(""));
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
         }
 
         [Fact]
@@ -50,11 +50,11 @@ namespace System.Threading.RateLimiting.Tests
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.CreateConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 0));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 0));
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.CreateConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 0));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 0));
             });
             var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
@@ -62,7 +62,7 @@ namespace System.Threading.RateLimiting.Tests
 
             Assert.Throws<ObjectDisposedException>(() => chainedLimiter.GetAvailablePermits(""));
             Assert.Throws<ObjectDisposedException>(() => chainedLimiter.Acquire(""));
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await chainedLimiter.WaitAsync(""));
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
         }
 
         [Fact]
@@ -70,15 +70,15 @@ namespace System.Threading.RateLimiting.Tests
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.CreateConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(34, QueueProcessingOrder.NewestFirst, 0));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(34, QueueProcessingOrder.NewestFirst, 0));
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.CreateConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(22, QueueProcessingOrder.NewestFirst, 0));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(22, QueueProcessingOrder.NewestFirst, 0));
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.CreateConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(13, QueueProcessingOrder.NewestFirst, 0));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(13, QueueProcessingOrder.NewestFirst, 0));
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
@@ -90,7 +90,7 @@ namespace System.Threading.RateLimiting.Tests
         {
             using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.CreateConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(34, QueueProcessingOrder.NewestFirst, 0));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(34, QueueProcessingOrder.NewestFirst, 0));
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
@@ -103,7 +103,7 @@ namespace System.Threading.RateLimiting.Tests
             var limiterFactory = new TrackingRateLimiterFactory<int>();
             using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(1, key => limiterFactory.GetLimiter(key));
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
@@ -116,21 +116,21 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncWorksWithSingleLimiter()
+        public async Task WaitAndAcquireAsyncWorksWithSingleLimiter()
         {
             var limiterFactory = new TrackingRateLimiterFactory<int>();
             using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(1, key => limiterFactory.GetLimiter(key));
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
-            using var lease = await chainedLimiter.WaitAsync("");
+            using var lease = await chainedLimiter.WaitAndAcquireAsync("");
 
             Assert.True(lease.IsAcquired);
             Assert.Single(limiterFactory.Limiters);
             Assert.Equal(1, limiterFactory.Limiters[0].Key);
-            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.WaitAsyncCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.WaitAndAcquireAsyncCallCount);
         }
 
         [Fact]
@@ -139,11 +139,11 @@ namespace System.Threading.RateLimiting.Tests
             var limiterFactory = new TrackingRateLimiterFactory<int>();
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(1, key => limiterFactory.GetLimiter(key));
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(2, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(2, key => limiterFactory.GetLimiter(key));
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
@@ -158,27 +158,27 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncWorksWithMultipleLimiters()
+        public async Task WaitAndAcquireAsyncWorksWithMultipleLimiters()
         {
             var limiterFactory = new TrackingRateLimiterFactory<int>();
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(1, key => limiterFactory.GetLimiter(key));
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(2, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(2, key => limiterFactory.GetLimiter(key));
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            using var lease = await chainedLimiter.WaitAsync("");
+            using var lease = await chainedLimiter.WaitAndAcquireAsync("");
 
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, limiterFactory.Limiters.Count);
             Assert.Equal(1, limiterFactory.Limiters[0].Key);
-            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.WaitAsyncCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.WaitAndAcquireAsyncCallCount);
             Assert.Equal(2, limiterFactory.Limiters[1].Key);
-            Assert.Equal(1, limiterFactory.Limiters[1].Limiter.WaitAsyncCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[1].Limiter.WaitAndAcquireAsyncCallCount);
         }
 
         [Fact]
@@ -188,11 +188,11 @@ namespace System.Threading.RateLimiting.Tests
             var concurrencyLimiter2 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter1);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter1);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(2, key => concurrencyLimiter2);
+                return RateLimitPartition.Get(2, key => concurrencyLimiter2);
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
@@ -208,21 +208,21 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncLeaseCorrectlyDisposesWithMultipleLimiters()
+        public async Task WaitAndAcquireAsyncLeaseCorrectlyDisposesWithMultipleLimiters()
         {
             var concurrencyLimiter1 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             var concurrencyLimiter2 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter1);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter1);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(2, key => concurrencyLimiter2);
+                return RateLimitPartition.Get(2, key => concurrencyLimiter2);
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            var lease = await chainedLimiter.WaitAsync("");
+            var lease = await chainedLimiter.WaitAndAcquireAsync("");
 
             Assert.True(lease.IsAcquired);
             Assert.Equal(0, concurrencyLimiter1.GetAvailablePermits());
@@ -239,7 +239,7 @@ namespace System.Threading.RateLimiting.Tests
             var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
@@ -253,16 +253,16 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncLeaseCorrectlyDisposesWithSingleLimiter()
+        public async Task WaitAndAcquireAsyncLeaseCorrectlyDisposesWithSingleLimiter()
         {
             var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
-            var lease = await chainedLimiter.WaitAsync("");
+            var lease = await chainedLimiter.WaitAndAcquireAsync("");
 
             Assert.True(lease.IsAcquired);
             Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
@@ -278,11 +278,11 @@ namespace System.Threading.RateLimiting.Tests
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(1, key => limiterFactory.GetLimiter(key));
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(2, key => concurrencyLimiter);
+                return RateLimitPartition.Get(2, key => concurrencyLimiter);
             });
 
             // Acquire the only permit on the ConcurrencyLimiter so the chained limiter fails when calling acquire
@@ -298,21 +298,21 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncFailsWhenOneLimiterDoesNotHaveEnoughResources()
+        public async Task WaitAndAcquireAsyncFailsWhenOneLimiterDoesNotHaveEnoughResources()
         {
             var limiterFactory = new TrackingRateLimiterFactory<int>();
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(1, key => limiterFactory.GetLimiter(key));
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(2, key => concurrencyLimiter);
+                return RateLimitPartition.Get(2, key => concurrencyLimiter);
             });
 
             // Acquire the only permit on the ConcurrencyLimiter so the chained limiter fails when calling acquire
-            var concurrencyLease = await concurrencyLimiter.WaitAsync();
+            var concurrencyLease = await concurrencyLimiter.WaitAndAcquireAsync();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
             using var lease = chainedLimiter.Acquire("");
@@ -330,11 +330,11 @@ namespace System.Threading.RateLimiting.Tests
             using var concurrencyLimiter2 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter1);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter1);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(2, key => concurrencyLimiter2);
+                return RateLimitPartition.Get(2, key => concurrencyLimiter2);
             });
 
             // Acquire the only permit on the ConcurrencyLimiter so the chained limiter fails when calling acquire
@@ -348,21 +348,21 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncFailsAndReleasesAcquiredResources()
+        public async Task WaitAndAcquireAsyncFailsAndReleasesAcquiredResources()
         {
             using var concurrencyLimiter1 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var concurrencyLimiter2 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter1);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter1);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(2, key => concurrencyLimiter2);
+                return RateLimitPartition.Get(2, key => concurrencyLimiter2);
             });
 
             // Acquire the only permit on the ConcurrencyLimiter so the chained limiter fails when calling acquire
-            var concurrencyLease = await concurrencyLimiter2.WaitAsync();
+            var concurrencyLease = await concurrencyLimiter2.WaitAndAcquireAsync();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
             using var lease = chainedLimiter.Acquire("");
@@ -377,11 +377,11 @@ namespace System.Threading.RateLimiting.Tests
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(2, key => new NotImplementedLimiter());
+                return RateLimitPartition.Get(2, key => new NotImplementedLimiter());
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
@@ -390,20 +390,20 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncThrowsAndReleasesAcquiredResources()
+        public async Task WaitAndAcquireAsyncThrowsAndReleasesAcquiredResources()
         {
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(2, key => new NotImplementedLimiter());
+                return RateLimitPartition.Get(2, key => new NotImplementedLimiter());
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.WaitAsync(""));
+            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
             Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
         }
 
@@ -412,7 +412,7 @@ namespace System.Threading.RateLimiting.Tests
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new NotImplementedLimiter());
+                return RateLimitPartition.Get(1, key => new NotImplementedLimiter());
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1);
@@ -420,15 +420,15 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncThrows_SingleLimiter()
+        public async Task WaitAndAcquireAsyncThrows_SingleLimiter()
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new NotImplementedLimiter());
+                return RateLimitPartition.Get(1, key => new NotImplementedLimiter());
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1);
-            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.WaitAsync(""));
+            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
         }
 
         internal sealed class ThrowDisposeLease : RateLimitLease
@@ -448,11 +448,11 @@ namespace System.Threading.RateLimiting.Tests
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
             var lease = concurrencyLimiter.Acquire();
@@ -464,19 +464,19 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncFailsDisposeThrows()
+        public async Task WaitAndAcquireAsyncFailsDisposeThrows()
         {
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
-            var lease = await concurrencyLimiter.WaitAsync();
+            var lease = await concurrencyLimiter.WaitAndAcquireAsync();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
             var ex = Assert.Throws<AggregateException>(() => chainedLimiter.Acquire(""));
@@ -490,15 +490,15 @@ namespace System.Threading.RateLimiting.Tests
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
             var lease = concurrencyLimiter.Acquire();
@@ -511,26 +511,26 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncFailsDisposeThrowsMultipleLimitersThrow()
+        public async Task WaitAndAcquireAsyncFailsDisposeThrowsMultipleLimitersThrow()
         {
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { WaitAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { WaitAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
             var lease = concurrencyLimiter.Acquire();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
-            var ex = await Assert.ThrowsAsync<AggregateException>(async () => await chainedLimiter.WaitAsync(""));
+            var ex = await Assert.ThrowsAsync<AggregateException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
             Assert.Equal(2, ex.InnerExceptions.Count);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[0]);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[1]);
@@ -542,15 +542,15 @@ namespace System.Threading.RateLimiting.Tests
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new NotImplementedLimiter());
+                return RateLimitPartition.Get(1, key => new NotImplementedLimiter());
             });
 
             var lease = concurrencyLimiter.Acquire();
@@ -564,26 +564,26 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncThrowsDisposeThrowsMultipleLimitersThrow()
+        public async Task WaitAndAcquireAsyncThrowsDisposeThrowsMultipleLimitersThrow()
         {
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { WaitAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { WaitAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new NotImplementedLimiter());
+                return RateLimitPartition.Get(1, key => new NotImplementedLimiter());
             });
 
             var lease = concurrencyLimiter.Acquire();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
-            var ex = await Assert.ThrowsAsync<AggregateException>(async () => await chainedLimiter.WaitAsync(""));
+            var ex = await Assert.ThrowsAsync<AggregateException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
             Assert.Equal(3, ex.InnerExceptions.Count);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[0]);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[1]);
@@ -596,11 +596,11 @@ namespace System.Threading.RateLimiting.Tests
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
@@ -615,20 +615,20 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncSucceedsDisposeThrowsAndReleasesResources()
+        public async Task WaitAndAcquireAsyncSucceedsDisposeThrowsAndReleasesResources()
         {
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new CustomizableLimiter() { WaitAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            var lease = await chainedLimiter.WaitAsync("");
+            var lease = await chainedLimiter.WaitAndAcquireAsync("");
             Assert.True(lease.IsAcquired);
             Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
             var ex = Assert.Throws<AggregateException>(() => lease.Dispose());
@@ -645,11 +645,11 @@ namespace System.Threading.RateLimiting.Tests
             using var concurrencyLimiter2 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(3, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter1);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter1);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter2);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter2);
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
@@ -664,21 +664,21 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncForwardsCorrectPermitCount()
+        public async Task WaitAndAcquireAsyncForwardsCorrectPermitCount()
         {
             using var concurrencyLimiter1 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(5, QueueProcessingOrder.OldestFirst, 0));
             using var concurrencyLimiter2 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(3, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter1);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter1);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter2);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter2);
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
-            var lease = await chainedLimiter.WaitAsync("", 3);
+            var lease = await chainedLimiter.WaitAndAcquireAsync("", 3);
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, concurrencyLimiter1.GetAvailablePermits());
             Assert.Equal(0, concurrencyLimiter2.GetAvailablePermits());
@@ -696,17 +696,17 @@ namespace System.Threading.RateLimiting.Tests
             {
                 if (resource == "1")
                 {
-                    return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                    return RateLimitPartition.Get(1, key => limiterFactory.GetLimiter(key));
                 }
-                return RateLimitPartition.Create(2, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(2, key => limiterFactory.GetLimiter(key));
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
                 if (resource == "1")
                 {
-                    return RateLimitPartition.Create(3, key => limiterFactory.GetLimiter(key));
+                    return RateLimitPartition.Get(3, key => limiterFactory.GetLimiter(key));
                 }
-                return RateLimitPartition.Create(4, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(4, key => limiterFactory.GetLimiter(key));
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
@@ -718,28 +718,28 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncForwardsCorrectResourceID()
+        public async Task WaitAndAcquireAsyncForwardsCorrectResourceID()
         {
             var limiterFactory = new TrackingRateLimiterFactory<int>();
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
                 if (resource == "1")
                 {
-                    return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                    return RateLimitPartition.Get(1, key => limiterFactory.GetLimiter(key));
                 }
-                return RateLimitPartition.Create(2, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(2, key => limiterFactory.GetLimiter(key));
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
                 if (resource == "1")
                 {
-                    return RateLimitPartition.Create(3, key => limiterFactory.GetLimiter(key));
+                    return RateLimitPartition.Get(3, key => limiterFactory.GetLimiter(key));
                 }
-                return RateLimitPartition.Create(4, key => limiterFactory.GetLimiter(key));
+                return RateLimitPartition.Get(4, key => limiterFactory.GetLimiter(key));
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
-            var lease = await chainedLimiter.WaitAsync("1");
+            var lease = await chainedLimiter.WaitAndAcquireAsync("1");
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, limiterFactory.Limiters.Count);
             Assert.Equal(1, limiterFactory.Limiters[0].Key);
@@ -747,11 +747,11 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncCanBeCanceled()
+        public async Task WaitAndAcquireAsyncCanBeCanceled()
         {
             using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.CreateConcurrencyLimiter(1, key => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1));
+                return RateLimitPartition.GetConcurrencyLimiter(1, key => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1));
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
 
@@ -759,23 +759,23 @@ namespace System.Threading.RateLimiting.Tests
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var task = chainedLimiter.WaitAsync("", 1, cts.Token);
+            var task = chainedLimiter.WaitAndAcquireAsync("", 1, cts.Token);
 
             cts.Cancel();
              await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
         }
 
         [Fact]
-        public async Task WaitAsyncCanceledReleasesAcquiredResources()
+        public async Task WaitAndAcquireAsyncCanceledReleasesAcquiredResources()
         {
             var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(2, QueueProcessingOrder.OldestFirst, 0));
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => concurrencyLimiter);
+                return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.CreateConcurrencyLimiter(1, key => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1));
+                return RateLimitPartition.GetConcurrencyLimiter(1, key => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1));
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
@@ -784,7 +784,7 @@ namespace System.Threading.RateLimiting.Tests
             Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
 
             var cts = new CancellationTokenSource();
-            var task = chainedLimiter.WaitAsync("", 1, cts.Token);
+            var task = chainedLimiter.WaitAndAcquireAsync("", 1, cts.Token);
 
             Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
             cts.Cancel();
@@ -793,24 +793,24 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAsyncWaitsForResourcesBeforeCallingNextLimiter()
+        public async Task WaitAndAcquireAsyncWaitsForResourcesBeforeCallingNextLimiter()
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.CreateConcurrencyLimiter(1, key => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1));
+                return RateLimitPartition.GetConcurrencyLimiter(1, key => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1));
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
                 // 0 queue limit to verify this isn't called while the previous limiter is waiting for resource(s)
                 // as it would return a failed lease when no queue is available
-                return RateLimitPartition.CreateConcurrencyLimiter(1, key => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
+                return RateLimitPartition.GetConcurrencyLimiter(1, key => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 0));
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
             var lease = chainedLimiter.Acquire("");
             Assert.True(lease.IsAcquired);
 
-            var task = chainedLimiter.WaitAsync("");
+            var task = chainedLimiter.WaitAndAcquireAsync("");
             Assert.False(task.IsCompleted);
 
             lease.Dispose();
@@ -825,11 +825,11 @@ namespace System.Threading.RateLimiting.Tests
             var customizableLimiter2 = new CustomizableLimiter();
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => customizableLimiter1);
+                return RateLimitPartition.Get(1, key => customizableLimiter1);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => customizableLimiter2);
+                return RateLimitPartition.Get(1, key => customizableLimiter2);
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
@@ -861,15 +861,15 @@ namespace System.Threading.RateLimiting.Tests
             var customizableLimiter2 = new CustomizableLimiter();
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => customizableLimiter1);
+                return RateLimitPartition.Get(1, key => customizableLimiter1);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => customizableLimiter2);
+                return RateLimitPartition.Get(1, key => customizableLimiter2);
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new NotImplementedLimiter());
+                return RateLimitPartition.Get(1, key => new NotImplementedLimiter());
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
 
@@ -892,21 +892,21 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task LeasesAreDisposedInReverseOrderWhenWaitAsyncThrows()
+        public async Task LeasesAreDisposedInReverseOrderWhenWaitAndAcquireAsyncThrows()
         {
             var customizableLimiter1 = new CustomizableLimiter();
             var customizableLimiter2 = new CustomizableLimiter();
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => customizableLimiter1);
+                return RateLimitPartition.Get(1, key => customizableLimiter1);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => customizableLimiter2);
+                return RateLimitPartition.Get(1, key => customizableLimiter2);
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => new NotImplementedLimiter());
+                return RateLimitPartition.Get(1, key => new NotImplementedLimiter());
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
 
@@ -916,16 +916,16 @@ namespace System.Threading.RateLimiting.Tests
             {
                 Assert.True(disposeCalled);
             };
-            customizableLimiter1.WaitAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(customizableLease1);
+            customizableLimiter1.WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(customizableLease1);
 
             var customizableLease2 = new CustomizableLease();
             customizableLease2.DisposeImpl = _ =>
             {
                 disposeCalled = true;
             };
-            customizableLimiter2.WaitAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(customizableLease2);
+            customizableLimiter2.WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(customizableLease2);
 
-            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.WaitAsync(""));
+            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
         }
 
         [Fact]
@@ -979,11 +979,11 @@ namespace System.Threading.RateLimiting.Tests
             };
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => customizableLimiter1);
+                return RateLimitPartition.Get(1, key => customizableLimiter1);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => customizableLimiter2);
+                return RateLimitPartition.Get(1, key => customizableLimiter2);
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
@@ -1058,11 +1058,11 @@ namespace System.Threading.RateLimiting.Tests
             };
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => customizableLimiter1);
+                return RateLimitPartition.Get(1, key => customizableLimiter1);
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Create(1, key => customizableLimiter2);
+                return RateLimitPartition.Get(1, key => customizableLimiter2);
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 

--- a/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
@@ -33,10 +33,10 @@ namespace System.Threading.RateLimiting.Test
         public override async Task CanAcquireResourceAsync()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1));
-            var lease = await limiter.WaitAsync();
+            var lease = await limiter.WaitAndAcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAsync();
+            var wait = limiter.WaitAndAcquireAsync();
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -48,11 +48,11 @@ namespace System.Threading.RateLimiting.Test
         public override async Task CanAcquireResourceAsync_QueuesAndGrabsOldest()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 2));
-            var lease = await limiter.WaitAsync();
+            var lease = await limiter.WaitAndAcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait1 = limiter.WaitAsync();
-            var wait2 = limiter.WaitAsync();
+            var wait1 = limiter.WaitAndAcquireAsync();
+            var wait2 = limiter.WaitAndAcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -72,11 +72,11 @@ namespace System.Threading.RateLimiting.Test
         public override async Task CanAcquireResourceAsync_QueuesAndGrabsNewest()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(2, QueueProcessingOrder.NewestFirst, 3));
-            var lease = await limiter.WaitAsync(2);
+            var lease = await limiter.WaitAndAcquireAsync(2);
 
             Assert.True(lease.IsAcquired);
-            var wait1 = limiter.WaitAsync(2);
-            var wait2 = limiter.WaitAsync();
+            var wait1 = limiter.WaitAndAcquireAsync(2);
+            var wait2 = limiter.WaitAndAcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -98,9 +98,9 @@ namespace System.Threading.RateLimiting.Test
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1));
             using var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
 
-            var failedLease = await limiter.WaitAsync(1);
+            var failedLease = await limiter.WaitAndAcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
         }
 
@@ -109,10 +109,10 @@ namespace System.Threading.RateLimiting.Test
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1));
             var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             var lease1 = await wait;
             Assert.False(lease1.IsAcquired);
             Assert.False(wait2.IsCompleted);
@@ -129,13 +129,13 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(2, QueueProcessingOrder.NewestFirst, 2));
             var lease = limiter.Acquire(2);
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait2.IsCompleted);
 
-            var wait3 = limiter.WaitAsync(2);
+            var wait3 = limiter.WaitAndAcquireAsync(2);
             var lease1 = await wait;
             var lease2 = await wait2;
             Assert.False(lease1.IsAcquired);
@@ -156,10 +156,10 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var lease1 = await limiter.WaitAsync(2);
+            var lease1 = await limiter.WaitAndAcquireAsync(2);
             Assert.False(lease1.IsAcquired);
 
             lease.Dispose();
@@ -175,10 +175,10 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAsync(3);
+            var wait = limiter.WaitAndAcquireAsync(3);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAsync(int.MaxValue);
+            var wait2 = limiter.WaitAndAcquireAsync(int.MaxValue);
             Assert.False(wait2.IsCompleted);
 
             var lease1 = await wait;
@@ -194,16 +194,16 @@ namespace System.Threading.RateLimiting.Test
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1));
             var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
 
-            var failedLease = await limiter.WaitAsync(1);
+            var failedLease = await limiter.WaitAndAcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
 
             lease.Dispose();
             lease = await wait;
             Assert.True(lease.IsAcquired);
 
-            wait = limiter.WaitAsync(1);
+            wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -223,7 +223,7 @@ namespace System.Threading.RateLimiting.Test
         public override async Task ThrowsWhenWaitingForMoreThanLimit()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1));
-            var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAsync(2));
+            var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(2));
             Assert.Equal("permitCount", ex.ParamName);
         }
 
@@ -238,7 +238,7 @@ namespace System.Threading.RateLimiting.Test
         public override async Task ThrowsWhenWaitingForLessThanZero()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAsync(-1));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(-1));
         }
 
         [Fact]
@@ -263,22 +263,22 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task WaitAsyncZero_WithAvailability()
+        public override async Task WaitAndAcquireAsyncZero_WithAvailability()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1));
 
-            using var lease = await limiter.WaitAsync(0);
+            using var lease = await limiter.WaitAndAcquireAsync(0);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task WaitAsyncZero_WithoutAvailabilityWaitsForAvailability()
+        public override async Task WaitAndAcquireAsyncZero_WithoutAvailabilityWaitsForAvailability()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1));
-            var lease = await limiter.WaitAsync(1);
+            var lease = await limiter.WaitAndAcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(0);
+            var wait = limiter.WaitAndAcquireAsync(0);
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -290,11 +290,11 @@ namespace System.Threading.RateLimiting.Test
         public override async Task CanDequeueMultipleResourcesAtOnce()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(2, QueueProcessingOrder.OldestFirst, 2));
-            using var lease = await limiter.WaitAsync(2);
+            using var lease = await limiter.WaitAndAcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAsync(1);
-            var wait2 = limiter.WaitAsync(1);
+            var wait1 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -307,15 +307,15 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanAcquireResourcesWithWaitAsyncWithQueuedItemsIfNewestFirst()
+        public override async Task CanAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfNewestFirst()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(2, QueueProcessingOrder.NewestFirst, 3));
-            using var lease = await limiter.WaitAsync(1);
+            using var lease = await limiter.WaitAndAcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAsync(2);
+            var wait1 = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait1.IsCompleted);
-            var wait2 = limiter.WaitAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             var lease2 = await wait2;
             Assert.True(lease2.IsAcquired);
 
@@ -329,14 +329,14 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CannotAcquireResourcesWithWaitAsyncWithQueuedItemsIfOldestFirst()
+        public override async Task CannotAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfOldestFirst()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(2, QueueProcessingOrder.OldestFirst, 3));
-            using var lease = await limiter.WaitAsync(1);
+            using var lease = await limiter.WaitAndAcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAsync(2);
-            var wait2 = limiter.WaitAsync(1);
+            var wait1 = limiter.WaitAndAcquireAsync(2);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -355,10 +355,10 @@ namespace System.Threading.RateLimiting.Test
         public override async Task CanAcquireResourcesWithAcquireWithQueuedItemsIfNewestFirst()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(2, QueueProcessingOrder.NewestFirst, 3));
-            using var lease = await limiter.WaitAsync(1);
+            using var lease = await limiter.WaitAndAcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAsync(2);
+            var wait1 = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait1.IsCompleted);
             var lease2 = limiter.Acquire(1);
             Assert.True(lease2.IsAcquired);
@@ -376,10 +376,10 @@ namespace System.Threading.RateLimiting.Test
         public override async Task CannotAcquireResourcesWithAcquireWithQueuedItemsIfOldestFirst()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(2, QueueProcessingOrder.OldestFirst, 3));
-            using var lease = await limiter.WaitAsync(1);
+            using var lease = await limiter.WaitAndAcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAsync(2);
+            var wait1 = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait1.IsCompleted);
             var lease2 = limiter.Acquire(1);
             Assert.False(lease2.IsAcquired);
@@ -391,14 +391,14 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAsyncAfterQueuing()
+        public override async Task CanCancelWaitAndAcquireAsyncAfterQueuing()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1));
             var lease = limiter.Acquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
@@ -410,7 +410,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAsyncBeforeQueuing()
+        public override async Task CanCancelWaitAndAcquireAsyncBeforeQueuing()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1));
             var lease = limiter.Acquire(1);
@@ -419,7 +419,7 @@ namespace System.Threading.RateLimiting.Test
             var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAsync(1, cts.Token).AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAndAcquireAsync(1, cts.Token).AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
             lease.Dispose();
@@ -435,13 +435,13 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
-            wait = limiter.WaitAsync(1);
+            wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -457,17 +457,17 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             // Add another item to queue, will be completed as failed later when we queue another item
-            var wait2 = limiter.WaitAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
-            var wait3 = limiter.WaitAsync(2);
+            var wait3 = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait3.IsCompleted);
 
             // will be kicked by wait3 because we're using NewestFirst
@@ -488,7 +488,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
@@ -520,9 +520,9 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 3));
             using var lease = limiter.Acquire(1);
 
-            var wait1 = limiter.WaitAsync(1);
-            var wait2 = limiter.WaitAsync(1);
-            var wait3 = limiter.WaitAsync(1);
+            var wait1 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait3 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -540,7 +540,7 @@ namespace System.Threading.RateLimiting.Test
 
             // Throws after disposal
             Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAsync(1).AsTask());
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -549,9 +549,9 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 3));
             using var lease = limiter.Acquire(1);
 
-            var wait1 = limiter.WaitAsync(1);
-            var wait2 = limiter.WaitAsync(1);
-            var wait3 = limiter.WaitAsync(1);
+            var wait1 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait3 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -569,7 +569,7 @@ namespace System.Threading.RateLimiting.Test
 
             // Throws after disposal
             Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAsync(1).AsTask());
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -578,7 +578,7 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(2, QueueProcessingOrder.OldestFirst, 1));
             using var lease = limiter.Acquire(2);
 
-            var failedLease = await limiter.WaitAsync(2);
+            var failedLease = await limiter.WaitAndAcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.ReasonPhrase.Name, out var metadata));
             Assert.Equal("Queue limit reached", metadata);

--- a/src/libraries/System.Threading.RateLimiting/tests/Infrastructure/Utils.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/Infrastructure/Utils.cs
@@ -39,7 +39,7 @@ namespace System.Threading.RateLimiting.Tests
     {
         public override int GetAvailablePermits(T resourceID) => throw new NotImplementedException();
         protected override RateLimitLease AcquireCore(T resourceID, int permitCount) => throw new NotImplementedException();
-        protected override ValueTask<RateLimitLease> WaitAsyncCore(T resourceID, int permitCount, CancellationToken cancellationToken) => throw new NotImplementedException();
+        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(T resourceID, int permitCount, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 
     internal sealed class TrackingRateLimiter : RateLimiter
@@ -52,7 +52,7 @@ namespace System.Threading.RateLimiting.Tests
 
         public int GetAvailablePermitsCallCount => _getAvailablePermitsCallCount;
         public int AcquireCallCount => _acquireCallCount;
-        public int WaitAsyncCallCount => _waitAsyncCallCount;
+        public int WaitAndAcquireAsyncCallCount => _waitAsyncCallCount;
         public int DisposeCallCount => _disposeCallCount;
         public int DisposeAsyncCallCount => _disposeAsyncCallCount;
 
@@ -70,7 +70,7 @@ namespace System.Threading.RateLimiting.Tests
             return new Lease();
         }
 
-        protected override ValueTask<RateLimitLease> WaitAsyncCore(int permitCount, CancellationToken cancellationToken)
+        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
         {
             Interlocked.Increment(ref _waitAsyncCallCount);
             return new ValueTask<RateLimitLease>(new Lease());
@@ -139,7 +139,7 @@ namespace System.Threading.RateLimiting.Tests
 
         public override int GetAvailablePermits() => throw new NotImplementedException();
         protected override RateLimitLease AcquireCore(int permitCount) => throw new NotImplementedException();
-        protected override ValueTask<RateLimitLease> WaitAsyncCore(int permitCount, CancellationToken cancellationToken) => throw new NotImplementedException();
+        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 
     internal sealed class CustomizableLimiter : RateLimiter
@@ -153,8 +153,8 @@ namespace System.Threading.RateLimiting.Tests
         public Func<int, RateLimitLease> AcquireCoreImpl { get; set; } = _ => new Lease();
         protected override RateLimitLease AcquireCore(int permitCount) => AcquireCoreImpl(permitCount);
 
-        public Func<int, CancellationToken, ValueTask<RateLimitLease>> WaitAsyncCoreImpl { get; set; } = (_, _) => new ValueTask<RateLimitLease>(new Lease());
-        protected override ValueTask<RateLimitLease> WaitAsyncCore(int permitCount, CancellationToken cancellationToken) => WaitAsyncCoreImpl(permitCount, cancellationToken);
+        public Func<int, CancellationToken, ValueTask<RateLimitLease>> WaitAndAcquireAsyncCoreImpl { get; set; } = (_, _) => new ValueTask<RateLimitLease>(new Lease());
+        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken) => WaitAndAcquireAsyncCoreImpl(permitCount, cancellationToken);
 
         public Action<bool> DisposeImpl { get; set; } = _ => { };
         protected override void Dispose(bool disposing) => DisposeImpl(disposing);
@@ -183,8 +183,8 @@ namespace System.Threading.RateLimiting.Tests
         public Func<int, RateLimitLease> AcquireCoreImpl { get; set; } = _ => new Lease();
         protected override RateLimitLease AcquireCore(int permitCount) => AcquireCoreImpl(permitCount);
 
-        public Func<int, CancellationToken, ValueTask<RateLimitLease>> WaitAsyncCoreImpl { get; set; } = (_, _) => new ValueTask<RateLimitLease>(new Lease());
-        protected override ValueTask<RateLimitLease> WaitAsyncCore(int permitCount, CancellationToken cancellationToken) => WaitAsyncCoreImpl(permitCount, cancellationToken);
+        public Func<int, CancellationToken, ValueTask<RateLimitLease>> WaitAndAcquireAsyncCoreImpl { get; set; } = (_, _) => new ValueTask<RateLimitLease>(new Lease());
+        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken) => WaitAndAcquireAsyncCoreImpl(permitCount, cancellationToken);
 
         public Func<ValueTask> DisposeAsyncCoreImpl { get; set; } = () => default;
         protected override ValueTask DisposeAsyncCore() => DisposeAsyncCoreImpl();

--- a/src/libraries/System.Threading.RateLimiting/tests/RateLimiterPartitionTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/RateLimiterPartitionTests.cs
@@ -12,7 +12,7 @@ namespace System.Threading.RateLimiting.Tests
         public void Create_Concurrency()
         {
             var options = new ConcurrencyLimiterOptions(10, QueueProcessingOrder.OldestFirst, 10);
-            var partition = RateLimitPartition.CreateConcurrencyLimiter(1, key => options);
+            var partition = RateLimitPartition.GetConcurrencyLimiter(1, key => options);
 
             var limiter = partition.Factory(1);
             var concurrencyLimiter = Assert.IsType<ConcurrencyLimiter>(limiter);
@@ -23,7 +23,7 @@ namespace System.Threading.RateLimiting.Tests
         public void Create_TokenBucket()
         {
             var options = new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 10, TimeSpan.FromMinutes(1), 1, true);
-            var partition = RateLimitPartition.CreateTokenBucketLimiter(1, key => options);
+            var partition = RateLimitPartition.GetTokenBucketLimiter(1, key => options);
 
             var limiter = partition.Factory(1);
             var tokenBucketLimiter = Assert.IsType<TokenBucketRateLimiter>(limiter);
@@ -35,7 +35,7 @@ namespace System.Threading.RateLimiting.Tests
         [Fact]
         public async Task Create_NoLimiter()
         {
-            var partition = RateLimitPartition.CreateNoLimiter(1);
+            var partition = RateLimitPartition.GetNoLimiter(1);
 
             var limiter = partition.Factory(1);
 
@@ -48,7 +48,7 @@ namespace System.Threading.RateLimiting.Tests
             lease = limiter.Acquire(int.MaxValue);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(int.MaxValue);
+            var wait = limiter.WaitAndAcquireAsync(int.MaxValue);
             Assert.True(wait.IsCompletedSuccessfully);
             lease = await wait;
             Assert.True(lease.IsAcquired);
@@ -59,13 +59,13 @@ namespace System.Threading.RateLimiting.Tests
         [Fact]
         public void Create_AnyLimiter()
         {
-            var partition = RateLimitPartition.Create(1, key => new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 10)));
+            var partition = RateLimitPartition.Get(1, key => new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 10)));
 
             var limiter = partition.Factory(1);
             var concurrencyLimiter = Assert.IsType<ConcurrencyLimiter>(limiter);
             Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
 
-            var partition2 = RateLimitPartition.Create(1, key => new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 10, TimeSpan.FromMilliseconds(100), 1, autoReplenishment: false)));
+            var partition2 = RateLimitPartition.Get(1, key => new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 10, TimeSpan.FromMilliseconds(100), 1, autoReplenishment: false)));
             limiter = partition2.Factory(1);
             var tokenBucketLimiter = Assert.IsType<TokenBucketRateLimiter>(limiter);
             Assert.Equal(1, tokenBucketLimiter.GetAvailablePermits());
@@ -75,7 +75,7 @@ namespace System.Threading.RateLimiting.Tests
         public void Create_FixedWindow()
         {
             var options = new FixedWindowRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 10, TimeSpan.FromMinutes(1), true);
-            var partition = RateLimitPartition.CreateFixedWindowLimiter(1, key => options);
+            var partition = RateLimitPartition.GetFixedWindowLimiter(1, key => options);
 
             var limiter = partition.Factory(1);
             var fixedWindowLimiter = Assert.IsType<FixedWindowRateLimiter>(limiter);
@@ -88,7 +88,7 @@ namespace System.Threading.RateLimiting.Tests
         public void Create_SlidingWindow()
         {
             var options = new SlidingWindowRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 10, TimeSpan.FromSeconds(33), 3, true);
-            var partition = RateLimitPartition.CreateSlidingWindowLimiter(1, key => options);
+            var partition = RateLimitPartition.GetSlidingWindowLimiter(1, key => options);
 
             var limiter = partition.Factory(1);
             var slidingWindowLimiter = Assert.IsType<SlidingWindowRateLimiter>(limiter);

--- a/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
@@ -44,17 +44,17 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(2, QueueProcessingOrder.NewestFirst, 4,
                 TimeSpan.Zero, 2, autoReplenishment: false));
 
-            using var lease = await limiter.WaitAsync();
+            using var lease = await limiter.WaitAndAcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAsync(2);
+            var wait = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
 
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAsync(2);
+            var wait2 = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait2.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
@@ -71,22 +71,22 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(4, QueueProcessingOrder.NewestFirst, 4,
                 TimeSpan.Zero, 3, autoReplenishment: false));
 
-            using var lease = await limiter.WaitAsync(2);
+            using var lease = await limiter.WaitAndAcquireAsync(2);
 
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAsync(3);
+            var wait = limiter.WaitAndAcquireAsync(3);
             Assert.False(wait.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
 
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAsync(2);
+            var wait2 = limiter.WaitAndAcquireAsync(2);
             Assert.True(wait2.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
 
-            var wait3 = limiter.WaitAsync(2);
+            var wait3 = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait3.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
@@ -101,11 +101,11 @@ namespace System.Threading.RateLimiting.Test
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(2, QueueProcessingOrder.OldestFirst, 3,
                 TimeSpan.FromMinutes(0), 2, autoReplenishment: false));
-            var lease = await limiter.WaitAsync(2);
+            var lease = await limiter.WaitAndAcquireAsync(2);
 
             Assert.True(lease.IsAcquired);
-            var wait1 = limiter.WaitAsync();
-            var wait2 = limiter.WaitAsync(2);
+            var wait1 = limiter.WaitAndAcquireAsync();
+            var wait2 = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -134,11 +134,11 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(2, QueueProcessingOrder.NewestFirst, 3,
                 TimeSpan.FromMinutes(0), 2, autoReplenishment: false));
 
-            var lease = await limiter.WaitAsync(2);
+            var lease = await limiter.WaitAndAcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAsync(2);
-            var wait2 = limiter.WaitAsync();
+            var wait1 = limiter.WaitAndAcquireAsync(2);
+            var wait2 = limiter.WaitAndAcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -167,9 +167,9 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1,
                 TimeSpan.Zero, 2, autoReplenishment: false));
             using var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
 
-            var failedLease = await limiter.WaitAsync(1);
+            var failedLease = await limiter.WaitAndAcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
         }
 
@@ -179,10 +179,10 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1,
                    TimeSpan.Zero, 2, autoReplenishment: false));
             var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             var lease1 = await wait;
             Assert.False(lease1.IsAcquired);
             Assert.False(wait2.IsCompleted);
@@ -201,13 +201,13 @@ namespace System.Threading.RateLimiting.Test
                    TimeSpan.Zero, 2, autoReplenishment: false));
             var lease = limiter.Acquire(2);
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait2.IsCompleted);
 
-            var wait3 = limiter.WaitAsync(2);
+            var wait3 = limiter.WaitAndAcquireAsync(2);
             var lease1 = await wait;
             var lease2 = await wait2;
             Assert.False(lease1.IsAcquired);
@@ -230,10 +230,10 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var lease1 = await limiter.WaitAsync(2);
+            var lease1 = await limiter.WaitAndAcquireAsync(2);
             Assert.False(lease1.IsAcquired);
 
             limiter.TryReplenish();
@@ -249,9 +249,9 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(3, QueueProcessingOrder.OldestFirst, 2,
                 TimeSpan.Zero, 3, autoReplenishment: false));
             var lease = limiter.Acquire(2);
-            var wait = limiter.WaitAsync(2);
+            var wait = limiter.WaitAndAcquireAsync(2);
 
-            var failedLease = await limiter.WaitAsync(2);
+            var failedLease = await limiter.WaitAndAcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
 
             limiter.TryReplenish();
@@ -262,7 +262,7 @@ namespace System.Threading.RateLimiting.Test
             lease = await wait;
             Assert.True(lease.IsAcquired);
 
-            wait = limiter.WaitAsync(2);
+            wait = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             limiter.TryReplenish();
@@ -282,10 +282,10 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAsync(3);
+            var wait = limiter.WaitAndAcquireAsync(3);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAsync(int.MaxValue);
+            var wait2 = limiter.WaitAndAcquireAsync(int.MaxValue);
             Assert.False(wait2.IsCompleted);
 
             var lease1 = await wait;
@@ -310,7 +310,7 @@ namespace System.Threading.RateLimiting.Test
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAsync(2));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(2));
         }
 
         [Fact]
@@ -326,7 +326,7 @@ namespace System.Threading.RateLimiting.Test
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAsync(-1));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(-1));
         }
 
         [Fact]
@@ -353,24 +353,24 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task WaitAsyncZero_WithAvailability()
+        public override async Task WaitAndAcquireAsyncZero_WithAvailability()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
 
-            using var lease = await limiter.WaitAsync(0);
+            using var lease = await limiter.WaitAndAcquireAsync(0);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task WaitAsyncZero_WithoutAvailabilityWaitsForAvailability()
+        public override async Task WaitAndAcquireAsyncZero_WithoutAvailabilityWaitsForAvailability()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1,
                 TimeSpan.Zero, 2, autoReplenishment: false));
-            var lease = await limiter.WaitAsync(1);
+            var lease = await limiter.WaitAndAcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(0);
+            var wait = limiter.WaitAndAcquireAsync(0);
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -385,11 +385,11 @@ namespace System.Threading.RateLimiting.Test
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(2, QueueProcessingOrder.OldestFirst, 4,
                 TimeSpan.Zero, 2, autoReplenishment: false));
-            using var lease = await limiter.WaitAsync(2);
+            using var lease = await limiter.WaitAndAcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAsync(1);
-            var wait2 = limiter.WaitAsync(1);
+            var wait1 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -404,7 +404,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAsyncAfterQueuing()
+        public override async Task CanCancelWaitAndAcquireAsyncAfterQueuing()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(2, QueueProcessingOrder.OldestFirst, 1,
                 TimeSpan.Zero, 2, autoReplenishment: false));
@@ -412,7 +412,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
@@ -425,7 +425,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAsyncBeforeQueuing()
+        public override async Task CanCancelWaitAndAcquireAsyncBeforeQueuing()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(2, QueueProcessingOrder.OldestFirst, 1,
                 TimeSpan.Zero, 2, autoReplenishment: false));
@@ -435,7 +435,7 @@ namespace System.Threading.RateLimiting.Test
             var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAsync(1, cts.Token).AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAndAcquireAsync(1, cts.Token).AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
             lease.Dispose();
@@ -453,13 +453,13 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
-            wait = limiter.WaitAsync(1);
+            wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             limiter.TryReplenish();
@@ -494,9 +494,9 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 3,
                 TimeSpan.Zero, 1, autoReplenishment: false));
             var lease = limiter.Acquire(1);
-            var wait1 = limiter.WaitAsync(1);
-            var wait2 = limiter.WaitAsync(1);
-            var wait3 = limiter.WaitAsync(1);
+            var wait1 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait3 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -512,7 +512,7 @@ namespace System.Threading.RateLimiting.Test
 
             // Throws after disposal
             Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAsync(1).AsTask());
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -521,9 +521,9 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 3,
                 TimeSpan.Zero, 2, autoReplenishment: false));
             var lease = limiter.Acquire(1);
-            var wait1 = limiter.WaitAsync(1);
-            var wait2 = limiter.WaitAsync(1);
-            var wait3 = limiter.WaitAsync(1);
+            var wait1 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait3 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -539,7 +539,7 @@ namespace System.Threading.RateLimiting.Test
 
             // Throws after disposal
             Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAsync(1).AsTask());
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -560,12 +560,12 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(2, limiter.GetAvailablePermits());
             limiter.Acquire(2);
 
-            var lease = await limiter.WaitAsync(1);
+            var lease = await limiter.WaitAndAcquireAsync(1);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task CanAcquireResourcesWithWaitAsyncWithQueuedItemsIfNewestFirst()
+        public override async Task CanAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfNewestFirst()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(2, QueueProcessingOrder.NewestFirst, 2,
                 TimeSpan.Zero, 3, autoReplenishment: false));
@@ -573,11 +573,11 @@ namespace System.Threading.RateLimiting.Test
             var lease = limiter.Acquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(2);
+            var wait = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             Assert.Equal(1, limiter.GetAvailablePermits());
-            lease = await limiter.WaitAsync(1);
+            lease = await limiter.WaitAndAcquireAsync(1);
             Assert.True(lease.IsAcquired);
             Assert.False(wait.IsCompleted);
 
@@ -592,7 +592,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CannotAcquireResourcesWithWaitAsyncWithQueuedItemsIfOldestFirst()
+        public override async Task CannotAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfOldestFirst()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(3, QueueProcessingOrder.OldestFirst, 5,
                 TimeSpan.Zero, 2, autoReplenishment: false));
@@ -600,8 +600,8 @@ namespace System.Threading.RateLimiting.Test
             var lease = limiter.Acquire(3);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(2);
-            var wait2 = limiter.WaitAsync(2);
+            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait2 = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -631,7 +631,7 @@ namespace System.Threading.RateLimiting.Test
             var lease = limiter.Acquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(2);
+            var wait = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             lease = limiter.Acquire(1);
@@ -654,7 +654,7 @@ namespace System.Threading.RateLimiting.Test
             var lease = limiter.Acquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(2);
+            var wait = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             lease = limiter.Acquire(1);
@@ -723,10 +723,10 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             // Add another item to queue, will be completed as failed later when we queue another item
-            var wait2 = limiter.WaitAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             cts.Cancel();
@@ -736,7 +736,7 @@ namespace System.Threading.RateLimiting.Test
             lease.Dispose();
             limiter.TryReplenish();
 
-            var wait3 = limiter.WaitAsync(2);
+            var wait3 = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait3.IsCompleted);
 
             // will be kicked by wait3 because we're using NewestFirst
@@ -757,7 +757,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());

--- a/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
@@ -43,10 +43,10 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
 
-            using var lease = await limiter.WaitAsync();
+            using var lease = await limiter.WaitAndAcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAsync();
+            var wait = limiter.WaitAndAcquireAsync();
             Assert.False(wait.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
@@ -59,11 +59,11 @@ namespace System.Threading.RateLimiting.Test
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 2,
                 TimeSpan.Zero, 1, autoReplenishment: false));
-            var lease = await limiter.WaitAsync();
+            var lease = await limiter.WaitAndAcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait1 = limiter.WaitAsync();
-            var wait2 = limiter.WaitAsync();
+            var wait1 = limiter.WaitAndAcquireAsync();
+            var wait2 = limiter.WaitAndAcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -88,11 +88,11 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(2, QueueProcessingOrder.NewestFirst, 3,
                 TimeSpan.FromMinutes(0), 1, autoReplenishment: false));
 
-            var lease = await limiter.WaitAsync(2);
+            var lease = await limiter.WaitAndAcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAsync(2);
-            var wait2 = limiter.WaitAsync();
+            var wait1 = limiter.WaitAndAcquireAsync(2);
+            var wait2 = limiter.WaitAndAcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -119,9 +119,9 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
             using var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
 
-            var failedLease = await limiter.WaitAsync(1);
+            var failedLease = await limiter.WaitAndAcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var timeSpan));
             Assert.Equal(TimeSpan.Zero, timeSpan);
@@ -133,10 +133,10 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1,
                    TimeSpan.Zero, 1, autoReplenishment: false));
             var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             var lease1 = await wait;
             Assert.False(lease1.IsAcquired);
             Assert.False(wait2.IsCompleted);
@@ -154,13 +154,13 @@ namespace System.Threading.RateLimiting.Test
                    TimeSpan.Zero, 1, autoReplenishment: false));
             var lease = limiter.Acquire(2);
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait2.IsCompleted);
 
-            var wait3 = limiter.WaitAsync(2);
+            var wait3 = limiter.WaitAndAcquireAsync(2);
             var lease1 = await wait;
             var lease2 = await wait2;
             Assert.False(lease1.IsAcquired);
@@ -183,10 +183,10 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var lease1 = await limiter.WaitAsync(2);
+            var lease1 = await limiter.WaitAndAcquireAsync(2);
             Assert.False(lease1.IsAcquired);
 
             limiter.TryReplenish();
@@ -201,16 +201,16 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
             var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
 
-            var failedLease = await limiter.WaitAsync(1);
+            var failedLease = await limiter.WaitAndAcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
 
             limiter.TryReplenish();
             lease = await wait;
             Assert.True(lease.IsAcquired);
 
-            wait = limiter.WaitAsync(1);
+            wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             limiter.TryReplenish();
@@ -227,10 +227,10 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAsync(3);
+            var wait = limiter.WaitAndAcquireAsync(3);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAsync(int.MaxValue);
+            var wait2 = limiter.WaitAndAcquireAsync(int.MaxValue);
             Assert.False(wait2.IsCompleted);
 
             var lease1 = await wait;
@@ -254,7 +254,7 @@ namespace System.Threading.RateLimiting.Test
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAsync(2));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(2));
         }
 
         [Fact]
@@ -270,7 +270,7 @@ namespace System.Threading.RateLimiting.Test
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAsync(-1));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(-1));
         }
 
         [Fact]
@@ -297,24 +297,24 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task WaitAsyncZero_WithAvailability()
+        public override async Task WaitAndAcquireAsyncZero_WithAvailability()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
 
-            using var lease = await limiter.WaitAsync(0);
+            using var lease = await limiter.WaitAndAcquireAsync(0);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task WaitAsyncZero_WithoutAvailabilityWaitsForAvailability()
+        public override async Task WaitAndAcquireAsyncZero_WithoutAvailabilityWaitsForAvailability()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
-            var lease = await limiter.WaitAsync(1);
+            var lease = await limiter.WaitAndAcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(0);
+            var wait = limiter.WaitAndAcquireAsync(0);
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -328,11 +328,11 @@ namespace System.Threading.RateLimiting.Test
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(2, QueueProcessingOrder.OldestFirst, 2,
                 TimeSpan.Zero, 2, autoReplenishment: false));
-            using var lease = await limiter.WaitAsync(2);
+            using var lease = await limiter.WaitAndAcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAsync(1);
-            var wait2 = limiter.WaitAsync(1);
+            var wait1 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -346,7 +346,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAsyncAfterQueuing()
+        public override async Task CanCancelWaitAndAcquireAsyncAfterQueuing()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
@@ -354,7 +354,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
@@ -375,10 +375,10 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             // Add another item to queue, will be completed as failed later when we queue another item
-            var wait2 = limiter.WaitAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             cts.Cancel();
@@ -387,7 +387,7 @@ namespace System.Threading.RateLimiting.Test
 
             lease.Dispose();
 
-            var wait3 = limiter.WaitAsync(2);
+            var wait3 = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait3.IsCompleted);
 
             // will be kicked by wait3 because we're using NewestFirst
@@ -408,7 +408,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
@@ -419,7 +419,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAsyncBeforeQueuing()
+        public override async Task CanCancelWaitAndAcquireAsyncBeforeQueuing()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1,
                 TimeSpan.Zero, 1, autoReplenishment: false));
@@ -429,7 +429,7 @@ namespace System.Threading.RateLimiting.Test
             var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAsync(1, cts.Token).AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAndAcquireAsync(1, cts.Token).AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
             lease.Dispose();
@@ -447,13 +447,13 @@ namespace System.Threading.RateLimiting.Test
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAsync(1, cts.Token);
+            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
-            wait = limiter.WaitAsync(1);
+            wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             limiter.TryReplenish();
@@ -485,9 +485,9 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 3,
                 TimeSpan.Zero, 1, autoReplenishment: false));
             var lease = limiter.Acquire(1);
-            var wait1 = limiter.WaitAsync(1);
-            var wait2 = limiter.WaitAsync(1);
-            var wait3 = limiter.WaitAsync(1);
+            var wait1 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait3 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -503,7 +503,7 @@ namespace System.Threading.RateLimiting.Test
 
             // Throws after disposal
             Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAsync(1).AsTask());
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -512,9 +512,9 @@ namespace System.Threading.RateLimiting.Test
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 3,
                 TimeSpan.Zero, 1, autoReplenishment: false));
             var lease = limiter.Acquire(1);
-            var wait1 = limiter.WaitAsync(1);
-            var wait2 = limiter.WaitAsync(1);
-            var wait3 = limiter.WaitAsync(1);
+            var wait1 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait3 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -530,7 +530,7 @@ namespace System.Threading.RateLimiting.Test
 
             // Throws after disposal
             Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAsync(1).AsTask());
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -542,7 +542,7 @@ namespace System.Threading.RateLimiting.Test
 
             using var lease = limiter.Acquire(2);
 
-            var failedLease = await limiter.WaitAsync(2);
+            var failedLease = await limiter.WaitAndAcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter.Name, out var metadata));
             var metaDataTime = Assert.IsType<TimeSpan>(metadata);
@@ -562,10 +562,10 @@ namespace System.Threading.RateLimiting.Test
 
             using var lease = limiter.Acquire(2);
             // Queue item which changes the retry after time for failed items
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var failedLease = await limiter.WaitAsync(2);
+            var failedLease = await limiter.WaitAndAcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var typedMetadata));
             Assert.Equal(options.ReplenishmentPeriod.Ticks * 3, typedMetadata.Ticks);
@@ -580,10 +580,10 @@ namespace System.Threading.RateLimiting.Test
 
             using var lease = limiter.Acquire(2);
             // Queue item which changes the retry after time for failed waits
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var failedLease = await limiter.WaitAsync(2);
+            var failedLease = await limiter.WaitAndAcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var typedMetadata));
             Assert.Equal(options.ReplenishmentPeriod, typedMetadata);
@@ -598,10 +598,10 @@ namespace System.Threading.RateLimiting.Test
 
             using var lease = limiter.Acquire(2);
             // Queue item which changes the retry after time for failed items
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var failedLease = await limiter.WaitAsync(2);
+            var failedLease = await limiter.WaitAndAcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var typedMetadata));
             Assert.Equal(options.ReplenishmentPeriod, typedMetadata);
@@ -616,7 +616,7 @@ namespace System.Threading.RateLimiting.Test
 
             using var lease = limiter.Acquire(2);
 
-            var failedLease = await limiter.WaitAsync(3);
+            var failedLease = await limiter.WaitAndAcquireAsync(3);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var typedMetadata));
             Assert.Equal(options.ReplenishmentPeriod.Ticks * 2, typedMetadata.Ticks);
@@ -666,12 +666,12 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(2, limiter.GetAvailablePermits());
             limiter.Acquire(2);
 
-            var lease = await limiter.WaitAsync(1);
+            var lease = await limiter.WaitAndAcquireAsync(1);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task CanAcquireResourcesWithWaitAsyncWithQueuedItemsIfNewestFirst()
+        public override async Task CanAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfNewestFirst()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(2, QueueProcessingOrder.NewestFirst, 2,
                 TimeSpan.Zero, 2, autoReplenishment: false));
@@ -679,11 +679,11 @@ namespace System.Threading.RateLimiting.Test
             var lease = limiter.Acquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(2);
+            var wait = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             Assert.Equal(1, limiter.GetAvailablePermits());
-            lease = await limiter.WaitAsync(1);
+            lease = await limiter.WaitAndAcquireAsync(1);
             Assert.True(lease.IsAcquired);
             Assert.False(wait.IsCompleted);
 
@@ -694,7 +694,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CannotAcquireResourcesWithWaitAsyncWithQueuedItemsIfOldestFirst()
+        public override async Task CannotAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfOldestFirst()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(2, QueueProcessingOrder.OldestFirst, 3,
                 TimeSpan.Zero, 2, autoReplenishment: false));
@@ -702,8 +702,8 @@ namespace System.Threading.RateLimiting.Test
             var lease = limiter.Acquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(2);
-            var wait2 = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait2 = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -728,7 +728,7 @@ namespace System.Threading.RateLimiting.Test
             var lease = limiter.Acquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(2);
+            var wait = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             lease = limiter.Acquire(1);
@@ -750,7 +750,7 @@ namespace System.Threading.RateLimiting.Test
             var lease = limiter.Acquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(2);
+            var wait = limiter.WaitAndAcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             lease = limiter.Acquire(1);
@@ -773,7 +773,7 @@ namespace System.Threading.RateLimiting.Test
             var lease = limiter.Acquire(10);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAsync(1);
+            var wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             var replenishInternalMethod = typeof(TokenBucketRateLimiter).GetMethod("ReplenishInternal", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance)!;
@@ -784,7 +784,7 @@ namespace System.Threading.RateLimiting.Test
             lease = await wait;
             Assert.True(lease.IsAcquired);
 
-            wait = limiter.WaitAsync(1);
+            wait = limiter.WaitAndAcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             // Tick 1 millisecond too soon and verify that the queued item wasn't completed


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/71775
Fixes https://github.com/dotnet/runtime/issues/71352