### PR TITLE
Remove IsPreRelease msbuild property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -277,9 +277,6 @@
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageThirdPartyNoticesFile>$(MSBuildThisFileDirectory)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
     <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</PackageReleaseNotes>
-    <!-- Indicates this is not an officially supported release. Release branches should set this to false. -->
-    <!-- Keep it in sync with PRERELEASE in eng/native/configureplatform.cmake -->
-    <IsPrerelease>false</IsPrerelease>
     <IsPrivateAssembly>$(MSBuildProjectName.Contains('Private'))</IsPrivateAssembly>
     <!-- Private packages should not be stable -->
     <SuppressFinalPackageVersion Condition="'$(SuppressFinalPackageVersion)' == '' and $(IsPrivateAssembly)">true</SuppressFinalPackageVersion>

--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -1,7 +1,7 @@
 include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
 
 # If set, indicates that this is not an officially supported release
-# Keep in sync with IsPrerelease in Directory.Build.props
+# Release branches should set this to false.
 set(PRERELEASE 0)
 
 #----------------------------------------

--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -2,7 +2,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
 
 # If set, indicates that this is not an officially supported release.
 # Release branches should set this to false.
-set(PRERELEASE 0)
+set(PRERELEASE 1)
 
 #----------------------------------------
 # Detect and set platform variable names

--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -1,6 +1,6 @@
 include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
 
-# If set, indicates that this is not an officially supported release
+# If set, indicates that this is not an officially supported release.
 # Release branches should set this to false.
 set(PRERELEASE 0)
 


### PR DESCRIPTION
The property was added in https://github.com/dotnet/coreclr/commit/809b8f792923c95b9d5fee824c60dde21079cca1 years ago and isn't used anymore. Remove it to ease branding.