### PR TITLE
JIT: Disqualify delegate calls to instance methods on value classes from GDV explicitly

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -22857,6 +22857,22 @@ void Compiler::considerGuardedDevirtualization(GenTreeCall*            call,
             return;
         }
 
+        CORINFO_CLASS_HANDLE definingClass = info.compCompHnd->getMethodClass(likelyMethod);
+        likelyClassAttribs = info.compCompHnd->getClassAttribs(definingClass);
+
+        // For instance methods on value classes we need an extended check to
+        // check for the unboxing stub. This is NYI.
+        // Note: Normally likelyMethod above will be the unboxing stub which
+        // would fail GDV for other reasons.
+        // However, with stale profiles or textual PGO input it is still
+        // possible that likelyMethod is not the unboxing stub.
+        // So we do need this explicit check.
+        if ((likelyClassAttribs & CORINFO_FLG_VALUECLASS) != 0)
+        {
+            JITDUMP("Cannot currently handle devirtualizing delegate calls on value types, sorry\n");
+            return;
+        }
+
         // Verify that the call target and args look reasonable so that the JIT
         // does not blow up during inlining/call morphing.
         //

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -22858,15 +22858,15 @@ void Compiler::considerGuardedDevirtualization(GenTreeCall*            call,
         }
 
         CORINFO_CLASS_HANDLE definingClass = info.compCompHnd->getMethodClass(likelyMethod);
-        likelyClassAttribs = info.compCompHnd->getClassAttribs(definingClass);
+        likelyClassAttribs                 = info.compCompHnd->getClassAttribs(definingClass);
 
         // For instance methods on value classes we need an extended check to
         // check for the unboxing stub. This is NYI.
-        // Note: Normally likelyMethod above will be the unboxing stub which
-        // would fail GDV for other reasons.
-        // However, with stale profiles or textual PGO input it is still
-        // possible that likelyMethod is not the unboxing stub.
-        // So we do need this explicit check.
+        // Note: For dynamic PGO likelyMethod above will be the unboxing stub
+        // which would fail GDV for other reasons.
+        // However, with static profiles or textual PGO input it is still
+        // possible that likelyMethod is not the unboxing stub. So we do need
+        // this explicit check.
         if ((likelyClassAttribs & CORINFO_FLG_VALUECLASS) != 0)
         {
             JITDUMP("Cannot currently handle devirtualizing delegate calls on value types, sorry\n");


### PR DESCRIPTION
This was relying on the profile data containing the unboxing stub before.
That really only works out for dynamic PGO. Static data or textual
PGO data can end up with the exact method and hit a JIT assert passing
a TYP_REF this arg to a TYP_BYREF this param.