### PR TITLE
Port perf improvement changes in new API back to runtime.

### DIFF
--- a/src/libraries/Common/src/Roslyn/CSharpSyntaxHelper.cs
+++ b/src/libraries/Common/src/Roslyn/CSharpSyntaxHelper.cs
@@ -104,5 +104,22 @@ namespace Microsoft.CodeAnalysis.DotnetRuntime.Extensions
             // C# doesn't have global aliases at the compilation level.
             return;
         }
+
+        public override bool ContainsGlobalAliases(SyntaxNode root)
+        {
+            // Global usings can only exist at the compilation-unit level, so no need to dive any deeper than that.
+            var compilationUnit = (CompilationUnitSyntax)root;
+
+            foreach (var directive in compilationUnit.Usings)
+            {
+                if (directive.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword) &&
+                    directive.Alias != null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/libraries/Common/src/Roslyn/ISyntaxHelper.cs
+++ b/src/libraries/Common/src/Roslyn/ISyntaxHelper.cs
@@ -35,6 +35,8 @@ namespace Microsoft.CodeAnalysis.DotnetRuntime.Extensions
         /// </summary>
         void AddAliases(SyntaxNode node, ref ValueListBuilder<(string aliasName, string symbolName)> aliases, bool global);
         void AddAliases(CompilationOptions options, ref ValueListBuilder<(string aliasName, string symbolName)> aliases);
+
+        bool ContainsGlobalAliases(SyntaxNode root);
     }
 
     internal abstract class AbstractSyntaxHelper : ISyntaxHelper
@@ -58,5 +60,7 @@ namespace Microsoft.CodeAnalysis.DotnetRuntime.Extensions
 
         public abstract void AddAliases(SyntaxNode node, ref ValueListBuilder<(string aliasName, string symbolName)> aliases, bool global);
         public abstract void AddAliases(CompilationOptions options, ref ValueListBuilder<(string aliasName, string symbolName)> aliases);
+
+        public abstract bool ContainsGlobalAliases(SyntaxNode root);
     }
 }

--- a/src/libraries/Common/src/Roslyn/SyntaxValueProvider_ForAttributeWithSimpleName.cs
+++ b/src/libraries/Common/src/Roslyn/SyntaxValueProvider_ForAttributeWithSimpleName.cs
@@ -17,11 +17,34 @@ namespace Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 
 internal static partial class SyntaxValueProviderExtensions
 {
+    // Normal class as Runtime does not seem to support records currently.
+
     /// <summary>
     /// Information computed about a particular tree.  Cached so we don't repeatedly recompute this important
     /// information each time the incremental pipeline is rerun.
     /// </summary>
-    private sealed record SyntaxTreeInfo(SyntaxTree Tree, bool ContainsGlobalAliases, bool ContainsAttributeList);
+    private sealed class SyntaxTreeInfo : IEquatable<SyntaxTreeInfo>
+    {
+        public readonly SyntaxTree Tree;
+        public readonly bool ContainsGlobalAliases;
+        public readonly bool ContainsAttributeList;
+
+        public SyntaxTreeInfo(SyntaxTree tree, bool containsGlobalAliases, bool containsAttributeList)
+        {
+            Tree = tree;
+            ContainsGlobalAliases = containsGlobalAliases;
+            ContainsAttributeList = containsAttributeList;
+        }
+
+        public bool Equals(SyntaxTreeInfo other)
+            => Tree == other?.Tree;
+
+        public override bool Equals(object obj)
+            => this.Equals(obj as SyntaxTreeInfo);
+
+        public override int GetHashCode()
+            => Tree.GetHashCode();
+    }
 
     /// <summary>
     /// Caching of syntax-tree to the info we've computed about it.  Used because compilations will have thousands of


### PR DESCRIPTION
These are changes we made on the roslyn side in the interim period after polyfilling the runtime.  They are simple changes taht remove less state-tables and work building and keeping the increment index up to date.    This also keeps the runtime code in sync with the latest Roslyn code.

Will document hte improvements for those that are interested.