### PR TITLE
Fixes for NonBacktracking NFA mode

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -70,6 +70,7 @@
     <Compile Include="System\Text\RegularExpressions\Symbolic\MintermGenerator.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\RegexNodeConverter.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\SparseIntMap.cs" />
+    <Compile Include="System\Text\RegularExpressions\Symbolic\StateFlags.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicMatch.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicRegexBuilder.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicRegexNode.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MatchingState.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MatchingState.cs
@@ -104,6 +104,43 @@ namespace System.Text.RegularExpressions.Symbolic
             return Node.IsNullableFor(context);
         }
 
+        /// <summary>
+        /// Builds a <see cref="StateFlags"/> with the relevant flags set.
+        /// </summary>
+        /// <param name="solver">a solver for <typeparamref name="TSet"/></param>
+        /// <param name="isInitial">whether this state is an initial state</param>
+        /// <returns>the flags for this matching state</returns>
+        internal StateFlags BuildStateFlags(ISolver<TSet> solver, bool isInitial)
+        {
+            StateFlags info = 0;
+
+            if (isInitial)
+            {
+                info |= StateFlags.IsInitialFlag;
+            }
+
+            if (IsDeadend(solver))
+            {
+                info |= StateFlags.IsDeadendFlag;
+            }
+
+            if (Node.CanBeNullable)
+            {
+                info |= StateFlags.CanBeNullableFlag;
+                if (Node.IsNullable)
+                {
+                    info |= StateFlags.IsNullableFlag;
+                }
+            }
+
+            if (Node.Kind != SymbolicRegexNodeKind.DisableBacktrackingSimulation)
+            {
+                info |= StateFlags.SimulatesBacktrackingFlag;
+            }
+
+            return info;
+        }
+
         public override bool Equals(object? obj) =>
             obj is MatchingState<TSet> s && PrevCharKind == s.PrevCharKind && Node.Equals(s.Node);
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/StateFlags.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/StateFlags.cs
@@ -27,15 +27,10 @@ namespace System.Text.RegularExpressions.Symbolic
     /// </summary>
     internal static class StateFlagsExtensions
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsInitial(this StateFlags info) => info.HasFlag(StateFlags.IsInitialFlag);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsDeadend(this StateFlags info) => info.HasFlag(StateFlags.IsDeadendFlag);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsNullable(this StateFlags info) => info.HasFlag(StateFlags.IsNullableFlag);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool CanBeNullable(this StateFlags info) => info.HasFlag(StateFlags.CanBeNullableFlag);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool SimulatesBacktracking(this StateFlags info) => info.HasFlag(StateFlags.SimulatesBacktrackingFlag);
+        internal static bool IsInitial(this StateFlags info) => (info & StateFlags.IsInitialFlag) != 0;
+        internal static bool IsDeadend(this StateFlags info) => (info & StateFlags.IsDeadendFlag) != 0;
+        internal static bool IsNullable(this StateFlags info) => (info & StateFlags.IsNullableFlag) != 0;
+        internal static bool CanBeNullable(this StateFlags info) => (info & StateFlags.CanBeNullableFlag) != 0;
+        internal static bool SimulatesBacktracking(this StateFlags info) => (info & StateFlags.SimulatesBacktrackingFlag) != 0;
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/StateFlags.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/StateFlags.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Text.RegularExpressions.Symbolic
+{
+    /// <summary>
+    /// These flags provide context-independent information available for every state. They provide a fast way to evaluate
+    /// conditions in the inner matching loops of <see cref="SymbolicRegexMatcher{TSet}"/>. The matcher caches one of these
+    /// for every state, for which they are created by <see cref="MatchingState{TSet}.BuildStateFlags(ISolver{TSet}, bool)"/>.
+    /// In DFA mode the cached flags are used directly, while in NFA mode the <see cref="SymbolicRegexMatcher{TSet}.NfaStateHandler"/>
+    /// handles aggregating the flags in the state set.
+    /// </summary>
+    [Flags]
+    internal enum StateFlags : byte
+    {
+        IsInitialFlag = 1,
+        IsDeadendFlag = 2,
+        IsNullableFlag = 4,
+        CanBeNullableFlag = 8,
+        SimulatesBacktrackingFlag = 16,
+    }
+
+    /// <summary>
+    /// These extension methods for <see cref="StateFlags"/> make checking for the presence of flags more concise.
+    /// </summary>
+    internal static class StateFlagsExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsInitial(this StateFlags info) => info.HasFlag(StateFlags.IsInitialFlag);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsDeadend(this StateFlags info) => info.HasFlag(StateFlags.IsDeadendFlag);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsNullable(this StateFlags info) => info.HasFlag(StateFlags.IsNullableFlag);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool CanBeNullable(this StateFlags info) => info.HasFlag(StateFlags.CanBeNullableFlag);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool SimulatesBacktracking(this StateFlags info) => info.HasFlag(StateFlags.SimulatesBacktrackingFlag);
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Dgml.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Dgml.cs
@@ -35,7 +35,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     string nodeDgmlView = $"{(info == string.Empty ? info : $"Previous: {info}&#13;")}{(deriv == string.Empty ? "()" : deriv)}";
 
                     writer.WriteLine("        <Node Id=\"{0}\" Label=\"{0}\" Category=\"State\" Group=\"Collapsed\" StateInfo=\"{1}\">", state.Id, nodeDgmlView);
-                    if (GetStateInfo(state.Id).IsInitial)
+                    if (_stateFlagsArray[state.Id].IsInitial())
                     {
                         writer.WriteLine("            <Category Ref=\"InitialState\" />");
                     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
@@ -79,11 +79,11 @@ namespace System.Text.RegularExpressions.Symbolic
 
                         // Gather the possible endings for satisfying nullability
                         possibleEndings.Clear();
-                        if (SymbolicRegexMatcher<TSet>.NfaStateHandler.CanBeNullable(this, in statesWrapper))
+                        StateFlags flags = SymbolicRegexMatcher<TSet>.NfaStateHandler.GetStateFlags(this, in statesWrapper);
+                        if (flags.CanBeNullable())
                         {
                             // Unconditionally final state or end of the input due to \Z anchor for example
-                            if (SymbolicRegexMatcher<TSet>.NfaStateHandler.IsNullable(this, in statesWrapper) ||
-                                SymbolicRegexMatcher<TSet>.NfaStateHandler.IsNullableFor(this, in statesWrapper, CharKind.BeginningEnd))
+                            if (flags.IsNullable() || SymbolicRegexMatcher<TSet>.NfaStateHandler.IsNullableFor(this, in statesWrapper, CharKind.BeginningEnd))
                             {
                                 possibleEndings.Add("");
                             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -453,8 +453,8 @@ namespace System.Text.RegularExpressions.Symbolic
                     input;
 
                 bool done = currentState.NfaState is not null ?
-                    FindEndPositionDeltas<NfaStateHandler, TInputReader, TFindOptimizationsHandler, TNullabilityHandler>(input, mode, ref pos, ref currentState, ref endPos, ref endStateId, ref initialStatePos, ref initialStatePosCandidate) :
-                    FindEndPositionDeltas<DfaStateHandler, TInputReader, TFindOptimizationsHandler, TNullabilityHandler>(input, mode, ref pos, ref currentState, ref endPos, ref endStateId, ref initialStatePos, ref initialStatePosCandidate);
+                    FindEndPositionDeltas<NfaStateHandler, TInputReader, TFindOptimizationsHandler, TNullabilityHandler>(inputForInnerLoop, mode, ref pos, ref currentState, ref endPos, ref endStateId, ref initialStatePos, ref initialStatePosCandidate) :
+                    FindEndPositionDeltas<DfaStateHandler, TInputReader, TFindOptimizationsHandler, TNullabilityHandler>(inputForInnerLoop, mode, ref pos, ref currentState, ref endPos, ref endStateId, ref initialStatePos, ref initialStatePosCandidate);
 
                 // If the inner loop indicates that the search finished (for example due to reaching a deadend state) or
                 // there is no more input available, then the whole search is done.

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/System.Text.RegularExpressions.Unit.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/System.Text.RegularExpressions.Unit.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\ISolver.cs" Link="Production\ISolver.cs" />
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\MintermGenerator.cs" Link="Production\MintermGenerator.cs" />
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\RegexNodeConverter.cs" Link="Production\RegexNodeConverter.cs" />
+    <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\StateFlags.cs" Link="Production\StateFlags.cs" />
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\SymbolicRegexBuilder.cs" Link="Production\SymbolicRegexBuilder.cs" />
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\SymbolicRegexInfo.cs" Link="Production\SymbolicRegexInfo.cs" />
     <Compile Include="..\..\src\System\Text\RegularExpressions\Symbolic\SymbolicRegexKind.cs" Link="Production\SymbolicRegexKind.cs" />


### PR DESCRIPTION
This PR fixes bugs uncovered by setting the DFA->NFA transition state limit to zero.

The main thing was that the non-capturing NFA execution mode was missing logic for backtracking simulation. The logic in taking NFA transitions is amended such that after the transitions for each source state (which are handled in order of priority) have been added to the set of next states, it is checked whether that source state is nullable. If so, the backtracking engine would prefer to end there rather than exploring lower priority paths, and as such any further source states are skipped.

Since the backtracking simulation logic must be disabled in the second reverse phase, as indicated by the presence of a `DisableBacktrackingSimulation` node on the top level, I added a new bit to the `ContextIndependentState` flags to cache the check. That brought up the number of booleans in the "state info" tuples up to five, which started feeling unweildly. I've refactored this into just returning the underlying enum and adding extension methods to make their use concise. The enum is now called `StateFlags`.

An existing bug affecting both the DFA and NFA modes was uncovered by setting the DFA state limit to zero: the first matching phase was not actually limiting the input for the inner loop to 1000 characters at a time, but this was hidden in the relevant unit test by the pattern switching from DFA to NFA mode after ~10000 characters, which also triggered a timeout check, thus letting the test pass. I'm guessing I introduced this in my latest refactoring of the matching loops. This is now fixed.

I ran the benchmarks and there are no significant slowdowns. In fact, some tests show a double digit speedup, which if I had to guess was due to the `StateFlags` refactoring.

summary:
better: 40, geomean: 1.056
worse: 5, geomean: 1.042
total diff: 46

| Slower                                                                                                                                           | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------:| ----------------:| ----------------:| --------:|
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: ".{0,2}(Tom\|Sawyer\|Huckleberry\|Finn)", Options: NonBacktracking) |      1.06 |      49273537.50 |      52179975.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_SliceSlice.Count(Options: Compiled)                                                     |      1.05 |     419165650.00 |     439475700.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 4, Options: NonBacktracking)                               |      1.05 |           125.20 |           131.23 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 1, Options: None)                                          |      1.03 |           114.91 |           118.19 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: ".{0,2}(Tom\|Sawyer\|Huckleberry\|Finn)", Options: None)            |      1.03 |    3424692200.00 |    3517604600.00 |         |

| Faster                                                                                                                                                                   | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------:| ----------------:| ----------------:| -------- |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: ".{2,4}(Tom\|Sawyer\|Huckleberry\|Finn)", Options: NonBacktracking)                         |      1.18 |      50448975.00 |      42751350.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?s).*", Options: NonBacktracking)                                            |      1.17 |       3470643.75 |       2969993.75 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\w+\\s+Holmes", Options: NonBacktracking)                                    |      1.14 |       2050385.29 |       1793558.39 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\w+\\s+Holmes\\s+\\w+", Options: NonBacktracking)                            |      1.13 |       2026005.74 |       1798357.78 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: ".*", Options: NonBacktracking)                                                |      1.10 |       5641125.00 |       5124262.50 | bimodal |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Mariomkas.Count(Pattern: "[\\w]+://[^/\\s?#]+[^\\s?#]+(?:\\?[^\\s#]*)?(?:#[^\\s]*)?", Options: NonBacktracking) |      1.09 |       3007115.88 |       2756977.72 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 2, Options: NonBacktracking)                                                       |      1.09 |           133.60 |           122.82 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "[a-zA-Z]+ing", Options: NonBacktracking)                                      |      1.07 |       4532033.04 |       4224599.18 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Mariomkas.Count(Pattern: "[\\w\\.+-]+@[\\w\\.-]+\\.[\\w\\.-]+", Options: Compiled)                              |      1.07 |        559869.61 |        522074.69 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sher[a-z]+\|Hol[a-z]+", Options: NonBacktracking)                              |      1.07 |        127917.56 |        119873.66 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\p{Ll}", Options: NonBacktracking)                                           |      1.06 |      29418175.00 |      27644175.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 0, Options: NonBacktracking)                                                       |      1.06 |            80.42 |            75.65 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "[^\\n]*", Options: NonBacktracking)                                           |      1.06 |       5669218.48 |       5337582.98 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 6, Options: NonBacktracking)                                                       |      1.06 |            91.26 |            86.06 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "Twain", Options: NonBacktracking)                                                       |      1.06 |       2462680.00 |       2323636.25 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?i)Sherlock", Options: NonBacktracking)                                      |      1.06 |        101281.09 |         95562.82 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "\\b\\w+n\\b", Options: NonBacktracking)                                       |      1.05 |       5851841.86 |       5577358.89 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 2, Options: Compiled)                                                              |      1.05 |            60.10 |            57.30 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?i)Sherlock Holmes", Options: NonBacktracking)                               |      1.05 |         99986.30 |         95350.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Holmes.{0,25}Watson\|Watson.{0,25}Holmes", Options: NonBacktracking)           |      1.05 |        111889.09 |        106935.70 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "(?i)Holmes", Options: NonBacktracking)                                        |      1.04 |        509017.50 |        489625.95 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Mariomkas.Count(Pattern: "[\\w\\.+-]+@[\\w\\.-]+\\.[\\w\\.-]+", Options: None)                                  |      1.04 |        586542.94 |        565490.07 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 3, Options: NonBacktracking)                                                       |      1.04 |           170.55 |           164.45 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 8, Options: NonBacktracking)                                                       |      1.04 |            88.83 |            85.74 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "Twain", Options: Compiled)                                                              |      1.04 |       2234738.54 |       2158540.63 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Holmes", Options: NonBacktracking)                                            |      1.03 |         85098.89 |         82319.31 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "[a-z]shing", Options: Compiled)                                                         |      1.03 |       2331271.88 |       2257754.46 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "[a-z]shing", Options: NonBacktracking)                                                  |      1.03 |       2409907.50 |       2335412.50 | several?|
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "Tom.{10,25}river\|river.{10,25}Tom", Options: NonBacktracking)                           |      1.03 |       9022710.34 |       8750925.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 9, Options: NonBacktracking)                                                       |      1.03 |            90.22 |            87.58 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Mariomkas.Count(Pattern: "[\\w]+://[^/\\s?#]+[^\\s?#]+(?:\\?[^\\s#]*)?(?:#[^\\s]*)?", Options: Compiled)        |      1.03 |       1348814.58 |       1311024.22 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_Leipzig.Count(Pattern: "Huck[a-zA-Z]+\|Saw[a-zA-Z]+", Options: None)                                             |      1.03 |       4728007.81 |       4599918.75 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 13, Options: NonBacktracking)                                                      |      1.03 |           113.54 |           110.51 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 1, Options: NonBacktracking)                                                       |      1.03 |           477.27 |           464.64 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sherlock Holmes", Options: NonBacktracking)                                   |      1.03 |         50447.27 |         49124.54 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sherlock\|Holmes\|Watson", Options: NonBacktracking)                            |      1.03 |        154421.26 |        150426.52 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "Sherlock\\s+Holmes", Options: NonBacktracking)                                |      1.02 |         55327.18 |         54023.55 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Count(Pattern: "[a-q][^u-z]{13}x", Options: NonBacktracking)                                  |      1.02 |         52648.28 |         51436.88 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 0, Options: Compiled)                                                              |      1.02 |            35.72 |            34.92 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Industry_BoostDocs_Simple.IsMatch(Id: 7, Options: NonBacktracking)                                                       |      1.02 |            82.40 |            80.62 |         |