### PR TITLE
Fix all outstanding S.Linq.Expressions failures

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidator.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidator.cs
@@ -87,8 +87,7 @@ namespace Internal.Reflection.Execution
 
                 if (!formalArg.SatisfiesConstraints(typeContext, actualArg))
                 {
-                    throw new ArgumentException(SR.Format(SR.Argument_ConstraintFailed, actualArg, definition.ToString(), formalArg),
-                        string.Format("GenericArguments[{0}]", i));
+                    throw new ArgumentException(SR.Format(SR.Argument_ConstraintFailed, actualArg, definition.ToString(), formalArg));
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -44,17 +44,6 @@ namespace ILCompiler.DependencyAnalysis
                 dependencies.Add(factory.ModuleMetadata(_type.Module), "Containing module of a reflectable type");
 
             var mdManager = (UsageBasedMetadataManager)factory.MetadataManager;
-            if (_type.IsDelegate)
-            {
-                // We've decided as a policy that delegate Invoke methods will be generated in full.
-                // The libraries (e.g. System.Linq.Expressions) have trimming warning suppressions
-                // in places where they assume IL-level trimming (where the method cannot be removed).
-                // We ask for a full reflectable method with its method body instead of just the
-                // metadata.
-                var invokeMethod = _type.GetMethod("Invoke", null);
-                if (!mdManager.IsReflectionBlocked(invokeMethod))
-                    dependencies.Add(factory.ReflectableMethod(invokeMethod), "Delegate invoke method");
-            }
 
             if (_type.IsEnum)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -216,6 +216,17 @@ namespace ILCompiler
         {
             TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, type, "Reflectable type");
 
+            if (type.IsDelegate)
+            {
+                // We've decided as a policy that delegate Invoke methods will be generated in full.
+                // The libraries (e.g. System.Linq.Expressions) have trimming warning suppressions
+                // in places where they assume IL-level trimming (where the method cannot be removed).
+                // We ask for a full reflectable method with its method body instead of just the
+                // metadata.
+                dependencies ??= new DependencyList();
+                dependencies.Add(factory.ReflectableMethod(type.GetMethod("Invoke", null)), "Delegate invoke method is always reflectable");
+            }
+
             MetadataType mdType = type as MetadataType;
 
             // If anonymous type heuristic is turned on and this is an anonymous type, make sure we have

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -223,8 +223,12 @@ namespace ILCompiler
                 // in places where they assume IL-level trimming (where the method cannot be removed).
                 // We ask for a full reflectable method with its method body instead of just the
                 // metadata.
-                dependencies ??= new DependencyList();
-                dependencies.Add(factory.ReflectableMethod(type.GetMethod("Invoke", null)), "Delegate invoke method is always reflectable");
+                MethodDesc invokeMethod = type.GetMethod("Invoke", null);
+                if (!IsReflectionBlocked(invokeMethod))
+                {
+                    dependencies ??= new DependencyList();
+                    dependencies.Add(factory.ReflectableMethod(invokeMethod), "Delegate invoke method is always reflectable");
+                }
             }
 
             MetadataType mdType = type as MetadataType;

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -205,8 +205,8 @@ namespace System
         public static bool UsesAppleCrypto => IsOSX || IsMacCatalyst || IsiOS || IstvOS;
         public static bool UsesMobileAppleCrypto => IsMacCatalyst || IsiOS || IstvOS;
 
-        // Changed to `true` when linking
-        public static bool IsBuiltWithAggressiveTrimming => false;
+        // Changed to `true` when trimming
+        public static bool IsBuiltWithAggressiveTrimming => IsNativeAot;
         public static bool IsNotBuiltWithAggressiveTrimming => !IsBuiltWithAggressiveTrimming;
 
         // Windows - Schannel supports alpn from win8.1/2012 R2 and higher.

--- a/src/libraries/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -550,7 +550,6 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69944", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static void MethodName_TypeArgsDontMatchConstraints_ThrowsArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.Call(Expression.Constant(new NonGenericClass()), nameof(NonGenericClass.ConstrainedInstanceMethod), new Type[] { typeof(object) }));

--- a/src/libraries/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
@@ -86,7 +86,6 @@ namespace System.Dynamic.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69944", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void GenericMethod()
         {
             dynamic d = new TestDerivedClass();

--- a/src/libraries/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -491,7 +491,6 @@ namespace System.Linq.Expressions.Tests
 
         [Fact]
         // this tests calling static methods by name (generic and non-generic)
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69928", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static void TestCallStaticMethodsByName()
         {
             NWindProxy.Customer[] custs = new[] { new NWindProxy.Customer { CustomerID = "BUBBA", ContactName = "Bubba Gump" } };
@@ -3002,7 +3001,6 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [ClassData(typeof(CompilationTypes))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69943", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static void NumericOperators(bool useInterpreter)
         {
             RelationalOperatorTests(typeof(sbyte), (sbyte)1, false, useInterpreter);

--- a/src/libraries/System.Linq.Expressions/tests/TrimCompatibilityTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/TrimCompatibilityTests.cs
@@ -13,8 +13,7 @@ namespace System.Linq.Expressions.Tests
         /// Verifies that the below Types don't have any DynamicallyAccessedMembers attributes,
         /// so we can safely call MakeGenericMethod on their methods.
         /// </summary>
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69944", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public static void VerifyMethodsCalledWithMakeGenericMethod()
         {
             Assembly linqExpressions = typeof(Expression).Assembly;

--- a/src/libraries/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
@@ -450,7 +450,6 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69944", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void Quote_RuntimeVariables_ClosureAndLocal(bool useInterpreter)
         {
             var x = Parameter(typeof(int));

--- a/src/libraries/System.Linq.Expressions/tests/default.rd.xml
+++ b/src/libraries/System.Linq.Expressions/tests/default.rd.xml
@@ -19,6 +19,32 @@
       </Type>
       <Type Name="System.Func`1[[System.Int32,System.Private.CoreLib]]" Dynamic="Required All" />
       <Type Name="System.Func`2[[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib]]" Dynamic="Required All" />
+
+      <Type Name="System.Func`2[[System.SByte,System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Byte,System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Int16,System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.UInt16,System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Int32,System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.UInt32,System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Int64,System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.UInt64,System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Single,System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Double,System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Decimal,System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+
+      <Type Name="System.Func`2[[System.Nullable`1[[System.SByte,System.Private.CoreLib]],System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Nullable`1[[System.Byte,System.Private.CoreLib]],System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Nullable`1[[System.Int16,System.Private.CoreLib]],System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Nullable`1[[System.UInt16,System.Private.CoreLib]],System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Nullable`1[[System.Int32,System.Private.CoreLib]],System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Nullable`1[[System.UInt32,System.Private.CoreLib]],System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Nullable`1[[System.Int64,System.Private.CoreLib]],System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Nullable`1[[System.UInt64,System.Private.CoreLib]],System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Nullable`1[[System.Single,System.Private.CoreLib]],System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Nullable`1[[System.Double,System.Private.CoreLib]],System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Func`2[[System.Nullable`1[[System.Decimal,System.Private.CoreLib]],System.Private.CoreLib],[System.Boolean,System.Private.CoreLib]]" Dynamic="Required All" />
+
+
       <Type Name="System.Func`2[[System.Linq.Expressions.Tests.InvocationTests+NoThread,System.Linq.Expressions.Tests],[System.Int32,System.Private.CoreLib]]" Dynamic="Required All" />
       <Type Name="System.Func`3[[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib]]" Dynamic="Required All" />
 
@@ -57,6 +83,15 @@
         </Method>
       </Type>
     </Assembly>
+    <Assembly Name="System.Linq.Queryable">
+      <Type Name="System.Linq.Queryable">
+        <Method Name="Aggregate" Dynamic="Required All">
+          <GenericArgument Name="System.Object, System.Private.CoreLib" />
+          <GenericArgument Name="System.Object, System.Private.CoreLib" />
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+      </Type>
+    </Assembly>
     <Assembly Name="System.Linq.Expressions">
       <Type Name="System.Linq.Expressions.Expression`1[[System.Func`6[[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib]],System.Private.CoreLib]]" Dynamic="Required All" />
       <Type Name="System.Linq.Expressions.Expression`1[[System.Func`7[[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib],[System.Int32,System.Private.CoreLib]],System.Private.CoreLib]]" Dynamic="Required All" />
@@ -65,6 +100,11 @@
       <Type Name="System.Runtime.CompilerServices.IRuntimeVariables" Dynamic="Required All" />
     </Assembly>
     <Assembly Name="System.Linq.Expressions.Tests">
+      <Type Name="System.Dynamic.Tests.InvokeMemberBindingTests+TestBaseClass">
+        <Method Name="TellType" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+      </Type>
       <Type Name="System.Linq.Expressions.Tests.OpAssign+Box`1[[System.Double,System.Private.CoreLib]]" Dynamic="Required All" />
       <Type Name="System.Linq.Expressions.Tests.OpAssign+Box`1[[System.Int32,System.Private.CoreLib]]" Dynamic="Required All" />
       <Type Name="System.Linq.Expressions.Tests.GeneralBinaryTests+GenericClassWithNonGenericMethod`1[[System.Boolean, System.Private.CoreLib]]" Dynamic="Required All" />


### PR DESCRIPTION
Product fixes:

* Don't try to be helpful in the exception when `MakeGeneric*` constraint validation fails. CoreCLR is not helpful and S.Linq.Expressions is testing for it.
* We need to inject delegate `Invoke` method dependencies elsewhere. A test looking to reflection-invoke the `Invoke` method was failing with `MissingMetadataException` but we have no right to be failing on that per policy.

Test fixes:

* Consider NativeAOT always trimmed. We could potentially do what Mono is doing, but we currently don't support substitution files (only embedded substitutions), and NativeAOT will always be trimmed.
* Mark a test that is fundamentally incompatible (and pointless) with trimming as such.
* Add a bunch of RD.XML.

Fixes #69944. Fixes #69928. Fixes #69943.

Cc @dotnet/ilc-contrib