### PR TITLE
[fxr] Use std::find_if when searching for root framework.

### DIFF
--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/ComplexHierarchies.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/ComplexHierarchies.cs
@@ -56,14 +56,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithFramework("OMWare", "7.3.1"))
                 // https://github.com/dotnet/runtime/issues/71027
                 // This should pass just fine and resolve all frameworks correctly
-                // Currently it fails because it does resolve frameworks, but incorrectly
-                // looks for hostpolicy in MiddleWare, instead of Microsoft.NETCore.App.
-                .Should().Fail().And.HaveStdErrContaining("hostpolicy");
-                //.ShouldHaveResolvedFramework(
-                //    MicrosoftNETCoreApp, "5.1.1")
-                //.And.HaveResolvedFramework("MiddleWare", "2.1.")
-                //.And.HaveResolvedFramework("SerializerWare", "3.0.1")
-                //.And.HaveResolvedFramework("OMWare", "7.3.1");
+                .ShouldHaveResolvedFramework(
+                    MicrosoftNETCoreApp, "5.1.1")
+                .And.HaveResolvedFramework("MiddleWare", "2.1.")
+                .And.HaveResolvedFramework("SerializerWare", "3.0.1")
+                .And.HaveResolvedFramework("OMWare", "7.3.1");
         }
 
         private CommandResult RunTest(

--- a/src/native/corehost/fx_definition.h
+++ b/src/native/corehost/fx_definition.h
@@ -56,7 +56,7 @@ static const fx_definition_t& get_root_framework(const fx_definition_vector_t& f
         fx_definitions.end(),
         [&](const std::unique_ptr<fx_definition_t>& fxdef)
         {
-            return fxdef->get_name() == L"Microsoft.NETCore.App";
+            return fxdef->get_name() == _X("Microsoft.NETCore.App");
         });
     return **fx;
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/71027.

### .NET 6:

Consider:
- Backport of https://github.com/dotnet/runtime/pull/71959 (before backporting this change) to Release/6.0.
- Backport of this PR to Release/6.0.

### Tests:

Test was updated to ensure that the modified code works.