### PR TITLE
Use correct runtime assembly in MetadataReader tests

### DIFF
--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/CustomAttributeDecoderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/CustomAttributeDecoderTests.cs
@@ -12,6 +12,7 @@ namespace System.Reflection.Metadata.Decoding.Tests
     public class CustomAttributeDecoderTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60579", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void TestCustomAttributeDecoder()
         {
             using (FileStream stream = File.OpenRead(AssemblyPathHelper.GetAssemblyLocation(typeof(HasAttributes).GetTypeInfo().Assembly)))

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/CustomAttributeDecoderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/CustomAttributeDecoderTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Reflection.Metadata.Tests;
@@ -13,8 +12,6 @@ namespace System.Reflection.Metadata.Decoding.Tests
     public class CustomAttributeDecoderTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60579", TestPlatforms.iOS | TestPlatforms.tvOS)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Type assembly name is different on .NET Framework.")]
         public void TestCustomAttributeDecoder()
         {
             using (FileStream stream = File.OpenRead(AssemblyPathHelper.GetAssemblyLocation(typeof(HasAttributes).GetTypeInfo().Assembly)))
@@ -340,12 +337,12 @@ namespace System.Reflection.Metadata.Decoding.Tests
         {
             public string GetSystemType()
             {
-                return "[System.Runtime]System.Type";
+                return $"[{MetadataReaderTestHelpers.RuntimeAssemblyName}]System.Type";
             }
 
             public bool IsSystemType(string type)
             {
-                return type == "[System.Runtime]System.Type"  // encountered as typeref
+                return type == $"[{MetadataReaderTestHelpers.RuntimeAssemblyName}]System.Type"  // encountered as typeref
                     || Type.GetType(type) == typeof(Type);    // encountered as serialized to reflection notation
             }
 

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/SignatureDecoderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/SignatureDecoderTests.cs
@@ -14,9 +14,6 @@ namespace System.Reflection.Metadata.Decoding.Tests
 {
     public partial class SignatureDecoderTests
     {
-        private static readonly string RuntimeAssemblyName = PlatformDetection.IsNetFramework ? "mscorlib" : "System.Runtime";
-        private static readonly string CollectionsAssemblyName = PlatformDetection.IsNetFramework ? "mscorlib" : "System.Collections";
-
         [Fact]
         public unsafe void VerifyMultipleOptionalModifiers()
         {
@@ -208,7 +205,7 @@ namespace System.Reflection.Metadata.Decoding.Tests
                     Assert.Equal(expected, provider.GetTypeFromHandle(reader, genericTypeContext, @event.Type));
                 }
 
-                Assert.Equal($"[{CollectionsAssemblyName}]System.Collections.Generic.List`1<!T>", provider.GetTypeFromHandle(reader, genericTypeContext, handle: type.BaseType));
+                Assert.Equal($"[{MetadataReaderTestHelpers.CollectionsAssemblyName}]System.Collections.Generic.List`1<!T>", provider.GetTypeFromHandle(reader, genericTypeContext, handle: type.BaseType));
             }
         }
 
@@ -323,12 +320,12 @@ namespace System.Reflection.Metadata.Decoding.Tests
                 { "UIntPtr", "native uint" },
                 { "Boolean", "bool" },
                 { "Char", "char" },
-                { "ModifiedType", $"int32 modreq([{RuntimeAssemblyName}]System.Runtime.CompilerServices.IsVolatile)" },
+                { "ModifiedType", $"int32 modreq([{MetadataReaderTestHelpers.RuntimeAssemblyName}]System.Runtime.CompilerServices.IsVolatile)" },
                 { "Pointer", "int32*"  },
                 { "SZArray", "int32[]" },
                 { "Array", "int32[0...,0...]" },
                 { "GenericTypeParameter", "!T" },
-                { "GenericInstantiation", $"[{CollectionsAssemblyName}]System.Collections.Generic.List`1<int32>" },
+                { "GenericInstantiation", $"[{MetadataReaderTestHelpers.CollectionsAssemblyName}]System.Collections.Generic.List`1<int32>" },
             };
         }
 
@@ -341,8 +338,8 @@ namespace System.Reflection.Metadata.Decoding.Tests
                 { "GenericMethodParameter", "method !!U *()" },
                 { ".ctor", "method void *()" },
                 { "get_Property", "method System.Reflection.Metadata.Decoding.Tests.SignatureDecoderTests/SignaturesToDecode`1/Nested<!T> *()"  },
-                { "add_Event",  $"method void *([{RuntimeAssemblyName}]System.EventHandler`1<[{RuntimeAssemblyName}]System.EventArgs>)" },
-                { "remove_Event", $"method void *([{RuntimeAssemblyName}]System.EventHandler`1<[{RuntimeAssemblyName}]System.EventArgs>)" },
+                { "add_Event",  $"method void *([{MetadataReaderTestHelpers.RuntimeAssemblyName}]System.EventHandler`1<[{MetadataReaderTestHelpers.RuntimeAssemblyName}]System.EventArgs>)" },
+                { "remove_Event", $"method void *([{MetadataReaderTestHelpers.RuntimeAssemblyName}]System.EventHandler`1<[{MetadataReaderTestHelpers.RuntimeAssemblyName}]System.EventArgs>)" },
             };
         }
 
@@ -360,7 +357,7 @@ namespace System.Reflection.Metadata.Decoding.Tests
             // event name -> signature
             return new Dictionary<string, string>()
             {
-                { "Event", $"[{RuntimeAssemblyName}]System.EventHandler`1<[{RuntimeAssemblyName}]System.EventArgs>" },
+                { "Event", $"[{MetadataReaderTestHelpers.RuntimeAssemblyName}]System.EventHandler`1<[{MetadataReaderTestHelpers.RuntimeAssemblyName}]System.EventArgs>" },
             };
         }
 

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTestHelpers.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTestHelpers.cs
@@ -8,6 +8,9 @@ namespace System.Reflection.Metadata.Tests
 {
     internal static class MetadataReaderTestHelpers
     {
+        public static readonly string RuntimeAssemblyName = PlatformDetection.IsNetFramework ? "mscorlib" : "System.Runtime";
+        public static readonly string CollectionsAssemblyName = PlatformDetection.IsNetFramework ? "mscorlib" : "System.Collections";
+
         internal static IEnumerable<ConstantHandle> GetConstants(this MetadataReader reader)
         {
             for (int i = 1, n = reader.GetTableRowCount(TableIndex.Constant); i <= n; i++)


### PR DESCRIPTION
Enable a test that was disabled on .NET Framework.