### PR TITLE
Fix most SafeHandle finalization occurrence in System.Net.Quic

### DIFF
--- a/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
+++ b/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
@@ -2725,7 +2725,7 @@ namespace System.IO.Tests
                 return;
             }
 
-            StreamPair streams = await CreateConnectedStreamsAsync();
+            using StreamPair streams = await CreateConnectedStreamsAsync();
 
             foreach (Stream stream in streams)
             {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
@@ -55,73 +55,95 @@ public partial class QuicConnection
         public unsafe int ValidateCertificate(QUIC_BUFFER* certificatePtr, QUIC_BUFFER* chainPtr, out X509Certificate2? certificate)
         {
             SslPolicyErrors sslPolicyErrors = SslPolicyErrors.None;
+            IntPtr certificateBuffer = 0;
+            int certificateLength = 0;
+
             X509Chain? chain = null;
-            IntPtr certificateBuffer = default;
-            int certificateLength = default;
-
-            certificate = null;
-
-            if (certificatePtr is not null)
+            X509Certificate2? result = null;
+            try
             {
-                chain = new X509Chain();
-                chain.ChainPolicy.RevocationMode = _revocationMode;
-                chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
-                chain.ChainPolicy.ApplicationPolicy.Add(_isClient ? s_serverAuthOid : s_clientAuthOid);
-
-                if (OperatingSystem.IsWindows())
+                if (certificatePtr is not null)
                 {
-                    certificate = new X509Certificate2((IntPtr)certificatePtr);
+                    chain = new X509Chain();
+                    chain.ChainPolicy.RevocationMode = _revocationMode;
+                    chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
+                    chain.ChainPolicy.ApplicationPolicy.Add(_isClient ? s_serverAuthOid : s_clientAuthOid);
+
+                    if (OperatingSystem.IsWindows())
+                    {
+                        result = new X509Certificate2((IntPtr)certificatePtr);
+                    }
+                    else
+                    {
+                        if (certificatePtr->Length > 0)
+                        {
+                            certificateBuffer = (IntPtr)certificatePtr->Buffer;
+                            certificateLength = (int)certificatePtr->Length;
+                            result = new X509Certificate2(certificatePtr->Span);
+                        }
+
+                        if (chainPtr->Length > 0)
+                        {
+                            X509Certificate2Collection additionalCertificates = new X509Certificate2Collection();
+                            additionalCertificates.Import(chainPtr->Span);
+                            chain.ChainPolicy.ExtraStore.AddRange(additionalCertificates);
+                        }
+                    }
                 }
-                else
+
+                if (result is not null)
                 {
-                    if (certificatePtr->Length > 0)
+                    sslPolicyErrors |= CertificateValidation.BuildChainAndVerifyProperties(chain!, result, checkCertName: true, !_isClient, _targetHost, certificateBuffer, certificateLength);
+                }
+                else if (_certificateRequired)
+                {
+                    sslPolicyErrors |= SslPolicyErrors.RemoteCertificateNotAvailable;
+                }
+
+                int status = QUIC_STATUS_SUCCESS;
+                if (_validationCallback is not null)
+                {
+                    if (!_validationCallback(_connection, result, chain, sslPolicyErrors))
                     {
-                        certificateBuffer = (IntPtr)certificatePtr->Buffer;
-                        certificateLength = (int)certificatePtr->Length;
-                        certificate = new X509Certificate2(certificatePtr->Span);
-                    }
-                    if (chainPtr->Length > 0)
-                    {
-                        X509Certificate2Collection additionalCertificates = new X509Certificate2Collection();
-                        additionalCertificates.Import(chainPtr->Span);
-                        chain.ChainPolicy.ExtraStore.AddRange(additionalCertificates);
+                        if (_isClient)
+                        {
+                            throw new AuthenticationException(SR.net_quic_cert_custom_validation);
+                        }
+
+                        status = QUIC_STATUS_USER_CANCELED;
                     }
                 }
-            }
-
-            if (certificate is not null)
-            {
-                sslPolicyErrors |= CertificateValidation.BuildChainAndVerifyProperties(chain!, certificate, true, !_isClient, _targetHost, certificateBuffer, certificateLength);
-            }
-
-            if (certificate is null && _certificateRequired)
-            {
-                sslPolicyErrors |= SslPolicyErrors.RemoteCertificateNotAvailable;
-            }
-
-            if (_validationCallback is not null)
-            {
-                if (!_validationCallback(_connection, certificate, chain, sslPolicyErrors))
+                else if (sslPolicyErrors != SslPolicyErrors.None)
                 {
                     if (_isClient)
                     {
-                        throw new AuthenticationException(SR.net_quic_cert_custom_validation);
+                        throw new AuthenticationException(SR.Format(SR.net_quic_cert_chain_validation, sslPolicyErrors));
                     }
-                    return QUIC_STATUS_USER_CANCELED;
-                }
-                return QUIC_STATUS_SUCCESS;
-            }
 
-            if (sslPolicyErrors != SslPolicyErrors.None)
+                    status = QUIC_STATUS_HANDSHAKE_FAILURE;
+                }
+
+                certificate = result;
+                return status;
+            }
+            catch
             {
-                if (_isClient)
-                {
-                    throw new AuthenticationException(SR.Format(SR.net_quic_cert_chain_validation, sslPolicyErrors));
-                }
-                return QUIC_STATUS_HANDSHAKE_FAILURE;
+                result?.Dispose();
+                throw;
             }
+            finally
+            {
+                if (chain is not null)
+                {
+                    X509ChainElementCollection elements = chain.ChainElements;
+                    for (int i = 0; i < elements.Count; i++)
+                    {
+                        elements[i].Certificate.Dispose();
+                    }
 
-            return QUIC_STATUS_SUCCESS;
+                    chain.Dispose();
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -81,7 +81,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// <summary>
     /// Handle to MsQuic connection object.
     /// </summary>
-    private MsQuicContextSafeHandle _handle;
+    private readonly MsQuicContextSafeHandle _handle;
 
     /// <summary>
     /// Set to non-zero once disposed. Prevents double and/or concurrent disposal.

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -118,8 +118,14 @@ namespace System.Net.Quic.Tests
             }
             catch
             {
-                stream1?.Dispose();
-                stream2?.Dispose();
+                if (stream1 is not null)
+                {
+                    await stream1.DisposeAsync();
+                }
+                if (stream2 is not null)
+                {
+                    await stream2.DisposeAsync();
+                }
                 if (connection1 is not null)
                 {
                     await connection1.DisposeAsync();

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -22,8 +22,17 @@ namespace System.Net.Quic.Tests
         protected override bool BlocksOnZeroByteReads => true;
         protected override bool CanTimeout => true;
 
-        public X509Certificate2 ServerCertificate = System.Net.Test.Common.Configuration.Certificates.GetServerCertificate();
+        public readonly X509Certificate2 ServerCertificate = System.Net.Test.Common.Configuration.Certificates.GetServerCertificate();
         public ITestOutputHelper _output;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                ServerCertificate.Dispose();
+            }
+            base.Dispose(disposing);
+        }
 
         public bool RemoteCertificateValidationCallback(object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors)
         {
@@ -66,44 +75,61 @@ namespace System.Net.Quic.Tests
             byte[] buffer = new byte[1] { 42 };
             QuicConnection connection1 = null, connection2 = null;
             QuicStream stream1 = null, stream2 = null;
-            await WhenAllOrAnyFailed(
-                Task.Run(async () =>
-                {
-                    connection1 = await listener.AcceptConnectionAsync();
-                    stream1 = await connection1.AcceptInboundStreamAsync();
-                    Assert.Equal(1, await stream1.ReadAsync(buffer));
-                }),
-                Task.Run(async () =>
-                {
-                    try
+            try
+            {
+                await WhenAllOrAnyFailed(
+                    Task.Run(async () =>
                     {
-                        connection2 = await QuicConnection.ConnectAsync(new QuicClientConnectionOptions()
+                        connection1 = await listener.AcceptConnectionAsync();
+                        stream1 = await connection1.AcceptInboundStreamAsync();
+                        Assert.Equal(1, await stream1.ReadAsync(buffer));
+                    }),
+                    Task.Run(async () =>
+                    {
+                        try
                         {
-                            DefaultStreamErrorCode = QuicTestBase.DefaultStreamErrorCodeClient,
-                            DefaultCloseErrorCode = QuicTestBase.DefaultCloseErrorCodeClient,
-                            RemoteEndPoint = listener.LocalEndPoint,
-                            ClientAuthenticationOptions = GetSslClientAuthenticationOptions()
-                        });
-                        stream2 = await connection2.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
-                        // OpenBidirectionalStream only allocates ID. We will force stream opening
-                        // by Writing there and receiving data on the other side.
-                        await stream2.WriteAsync(buffer);
-                    }
-                    catch (Exception ex)
-                    {
-                        _output?.WriteLine($"Failed to {ex.Message}");
-                        throw;
-                    }
-                }));
+                            connection2 = await QuicConnection.ConnectAsync(new QuicClientConnectionOptions()
+                            {
+                                DefaultStreamErrorCode = QuicTestBase.DefaultStreamErrorCodeClient,
+                                DefaultCloseErrorCode = QuicTestBase.DefaultCloseErrorCodeClient,
+                                RemoteEndPoint = listener.LocalEndPoint,
+                                ClientAuthenticationOptions = GetSslClientAuthenticationOptions()
+                            });
+                            stream2 = await connection2.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+                            // OpenBidirectionalStream only allocates ID. We will force stream opening
+                            // by Writing there and receiving data on the other side.
+                            await stream2.WriteAsync(buffer);
+                        }
+                        catch (Exception ex)
+                        {
+                            _output?.WriteLine($"Failed to {ex.Message}");
+                            throw;
+                        }
+                    }));
 
-            // No need to keep the listener once we have connected connection and streams
-            await listener.DisposeAsync();
+                // No need to keep the listener once we have connected connection and streams
+                await listener.DisposeAsync();
 
-            var result = new StreamPairWithOtherDisposables(stream1, stream2);
-            result.Disposables.Add(connection1);
-            result.Disposables.Add(connection2);
+                var result = new StreamPairWithOtherDisposables(stream1, stream2);
+                result.Disposables.Add(connection1);
+                result.Disposables.Add(connection2);
 
-            return result;
+                return result;
+            }
+            catch
+            {
+                stream1?.Dispose();
+                stream2?.Dispose();
+                if (connection1 is not null)
+                {
+                    await connection1.DisposeAsync();
+                }
+                if (connection2 is not null)
+                {
+                    await connection2.DisposeAsync();
+                }
+                throw;
+            }
         }
 
         private sealed class StreamPairWithOtherDisposables : StreamPair

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -167,7 +167,7 @@ namespace System.Net.Quic.Tests
             {
                 byte[] buffer = new byte[64];
 
-                using QuicStream clientStream = await clientConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+                await using QuicStream clientStream = await clientConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
                 Task writeTask = clientStream.WriteAsync("PING"u8.ToArray(), completeWrites: true).AsTask();
                 Task<QuicStream> acceptTask = serverConnection.AcceptInboundStreamAsync().AsTask();
                 await new Task[] { writeTask, acceptTask }.WhenAllOrAnyFailed(PassingTestTimeoutMilliseconds);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -172,7 +172,7 @@ namespace System.Net.Quic.Tests
                 Task<QuicStream> acceptTask = serverConnection.AcceptInboundStreamAsync().AsTask();
                 await new Task[] { writeTask, acceptTask }.WhenAllOrAnyFailed(PassingTestTimeoutMilliseconds);
 
-                using QuicStream serverStream = acceptTask.Result;
+                await using QuicStream serverStream = acceptTask.Result;
                 await serverStream.ReadAsync(buffer);
             }
         }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -16,7 +16,7 @@ using System.Net.Sockets;
 
 namespace System.Net.Quic.Tests
 {
-    public abstract class QuicTestBase
+    public abstract class QuicTestBase : IDisposable
     {
         public const long DefaultStreamErrorCodeClient = 123456;
         public const long DefaultStreamErrorCodeServer = 654321;
@@ -30,8 +30,8 @@ namespace System.Net.Quic.Tests
 
         public static SslApplicationProtocol ApplicationProtocol { get; } = new SslApplicationProtocol("quictest");
 
-        public X509Certificate2 ServerCertificate = System.Net.Test.Common.Configuration.Certificates.GetServerCertificate();
-        public X509Certificate2 ClientCertificate = System.Net.Test.Common.Configuration.Certificates.GetClientCertificate();
+        public readonly X509Certificate2 ServerCertificate = System.Net.Test.Common.Configuration.Certificates.GetServerCertificate();
+        public readonly X509Certificate2 ClientCertificate = System.Net.Test.Common.Configuration.Certificates.GetClientCertificate();
 
         public ITestOutputHelper _output;
         public const int PassingTestTimeoutMilliseconds = 4 * 60 * 1000;
@@ -41,6 +41,13 @@ namespace System.Net.Quic.Tests
         {
             _output = output;
         }
+
+        public void Dispose()
+        {
+            ServerCertificate.Dispose();
+            ClientCertificate.Dispose();
+        }
+
         public bool RemoteCertificateValidationCallback(object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors)
         {
             Assert.Equal(ServerCertificate.GetCertHash(), certificate?.GetCertHash());
@@ -168,35 +175,46 @@ namespace System.Net.Quic.Tests
 
             QuicConnection clientConnection = null;
             ValueTask<QuicConnection> serverTask = listener.AcceptConnectionAsync();
-            while (retry > 0)
+            try
             {
-                retry--;
-                try
+                while (retry > 0)
                 {
-                    clientConnection = await CreateQuicConnection(clientOptions).ConfigureAwait(false);
-                    break;
-                }
-                catch (QuicException ex) when (ex.HResult == (int)SocketError.ConnectionRefused)
-                {
-                    _output.WriteLine($"ConnectAsync to {clientConnection.RemoteEndPoint} failed with {ex.Message}");
-                    await Task.Delay(delay);
-                    delay *= 2;
-
-                    if (retry == 0)
+                    retry--;
+                    try
                     {
-                        Debug.Fail($"ConnectAsync to {clientConnection.RemoteEndPoint} failed with {ex.Message}");
-                        throw ex;
+                        clientConnection = await CreateQuicConnection(clientOptions).ConfigureAwait(false);
+                        break;
+                    }
+                    catch (QuicException ex) when (ex.HResult == (int)SocketError.ConnectionRefused)
+                    {
+                        _output.WriteLine($"ConnectAsync to {clientOptions.RemoteEndPoint} failed with {ex.Message}");
+                        await Task.Delay(delay);
+                        delay *= 2;
+
+                        if (retry == 0)
+                        {
+                            Debug.Fail($"ConnectAsync to {clientOptions.RemoteEndPoint} failed with {ex.Message}");
+                            throw ex;
+                        }
                     }
                 }
-            }
 
-            QuicConnection serverConnection = await serverTask.ConfigureAwait(false);
-            if (disposeListener)
+                QuicConnection serverConnection = await serverTask.ConfigureAwait(false);
+                if (disposeListener)
+                {
+                    await listener.DisposeAsync();
+                }
+
+                return (clientConnection, serverConnection);
+            }
+            catch
             {
-                await listener.DisposeAsync();
+                if (clientConnection is not null)
+                {
+                    await clientConnection.DisposeAsync();
+                }
+                throw;
             }
-
-            return (clientConnection, serverTask.Result);
         }
 
         internal async Task PingPong(QuicConnection client, QuicConnection server)


### PR DESCRIPTION
All of the remaining ones are coming from SslStreamCertificateContext.