### PR TITLE
Re-enable releaseondetach profiler test

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -180,9 +180,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/profiler/eventpipe/eventpipe/*">
             <Issue>TraceEvent can't parse unaligned floats on arm32</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/profiler/unittest/releaseondetach/*">
-            <Issue>https://github.com/dotnet/runtime/issues/64986</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/profiler/eventpipe/eventpipe_readevents/*">
             <Issue>TraceEvent can't parse unaligned floats on arm32</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes #64986

This test was disabled due to the rollout of the !! C# feature, but that has been reverted.