### PR TITLE
[mono][workloads] Clean up runtime pack versioning logic

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
@@ -90,38 +90,10 @@
       <_MonoWorkloadRuntimePackPackageVersion>$(RuntimePackInWorkloadVersion)</_MonoWorkloadRuntimePackPackageVersion>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(_MonoWorkloadTargetsMobile)' == 'true' and '$(TargetFramework)' == '${NetCoreAppCurrent}'">
-      <MonoRuntimePackRids Include="
-        linux-x64;
-        win-x64;
-        osx-x64;
-        osx-arm64;
-        maccatalyst-x64;
-        maccatalyst-arm64;
-        browser-wasm;
-        ios-arm64;
-        ios-arm;
-        iossimulator-arm64;
-        iossimulator-x64;
-        iossimulator-x86;
-        tvos-arm64;
-        tvossimulator-arm64;
-        tvossimulator-x64;
-        android-arm64;
-        android-arm;
-        android-x64;
-        android-x86;
-        " />
-
-      <KnownRuntimePack Remove="Microsoft.NETCore.App" />
-      <KnownRuntimePack Include="Microsoft.NETCore.App"
-                        TargetFramework="${NetCoreAppCurrent}"
-                        RuntimeFrameworkName="Microsoft.NETCore.App"
-                        LatestRuntimeFrameworkVersion="**FromWorkload**"
-                        RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.Mono.**RID**"
-                        RuntimePackRuntimeIdentifiers="@(MonoRuntimePackRids, '%3B')"
-                        RuntimePackLabels="Mono"
-                        />
+    <ItemGroup Condition="'$(_MonoWorkloadTargetsMobile)' == 'true'">
+      <KnownRuntimePack Update="@(KnownRuntimePack)">
+        <LatestRuntimeFrameworkVersion Condition="'%(KnownRuntimePack.TargetFramework)' == '${NetCoreAppCurrent}' and '%(KnownRuntimePack.RuntimePackLabels)' == 'Mono'">**FromWorkload**</LatestRuntimeFrameworkVersion>
+      </KnownRuntimePack>
     </ItemGroup>
 
     <!-- we can't condition sdk imports on the item @(NativeFileReference). Instead, explicitly check before the build


### PR DESCRIPTION
Now that runtime flavors work properly update the known runtimes rather than brute forcing the selection