### PR TITLE
Fix handling of non-bidirectional MarshalMode.Default with collection marshalling

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
@@ -357,7 +357,7 @@ namespace Microsoft.Interop
                 if (mode != MarshalMode.Default && !shape.HasFlag(MarshallerShape.CallerAllocatedBuffer) && !shape.HasFlag(MarshallerShape.ToUnmanaged))
                     return null;
 
-                if (isLinearCollectionMarshaller)
+                if (isLinearCollectionMarshaller && methods.ManagedValuesSource is not null)
                 {
                     // Element type is the type parameter of the ReadOnlySpan returned by GetManagedValuesSource
                     collectionElementType = ((INamedTypeSymbol)methods.ManagedValuesSource.ReturnType).TypeArguments[0];
@@ -382,13 +382,19 @@ namespace Microsoft.Interop
 
                 if (isLinearCollectionMarshaller)
                 {
-                    // Native type is the first parameter of GetUnmanagedValuesSource
-                    nativeType = methods.UnmanagedValuesSource.Parameters[0].Type;
+                    if (nativeType is null && methods.UnmanagedValuesSource is not null)
+                    {
+                        // Native type is the first parameter of GetUnmanagedValuesSource
+                        nativeType = methods.UnmanagedValuesSource.Parameters[0].Type;
+                    }
 
-                    // Element type is the type parameter of the Span returned by GetManagedValuesDestination
-                    collectionElementType = ((INamedTypeSymbol)methods.ManagedValuesDestination.ReturnType).TypeArguments[0];
+                    if (collectionElementType is null && methods.ManagedValuesDestination is not null)
+                    {
+                        // Element type is the type parameter of the Span returned by GetManagedValuesDestination
+                        collectionElementType = ((INamedTypeSymbol)methods.ManagedValuesDestination.ReturnType).TypeArguments[0];
+                    }
                 }
-                else
+                else if (nativeType is null)
                 {
                     // Native type is the first parameter of ConvertToManaged or ConvertToManagedFinally
                     if (methods.ToManagedFinally is not null)
@@ -457,7 +463,7 @@ namespace Microsoft.Interop
                     nativeType = methods.ToUnmanaged.ReturnType;
                 }
 
-                if (isLinearCollectionMarshaller)
+                if (isLinearCollectionMarshaller && methods.ManagedValuesSource is not null)
                 {
                     // Element type is the type parameter of the ReadOnlySpan returned by GetManagedValuesSource
                     collectionElementType = ((INamedTypeSymbol)methods.ManagedValuesSource.ReturnType).TypeArguments[0];
@@ -475,7 +481,7 @@ namespace Microsoft.Interop
                     nativeType = methods.FromUnmanaged.Parameters[0].Type;
                 }
 
-                if (isLinearCollectionMarshaller && collectionElementType is null)
+                if (isLinearCollectionMarshaller && collectionElementType is null && methods.ManagedValuesDestination is not null)
                 {
                     // Element type is the type parameter of the Span returned by GetManagedValuesDestination
                     collectionElementType = ((INamedTypeSymbol)methods.ManagedValuesDestination.ReturnType).TypeArguments[0];

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
@@ -804,7 +804,7 @@ public static class Marshaller
 }
 ";
                 private static string DefaultOut = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller))]
+[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
 public static class Marshaller
 {
     public struct Native { }
@@ -1398,7 +1398,7 @@ static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : u
     public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
 }
 ";
-                public const string Ref = @"
+                public const string Default = @"
 [CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>))]
 [ContiguousCollectionMarshaller]
 static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
@@ -1412,7 +1412,7 @@ static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : u
     public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
 }
 ";
-                public const string RefNested = @"
+                public const string DefaultNested = @"
 [CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>.Nested.Ref))]
 [ContiguousCollectionMarshaller]
 static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
@@ -1442,6 +1442,26 @@ static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : u
     public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
 }
 ";
+                public const string DefaultIn = @"
+[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>))]
+[ContiguousCollectionMarshaller]
+static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+{
+    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
+    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
+    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
+}
+";
+                public const string DefaultOut = @"
+[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>))]
+[ContiguousCollectionMarshaller]
+static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+{
+    public static TestCollection<T> AllocateContainerForManagedElements(byte* unmanaged, int length) => throw null;
+    public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
+    public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
+}
+";
                 public static string ByValue<T>() => ByValue(typeof(T).ToString());
                 public static string ByValue(string elementType) => BasicParameterByValue($"TestCollection<{elementType}>", DisableRuntimeMarshalling)
                     + TestCollection()
@@ -1460,17 +1480,17 @@ static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : u
                 public static string DefaultMarshallerParametersAndModifiers<T>() => DefaultMarshallerParametersAndModifiers(typeof(T).ToString());
                 public static string DefaultMarshallerParametersAndModifiers(string elementType) => MarshalUsingCollectionCountInfoParametersAndModifiers($"TestCollection<{elementType}>")
                     + TestCollection()
-                    + Ref;
+                    + Default;
 
                 public static string CustomMarshallerParametersAndModifiers<T>() => CustomMarshallerParametersAndModifiers(typeof(T).ToString());
                 public static string CustomMarshallerParametersAndModifiers(string elementType) => MarshalUsingCollectionParametersAndModifiers($"TestCollection<{elementType}>", $"Marshaller<,>")
                     + TestCollection(defineNativeMarshalling: false)
-                    + Ref;
+                    + Default;
 
                 public static string CustomMarshallerReturnValueLength<T>() => CustomMarshallerReturnValueLength(typeof(T).ToString());
                 public static string CustomMarshallerReturnValueLength(string elementType) => MarshalUsingCollectionReturnValueLength($"TestCollection<{elementType}>", $"Marshaller<,>")
                     + TestCollection(defineNativeMarshalling: false)
-                    + Ref;
+                    + Default;
 
                 public static string NativeToManagedOnlyOutParameter<T>() => NativeToManagedOnlyOutParameter(typeof(T).ToString());
                 public static string NativeToManagedOnlyOutParameter(string elementType) => CollectionOutParameter($"TestCollection<{elementType}>")
@@ -1485,7 +1505,7 @@ static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : u
                 public static string NestedMarshallerParametersAndModifiers<T>() => NestedMarshallerParametersAndModifiers(typeof(T).ToString());
                 public static string NestedMarshallerParametersAndModifiers(string elementType) => MarshalUsingCollectionCountInfoParametersAndModifiers($"TestCollection<{elementType}>")
                     + TestCollection()
-                    + RefNested;
+                    + DefaultNested;
 
                 public static string NonBlittableElementParametersAndModifiers => DefaultMarshallerParametersAndModifiers("Element")
                     + NonBlittableElement
@@ -1502,6 +1522,14 @@ static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : u
                 public static string NonBlittableElementNativeToManagedOnlyReturnValue => NativeToManagedOnlyOutParameter("Element")
                     + NonBlittableElement
                     + ElementOut;
+
+                public static string DefaultModeByValueInParameter => BasicParameterByValue($"TestCollection<int>", DisableRuntimeMarshalling)
+                    + TestCollection()
+                    + DefaultIn;
+
+                public static string DefaultModeReturnValue => CollectionOutParameter($"TestCollection<int>")
+                    + TestCollection()
+                    + DefaultOut;
 
                 public static string GenericCollectionMarshallingArityMismatch => BasicParameterByValue("TestCollection<int>", DisableRuntimeMarshalling)
                     + @"
@@ -1542,7 +1570,7 @@ partial class Test
 }}
 "
                     + TestCollection()
-                    + Ref
+                    + Default
                     + CustomIntMarshaller;
 
                 public static string CustomElementMarshallingDuplicateElementIndirectionDepth => $@"
@@ -1670,6 +1698,34 @@ static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : u
     }
 }
 ";
+                public const string DefaultIn = @"
+[ContiguousCollectionMarshaller]
+[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>.In))]
+static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+{
+    public ref struct In
+    {
+        public void FromManaged(TestCollection<T> managed) => throw null;
+        public byte* ToUnmanaged() => throw null;
+        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
+        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;        
+    }
+}
+";
+                public const string DefaultOut = @"
+[ContiguousCollectionMarshaller]
+[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>.Out))]
+static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+{
+    public ref struct Out
+    {
+        public void FromUnmanaged(byte* value) => throw null;
+        public TestCollection<T> ToManaged() => throw null;
+        public System.Span<T> GetManagedValuesDestination(int numElements) => throw null;
+        public System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements) => throw null;
+    }
+}
+";
                 public static string ByValue<T>() => ByValue(typeof(T).ToString());
                 public static string ByValue(string elementType) => BasicParameterByValue($"TestCollection<{elementType}>", DisableRuntimeMarshalling)
                     + TestCollection()
@@ -1730,6 +1786,14 @@ static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : u
                 public static string NonBlittableElementNativeToManagedOnlyReturnValue => NativeToManagedOnlyOutParameter("Element")
                     + NonBlittableElement
                     + ElementOut;
+
+                public static string DefaultModeByValueInParameter => BasicParameterByValue($"TestCollection<int>", DisableRuntimeMarshalling)
+                    + TestCollection()
+                    + DefaultIn;
+
+                public static string DefaultModeReturnValue => CollectionOutParameter($"TestCollection<int>")
+                    + TestCollection()
+                    + DefaultOut;
 
                 public static string CustomElementMarshalling => $@"
 using System.Runtime.InteropServices;

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -360,6 +360,8 @@ namespace LibraryImportGenerator.UnitTests
             yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateless.NonBlittableElementParametersAndModifiers };
             yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateless.NonBlittableElementNativeToManagedOnlyOutParameter };
             yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateless.NonBlittableElementNativeToManagedOnlyReturnValue };
+            yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateless.DefaultModeByValueInParameter };
+            yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateless.DefaultModeReturnValue };
             yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateless.CustomElementMarshalling };
             yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateful.DefaultMarshallerParametersAndModifiers<byte>() };
             yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateful.DefaultMarshallerParametersAndModifiers<sbyte>() };
@@ -392,6 +394,8 @@ namespace LibraryImportGenerator.UnitTests
             yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateful.NonBlittableElementParametersAndModifiers };
             yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateful.NonBlittableElementNativeToManagedOnlyOutParameter };
             yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateful.NonBlittableElementNativeToManagedOnlyReturnValue };
+            yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateful.DefaultModeByValueInParameter };
+            yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateful.DefaultModeReturnValue };
             yield return new[] { ID(), CodeSnippets.CustomCollectionMarshalling.Stateful.CustomElementMarshalling };
             yield return new[] { ID(), CodeSnippets.CollectionsOfCollectionsStress };
         }


### PR DESCRIPTION
Check for existence of the specific methods on the collection marshaller shape before trying to get information from them. For `MarshalMode.Default`, we use whatever is available, so the methods aren't required to exist.