### PR TITLE
Make 'RC' lowercase in versions.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <SdkBandVersion>7.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>RC</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Set assembly version to align with major and minor version,
          as for the patches and revisions should be manually updated per assembly if it is serviced. -->


### PR DESCRIPTION
We merged this PR https://github.com/dotnet/runtime/pull/72068 which bumps the preview and number versions in main from preview+7 to RC+1.

But looking at 6.0 changes, the preview name was submitted in lowercase:

https://github.com/dotnet/runtime/commit/da9b16f2804e87c9c1ca9dcd9036e7b53e724f5d
https://github.com/dotnet/runtime/commit/5a5d7f0518b564e7f840c6c939bb6618c778b21b
https://github.com/dotnet/runtime/commit/4e84cdffd76e4506848241111018b044bc1f1200

We don't know if there would be unintended consequences from having the preview name in uppercase, so I'm changing it to lowercase.