### PR TITLE
Improve reliability of WarningsAsErrors replacement

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -33,8 +33,13 @@
          SYSLIB0036: Regex.CompileToAssembly
     -->
     <NoWarn Condition="'$(IsPartialFacadeAssembly)' == 'true'">$(NoWarn);SYSLIB0003;SYSLIB0004;SYSLIB0015;SYSLIB0017;SYSLIB0021;SYSLIB0022;SYSLIB0023;SYSLIB0025;SYSLIB0032;SYSLIB0036</NoWarn>
-    <!-- Reset these properties back to blank, since they are defaulted by Microsoft.NET.Sdk -->
-    <WarningsAsErrors Condition="'$(WarningsAsErrors)' == 'NU1605'" />
+    <!-- Microsoft.NET.Sdk enables some warnings as errors out of the box.
+         We want to remove some items from this list so they don't fail the build.
+         Can't use 'WarningsNotAsErrors' element because vbproj doesn't honor it.
+         Items to remove:
+         NU1605: Package downgrade detected
+    -->
+    <WarningsAsErrors>$([System.Text.RegularExpressions.Regex]::Replace($(WarningsAsErrors), '\bNU1605\b', ''))</WarningsAsErrors>
 
     <IsRuntimeAndReferenceAssembly Condition="'$(IsRuntimeAndReferenceAssembly)' == '' and
                                               '$(IsSourceProject)' == 'true' and

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -39,7 +39,7 @@
          Items to remove:
          NU1605: Package downgrade detected
     -->
-    <WarningsAsErrors>$([System.Text.RegularExpressions.Regex]::Replace($(WarningsAsErrors), '\bNU1605\b', ''))</WarningsAsErrors>
+    <WarningsAsErrors>$(WarningsAsErrors.Replace('NU1605', ''))</WarningsAsErrors>
 
     <IsRuntimeAndReferenceAssembly Condition="'$(IsRuntimeAndReferenceAssembly)' == '' and
                                               '$(IsSourceProject)' == 'true' and


### PR DESCRIPTION
The _Microsoft.NET.Sdk_ target will soon enable more warnings as errors. Since this means the syntax will be:

```xml
<WarningsAsErrors>aaaaa;bbbbb;ccccc;...</WarningsAsErrors>
```

The existing logic comparing against a known literal string becomes fragile. Normally we could use `<WarningsNotAsErrors>` to remove these, but: (a) the warnings can no longer be turned back into errors by a "closer" project file; and (b) .vbproj files don't honor the `<WarningsNotAsErrors>` element.

Workaround for now is to use a regex to selectively remove the error codes we don't want to inherit from the root SDK.

If we want to add more entries in the future, we could just copy this line and change the contents of the `'\b...\b'` string.