### PR TITLE
[wasm] Re-enable `System.Text.RegularExpressions.Tests.csproj`

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -28,8 +28,7 @@
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
     <!-- https://github.com/dotnet/runtime/issues/65356 - OOM while linking -->
     <HighAOTResourceRequiringProject Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Tests\System.Text.Json.SourceGeneration.Roslyn3.11.Tests.csproj" />
-    <!-- Disabling for AOT, and HighAOT - https://github.com/dotnet/runtime/issues/71848 -->
-    <!--<HighAOTResourceRequiringProject Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\FunctionalTests\System.Text.RegularExpressions.Tests.csproj" />-->
+    <HighAOTResourceRequiringProject Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\FunctionalTests\System.Text.RegularExpressions.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/65411 - possible OOM when compiling
          System.Text.Json.SourceGeneration.Roslyn4.0.Tests.dll.bc -> .o -->
@@ -67,8 +66,6 @@
 
   <!-- wasm EAT/AOT -->
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(RunDisabledWasmTests)' != 'true' and '$(EnableAggressiveTrimming)' == 'true'">
-    <!-- Disabling for EAT/AOT - https://github.com/dotnet/runtime/issues/71848 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\FunctionalTests\System.Text.RegularExpressions.Tests.csproj" />
   </ItemGroup>
 
   <!-- Wasm aot on all platforms -->


### PR DESCRIPTION
The linker bump in https://github.com/dotnet/linker/pull/2889 should
have fixed the issue.

Closes https://github.com/dotnet/runtime/issues/71848 .