### PR TITLE
If the base type is a sequential zero-sized type, treat a derived auto-layout type as starting from field offset 0.

### DIFF
--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -7991,7 +7991,26 @@ VOID    MethodTableBuilder::PlaceInstanceFields(MethodTable ** pByValueClassCach
         DWORD   dwCumulativeInstanceFieldPos;
 
         // Instance fields start right after the parent
-        dwCumulativeInstanceFieldPos    = HasParent() ? GetParentMethodTable()->GetNumInstanceFieldBytes() : 0;
+        if (HasParent())
+        {
+            MethodTable* pParentMT = GetParentMethodTable();
+            if (pParentMT->HasLayout() && pParentMT->GetLayoutInfo()->IsZeroSized())
+            {
+                // If the parent type has sequential/explicit layout and is "zero sized"
+                // then we don't want to use the actual class size here.
+                // That includes an extra byte that isn't actually used, so we shouldn't
+                // count it here.
+                dwCumulativeInstanceFieldPos = 0;
+            }
+            else
+            {
+                dwCumulativeInstanceFieldPos = pParentMT->GetNumInstanceFieldBytes();
+            }
+        }
+        else
+        {
+            dwCumulativeInstanceFieldPos = 0;
+        }
 
         DWORD dwOffsetBias = 0;
 #ifdef FEATURE_64BIT_ALIGNMENT

--- a/src/tests/Loader/classloader/SequentialLayout/ManagedSequential/ManagedSequential.cs
+++ b/src/tests/Loader/classloader/SequentialLayout/ManagedSequential/ManagedSequential.cs
@@ -34,6 +34,28 @@ unsafe class ManagedSequential
         public long l2;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    class EmptySequentialClassObjectBase
+    {
+    }
+
+    class AutoClassDerived : EmptySequentialClassObjectBase
+    {
+        public int i;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    class ManagedSequentialDisqualifiedClassDerived : EmptySequentialClassObjectBase
+    {
+        public AutoClassObjectBase o;
+        public byte b;
+    }
+
+    class RawData
+    {
+        public byte data;
+    }
+
     [Fact]
     public static void LayoutClassObjectBaseIsManagedSequential()
     {
@@ -64,5 +86,23 @@ unsafe class ManagedSequential
         var o = new AutoClassObjectBase();
         // Validate that the long member is placed before the byte member, as is done with auto layout in this case.
         Assert.Equal(-8, (int)Unsafe.ByteOffset(ref o.b1, ref Unsafe.As<long, byte>(ref o.l1)));
+    }
+
+    [Fact]
+    public static void AutoClassDerivedFromManagedSequentialEmpty()
+    {
+        var o = new AutoClassDerived();
+        // Validate that the int member is placed at the 0 offset.
+        Assert.Equal(0, (int)Unsafe.ByteOffset(ref Unsafe.As<RawData>(o).data, ref Unsafe.As<int, byte>(ref o.i)));
+    }
+
+    [Fact]
+    public static void ManagedSequentialDisqualifiedClassDerivedFromManagedSequentialEmpty()
+    {
+        var o = new ManagedSequentialDisqualifiedClassDerived();
+        // Validate that the object member is placed at the 0 offset.
+        Assert.Equal(0, (int)Unsafe.ByteOffset(ref Unsafe.As<RawData>(o).data, ref Unsafe.As<AutoClassObjectBase, byte>(ref o.o)));
+        // Validate that the byte member is placed immediately after the object member.
+        Assert.Equal(sizeof(nint), (int)Unsafe.ByteOffset(ref Unsafe.As<AutoClassObjectBase, byte>(ref o.o), ref o.b));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/63106 by making CoreCLR match the managed type system's layout rules for this case.

I decided to fix CoreCLR instead of changing Crossgen2 for a few reasons:

1. I think the behavior in Crossgen2 is more correct
2. The behavior in Crossgen2 is more performant (less memory consumption)
3. Changing the layout rules in Crossgen2 requires us to rev the R2R version in a backward-incompatible way, which breaks all R2R images. Changing the rules in CoreCLR doesn't cause any breaks as the CoreCLR layout rules are not persisted outside of the process.

~~Unless someone feels that this should be merged into .NET 7, I would think that we should wait until .NET 8 to merge this as layout-related changes are relatively higher risk.~~ Let's get this in for 7 based on feedback from Jan.