### PR TITLE
Speed up ThreadLocalStatics_Test in DEBUG builds

### DIFF
--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/threadstatics.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/threadstatics.cs
@@ -485,7 +485,12 @@ namespace ThreadLocalStatics
                 GC.Collect();
             }
 
-            MultiThreaded_Test(TypeOf.TLS_T4, TypeOf.TLS_T5, 20, 20);
+#if DEBUG
+            const int numTasks = 15;
+#else
+            const int numTasks = 20;
+#endif
+            MultiThreaded_Test(TypeOf.TLS_T4, TypeOf.TLS_T5, numTasks, 20);
         }
     }
 }


### PR DESCRIPTION
Saw this test timeout in https://github.com/dotnet/runtime/pull/72077. This should decrease the amount of work done by the test by 25%. It is the longest test in DynamicGenerics. It was only recently enabled.

```
Running Test: ThreadLocalStatics.TLSTesting.ThreadLocalStatics_Test

cmdLine:D:\a\_work\1\s\artifacts\tests\coreclr\windows.x64.Debug\nativeaot\SmokeTests\DynamicGenerics\DynamicGenerics\DynamicGenerics.cmd Timed Out (timeout in milliseconds: 1800000 from variable __TestTimeout, start: 7/13/2022 7:46:11 AM, end: 7/13/2022 8:16:11 AM)
Test Harness Exitcode is : -100
```

Cc @dotnet/ilc-contrib 