### PR TITLE
Fix stackoverflow issue when creating recursive contracts using JsonIgnoreCondition

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -200,7 +200,7 @@ namespace System.Text.Json.Serialization.Converters
 
                     if (state.Current.PropertyState < StackFramePropertyState.ReadValue)
                     {
-                        if (!jsonPropertyInfo.HasSetter)
+                        if (!jsonPropertyInfo.CanDeserialize)
                         {
                             if (!reader.TrySkip())
                             {
@@ -289,7 +289,7 @@ namespace System.Text.Json.Serialization.Converters
                 for (int i = 0; i < properties.Count; i++)
                 {
                     JsonPropertyInfo jsonPropertyInfo = properties[i].Value;
-                    if (jsonPropertyInfo.HasGetter)
+                    if (jsonPropertyInfo.CanSerialize)
                     {
                         // Remember the current property for JsonPath support if an exception is thrown.
                         state.Current.JsonPropertyInfo = jsonPropertyInfo;
@@ -305,7 +305,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 // Write extension data after the normal properties.
                 JsonPropertyInfo? extensionDataProperty = jsonTypeInfo.ExtensionDataProperty;
-                if (extensionDataProperty?.HasGetter == true)
+                if (extensionDataProperty?.CanSerialize == true)
                 {
                     // Remember the current property for JsonPath support if an exception is thrown.
                     state.Current.JsonPropertyInfo = extensionDataProperty;
@@ -339,7 +339,7 @@ namespace System.Text.Json.Serialization.Converters
                 while (state.Current.EnumeratorIndex < propertyList.Count)
                 {
                     JsonPropertyInfo jsonPropertyInfo = propertyList[state.Current.EnumeratorIndex].Value;
-                    if (jsonPropertyInfo.HasGetter)
+                    if (jsonPropertyInfo.CanSerialize)
                     {
                         state.Current.JsonPropertyInfo = jsonPropertyInfo;
                         state.Current.NumberHandling = jsonPropertyInfo.EffectiveNumberHandling;
@@ -368,7 +368,7 @@ namespace System.Text.Json.Serialization.Converters
                 if (state.Current.EnumeratorIndex == propertyList.Count)
                 {
                     JsonPropertyInfo? extensionDataProperty = jsonTypeInfo.ExtensionDataProperty;
-                    if (extensionDataProperty?.HasGetter == true)
+                    if (extensionDataProperty?.CanSerialize == true)
                     {
                         // Remember the current property for JsonPath support if an exception is thrown.
                         state.Current.JsonPropertyInfo = extensionDataProperty;
@@ -415,7 +415,7 @@ namespace System.Text.Json.Serialization.Converters
             bool useExtensionProperty)
         {
             // Skip the property if not found.
-            if (!jsonPropertyInfo.HasSetter)
+            if (!jsonPropertyInfo.CanDeserialize)
             {
                 reader.Skip();
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -287,7 +287,7 @@ namespace System.Text.Json.Serialization.Converters
                         out _,
                         createExtensionProperty: false);
 
-                    if (jsonPropertyInfo.HasSetter)
+                    if (jsonPropertyInfo.CanDeserialize)
                     {
                         ArgumentState argumentState = state.Current.CtorArgumentState!;
 
@@ -452,7 +452,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             if (state.Current.PropertyState < StackFramePropertyState.ReadValue)
             {
-                if (!jsonPropertyInfo.HasSetter)
+                if (!jsonPropertyInfo.CanDeserialize)
                 {
                     if (!reader.TrySkip())
                     {
@@ -486,7 +486,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
             }
 
-            Debug.Assert(jsonPropertyInfo.HasSetter);
+            Debug.Assert(jsonPropertyInfo.CanDeserialize);
 
             // Ensure that the cache has enough capacity to add this property.
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -205,9 +205,9 @@ namespace System.Text.Json.Serialization.Metadata
         private protected override void DetermineEffectiveConverter()
         {
             JsonConverter converter =
-                Options.ExpandConverterFactory(CustomConverter, PropertyType) ??
-                DefaultConverterForType ??
-                Options.GetConverterFromTypeInfo(PropertyType);
+                Options.ExpandConverterFactory(CustomConverter, PropertyType)
+                ?? DefaultConverterForType
+                ?? Options.GetConverterFromTypeInfo(PropertyType);
 
             TypedEffectiveConverter = converter is JsonConverter<T> typedConv ? typedConv : converter.CreateCastingConverter<T>();
             ConverterStrategy = TypedEffectiveConverter.ConverterStrategy;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -197,21 +197,18 @@ namespace System.Text.Json.Serialization.Metadata
                 Set = propertyInfo.Setter;
             }
 
-            // NB setting the ignore condition must follow converter & getter/setter
-            // configuration in order for access policies to be applied correctly.
             IgnoreCondition = propertyInfo.IgnoreCondition;
             JsonTypeInfo = propertyInfo.PropertyTypeInfo;
             NumberHandling = propertyInfo.NumberHandling;
         }
 
-        private protected override void DetermineEffectiveConverter(JsonConverter? customConverter)
+        private protected override void DetermineEffectiveConverter()
         {
-            if (customConverter != null)
-            {
-                customConverter = Options.ExpandConverterFactory(customConverter, PropertyType);
-            }
+            JsonConverter converter =
+                Options.ExpandConverterFactory(CustomConverter, PropertyType) ??
+                DefaultConverterForType ??
+                Options.GetConverterFromTypeInfo(PropertyType);
 
-            JsonConverter converter = customConverter ?? DefaultConverterForType ?? Options.GetConverterFromTypeInfo(PropertyType);
             TypedEffectiveConverter = converter is JsonConverter<T> typedConv ? typedConv : converter.CreateCastingConverter<T>();
             ConverterStrategy = TypedEffectiveConverter.ConverterStrategy;
         }
@@ -422,8 +419,6 @@ namespace System.Text.Json.Serialization.Metadata
 
         private protected override void ConfigureIgnoreCondition(JsonIgnoreCondition? ignoreCondition)
         {
-            DetermineSerializationCapabilities(ignoreCondition);
-
             switch (ignoreCondition)
             {
                 case null:
@@ -470,41 +465,6 @@ namespace System.Text.Json.Serialization.Metadata
         private static bool IsDefaultValue(T? value)
         {
             return default(T) is null ? value is null : EqualityComparer<T>.Default.Equals(default, value);
-        }
-
-        private void DetermineSerializationCapabilities(JsonIgnoreCondition? ignoreCondition)
-        {
-            if (ignoreCondition == JsonIgnoreCondition.Always)
-            {
-                Debug.Assert(Get == null && Set == null, "Getters or Setters should not be set when JsonIgnoreCondition.Always is specified.");
-                return;
-            }
-
-            Debug.Assert(TypedEffectiveConverter != null, "Must have calculated the effective converter strategy.");
-            if ((ConverterStrategy & (ConverterStrategy.Enumerable | ConverterStrategy.Dictionary)) == 0)
-            {
-                // We serialize if there is a getter + not ignoring readonly properties.
-                if (Get != null && Set == null)
-                {
-                    // Three possible values for ignoreCondition:
-                    // null = JsonIgnore was not placed on this property, global IgnoreReadOnlyProperties/Fields wins
-                    // WhenNull = only ignore when null, global IgnoreReadOnlyProperties/Fields loses
-                    // Never = never ignore (always include), global IgnoreReadOnlyProperties/Fields loses
-                    bool serializeReadOnlyProperty = ignoreCondition != null || !IgnoreReadOnlyMember;
-                    if (!serializeReadOnlyProperty)
-                    {
-                        Get = null;
-                    }
-                }
-            }
-            else
-            {
-                if (Get == null && Set != null)
-                {
-                    // Collection properties with setters only are not supported.
-                    Set = null;
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Partially reverts #71908 moving serialization capability resolution back to the final configure stage. While these policies are no longer reflected in the user-modifiable JSON contracts, I've added more escape hatches so that any user-provided configuration is respected.

Fix #72175.