### PR TITLE
Fix a broken dprintf

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -13117,7 +13117,7 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
     }
 
     GCConfig::SetConcurrentGC(gc_can_use_concurrent);
-#else //BACKGROUND_GC 
+#else //BACKGROUND_GC
     GCConfig::SetConcurrentGC(false);
 #endif //BACKGROUND_GC
 #endif //WRITE_WATCH
@@ -41233,7 +41233,7 @@ void gc_heap::should_check_bgc_mark (heap_segment* seg,
         }
         else if (heap_segment_background_allocated (seg) == 0)
         {
-            dprintf (3, ("seg %Ix newly alloc during bgc"));
+            dprintf (3, ("seg %Ix newly alloc during bgc", seg));
         }
         else
         {
@@ -44255,7 +44255,7 @@ HRESULT GCHeap::Initialize()
     GCConfig::SetGCCpuGroup(can_use_cpu_groups);
 
 #ifdef HEAP_BALANCE_INSTRUMENTATION
-    cpu_group_enabled_p = can_use_cpu_groups; 
+    cpu_group_enabled_p = can_use_cpu_groups;
 
     if (!GCToOSInterface::GetNumaInfo (&total_numa_nodes_on_machine, &procs_per_numa_node))
     {
@@ -44566,13 +44566,13 @@ Object * GCHeap::NextObj (Object * object)
 
     // We still want to verify nextobj that lands between heap_segment_allocated and alloc_allocated
     // on the ephemeral segment. In regions these 2 could be changed by another thread so we need
-    // to make sure they are still in sync by the time we check. If they are not in sync, we just 
+    // to make sure they are still in sync by the time we check. If they are not in sync, we just
     // bail which means we don't validate the next object during that small window and that's fine.
     //
-    // We also miss validating nextobj if it's in the segment that just turned into the new ephemeral 
+    // We also miss validating nextobj if it's in the segment that just turned into the new ephemeral
     // segment since we saved which is also a very small window and again that's fine.
-    if ((nextobj >= heap_segment_allocated (hs)) && 
-        ((hs != saved_ephemeral_heap_segment) || 
+    if ((nextobj >= heap_segment_allocated (hs)) &&
+        ((hs != saved_ephemeral_heap_segment) ||
          !in_range_for_segment(saved_alloc_allocated, saved_ephemeral_heap_segment) ||
          (nextobj >= saved_alloc_allocated)))
     {


### PR DESCRIPTION
The `dprintf` on line `41236` is broken, it has a `%Ix` but there is no parameter passed to it.

In the same change, I just trimmed a few accidental white spaces at the end of lines, this will prepare me for the next change.

@dotnet/gc