### PR TITLE
Remove Mono LLVM tools from Darc subscription

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -178,6 +178,7 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>86e7816b9869ab19ee3f44aba7ac5f0ef7d04c8c</Sha>
     </Dependency>
+<!--
     <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.22259.2">
       <Uri>https://github.com/dotnet/llvm-project</Uri>
       <Sha>54cc196d506692c366d9e116cdb3a9a56342f720</Sha>
@@ -210,6 +211,7 @@
       <Uri>https://github.com/dotnet/llvm-project</Uri>
       <Sha>54cc196d506692c366d9e116cdb3a9a56342f720</Sha>
     </Dependency>
+-->
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-preview.7.22358.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1967649721058a457157d4321af3e6fceaa5441b</Sha>


### PR DESCRIPTION
Someone disabled the llvm-project -> runtime subscription, presumably
to disable the update of the Mono llvm tools. But NativeAOT also gets
the objwriter from that subscription. That needs to stay. This change
just removes the Mono LLVM items from the subscription.