### PR TITLE
Add missing inlining attribute (System.Numerics.Vector3)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
@@ -428,6 +428,7 @@ namespace System.Numerics
         /// <param name="value2">The second vector.</param>
         /// <returns>The minimized vector.</returns>
         [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 Min(Vector3 value1, Vector3 value2)
         {
             return new Vector3(


### PR DESCRIPTION
Hello,

the `Min` method here appears to be missing the inlining attribute. Other similar methods in the struct have the attribute, e.g. `Max`. I have checked the whole commit history for this file, and the attribute appears to be missing from the start, rather than having been removed.

Note: I haven't been able to observe any performance benefits from this change in local tests (nor any of the other inlining attributes in the struct!). But maybe this is still a helpful PR based on the other points above.

Thanks