### PR TITLE
Fix WritePGOData

### DIFF
--- a/src/coreclr/vm/pgo.cpp
+++ b/src/coreclr/vm/pgo.cpp
@@ -257,18 +257,18 @@ void PgoManager::WritePgoData()
                         break;
                     case ICorJitInfo::PgoInstrumentationKind::TypeHandle:
                         {
-                            intptr_t typehandleData = *(intptr_t*)(data + entryOffset);
-                            TypeHandle th = TypeHandle::FromPtr((void*)typehandleData);
-                            if (th.IsNull())
+                            intptr_t thData = *(intptr_t*)(data + entryOffset);
+                            if (thData == 0)
                             {
                                 fprintf(pgoDataFile, s_TypeHandle, "NULL");
                             }
-                            else if (ICorJitInfo::IsUnknownHandle(typehandleData))
+                            else if (ICorJitInfo::IsUnknownHandle(thData))
                             {
                                 fprintf(pgoDataFile, s_TypeHandle, "UNKNOWN");
                             }
                             else
                             {
+                                TypeHandle th = TypeHandle::FromPtr((void*)thData);
                                 StackSString ss;
                                 TypeString::AppendType(ss, th, TypeString::FormatNamespace | TypeString::FormatFullInst | TypeString::FormatAssembly);
                                 if (ss.GetCount() > 8192)
@@ -284,18 +284,18 @@ void PgoManager::WritePgoData()
                         }
                     case ICorJitInfo::PgoInstrumentationKind::MethodHandle:
                         {
-                            intptr_t methodHandleData = *(intptr_t*)(data + entryOffset);
-                            MethodDesc* md = reinterpret_cast<MethodDesc*>(methodHandleData);
-                            if (md == nullptr)
+                            intptr_t mdData = *(intptr_t*)(data + entryOffset);
+                            if (mdData == 0)
                             {
                                 fprintf(pgoDataFile, "MethodHandle: NULL\n");
                             }
-                            else if (ICorJitInfo::IsUnknownHandle(methodHandleData))
+                            else if (ICorJitInfo::IsUnknownHandle(mdData))
                             {
                                 fprintf(pgoDataFile, "MethodHandle: UNKNOWN\n");
                             }
                             else
                             {
+                                MethodDesc* md = reinterpret_cast<MethodDesc*>(mdData);
                                 SString garbage1, tMethodName, garbage2;
                                 md->GetMethodInfo(garbage1, tMethodName, garbage2);
                                 StackSString tTypeName;


### PR DESCRIPTION
We were constructing the TypeHandle before validating that the handle
did not represent an unknown handle. On unknown handles this crashes
in the constructor in debug builds due to some debug-only validation
running there.