### PR TITLE
Fix more SafeHandle cleanup in Windows crypto PAL

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.Import.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.Import.cs
@@ -74,12 +74,17 @@ namespace System.Security.Cryptography.X509Certificates
 
                     if (contentType == Interop.Crypt32.ContentType.CERT_QUERY_CONTENT_PKCS7_SIGNED || contentType == Interop.Crypt32.ContentType.CERT_QUERY_CONTENT_PKCS7_SIGNED_EMBED)
                     {
+                        pCertContext?.Dispose();
                         pCertContext = GetSignerInPKCS7Store(hCertStore, hCryptMsg);
                     }
                     else if (contentType == Interop.Crypt32.ContentType.CERT_QUERY_CONTENT_PFX)
                     {
                         if (loadFromFile)
+                        {
                             rawData = File.ReadAllBytes(fileName!);
+                        }
+
+                        pCertContext?.Dispose();
                         pCertContext = FilterPFXStore(rawData, password, pfxCertStoreFlags);
 
                         // If PersistKeySet is set we don't delete the key, so that it persists.
@@ -198,6 +203,7 @@ namespace System.Security.Cryptography.X509Certificates
                         if (pCertContext.IsInvalid)
                         {
                             // Doesn't have a private key but hang on to it anyway in case we don't find any certs with a private key.
+                            pCertContext.Dispose();
                             pCertContext = pEnumContext.Duplicate();
                         }
                     }
@@ -205,6 +211,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 if (pCertContext.IsInvalid)
                 {
+                    pCertContext.Dispose();
                     throw new CryptographicException(SR.Cryptography_Pfx_NoCertificates);
                 }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.PrivateKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.PrivateKey.cs
@@ -202,11 +202,14 @@ namespace System.Security.Cryptography.X509Certificates
         private T? GetPrivateKey<T>(Func<CspParameters, T> createCsp, Func<CngKey, T> createCng) where T : AsymmetricAlgorithm
         {
             CngKeyHandleOpenOptions cngHandleOptions;
-            SafeNCryptKeyHandle? ncryptKey = TryAcquireCngPrivateKey(CertContext, out cngHandleOptions);
-            if (ncryptKey != null)
+            using (SafeCertContextHandle certContext = GetCertContext())
             {
-                CngKey cngKey = CngKey.Open(ncryptKey, cngHandleOptions);
-                return createCng(cngKey);
+                SafeNCryptKeyHandle? ncryptKey = TryAcquireCngPrivateKey(certContext, out cngHandleOptions);
+                if (ncryptKey != null)
+                {
+                    CngKey cngKey = CngKey.Open(ncryptKey, cngHandleOptions);
+                    return createCng(cngKey);
+                }
             }
 
             CspParameters? cspParameters = GetPrivateKeyCsp();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.cs
@@ -475,14 +475,11 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        internal SafeCertContextHandle CertContext
+        internal SafeCertContextHandle GetCertContext()
         {
-            get
-            {
-                SafeCertContextHandle certContext = Interop.Crypt32.CertDuplicateCertificateContext(_certContext.DangerousGetHandle());
-                GC.KeepAlive(_certContext);
-                return certContext;
-            }
+            SafeCertContextHandle certContext = Interop.Crypt32.CertDuplicateCertificateContext(_certContext.DangerousGetHandle());
+            GC.KeepAlive(_certContext);
+            return certContext;
         }
 
         private static Interop.Crypt32.CertNameType MapNameType(X509NameType nameType)
@@ -530,9 +527,10 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 // We need to delete any associated key container upon disposition. Thus, replace the safehandle we got with a safehandle whose
                 // Release() method performs the key container deletion.
-                SafeCertContextHandle oldCertContext = certContext;
-                certContext = Interop.Crypt32.CertDuplicateCertificateContextWithKeyContainerDeletion(oldCertContext.DangerousGetHandle());
-                GC.KeepAlive(oldCertContext);
+                using (SafeCertContextHandle oldCertContext = certContext)
+                {
+                    certContext = Interop.Crypt32.CertDuplicateCertificateContextWithKeyContainerDeletion(oldCertContext.DangerousGetHandle());
+                }
             }
             _certContext = certContext;
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Windows.BuildChain.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Windows.BuildChain.cs
@@ -63,9 +63,12 @@ namespace System.Security.Cryptography.X509Certificates
                             Interop.Crypt32.FILETIME ft = Interop.Crypt32.FILETIME.FromDateTime(verificationTime);
                             Interop.Crypt32.CertChainFlags flags = MapRevocationFlags(revocationMode, revocationFlag, disableAia);
                             SafeX509ChainHandle chain;
-                            if (!Interop.Crypt32.CertGetCertificateChain(storeHandle.DangerousGetHandle(), certificatePal.CertContext, &ft, extraStoreHandle, ref chainPara, flags, IntPtr.Zero, out chain))
+                            using (SafeCertContextHandle certContext = certificatePal.GetCertContext())
                             {
-                                return null;
+                                if (!Interop.Crypt32.CertGetCertificateChain(storeHandle.DangerousGetHandle(), certContext, &ft, extraStoreHandle, ref chainPara, flags, IntPtr.Zero, out chain))
+                                {
+                                    return null;
+                                }
                             }
 
                             return new ChainPal(chain);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Windows.BuildChain.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Windows.BuildChain.cs
@@ -67,6 +67,7 @@ namespace System.Security.Cryptography.X509Certificates
                             {
                                 if (!Interop.Crypt32.CertGetCertificateChain(storeHandle.DangerousGetHandle(), certContext, &ft, extraStoreHandle, ref chainPara, flags, IntPtr.Zero, out chain))
                                 {
+                                    chain.Dispose();
                                     return null;
                                 }
                             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.Import.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.Import.cs
@@ -124,7 +124,7 @@ namespace System.Security.Cryptography.X509Certificates
                     !Interop.Crypt32.CertAddCertificateLinkToStore(certStore, certContext, Interop.Crypt32.CertStoreAddDisposition.CERT_STORE_ADD_ALWAYS, IntPtr.Zero))
                 {
                     Exception e = Marshal.GetHRForLastWin32Error().ToCryptographicException();
-                    certStore?.Dispose();
+                    certStore.Dispose();
                     throw e;
                 }
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.PublicKey.cs
@@ -80,7 +80,8 @@ namespace System.Security.Cryptography.X509Certificates
         {
             TAlgorithm key;
 
-            using (SafeBCryptKeyHandle bCryptKeyHandle = ImportPublicKeyInfo(certificatePal.CertContext, importFlags))
+            using (SafeCertContextHandle certContext = certificatePal.GetCertContext())
+            using (SafeBCryptKeyHandle bCryptKeyHandle = ImportPublicKeyInfo(certContext, importFlags))
             {
                 CngKeyBlobFormat blobFormat;
                 byte[] keyBlob;


### PR DESCRIPTION
Most of these are actually on the success path.  These were highlighted via the System.Net.WebSockets.Client tests with the new checked SafeHandle finalization flag.