### PR TITLE
Fix some SafeHandle finalization in System.Net.Security

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
@@ -192,6 +192,7 @@ namespace System.Net
             int errorCode = secModule.QueryContextChannelBinding(securityContext, contextAttribute, out result);
             if (errorCode != 0)
             {
+                result.Dispose();
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, $"ERROR = {ErrorDescription(errorCode)}");
                 return null;
             }

--- a/src/libraries/Common/tests/System/Net/Capability.Security.cs
+++ b/src/libraries/Common/tests/System/Net/Capability.Security.cs
@@ -70,12 +70,29 @@ namespace System.Net.Test.Common
             {
                 store.Open(OpenFlags.ReadOnly);
 
-                X509Certificate2Collection certs =
-                    store.Certificates.Find(X509FindType.FindByThumbprint, CARootThumbprint, false);
-
-                if (certs.Count == 1)
+                X509Certificate2Collection? certs = null;
+                X509Certificate2Collection? found = null;
+                try
                 {
-                    return true;
+                    certs = store.Certificates;
+                    found = certs.Find(X509FindType.FindByThumbprint, CARootThumbprint, false);
+
+                    if (found.Count == 1)
+                    {
+                        return true;
+                    }
+                }
+                finally
+                {
+                    if (found != null)
+                    {
+                        foreach (X509Certificate2 c in found) c.Dispose();
+                    }
+
+                    if (certs != null)
+                    {
+                        foreach (X509Certificate2 c in certs) c.Dispose();
+                    }
                 }
             }
 

--- a/src/libraries/Common/tests/System/Net/HttpsTestClient.cs
+++ b/src/libraries/Common/tests/System/Net/HttpsTestClient.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Test.Common
 {
-    public class HttpsTestClient
+    public class HttpsTestClient : IDisposable
     {
         public class Options
         {
@@ -39,15 +39,20 @@ User-Agent: Testing application
             public SslPolicyErrors IgnoreSslPolicyErrors { get; set; } = SslPolicyErrors.None;
         }
 
-        private Options _options;
+        private readonly Options _options;
         private int _requestCount = 0;
-        private VerboseTestLogging _log = VerboseTestLogging.GetInstance();
+        private readonly VerboseTestLogging _log = VerboseTestLogging.GetInstance();
 
         public SslStream Stream { get; private set; }
 
         public HttpsTestClient(Options options)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public void Dispose()
+        {
+            _options.ClientCertificate?.Dispose();
         }
 
         public async Task HttpsRequestAsync(Func<string, Task<string>> httpConversation = null)

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -118,6 +118,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
         public void Dispose()
         {
             _cert.Dispose();
+            _ocspResponder?.Dispose();
         }
 
         internal string SubjectName => _cert.Subject;
@@ -899,7 +900,9 @@ SingleResponse ::= SEQUENCE {
                     eeKey,
                     extensions);
 
+                X509Certificate2 tmp = endEntityCert;
                 endEntityCert = endEntityCert.CopyWithPrivateKey(eeKey);
+                tmp.Dispose();
             }
 
             if (registerAuthorities)

--- a/src/libraries/System.Net.Security/tests/EnterpriseTests/NegotiateStreamLoopbackTest.cs
+++ b/src/libraries/System.Net.Security/tests/EnterpriseTests/NegotiateStreamLoopbackTest.cs
@@ -223,9 +223,12 @@ namespace System.Net.Security.Enterprise.Tests
             Assert.False(stream.LeaveInnerStreamOpen);
 
             IIdentity remoteIdentity = stream.RemoteIdentity;
-            Assert.Equal("Kerberos", remoteIdentity.AuthenticationType);
-            Assert.True(remoteIdentity.IsAuthenticated);
-            Assert.Equal(remoteName, remoteIdentity.Name);
+            using (remoteIdentity as IDisposable)
+            {
+                Assert.Equal("Kerberos", remoteIdentity.AuthenticationType);
+                Assert.True(remoteIdentity.IsAuthenticated);
+                Assert.Equal(remoteName, remoteIdentity.Name);
+            }
         }
     }
 }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -157,7 +157,6 @@ namespace System.Net.Security.Tests
                     serverConnection.GetStream(),
                     false,
                     ServerSideRemoteClientCertificateValidation))
-
                 {
                     string serverName = _serverCertificate.GetNameInfo(X509NameType.SimpleName, false);
                     var clientCerts = new X509CertificateCollection();
@@ -181,22 +180,25 @@ namespace System.Net.Security.Tests
 
                     await TestConfiguration.WhenAllOrAnyFailedWithTimeout(clientAuthentication, serverAuthentication);
 
-                    if (!_clientCertificateRemovedByFilter)
+                    using (sslServerStream.RemoteCertificate)
                     {
-                        Assert.True(sslClientStream.IsMutuallyAuthenticated, "sslClientStream.IsMutuallyAuthenticated");
-                        Assert.True(sslServerStream.IsMutuallyAuthenticated, "sslServerStream.IsMutuallyAuthenticated");
+                        if (!_clientCertificateRemovedByFilter)
+                        {
+                            Assert.True(sslClientStream.IsMutuallyAuthenticated, "sslClientStream.IsMutuallyAuthenticated");
+                            Assert.True(sslServerStream.IsMutuallyAuthenticated, "sslServerStream.IsMutuallyAuthenticated");
 
-                        Assert.Equal(sslServerStream.RemoteCertificate.Subject, _clientCertificate.Subject);
+                            Assert.Equal(sslServerStream.RemoteCertificate.Subject, _clientCertificate.Subject);
+                        }
+                        else
+                        {
+                            Assert.False(sslClientStream.IsMutuallyAuthenticated, "sslClientStream.IsMutuallyAuthenticated");
+                            Assert.False(sslServerStream.IsMutuallyAuthenticated, "sslServerStream.IsMutuallyAuthenticated");
+
+                            Assert.Null(sslServerStream.RemoteCertificate);
+                        }
+
+                        Assert.Equal(sslClientStream.RemoteCertificate.Subject, _serverCertificate.Subject);
                     }
-                    else
-                    {
-                        Assert.False(sslClientStream.IsMutuallyAuthenticated, "sslClientStream.IsMutuallyAuthenticated");
-                        Assert.False(sslServerStream.IsMutuallyAuthenticated, "sslServerStream.IsMutuallyAuthenticated");
-
-                        Assert.Null(sslServerStream.RemoteCertificate);
-                    }
-
-                    Assert.Equal(sslClientStream.RemoteCertificate.Subject, _serverCertificate.Subject);
                 }
             }
         }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
@@ -150,6 +150,7 @@ namespace System.Net.Security.Tests
 
                     Assert.Equal(expectedAuthenticationType, auth.RemoteIdentity.AuthenticationType);
                     Assert.Equal(serverSPN, auth.RemoteIdentity.Name);
+                    (auth.RemoteIdentity as IDisposable)?.Dispose();
 
                     Assert.True(auth.IsAuthenticated);
                     Assert.True(auth.IsEncrypted);
@@ -195,6 +196,7 @@ namespace System.Net.Security.Tests
 
                     Assert.Equal(expectedAuthenticationType, serverAuth.RemoteIdentity.AuthenticationType);
                     Assert.Equal(expectedUser, serverAuth.RemoteIdentity.Name);
+                    (serverAuth.RemoteIdentity as IDisposable)?.Dispose();
 
                     // Receive a message from the client.
                     var message = "Hello from the client.";

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -63,9 +63,12 @@ namespace System.Net.Security.Tests
                 Assert.False(client.LeaveInnerStreamOpen);
 
                 IIdentity serverIdentity = client.RemoteIdentity;
-                Assert.Equal("NTLM", serverIdentity.AuthenticationType);
-                Assert.False(serverIdentity.IsAuthenticated);
-                Assert.Equal("", serverIdentity.Name);
+                using (serverIdentity as IDisposable)
+                {
+                    Assert.Equal("NTLM", serverIdentity.AuthenticationType);
+                    Assert.False(serverIdentity.IsAuthenticated);
+                    Assert.Equal("", serverIdentity.Name);
+                }
 
                 // Expected Server property values:
                 Assert.True(server.IsAuthenticated);
@@ -77,11 +80,14 @@ namespace System.Net.Security.Tests
                 Assert.False(server.LeaveInnerStreamOpen);
 
                 IIdentity clientIdentity = server.RemoteIdentity;
-                Assert.Equal("NTLM", clientIdentity.AuthenticationType);
+                using (clientIdentity as IDisposable)
+                {
+                    Assert.Equal("NTLM", clientIdentity.AuthenticationType);
 
-                Assert.True(clientIdentity.IsAuthenticated);
+                    Assert.True(clientIdentity.IsAuthenticated);
 
-                IdentityValidator.AssertIsCurrentIdentity(clientIdentity);
+                    IdentityValidator.AssertIsCurrentIdentity(clientIdentity);
+                }
             }
         }
 
@@ -153,9 +159,12 @@ namespace System.Net.Security.Tests
                 Assert.False(client.LeaveInnerStreamOpen);
 
                 IIdentity serverIdentity = client.RemoteIdentity;
-                Assert.Equal("NTLM", serverIdentity.AuthenticationType);
-                Assert.True(serverIdentity.IsAuthenticated);
-                Assert.Equal(targetName, serverIdentity.Name);
+                using (serverIdentity as IDisposable)
+                {
+                    Assert.Equal("NTLM", serverIdentity.AuthenticationType);
+                    Assert.True(serverIdentity.IsAuthenticated);
+                    Assert.Equal(targetName, serverIdentity.Name);
+                }
 
                 // Expected Server property values:
                 Assert.True(server.IsAuthenticated);
@@ -167,11 +176,14 @@ namespace System.Net.Security.Tests
                 Assert.False(server.LeaveInnerStreamOpen);
 
                 IIdentity clientIdentity = server.RemoteIdentity;
-                Assert.Equal("NTLM", clientIdentity.AuthenticationType);
+                using (clientIdentity as IDisposable)
+                {
+                    Assert.Equal("NTLM", clientIdentity.AuthenticationType);
 
-                Assert.True(clientIdentity.IsAuthenticated);
+                    Assert.True(clientIdentity.IsAuthenticated);
 
-                IdentityValidator.AssertIsCurrentIdentity(clientIdentity);
+                    IdentityValidator.AssertIsCurrentIdentity(clientIdentity);
+                }
             }
         }
 
@@ -210,9 +222,12 @@ namespace System.Net.Security.Tests
                 Assert.False(client.LeaveInnerStreamOpen);
 
                 IIdentity serverIdentity = client.RemoteIdentity;
-                Assert.Equal("NTLM", serverIdentity.AuthenticationType);
-                Assert.True(serverIdentity.IsAuthenticated);
-                Assert.Equal(targetName, serverIdentity.Name);
+                using (serverIdentity as IDisposable)
+                {
+                    Assert.Equal("NTLM", serverIdentity.AuthenticationType);
+                    Assert.True(serverIdentity.IsAuthenticated);
+                    Assert.Equal(targetName, serverIdentity.Name);
+                }
 
                 // Expected Server property values:
                 Assert.True(server.IsAuthenticated);
@@ -224,12 +239,15 @@ namespace System.Net.Security.Tests
                 Assert.False(server.LeaveInnerStreamOpen);
 
                 IIdentity clientIdentity = server.RemoteIdentity;
-                Assert.Equal("NTLM", clientIdentity.AuthenticationType);
+                using (clientIdentity as IDisposable)
+                {
+                    Assert.Equal("NTLM", clientIdentity.AuthenticationType);
 
-                Assert.False(clientIdentity.IsAuthenticated);
-                // On .NET Desktop: Assert.True(clientIdentity.IsAuthenticated);
+                    Assert.False(clientIdentity.IsAuthenticated);
+                    // On .NET Desktop: Assert.True(clientIdentity.IsAuthenticated);
 
-                IdentityValidator.AssertHasName(clientIdentity, new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).Value);
+                    IdentityValidator.AssertHasName(clientIdentity, new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).Value);
+                }
             }
         }
     }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
@@ -35,10 +35,11 @@ namespace System.Net.Security.Tests
             Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             await s.ConnectAsync(Configuration.Security.TlsRenegotiationServer, 443);
             using (NetworkStream ns = new NetworkStream(s))
+            using (X509Certificate2 clientCert = Configuration.Certificates.GetClientCertificate())
             using (SslStream ssl = new SslStream(ns, true, validationCallback))
             {
                 X509CertificateCollection certBundle = new X509CertificateCollection();
-                certBundle.Add(Configuration.Certificates.GetClientCertificate());
+                certBundle.Add(clientCert);
 
                 SslClientAuthenticationOptions options = new SslClientAuthenticationOptions
                 {
@@ -74,10 +75,11 @@ namespace System.Net.Security.Tests
             Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             await s.ConnectAsync(Configuration.Security.TlsRenegotiationServer, 443);
             using (NetworkStream ns = new NetworkStream(s))
+            using (X509Certificate2 clientCert = Configuration.Certificates.GetClientCertificate())
             using (SslStream ssl = new SslStream(ns, true))
             {
                 X509CertificateCollection certBundle = new X509CertificateCollection();
-                certBundle.Add(Configuration.Certificates.GetClientCertificate());
+                certBundle.Add(clientCert);
 
                 SslClientAuthenticationOptions options = new SslClientAuthenticationOptions
                 {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamConformanceTests.cs
@@ -21,7 +21,7 @@ namespace System.Net.Security.Tests
 
         protected override async Task<StreamPair> CreateWrappedConnectedStreamsAsync(StreamPair wrapped, bool leaveOpen = false)
         {
-            X509Certificate2? cert = Test.Common.Configuration.Certificates.GetServerCertificate();
+            using X509Certificate2 cert = Test.Common.Configuration.Certificates.GetServerCertificate();
             var ssl1 = new SslStream(wrapped.Stream1, leaveOpen, delegate { return true; });
             var ssl2 = new SslStream(wrapped.Stream2, leaveOpen, delegate { return true; });
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamEKUTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamEKUTest.cs
@@ -20,13 +20,13 @@ namespace System.Net.Security.Tests
 
         public const int TestTimeoutMilliseconds = 15 * 1000;
 
-        public static X509Certificate2 serverCertificateServerEku = Configuration.Certificates.GetServerCertificate();
-        public static X509Certificate2 serverCertificateNoEku = Configuration.Certificates.GetNoEKUCertificate();
-        public static X509Certificate2 serverCertificateWrongEku = Configuration.Certificates.GetClientCertificate();
+        public static readonly X509Certificate2 serverCertificateServerEku = Configuration.Certificates.GetServerCertificate();
+        public static readonly X509Certificate2 serverCertificateNoEku = Configuration.Certificates.GetNoEKUCertificate();
+        public static readonly X509Certificate2 serverCertificateWrongEku = Configuration.Certificates.GetClientCertificate();
 
-        public static X509Certificate2 clientCertificateWrongEku = Configuration.Certificates.GetServerCertificate();
-        public static X509Certificate2 clientCertificateNoEku = Configuration.Certificates.GetNoEKUCertificate();
-        public static X509Certificate2 clientCertificateClientEku = Configuration.Certificates.GetClientCertificate();
+        public static readonly X509Certificate2 clientCertificateWrongEku = Configuration.Certificates.GetServerCertificate();
+        public static readonly X509Certificate2 clientCertificateNoEku = Configuration.Certificates.GetNoEKUCertificate();
+        public static readonly X509Certificate2 clientCertificateClientEku = Configuration.Certificates.GetClientCertificate();
 
         [ConditionalFact(nameof(IsRootCertificateInstalled))]
         public async Task SslStream_NoEKUServerAuth_Ok()
@@ -41,7 +41,7 @@ namespace System.Net.Security.Tests
                 var clientOptions = new HttpsTestClient.Options(new IPEndPoint(IPAddress.Loopback, server.Port));
                 clientOptions.ServerName = serverOptions.ServerCertificate.GetNameInfo(X509NameType.SimpleName, false);
 
-                var client = new HttpsTestClient(clientOptions);
+                using var client = new HttpsTestClient(clientOptions);
 
                 var tasks = new Task[2];
                 tasks[0] = server.AcceptHttpsClientAsync();
@@ -64,7 +64,7 @@ namespace System.Net.Security.Tests
                 var clientOptions = new HttpsTestClient.Options(new IPEndPoint(IPAddress.Loopback, server.Port));
                 clientOptions.ServerName = serverOptions.ServerCertificate.GetNameInfo(X509NameType.SimpleName, false);
 
-                var client = new HttpsTestClient(clientOptions);
+                using var client = new HttpsTestClient(clientOptions);
 
                 var tasks = new Task[2];
                 tasks[0] = server.AcceptHttpsClientAsync();
@@ -89,7 +89,7 @@ namespace System.Net.Security.Tests
                 clientOptions.ServerName = serverOptions.ServerCertificate.GetNameInfo(X509NameType.SimpleName, false);
                 clientOptions.ClientCertificate = clientCertificateNoEku;
 
-                var client = new HttpsTestClient(clientOptions);
+                using var client = new HttpsTestClient(clientOptions);
 
                 var tasks = new Task[2];
                 tasks[0] = server.AcceptHttpsClientAsync();
@@ -114,7 +114,7 @@ namespace System.Net.Security.Tests
                 clientOptions.ServerName = serverOptions.ServerCertificate.GetNameInfo(X509NameType.SimpleName, false);
                 clientOptions.ClientCertificate = clientCertificateWrongEku;
 
-                var client = new HttpsTestClient(clientOptions);
+                using var client = new HttpsTestClient(clientOptions);
 
                 var tasks = new Task[2];
                 tasks[0] = server.AcceptHttpsClientAsync();
@@ -143,15 +143,16 @@ namespace System.Net.Security.Tests
             serverOptions.RequireClientAuthentication = true;
             serverOptions.IgnoreSslPolicyErrors = SslPolicyErrors.RemoteCertificateChainErrors;
 
+            using (X509Certificate2 clientCert = Configuration.Certificates.GetSelfSignedClientCertificate())
             using (var server = new HttpsTestServer(serverOptions))
             {
                 server.Start();
 
                 var clientOptions = new HttpsTestClient.Options(new IPEndPoint(IPAddress.Loopback, server.Port));
                 clientOptions.ServerName = serverOptions.ServerCertificate.GetNameInfo(X509NameType.SimpleName, false);
-                clientOptions.ClientCertificate = Configuration.Certificates.GetSelfSignedClientCertificate();
+                clientOptions.ClientCertificate = clientCert;
 
-                var client = new HttpsTestClient(clientOptions);
+                using var client = new HttpsTestClient(clientOptions);
 
                 var tasks = new Task[2];
                 tasks[0] = server.AcceptHttpsClientAsync();

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
@@ -12,7 +12,7 @@ namespace System.Net.Security.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public class SslStreamMutualAuthenticationTest
+    public class SslStreamMutualAuthenticationTest : IDisposable
     {
         private readonly X509Certificate2 _clientCertificate;
         private readonly X509Certificate2 _serverCertificate;
@@ -21,6 +21,12 @@ namespace System.Net.Security.Tests
         {
             _serverCertificate = Configuration.Certificates.GetServerCertificate();
             _clientCertificate = Configuration.Certificates.GetClientCertificate();
+        }
+
+        public void Dispose()
+        {
+            _serverCertificate.Dispose();
+            _clientCertificate.Dispose();
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNegotiatedCipherSuiteTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNegotiatedCipherSuiteTest.cs
@@ -696,11 +696,12 @@ namespace System.Net.Security.Tests
 
             using (clientStream)
             using (serverStream)
+            using (X509Certificate2 serverCert = Configuration.Certificates.GetSelfSignedServerCertificate())
             using (SslStream server = new SslStream(serverStream, leaveInnerStreamOpen: false),
                              client = new SslStream(clientStream, leaveInnerStreamOpen: false))
             {
                 var serverOptions = new SslServerAuthenticationOptions();
-                serverOptions.ServerCertificate = Configuration.Certificates.GetSelfSignedServerCertificate();
+                serverOptions.ServerCertificate = serverCert;
                 serverOptions.EncryptionPolicy = serverParams.EncryptionPolicy;
                 serverOptions.EnabledSslProtocols = serverParams.SslProtocols;
                 serverOptions.CipherSuitesPolicy = serverParams.CipherSuitesPolicy;

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -153,10 +153,11 @@ namespace System.Net.Security.Tests
             Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             await s.ConnectAsync(Configuration.Security.TlsRenegotiationServer, 443);
             using (NetworkStream ns = new NetworkStream(s))
+            using (X509Certificate2 clientCert = Configuration.Certificates.GetClientCertificate())
             using (SslStream ssl = new SslStream(ns, true, validationCallback))
             {
                 X509CertificateCollection certBundle = new X509CertificateCollection();
-                certBundle.Add(Configuration.Certificates.GetClientCertificate());
+                certBundle.Add(clientCert);
 
                 // Perform handshake to establish secure connection.
                 await ssl.AuthenticateAsClientAsync(Configuration.Security.TlsRenegotiationServer, certBundle, SslProtocols.Tls12, false);
@@ -256,6 +257,8 @@ namespace System.Net.Security.Tests
                 // verify that the session is usable with or without client's certificate
                 await TestHelper.PingPong(client, server, cts.Token);
                 await TestHelper.PingPong(server, client, cts.Token);
+
+                server.RemoteCertificate?.Dispose();
             }
         }
 
@@ -333,6 +336,8 @@ namespace System.Net.Security.Tests
                 // verify that the session is usable with or without client's certificate
                 await TestHelper.PingPong(client, server, cts.Token);
                 await TestHelper.PingPong(server, client, cts.Token);
+
+                server.RemoteCertificate?.Dispose();
             }
         }
 
@@ -560,6 +565,8 @@ namespace System.Net.Security.Tests
                 // verify that the session is usable with or without client's certificate
                 await TestHelper.PingPong(client, server, cts.Token);
                 await TestHelper.PingPong(server, client, cts.Token);
+
+                server.RemoteCertificate?.Dispose();
             }
         }
 
@@ -619,6 +626,8 @@ namespace System.Net.Security.Tests
                 await t;
 
                 await Assert.ThrowsAsync<InvalidOperationException>(() => server.NegotiateClientCertificateAsync());
+
+                server.RemoteCertificate?.Dispose();
             }
         }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -21,7 +21,7 @@ namespace System.Net.Security.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/68206", TestPlatforms.Android)]
         public async Task SslStream_ClientSendsSNIServerReceives_Ok(string hostName)
         {
-            X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
+            using X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
 
             await WithVirtualConnection(async (server, client) =>
                 {
@@ -55,7 +55,7 @@ namespace System.Net.Security.Tests
         [MemberData(nameof(HostNameData))]
         public async Task SslStream_ServerCallbackAndLocalCertificateSelectionSet_Throws(string hostName)
         {
-            X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
+            using X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
 
             int timesCallbackCalled = 0;
 
@@ -99,7 +99,7 @@ namespace System.Net.Security.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/68206", TestPlatforms.Android)]
         public async Task SslStream_ServerCallbackNotSet_UsesLocalCertificateSelection(string hostName)
         {
-            X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
+            using X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
 
             int timesCallbackCalled = 0;
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
@@ -28,7 +29,7 @@ namespace System.Net.Security.Tests
         public static bool SupportsHandshakeAlerts { get { return OperatingSystem.IsLinux() || OperatingSystem.IsWindows() || OperatingSystem.IsFreeBSD(); } }
         public static bool SupportsRenegotiation { get { return (OperatingSystem.IsWindows() && !PlatformDetection.IsWindows7) || ((OperatingSystem.IsLinux() || OperatingSystem.IsFreeBSD()) && PlatformDetection.OpenSslVersion >= new Version(1, 1, 1)); } }
 
-        public static X509Certificate2 ServerCertificate = System.Net.Test.Common.Configuration.Certificates.GetServerCertificate();
+        public static readonly X509Certificate2 ServerCertificate = System.Net.Test.Common.Configuration.Certificates.GetServerCertificate();
 
         public static Task WhenAllOrAnyFailedWithTimeout(params Task[] tasks)
             => tasks.WhenAllOrAnyFailed(PassingTestTimeoutMilliseconds);
@@ -49,7 +50,8 @@ namespace System.Net.Security.Tests
                     // New Windows can support null but it may be disabled in Azure images
                     using (Process p = Process.Start(new ProcessStartInfo("powershell", "-Command Get-TlsCipherSuite") { RedirectStandardOutput = true, RedirectStandardError = true }))
                     {
-                        return p.StandardOutput.ReadToEnd().Contains("WITH_NULL");
+                        using StreamReader reader = p.StandardOutput;
+                        return reader.ReadToEnd().Contains("WITH_NULL");
                     }
                 }
                 catch { return true; }  // assume availability

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -119,6 +119,7 @@ namespace System.Net.Security.Tests
                         {
                             store.Remove(cert);
                         }
+                        cert.Dispose();
                     }
                 }
             }
@@ -135,6 +136,7 @@ namespace System.Net.Security.Tests
                         {
                             store.Remove(cert);
                         }
+                        cert.Dispose();
                     }
                 }
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
@@ -36,9 +36,9 @@ namespace System.Net.Security.Tests
 
         private static void CheckTransportContext(TransportContext context)
         {
-            var cbt1 = context.GetChannelBinding(ChannelBindingKind.Endpoint);
-            var cbt2 = context.GetChannelBinding(ChannelBindingKind.Unique);
-            var cbt3 = context.GetChannelBinding(ChannelBindingKind.Unknown);
+            using ChannelBinding cbt1 = context.GetChannelBinding(ChannelBindingKind.Endpoint);
+            using ChannelBinding cbt2 = context.GetChannelBinding(ChannelBindingKind.Unique);
+            using ChannelBinding cbt3 = context.GetChannelBinding(ChannelBindingKind.Unknown);
 
             CheckChannelBinding(ChannelBindingKind.Endpoint, cbt1);
             CheckChannelBinding(ChannelBindingKind.Unique, cbt2);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.cs
@@ -66,6 +66,8 @@ namespace System.Security.Cryptography.X509Certificates
                     return; // The certificate is not present in the store, simply return.
 
                 Interop.Crypt32.CERT_CONTEXT* pCertContextToDelete = enumCertContext.Disconnect();  // CertDeleteCertificateFromContext always frees the context (even on error)
+                enumCertContext.Dispose();
+
                 if (!Interop.Crypt32.CertDeleteCertificateFromStore(pCertContextToDelete))
                     throw Marshal.GetLastWin32Error().ToCryptographicException();
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/WindowsInterop.crypt32.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/WindowsInterop.crypt32.cs
@@ -150,7 +150,13 @@ internal static partial class Interop
         /// </summary>
         public static unsafe bool CertFindCertificateInStore(SafeCertStoreHandle hCertStore, Interop.Crypt32.CertFindType dwFindType, void* pvFindPara, [NotNull] ref SafeCertContextHandle? pCertContext)
         {
-            Interop.Crypt32.CERT_CONTEXT* pPrevCertContext = pCertContext == null ? null : pCertContext.Disconnect();
+            Interop.Crypt32.CERT_CONTEXT* pPrevCertContext = null;
+            if (pCertContext != null)
+            {
+                pPrevCertContext = pCertContext.Disconnect();
+                pCertContext.Dispose();
+            }
+
             pCertContext = Interop.Crypt32.CertFindCertificateInStore(hCertStore, Interop.Crypt32.CertEncodingType.All, Interop.Crypt32.CertFindFlags.None, dwFindType, pvFindPara, pPrevCertContext);
             return !pCertContext.IsInvalid;
         }


### PR DESCRIPTION
There's still a lot more, but most of it appears to be inevitable given the current design and public APIs in the library, e.g. SslStreamCertificateContext creating resources it internally stores and not providing any way to explicitly clean them up.

Some of the changes here are in production code in System.Security.Cryptography and System.Net.Security, but the majority are in tests.