### PR TITLE
Utilize new APIs more in System.Formats.Asn1

### DIFF
--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -378,8 +379,7 @@ namespace System.Formats.Asn1
 
             for (int i = 0; i < bytes.Length; i += 2)
             {
-                int val = bytes[i] << 8 | bytes[i + 1];
-                char c = (char)val;
+                char c = (char)BinaryPrimitives.ReadInt16BigEndian(bytes.Slice(i));
 
                 if (char.IsSurrogate(c))
                 {

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
@@ -105,7 +105,7 @@ namespace System.Formats.Asn1
             ReadOnlySpan<byte> contents = ReadIntegerBytes(source, ruleSet, out int consumed, expectedTag);
 
 #if NETCOREAPP2_1_OR_GREATER
-            BigInteger value = new BigInteger(contents, isUnsigned: false, isBigEndian: true);
+            BigInteger value = new BigInteger(contents, isBigEndian: true);
 #else
             byte[] tmp = CryptoPool.Rent(contents.Length);
             BigInteger value;
@@ -114,10 +114,10 @@ namespace System.Formats.Asn1
             {
                 byte fill = (contents[0] & 0x80) == 0 ? (byte)0 : (byte)0xFF;
                 // Fill the unused portions of tmp with positive or negative padding.
-                new Span<byte>(tmp, contents.Length, tmp.Length - contents.Length).Fill(fill);
+                tmp.AsSpan(contents.Length, tmp.Length - contents.Length).Fill(fill);
                 contents.CopyTo(tmp);
                 // Convert to Little-Endian.
-                new Span<byte>(tmp, 0, contents.Length).Reverse();
+                tmp.AsSpan(0, contents.Length).Reverse();
                 value = new BigInteger(tmp);
             }
             finally

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
@@ -104,7 +104,9 @@ namespace System.Formats.Asn1
         {
             ReadOnlySpan<byte> contents = ReadIntegerBytes(source, ruleSet, out int consumed, expectedTag);
 
-            // TODO: Split this for netcoreapp/netstandard to use the Big-Endian BigInteger parsing
+#if NETCOREAPP2_1_OR_GREATER
+            BigInteger value = new BigInteger(contents, isUnsigned: false, isBigEndian: true);
+#else
             byte[] tmp = CryptoPool.Rent(contents.Length);
             BigInteger value;
 
@@ -124,6 +126,7 @@ namespace System.Formats.Asn1
                 // is returned to the array pool.
                 CryptoPool.Return(tmp);
             }
+#endif
 
             bytesConsumed = consumed;
             return value;

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
@@ -115,7 +115,7 @@ namespace System.Formats.Asn1
                 new Span<byte>(tmp, contents.Length, tmp.Length - contents.Length).Fill(fill);
                 contents.CopyTo(tmp);
                 // Convert to Little-Endian.
-                AsnWriter.Reverse(new Span<byte>(tmp, 0, contents.Length));
+                new Span<byte>(tmp, 0, contents.Length).Reverse();
                 value = new BigInteger(tmp);
             }
             finally

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Integer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Integer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Numerics;
 
@@ -254,9 +255,8 @@ namespace System.Formats.Asn1
             }
 
             // T-REC-X.690-201508 sec 8.3.2
-            if (value.Length > 1)
+            if (BinaryPrimitives.TryReadUInt16BigEndian(value, out ushort bigEndianValue))
             {
-                ushort bigEndianValue = (ushort)(value[0] << 8 | value[1]);
                 const ushort RedundancyMask = 0b1111_1111_1000_0000;
                 ushort masked = (ushort)(bigEndianValue & RedundancyMask);
 

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Oid.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Oid.cs
@@ -141,14 +141,6 @@ namespace System.Formats.Asn1
                 throw new ArgumentException(SR.Argument_InvalidOidValue, nameof(oidValue));
             }
 
-#if NETCOREAPP2_1_OR_GREATER
-            if ((endIndex > 1 && oidValue[0] == '0') ||
-                !BigInteger.TryParse(oidValue.Slice(0, endIndex), NumberStyles.None, CultureInfo.InvariantCulture, out BigInteger value))
-            {
-                // T-REC X.680-201508 sec 12.26
-                throw new ArgumentException(SR.Argument_InvalidOidValue, nameof(oidValue));
-            }
-#else
             BigInteger value = BigInteger.Zero;
 
             for (int position = 0; position < endIndex; position++)
@@ -162,7 +154,6 @@ namespace System.Formats.Asn1
                 value *= 10;
                 value += AtoI(oidValue[position]);
             }
-#endif
             oidValue = oidValue.Slice(Math.Min(oidValue.Length, endIndex + 1));
             return value;
         }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Oid.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Oid.cs
@@ -201,7 +201,7 @@ namespace System.Formats.Asn1
             }
             while (unencoded != BigInteger.Zero);
 
-            Reverse(dest.Slice(0, idx));
+            dest.Slice(0, idx).Reverse();
             return idx;
         }
     }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
@@ -615,22 +615,6 @@ namespace System.Formats.Asn1
             CryptoPool.Return(tmp, len);
         }
 
-        internal static void Reverse(Span<byte> span)
-        {
-            int i = 0;
-            int j = span.Length - 1;
-
-            while (i < j)
-            {
-                byte tmp = span[i];
-                span[i] = span[j];
-                span[j] = tmp;
-
-                i++;
-                j--;
-            }
-        }
-
         private static void CheckUniversalTag(Asn1Tag? tag, UniversalTagNumber universalTagNumber)
         {
             if (tag != null)


### PR DESCRIPTION
While browsing deep into some X509Extension parsing implementation I came across some TODO comments and couple low-hanging fruits on the `System.Formats.Asn1` namespace so I decided to do little housekeeping.

* First commit replaces the simple `for`-based `AsnWriter.Reverse(Span<byte> span)` with equivalent but optimized `MemoryExtensions.Reverse`.
* Second commit splits the decoding/encoding logic to utilize spanified BigInteger parsing/formatting APIs whenever possible. This addresses the old TODO comments.
  * ~~This reduces allocations in general but causes minor regressions with some object identifiers.~~ Reverted changes causing the regression in the fourth commit.
* Third commit utilizes the `BinaryPrimitives.Read(U)Int16BigEndian` in couple places instead of doing the bit twiddling manually.
* Fifth commit does a small clean-up on the `AsnDecoder.ReadInteger` to make it a bit more readable with `AsSpan` instead of ctor

Benchmarks: https://gist.github.com/PaulusParssinen/1392d166eb5e5d11720b18925ac4dc0c
<details>
<summary>Results</summary>

|                 Method |        Job |         Toolchain |     Mean |   Error |  StdDev | Ratio |  Gen 0 | Allocated |
|----------------------- |----------- |------------------ |---------:|--------:|--------:|------:|-------:|----------:|
| ReadInteger_BigInteger | Job-KOYFOU | \main\corerun.exe | 559.6 ns | 8.68 ns | 8.12 ns |  1.00 | 0.0391 |     328 B |
| ReadInteger_BigInteger | Job-DXPHAR |   \pr\corerun.exe | 284.6 ns | 2.69 ns | 2.38 ns |  0.51 | 0.0391 |     328 B |

|                       Method |        Job |         Toolchain |        Mean |     Error |    StdDev |      Median | Ratio | RatioSD |  Gen 0 |  Gen 1 | Allocated |
|----------------------------- |----------- |------------------ |------------:|----------:|----------:|------------:|------:|--------:|-------:|-------:|----------:|
|           WriteInteger_Small | Job-KOYFOU | \main\corerun.exe |    85.84 ns |  0.620 ns |  0.549 ns |    85.75 ns |  1.00 |    0.00 | 0.1348 |      - |      1 KB |
|           WriteInteger_Small | Job-DXPHAR |   \pr\corerun.exe |    77.34 ns |  0.153 ns |  0.143 ns |    77.29 ns |  0.90 |    0.01 | 0.1301 |      - |      1 KB |
|                              |            |                   |             |           |           |             |       |         |        |        |           |
|             WriteInteger_Big | Job-KOYFOU | \main\corerun.exe |   243.95 ns | 16.725 ns | 49.315 ns |   228.18 ns |  1.00 |    0.00 | 0.1645 | 0.0002 |      1 KB |
|             WriteInteger_Big | Job-DXPHAR |   \pr\corerun.exe |   190.86 ns |  0.317 ns |  0.297 ns |   190.80 ns |  0.81 |    0.17 | 0.1299 |      - |      1 KB |
|                              |            |                   |             |           |           |             |       |         |        |        |           |

</details>