### PR TITLE
JIT: Ensure object derefs do not remove previous conditions in loop cloning

### DIFF
--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -462,10 +462,10 @@ JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>* LoopCloneContext::Ensur
 
     JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>* levelCond = blockConditions[loopNum];
     // Iterate backwards to make sure the expand array stack reallocs just once here.
-    unsigned existingSize = levelCond->Size();
-    for (unsigned index = condBlocks; index > existingSize; index--)
+    unsigned prevSize = levelCond->Size();
+    for (unsigned i = condBlocks; i > prevSize; i--)
     {
-        levelCond->Set(index - 1, new (alloc) JitExpandArrayStack<LC_Condition>(alloc));
+        levelCond->Set(i - 1, new (alloc) JitExpandArrayStack<LC_Condition>(alloc));
     }
 
     return levelCond;

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -457,13 +457,17 @@ JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>* LoopCloneContext::Ensur
     if (blockConditions[loopNum] == nullptr)
     {
         blockConditions[loopNum] =
-            new (alloc) JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>(alloc, condBlocks);
+            new (alloc) JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>(alloc);
     }
+
     JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>* levelCond = blockConditions[loopNum];
-    for (unsigned i = 0; i < condBlocks; ++i)
+    // Iterate backwards to make sure the expand array stack reallocs just once here.
+    unsigned existingSize = levelCond->Size();
+    for (unsigned index = condBlocks; index > existingSize; index--)
     {
-        levelCond->Set(i, new (alloc) JitExpandArrayStack<LC_Condition>(alloc));
+        levelCond->Set(index - 1, new (alloc) JitExpandArrayStack<LC_Condition>(alloc));
     }
+
     return levelCond;
 }
 

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -456,8 +456,7 @@ JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>* LoopCloneContext::Ensur
 {
     if (blockConditions[loopNum] == nullptr)
     {
-        blockConditions[loopNum] =
-            new (alloc) JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>(alloc);
+        blockConditions[loopNum] = new (alloc) JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>(alloc);
     }
 
     JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>* levelCond = blockConditions[loopNum];

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71611/Runtime_71611.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71611/Runtime_71611.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+public class Runtime_71611
+{
+    interface I
+    {
+        public int F(int x, int y);
+    }
+
+    class Add : I 
+    {
+        int I.F(int x, int y) => x + y;
+    }
+
+    class Mul : I
+    {
+        int I.F(int x, int y) => x * y;
+    }
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Cloned(I m, int[] xs, int[] ys, int from, int to)
+    {
+        int r = 0;
+        // This loop was being cloned without a null check on 'ys'
+        for (int i = from; i < to; i++)
+        {
+            int y = ys != null ? ys[i] : 0;
+            r += m.F(xs[i], y);
+        }
+        return r;
+    }
+    
+    public static int Main()
+    {
+        int[] xs = new int[] { 1, 2, 3, 4 };
+        I m = new Add();
+
+        int r = 0;
+
+        for (int i = 0; i < 30; i++)
+        {
+            r += Cloned(m, xs, null, 0, 3);
+            Thread.Sleep(15);
+        }
+
+        Thread.Sleep(50);
+
+        for (int i = 0; i < 70; i++)
+        {
+            r += Cloned(m, xs, null, 0, 3);
+        }
+        
+        return r / 6;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71611/Runtime_71611.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71611/Runtime_71611.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_TieredCompilation=1
+set COMPlus_TieredPGO=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_TieredCompilation=1
+export COMPlus_TieredPGO=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Adding object dereferences was calling EnsureBlockConditions which would
reallocate all the lists, removing previous array dereferences. This
resulted in missing array null checks in some cases.

Fix #71611