### PR TITLE
Remove fallback to reflection converter resolution

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -581,9 +581,6 @@
   <data name="ConverterForPropertyMustBeValid" xml:space="preserve">
     <value>The generic type of the converter for property '{0}.{1}' must match with the specified converter type '{2}'. The converter must not be 'null'.</value>
   </data>
-  <data name="BuiltInConvertersNotRooted" xml:space="preserve">
-    <value>Built-in type converters have not been initialized. There is no converter available for type '{0}'. To root all built-in converters, use a 'JsonSerializerOptions'-based method of the 'JsonSerializer'.</value>
-  </data>
   <data name="NoMetadataForType" xml:space="preserve">
     <value>Metadata for type '{0}' was not provided by TypeInfoResolver of type '{1}'. If using source generation, ensure that all root types passed to the serializer have been indicated with 'JsonSerializableAttribute', along with any types that might be serialized polymorphically.</value>
   </data>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpTypeConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpTypeConverterFactory.cs
@@ -37,12 +37,12 @@ namespace System.Text.Json.Serialization.Converters
                 case FSharpKind.Option:
                     elementType = typeToConvert.GetGenericArguments()[0];
                     converterFactoryType = typeof(FSharpOptionConverter<,>).MakeGenericType(typeToConvert, elementType);
-                    constructorArguments = new object[] { options.GetConverterFromTypeInfo(elementType) };
+                    constructorArguments = new object[] { options.GetConverterInternal(elementType) };
                     break;
                 case FSharpKind.ValueOption:
                     elementType = typeToConvert.GetGenericArguments()[0];
                     converterFactoryType = typeof(FSharpValueOptionConverter<,>).MakeGenericType(typeToConvert, elementType);
-                    constructorArguments = new object[] { options.GetConverterFromTypeInfo(elementType) };
+                    constructorArguments = new object[] { options.GetConverterInternal(elementType) };
                     break;
                 case FSharpKind.List:
                     elementType = typeToConvert.GetGenericArguments()[0];

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
@@ -86,7 +86,7 @@ namespace System.Text.Json.Serialization.Converters
             Debug.Assert(value != null);
 
             Type runtimeType = value.GetType();
-            JsonConverter runtimeConverter = options.GetConverterFromTypeInfo(runtimeType);
+            JsonConverter runtimeConverter = options.GetConverterInternal(runtimeType);
             if (runtimeConverter == this)
             {
                 ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(runtimeType, this);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverterFactory.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization.Converters
 
             Type valueTypeToConvert = typeToConvert.GetGenericArguments()[0];
 
-            JsonConverter valueConverter = options.GetConverterFromTypeInfo(valueTypeToConvert);
+            JsonConverter valueConverter = options.GetConverterInternal(valueTypeToConvert);
             Debug.Assert(valueConverter != null);
 
             // If the value type has an interface or object converter, just return that converter directly.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -67,8 +67,6 @@ namespace System.Text.Json.Serialization
             throw new InvalidOperationException(SR.NodeJsonObjectCustomConverterNotAllowedOnExtensionProperty);
         }
 
-        internal abstract JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, JsonSerializerOptions options);
-
         internal abstract JsonParameterInfo CreateJsonParameterInfo();
 
         internal abstract JsonConverter<TTarget> CreateCastingConverter<TTarget>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -32,13 +32,6 @@ namespace System.Text.Json.Serialization
         /// </returns>
         public abstract JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options);
 
-        internal override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, JsonSerializerOptions options)
-        {
-            Debug.Fail("We should never get here.");
-
-            throw new InvalidOperationException();
-        }
-
         internal override JsonParameterInfo CreateJsonParameterInfo()
         {
             Debug.Fail("We should never get here.");

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -69,11 +69,6 @@ namespace System.Text.Json.Serialization
 
         internal override ConverterStrategy ConverterStrategy => ConverterStrategy.Value;
 
-        internal sealed override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, JsonSerializerOptions options)
-        {
-            return new JsonPropertyInfo<T>(declaringTypeInfo.Type, declaringTypeInfo, options);
-        }
-
         internal sealed override JsonParameterInfo CreateJsonParameterInfo()
         {
             return new JsonParameterInfo<T>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -71,10 +71,7 @@ namespace System.Text.Json.Serialization
 
         internal sealed override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, JsonSerializerOptions options)
         {
-            return new JsonPropertyInfo<T>(declaringTypeInfo.Type, declaringTypeInfo, options)
-            {
-                DefaultConverterForType = this
-            };
+            return new JsonPropertyInfo<T>(declaringTypeInfo.Type, declaringTypeInfo, options);
         }
 
         internal sealed override JsonParameterInfo CreateJsonParameterInfo()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -125,7 +125,7 @@ namespace System.Text.Json
         {
             Debug.Assert(IsLockedInstance);
 
-            if (_cachingContext is null && _typeInfoResolver is not null)
+            if (_cachingContext is null)
             {
                 _cachingContext = TrackedCachingContexts.GetOrCreate(this);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -115,12 +115,7 @@ namespace System.Text.Json
         {
             Debug.Assert(IsLockedInstance);
 
-            if (_cachingContext is null)
-            {
-                _cachingContext = TrackedCachingContexts.GetOrCreate(this);
-            }
-
-            return _cachingContext;
+            return _cachingContext ??= TrackedCachingContexts.GetOrCreate(this);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Reflection;
 using System.Text.Json.Serialization;
@@ -53,34 +52,15 @@ namespace System.Text.Json
                 return DefaultJsonTypeInfoResolver.GetConverterForType(typeToConvert, this);
             }
 
-            return GetConverterFromTypeInfo(typeToConvert);
+            return GetConverterInternal(typeToConvert);
         }
 
         /// <summary>
-        /// Same as GetConverter but does not root converters
+        /// Same as GetConverter but without defaulting to reflection converters.
         /// </summary>
-        internal JsonConverter GetConverterFromTypeInfo(Type typeToConvert)
+        internal JsonConverter GetConverterInternal(Type typeToConvert)
         {
-            JsonTypeInfo? jsonTypeInfo;
-
-            if (IsLockedInstance)
-            {
-                jsonTypeInfo = GetCachingContext()?.GetOrAddJsonTypeInfo(typeToConvert);
-            }
-            else
-            {
-                // We do not want to lock options instance here but we need to return correct answer
-                // which means we need to go through TypeInfoResolver but without caching because that's the
-                // only place which will have correct converter for JsonSerializerContext and reflection
-                // based resolver. It will also work correctly for combined resolvers.
-                jsonTypeInfo = GetTypeInfoNoCaching(typeToConvert);
-            }
-
-            if (jsonTypeInfo is null)
-            {
-                ThrowHelper.ThrowNotSupportedException_NoMetadataForType(typeToConvert, TypeInfoResolver);
-            }
-
+            JsonTypeInfo jsonTypeInfo = GetTypeInfoInternal(typeToConvert, ensureConfigured: false, resolveIfMutable: true);
             return jsonTypeInfo.Converter;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
@@ -18,8 +18,8 @@ namespace System.Text.Json.Serialization.Metadata
         /// <summary>
         /// Creates serialization metadata for a type using a simple converter.
         /// </summary>
-        internal CustomJsonTypeInfo(JsonSerializerOptions options)
-            : base(options.GetConverterFromListOrBuiltInConverter(typeof(T)), options)
+        internal CustomJsonTypeInfo(JsonConverter converter, JsonSerializerOptions options)
+            : base(converter, options)
         {
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
@@ -119,11 +119,6 @@ namespace System.Text.Json.Serialization.Metadata
             return s_defaultSimpleConverters.TryGetValue(typeToConvert, out converter);
         }
 
-        // This method gets the runtime information for a given type or property.
-        // The runtime information consists of the following:
-        // - class type,
-        // - element type (if the type is a collection),
-        // - the converter (either native or custom), if one exists.
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
         internal static JsonConverter? GetCustomConverterForMember(Type typeToConvert, MemberInfo memberInfo, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
@@ -81,16 +81,10 @@ namespace System.Text.Json.Serialization.Metadata
                 converters.Add(converter.TypeToConvert, converter);
         }
 
-        internal static JsonConverter GetBuiltInConverter(Type typeToConvert)
+        private static JsonConverter GetBuiltInConverter(Type typeToConvert)
         {
-            if (s_defaultSimpleConverters == null || s_defaultFactoryConverters == null)
-            {
-                // (De)serialization using serializer's options-based methods has not yet occurred, so the built-in converters are not rooted.
-                // Even though source-gen code paths do not call this method <i.e. JsonSerializerOptions.GetConverter(Type)>, we do not root all the
-                // built-in converters here since we fetch converters for any type included for source generation from the binded context (Priority 1).
-                ThrowHelper.ThrowNotSupportedException_BuiltInConvertersNotRooted(typeToConvert);
-                return null!;
-            }
+            Debug.Assert(s_defaultSimpleConverters != null);
+            Debug.Assert(s_defaultFactoryConverters != null);
 
             JsonConverter? converter;
             if (s_defaultSimpleConverters.TryGetValue(typeToConvert, out converter))
@@ -99,11 +93,11 @@ namespace System.Text.Json.Serialization.Metadata
             }
             else
             {
-                foreach (JsonConverter item in s_defaultFactoryConverters)
+                foreach (JsonConverterFactory factory in s_defaultFactoryConverters)
                 {
-                    if (item.CanConvert(typeToConvert))
+                    if (factory.CanConvert(typeToConvert))
                     {
-                        converter = item;
+                        converter = factory;
                         break;
                     }
                 }
@@ -132,32 +126,26 @@ namespace System.Text.Json.Serialization.Metadata
         // - the converter (either native or custom), if one exists.
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        internal static JsonConverter GetConverterForMember(
-            Type typeToConvert,
-            MemberInfo memberInfo,
-            JsonSerializerOptions options,
-            out JsonConverter? customConverter)
+        internal static JsonConverter? GetCustomConverterForMember(Type typeToConvert, MemberInfo memberInfo, JsonSerializerOptions options)
         {
             Debug.Assert(memberInfo is FieldInfo or PropertyInfo);
             Debug.Assert(typeToConvert != null);
 
             JsonConverterAttribute? converterAttribute = memberInfo.GetUniqueCustomAttribute<JsonConverterAttribute>(inherit: false);
-            customConverter = converterAttribute is null ? null : GetConverterFromAttribute(converterAttribute, typeToConvert, memberInfo, options);
-
-            return options.TryGetTypeInfoCached(typeToConvert, out JsonTypeInfo? typeInfo)
-                ? typeInfo.Converter
-                : GetConverterForType(typeToConvert, options);
+            return converterAttribute is null ? null : GetConverterFromAttribute(converterAttribute, typeToConvert, memberInfo, options);
         }
 
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        internal static JsonConverter GetConverterForType(Type typeToConvert, JsonSerializerOptions options)
+        internal static JsonConverter GetConverterForType(Type typeToConvert, JsonSerializerOptions options, bool resolveJsonConverterAttribute = true)
         {
+            RootDefaultInstance(); // Ensure default converters are rooted.
+
             // Priority 1: Attempt to get custom converter from the Converters list.
             JsonConverter? converter = options.GetConverterFromList(typeToConvert);
 
             // Priority 2: Attempt to get converter from [JsonConverter] on the type being converted.
-            if (converter == null)
+            if (resolveJsonConverterAttribute && converter == null)
             {
                 JsonConverterAttribute? converterAttribute = typeToConvert.GetUniqueCustomAttribute<JsonConverterAttribute>(inherit: false);
                 if (converterAttribute != null)
@@ -166,8 +154,18 @@ namespace System.Text.Json.Serialization.Metadata
                 }
             }
 
-            // Priority 3: Fall back to built-in converters and validate result
-            return options.GetCustomOrBuiltInConverter(typeToConvert, converter);
+            // Priority 3: Query the built-in converters.
+            converter ??= GetBuiltInConverter(typeToConvert);
+
+            // Expand if factory converter & validate.
+            converter = options.ExpandConverterFactory(converter, typeToConvert);
+            if (!converter.TypeToConvert.IsInSubtypeRelationshipWith(typeToConvert))
+            {
+                ThrowHelper.ThrowInvalidOperationException_SerializationConverterNotCompatible(converter.GetType(), converter.TypeToConvert);
+            }
+
+            JsonSerializerOptions.CheckConverterNullabilityIsSameAsPropertyType(converter, typeToConvert);
+            return converter;
         }
 
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
@@ -90,7 +90,11 @@ namespace System.Text.Json.Serialization.Metadata
 
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        private static JsonTypeInfo<T> CreateReflectionJsonTypeInfo<T>(JsonSerializerOptions options) => new ReflectionJsonTypeInfo<T>(options);
+        private static JsonTypeInfo<T> CreateReflectionJsonTypeInfo<T>(JsonSerializerOptions options)
+        {
+            JsonConverter converter = GetConverterForType(typeof(T), options);
+            return new ReflectionJsonTypeInfo<T>(converter, options);
+        }
 
         /// <summary>
         /// List of JsonTypeInfo modifiers. Modifying callbacks are called consecutively after initial resolution

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
@@ -283,7 +283,7 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowArgumentNullException(nameof(options));
             }
 
-            JsonConverter<T> underlyingConverter = GetTypedConverter<T>(options.GetConverterFromTypeInfo(typeof(T)));
+            JsonConverter<T> underlyingConverter = GetTypedConverter<T>(options.GetConverterInternal(typeof(T)));
 
             return new NullableConverter<T>(underlyingConverter);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
@@ -39,7 +39,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 Debug.Assert(Options != null);
                 Debug.Assert(ShouldDeserialize);
-                return _jsonTypeInfo ??= Options.GetTypeInfoCached(PropertyType);
+                return _jsonTypeInfo ??= Options.GetTypeInfoInternal(PropertyType);
             }
             set
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -734,7 +734,6 @@ namespace System.Text.Json.Serialization.Metadata
             }
             set
             {
-                // Used by JsonMetadataServices.
                 // This could potentially be double initialized
                 Debug.Assert(_jsonTypeInfo == null || _jsonTypeInfo == value);
                 _jsonTypeInfo = value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -23,23 +23,6 @@ namespace System.Text.Json.Serialization.Metadata
         internal ConverterStrategy ConverterStrategy { get; private protected set; }
 
         /// <summary>
-        /// Converter resolved from PropertyType and not taking in consideration any custom attributes or custom settings.
-        /// - for reflection we store the original value since we need it in order to construct typed JsonPropertyInfo
-        /// - for source gen it remains null, we will initialize it only if someone used resolver to remove CustomConverter
-        /// </summary>
-        internal JsonConverter? DefaultConverterForType
-        {
-            get => _defaultConverterForType;
-            set
-            {
-                _defaultConverterForType = value;
-                ConverterStrategy = value?.ConverterStrategy ?? default;
-            }
-        }
-
-        private JsonConverter? _defaultConverterForType;
-
-        /// <summary>
         /// Converter after applying CustomConverter (i.e. JsonConverterAttribute)
         /// </summary>
         internal abstract JsonConverter EffectiveConverter { get; }
@@ -255,7 +238,8 @@ namespace System.Text.Json.Serialization.Metadata
                 CacheNameAsUtf8BytesAndEscapedNameSection();
             }
 
-            DetermineEffectiveConverter();
+            _jsonTypeInfo ??= Options.GetTypeInfoInternal(PropertyType, ensureConfigured: false);
+            DetermineEffectiveConverter(_jsonTypeInfo);
 
             if (IsForTypeInfo)
             {
@@ -269,7 +253,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
-        private protected abstract void DetermineEffectiveConverter();
+        private protected abstract void DetermineEffectiveConverter(JsonTypeInfo jsonTypeInfo);
         private protected abstract void DetermineMemberAccessors(MemberInfo memberInfo);
 
         private void DeterminePoliciesFromMember(MemberInfo memberInfo)
@@ -406,12 +390,15 @@ namespace System.Text.Json.Serialization.Metadata
 
         private void DetermineNumberHandlingForProperty()
         {
+            Debug.Assert(!IsConfigured, "Should not be called post-configuration.");
+            Debug.Assert(_jsonTypeInfo != null, "Must have already been determined on configuration.");
+
             bool numberHandlingIsApplicable = NumberHandingIsApplicable();
 
             if (numberHandlingIsApplicable)
             {
                 // Priority 1: Get handling from attribute on property/field, its parent class type or property type.
-                JsonNumberHandling? handling = NumberHandling ?? DeclaringTypeNumberHandling ?? JsonTypeInfo.NumberHandling;
+                JsonNumberHandling? handling = NumberHandling ?? DeclaringTypeNumberHandling ?? _jsonTypeInfo.NumberHandling;
 
                 // Priority 2: Get handling from JsonSerializerOptions instance.
                 if (!handling.HasValue && Options.NumberHandling != JsonNumberHandling.Strict)
@@ -563,7 +550,11 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public string Name
         {
-            get => _name;
+            get
+            {
+                Debug.Assert(_name != null);
+                return _name;
+            }
             set
             {
                 VerifyMutable();
@@ -577,7 +568,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
-        private string _name = null!;
+        private string? _name;
 
         /// <summary>
         /// Utf8 version of Name.
@@ -664,7 +655,7 @@ namespace System.Text.Json.Serialization.Metadata
                     // Slower path for non-generic types that implement IDictionary<,>.
                     // It is possible to cache this converter on JsonTypeInfo if we assume the property value
                     // will always be the same type for all instances.
-                    converter = Options.GetConverterFromTypeInfo(dictionaryValueType);
+                    converter = Options.GetConverterInternal(dictionaryValueType);
                 }
 
                 Debug.Assert(converter != null);
@@ -686,7 +677,7 @@ namespace System.Text.Json.Serialization.Metadata
                 return true;
             }
 
-            JsonConverter<JsonElement> converter = (JsonConverter<JsonElement>)Options.GetConverterFromTypeInfo(typeof(JsonElement));
+            JsonConverter<JsonElement> converter = (JsonConverter<JsonElement>)Options.GetConverterInternal(typeof(JsonElement));
             if (!converter.TryRead(ref reader, typeof(JsonElement), Options, ref state, out JsonElement jsonElement))
             {
                 // JsonElement is a struct that must be read in full.
@@ -717,25 +708,17 @@ namespace System.Text.Json.Serialization.Metadata
         {
             get
             {
-                if (_jsonTypeInfo != null)
-                {
-                    // We should not call it on set as it's usually called during initialization
-                    // which is too early to `lock` the JsonTypeInfo
-                    // If this property ever becomes public we should move this to callsites
-                    _jsonTypeInfo.EnsureConfigured();
-                }
-                else
-                {
-                    // GetOrAddJsonTypeInfo already ensures it's configured.
-                    _jsonTypeInfo = Options.GetTypeInfoCached(PropertyType);
-                }
-
+                Debug.Assert(IsConfigured);
+                Debug.Assert(_jsonTypeInfo != null);
+                _jsonTypeInfo.EnsureConfigured();
                 return _jsonTypeInfo;
             }
             set
             {
                 // This could potentially be double initialized
                 Debug.Assert(_jsonTypeInfo == null || _jsonTypeInfo == value);
+                // Ensure the right strategy is surfaced in PropertyInfoForTypeInfo early
+                ConverterStrategy = value?.Converter.ConverterStrategy ?? default;
                 _jsonTypeInfo = value;
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -188,7 +188,6 @@ namespace System.Text.Json.Serialization.Metadata
             SrcGen_IsPublic = propertyInfo.IsPublic;
             SrcGen_HasJsonInclude = propertyInfo.HasJsonInclude;
             IsExtensionData = propertyInfo.IsExtensionData;
-            DefaultConverterForType = propertyInfo.PropertyTypeInfo?.Converter as JsonConverter<T>;
             CustomConverter = propertyInfo.Converter;
 
             if (propertyInfo.IgnoreCondition != JsonIgnoreCondition.Always)
@@ -202,12 +201,11 @@ namespace System.Text.Json.Serialization.Metadata
             NumberHandling = propertyInfo.NumberHandling;
         }
 
-        private protected override void DetermineEffectiveConverter()
+        private protected override void DetermineEffectiveConverter(JsonTypeInfo jsonTypeInfo)
         {
             JsonConverter converter =
                 Options.ExpandConverterFactory(CustomConverter, PropertyType)
-                ?? DefaultConverterForType
-                ?? Options.GetConverterFromTypeInfo(PropertyType);
+                ?? jsonTypeInfo.Converter;
 
             TypedEffectiveConverter = converter is JsonConverter<T> typedConv ? typedConv : converter.CreateCastingConverter<T>();
             ConverterStrategy = TypedEffectiveConverter.ConverterStrategy;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -60,7 +60,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             if (Options.TryGetTypeInfoCached(propertyType, out JsonTypeInfo? jsonTypeInfo))
             {
-                // If a JsonTypeInfo has already cached for the property type,
+                // If a JsonTypeInfo has already been cached for the property type,
                 // avoid reflection-based initialization by delegating construction
                 // of JsonPropertyInfo<T> construction to the property type metadata.
                 return jsonTypeInfo.CreateJsonPropertyInfo(declaringTypeInfo: this, Options);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -63,7 +63,7 @@ namespace System.Text.Json.Serialization.Metadata
                 // If a JsonTypeInfo has already cached for the property type,
                 // avoid reflection-based initialization by delegating construction
                 // of JsonPropertyInfo<T> construction to the property type metadata.
-                return jsonTypeInfo.CreateJsonPropertyInfo(declaringTypeInfo: this);
+                return jsonTypeInfo.CreateJsonPropertyInfo(declaringTypeInfo: this, Options);
             }
             else
             {
@@ -81,7 +81,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <summary>
         /// Creates a JsonPropertyInfo whose property type matches the type of this JsonTypeInfo instance.
         /// </summary>
-        private protected abstract JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo);
+        private protected abstract JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, JsonSerializerOptions options);
 
         private static JsonPropertyInfo CreateJsonPropertyInfo<T>(JsonTypeInfo declaringTypeInfo, JsonSerializerOptions options)
             => new JsonPropertyInfo<T>(declaringTypeInfo.Type, declaringTypeInfo, options);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -226,7 +226,7 @@ namespace System.Text.Json.Serialization.Metadata
                     {
                         // GetOrAddJsonTypeInfo already ensures JsonTypeInfo is configured
                         // also see comment on JsonPropertyInfo.JsonTypeInfo
-                        _elementTypeInfo = Options.GetTypeInfoCached(ElementType);
+                        _elementTypeInfo = Options.GetTypeInfoInternal(ElementType);
                     }
                 }
                 else
@@ -268,7 +268,7 @@ namespace System.Text.Json.Serialization.Metadata
 
                         // GetOrAddJsonTypeInfo already ensures JsonTypeInfo is configured
                         // also see comment on JsonPropertyInfo.JsonTypeInfo
-                        _keyTypeInfo = Options.GetTypeInfoCached(KeyType);
+                        _keyTypeInfo = Options.GetTypeInfoInternal(KeyType);
                     }
                 }
                 else

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -508,11 +508,22 @@ namespace System.Text.Json.Serialization.Metadata
         internal virtual void LateAddProperties() { }
 
         /// <summary>
-        /// Creates JsonTypeInfo
+        /// Creates a blank <see cref="JsonTypeInfo{T}"/> instance.
         /// </summary>
-        /// <typeparam name="T">Type for which JsonTypeInfo stores metadata for</typeparam>
-        /// <param name="options">Options associated with JsonTypeInfo</param>
-        /// <returns>JsonTypeInfo instance</returns>
+        /// <typeparam name="T">The type for which contract metadata is specified.</typeparam>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/> instance the metadata is associated with.</param>
+        /// <returns>A blank <see cref="JsonTypeInfo{T}"/> instance.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+        /// <remarks>
+        /// The returned <see cref="JsonTypeInfo{T}"/> will be blank, with the exception of the
+        /// <see cref="JsonTypeInfo.Converter"/> property which will be resolved either from
+        /// <see cref="JsonSerializerOptions.Converters"/> or the built-in converters for the type.
+        /// Any converters specified via <see cref="JsonConverterAttribute"/> on the type declaration
+        /// will not be resolved by this method.
+        ///
+        /// What converter does get resolved influences the value of <see cref="JsonTypeInfo.Kind"/>,
+        /// which constrains the type of metadata that can be modified in the <see cref="JsonTypeInfo"/> instance.
+        /// </remarks>
         [RequiresUnreferencedCode(MetadataFactoryRequiresUnreferencedCode)]
         [RequiresDynamicCode(MetadataFactoryRequiresUnreferencedCode)]
         public static JsonTypeInfo<T> CreateJsonTypeInfo<T>(JsonSerializerOptions options)
@@ -522,18 +533,30 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowArgumentNullException(nameof(options));
             }
 
-            DefaultJsonTypeInfoResolver.RootDefaultInstance();
-            return new CustomJsonTypeInfo<T>(options);
+            JsonConverter converter = DefaultJsonTypeInfoResolver.GetConverterForType(typeof(T), options, resolveJsonConverterAttribute: false);
+            return new CustomJsonTypeInfo<T>(converter, options);
         }
 
         private static MethodInfo? s_createJsonTypeInfo;
 
         /// <summary>
-        /// Creates JsonTypeInfo
+        /// Creates a blank <see cref="JsonTypeInfo"/> instance.
         /// </summary>
-        /// <param name="type">Type for which JsonTypeInfo stores metadata for</param>
-        /// <param name="options">Options associated with JsonTypeInfo</param>
-        /// <returns>JsonTypeInfo instance</returns>
+        /// <param name="type">The type for which contract metadata is specified.</param>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/> instance the metadata is associated with.</param>
+        /// <returns>A blank <see cref="JsonTypeInfo{T}"/> instance.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="type"/> or <paramref name="options"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="type"/> cannot be used for serialization.</exception>
+        /// <remarks>
+        /// The returned <see cref="JsonTypeInfo{T}"/> will be blank, with the exception of the
+        /// <see cref="JsonTypeInfo.Converter"/> property which will be resolved either from
+        /// <see cref="JsonSerializerOptions.Converters"/> or the built-in converters for the type.
+        /// Any converters specified via <see cref="JsonConverterAttribute"/> on the type declaration
+        /// will not be resolved by this method.
+        ///
+        /// What converter does get resolved influences the value of <see cref="JsonTypeInfo.Kind"/>,
+        /// which constrains the type of metadata that can be modified in the <see cref="JsonTypeInfo"/> instance.
+        /// </remarks>
         [RequiresUnreferencedCode(MetadataFactoryRequiresUnreferencedCode)]
         [RequiresDynamicCode(MetadataFactoryRequiresUnreferencedCode)]
         public static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options)
@@ -553,18 +576,19 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowArgumentException_CannotSerializeInvalidType(nameof(type), type, null, null);
             }
 
-            DefaultJsonTypeInfoResolver.RootDefaultInstance();
             s_createJsonTypeInfo ??= typeof(JsonTypeInfo).GetMethod(nameof(CreateJsonTypeInfo), new Type[] { typeof(JsonSerializerOptions) })!;
             return (JsonTypeInfo)s_createJsonTypeInfo.MakeGenericMethod(type)
                 .Invoke(null, new object[] { options })!;
         }
 
         /// <summary>
-        /// Creates JsonPropertyInfo
+        /// Creates a blank <see cref="JsonPropertyInfo"/> instance for the current <see cref="JsonTypeInfo"/>.
         /// </summary>
-        /// <param name="propertyType">Type of the property</param>
-        /// <param name="name">Name of the property</param>
-        /// <returns>JsonPropertyInfo instance</returns>
+        /// <param name="propertyType">The declared type for the property.</param>
+        /// <param name="name">The property name used in JSON serialization and deserialization.</param>
+        /// <returns>A blank <see cref="JsonPropertyInfo"/> instance.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="propertyType"/> or <paramref name="name"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="propertyType"/> cannot be used for serialization.</exception>
         [RequiresUnreferencedCode(MetadataFactoryRequiresUnreferencedCode)]
         [RequiresDynamicCode(MetadataFactoryRequiresUnreferencedCode)]
         public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name)
@@ -584,7 +608,11 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowArgumentException_CannotSerializeInvalidType(nameof(propertyType), propertyType, Type, name);
             }
 
-            JsonConverter converter = Options.GetConverterFromListOrBuiltInConverter(propertyType);
+            JsonConverter? converter =
+                Options.TryGetTypeInfoCached(propertyType, out JsonTypeInfo? jsonTypeInfo)
+                ? jsonTypeInfo.Converter
+                : null;
+
             JsonPropertyInfo propertyInfo = CreatePropertyUsingReflection(propertyType, converter);
             propertyInfo.Name = name;
 
@@ -885,7 +913,7 @@ namespace System.Text.Json.Serialization.Metadata
                 // Avoid a reference to typeof(JsonNode) to support trimming.
                 (memberType.FullName == JsonObjectTypeName && ReferenceEquals(memberType.Assembly, typeof(JsonTypeInfo).Assembly));
 
-            return typeIsValid && jsonPropertyInfo.Options.GetConverterFromTypeInfo(memberType) != null;
+            return typeIsValid;
         }
 
         internal JsonPropertyDictionary<JsonPropertyInfo> CreatePropertyCache(int capacity)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -516,12 +516,12 @@ namespace System.Text.Json.Serialization.Metadata
         /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
         /// <remarks>
         /// The returned <see cref="JsonTypeInfo{T}"/> will be blank, with the exception of the
-        /// <see cref="JsonTypeInfo.Converter"/> property which will be resolved either from
+        /// <see cref="Converter"/> property which will be resolved either from
         /// <see cref="JsonSerializerOptions.Converters"/> or the built-in converters for the type.
         /// Any converters specified via <see cref="JsonConverterAttribute"/> on the type declaration
         /// will not be resolved by this method.
         ///
-        /// What converter does get resolved influences the value of <see cref="JsonTypeInfo.Kind"/>,
+        /// What converter does get resolved influences the value of <see cref="Kind"/>,
         /// which constrains the type of metadata that can be modified in the <see cref="JsonTypeInfo"/> instance.
         /// </remarks>
         [RequiresUnreferencedCode(MetadataFactoryRequiresUnreferencedCode)]
@@ -544,17 +544,17 @@ namespace System.Text.Json.Serialization.Metadata
         /// </summary>
         /// <param name="type">The type for which contract metadata is specified.</param>
         /// <param name="options">The <see cref="JsonSerializerOptions"/> instance the metadata is associated with.</param>
-        /// <returns>A blank <see cref="JsonTypeInfo{T}"/> instance.</returns>
+        /// <returns>A blank <see cref="JsonTypeInfo"/> instance.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="type"/> or <paramref name="options"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="type"/> cannot be used for serialization.</exception>
         /// <remarks>
-        /// The returned <see cref="JsonTypeInfo{T}"/> will be blank, with the exception of the
-        /// <see cref="JsonTypeInfo.Converter"/> property which will be resolved either from
+        /// The returned <see cref="JsonTypeInfo"/> will be blank, with the exception of the
+        /// <see cref="Converter"/> property which will be resolved either from
         /// <see cref="JsonSerializerOptions.Converters"/> or the built-in converters for the type.
         /// Any converters specified via <see cref="JsonConverterAttribute"/> on the type declaration
         /// will not be resolved by this method.
         ///
-        /// What converter does get resolved influences the value of <see cref="JsonTypeInfo.Kind"/>,
+        /// What converter does get resolved influences the value of <see cref="Kind"/>,
         /// which constrains the type of metadata that can be modified in the <see cref="JsonTypeInfo"/> instance.
         /// </remarks>
         [RequiresUnreferencedCode(MetadataFactoryRequiresUnreferencedCode)]
@@ -608,12 +608,7 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowArgumentException_CannotSerializeInvalidType(nameof(propertyType), propertyType, Type, name);
             }
 
-            JsonConverter? converter =
-                Options.TryGetTypeInfoCached(propertyType, out JsonTypeInfo? jsonTypeInfo)
-                ? jsonTypeInfo.Converter
-                : null;
-
-            JsonPropertyInfo propertyInfo = CreatePropertyUsingReflection(propertyType, converter);
+            JsonPropertyInfo propertyInfo = CreatePropertyUsingReflection(propertyType);
             propertyInfo.Name = name;
 
             return propertyInfo;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -96,10 +96,17 @@ namespace System.Text.Json.Serialization.Metadata
                 declaringTypeInfo: null,
                 Options)
             {
-                DefaultConverterForType = Converter,
                 JsonTypeInfo = this,
                 IsForTypeInfo = true,
             };
+        }
+
+        private protected override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo)
+        {
+            return new JsonPropertyInfo<T>(declaringTypeInfo.Type, declaringTypeInfo, Options)
+            {
+                JsonTypeInfo = this
+            };;
         }
 
         private protected void MapInterfaceTypesToCallbacks()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -101,12 +101,12 @@ namespace System.Text.Json.Serialization.Metadata
             };
         }
 
-        private protected override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo)
+        private protected override JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, JsonSerializerOptions options)
         {
-            return new JsonPropertyInfo<T>(declaringTypeInfo.Type, declaringTypeInfo, Options)
+            return new JsonPropertyInfo<T>(declaringTypeInfo.Type, declaringTypeInfo, options)
             {
                 JsonTypeInfo = this
-            };;
+            };
         }
 
         private protected void MapInterfaceTypesToCallbacks()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -249,7 +249,7 @@ namespace System.Text.Json.Serialization.Metadata
             public Type DerivedType { get; }
             public object? TypeDiscriminator { get; }
             public JsonTypeInfo GetJsonTypeInfo(JsonSerializerOptions options)
-                => _jsonTypeInfo ??= options.GetTypeInfoCached(DerivedType);
+                => _jsonTypeInfo ??= options.GetTypeInfoInternal(DerivedType);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -185,13 +185,6 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowInvalidOperationException_CannotSerializeInvalidType(typeToConvert, memberInfo.DeclaringType, memberInfo);
             }
 
-            // Resolve the default converter for the member type, if it has already been cached.
-            // If not found, converter resolution will be delayed until the Configure() stage.
-            JsonConverter? converter =
-                options.TryGetTypeInfoCached(typeToConvert, out JsonTypeInfo? jsonTypeInfo)
-                ? jsonTypeInfo.Converter
-                : null;
-
             // Resolve any custom converters on the attribute level.
             JsonConverter? customConverter;
             try
@@ -204,7 +197,7 @@ namespace System.Text.Json.Serialization.Metadata
                 return null;
             }
 
-            JsonPropertyInfo jsonPropertyInfo = CreatePropertyUsingReflection(typeToConvert, converter);
+            JsonPropertyInfo jsonPropertyInfo = CreatePropertyUsingReflection(typeToConvert);
             jsonPropertyInfo.InitializeUsingMemberReflection(memberInfo, customConverter, ignoreCondition);
             return jsonPropertyInfo;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -17,13 +17,6 @@ namespace System.Text.Json.Serialization.Metadata
     {
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        internal ReflectionJsonTypeInfo(JsonSerializerOptions options)
-            : this(DefaultJsonTypeInfoResolver.GetConverterForType(typeof(T), options), options)
-        {
-        }
-
-        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
         internal ReflectionJsonTypeInfo(JsonConverter converter, JsonSerializerOptions options)
             : base(converter, options)
         {
@@ -160,7 +153,7 @@ namespace System.Text.Json.Serialization.Metadata
             ref bool propertyOrderSpecified,
             ref Dictionary<string, JsonPropertyInfo>? ignoredMembers)
         {
-            JsonPropertyInfo? jsonPropertyInfo = AddProperty(typeToConvert, memberInfo, Options);
+            JsonPropertyInfo? jsonPropertyInfo = CreateProperty(typeToConvert, memberInfo, Options);
             if (jsonPropertyInfo == null)
             {
                 // ignored invalid property
@@ -177,7 +170,7 @@ namespace System.Text.Json.Serialization.Metadata
             Justification = "The ctor is marked as RequiresUnreferencedCode")]
         [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
             Justification = "The ctor is marked RequiresDynamicCode.")]
-        private JsonPropertyInfo? AddProperty(
+        private JsonPropertyInfo? CreateProperty(
             Type typeToConvert,
             MemberInfo memberInfo,
             JsonSerializerOptions options)
@@ -192,19 +185,22 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowInvalidOperationException_CannotSerializeInvalidType(typeToConvert, memberInfo.DeclaringType, memberInfo);
             }
 
-            JsonConverter? customConverter;
-            JsonConverter converter;
+            // Resolve the default converter for the member type, if it has already been cached.
+            // If not found, converter resolution will be delayed until the Configure() stage.
+            JsonConverter? converter =
+                options.TryGetTypeInfoCached(typeToConvert, out JsonTypeInfo? jsonTypeInfo)
+                ? jsonTypeInfo.Converter
+                : null;
 
+            // Resolve any custom converters on the attribute level.
+            JsonConverter? customConverter;
             try
             {
-                converter = DefaultJsonTypeInfoResolver.GetConverterForMember(
-                    typeToConvert,
-                    memberInfo,
-                    options,
-                    out customConverter);
+                customConverter = DefaultJsonTypeInfoResolver.GetCustomConverterForMember(typeToConvert, memberInfo, options);
             }
             catch (InvalidOperationException) when (ignoreCondition == JsonIgnoreCondition.Always)
             {
+                // skip property altogether if attribute is invalid and the property is ignored
                 return null;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -126,7 +126,7 @@ namespace System.Text.Json
             // if the current element is the same type as the previous element.
             if (PolymorphicJsonTypeInfo?.PropertyType != runtimeType)
             {
-                JsonTypeInfo typeInfo = options.GetTypeInfoCached(runtimeType);
+                JsonTypeInfo typeInfo = options.GetTypeInfoInternal(runtimeType);
                 PolymorphicJsonTypeInfo = typeInfo.PropertyInfoForTypeInfo;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -645,12 +645,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowNotSupportedException_BuiltInConvertersNotRooted(Type type)
-        {
-            throw new NotSupportedException(SR.Format(SR.BuiltInConvertersNotRooted, type));
-        }
-
-        [DoesNotReturn]
         public static void ThrowNotSupportedException_NoMetadataForType(Type type, IJsonTypeInfoResolver? resolver)
         {
             throw new NotSupportedException(SR.Format(SR.NoMetadataForType, type, resolver?.GetType().FullName ?? "<null>"));

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/RecordTests.fs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/RecordTests.fs
@@ -49,3 +49,30 @@ let ``Support F# struct record serialization``() =
 let ``Support F# struct record deserialization``() =
     let result = JsonSerializer.Deserialize<MyStructRecord>(MyStructRecord.ExpectedJson)
     Assert.Equal(MyStructRecord.Value, result)
+
+type RecursiveRecord =
+    {
+        Next : RecursiveRecord option
+    }
+
+[<Fact>]
+let ``Recursive records are supported``() =
+    let value = { Next = Some { Next = None } }
+    let json = JsonSerializer.Serialize(value)
+    Assert.Equal("""{"Next":{"Next":null}}""", json)
+    let deserializedValue = JsonSerializer.Deserialize<RecursiveRecord>(json)
+    Assert.Equal(value, deserializedValue)
+
+[<Struct>]
+type RecursiveStructRecord =
+    {
+        Next : RecursiveStructRecord voption []
+    }
+
+[<Fact>]
+let ``Recursive struct records are supported``() =
+    let value = { Next = [| ValueSome { Next = [| ValueNone |] } |] }
+    let json = JsonSerializer.Serialize(value)
+    Assert.Equal("""{"Next":[{"Next":[null]}]}""", json)
+    let deserializedValue = JsonSerializer.Deserialize<RecursiveStructRecord>(json)
+    Assert.Equal(value, deserializedValue)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoOptionsAreSet()
         {
-            JsonSerializerOptions options = JsonSerializerOptions.Default;
+            JsonSerializerOptions options = new() { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
             JsonTypeInfo typeInfo = JsonTypeInfo.CreateJsonTypeInfo(typeof(MyClass), options);
             CreatePropertyAndCheckOptions(options, typeInfo);
 
@@ -26,6 +26,9 @@ namespace System.Text.Json.Serialization.Tests
             CreatePropertyAndCheckOptions(options, typeInfo);
 
             typeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(MyClass), options);
+            CreatePropertyAndCheckOptions(options, typeInfo);
+
+            typeInfo = options.GetTypeInfo(typeof(MyClass));
             CreatePropertyAndCheckOptions(options, typeInfo);
 
             static void CreatePropertyAndCheckOptions(JsonSerializerOptions expectedOptions, JsonTypeInfo typeInfo)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonPropertyInfo.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void JsonPropertyInfoOptionsAreSet()
         {
-            JsonSerializerOptions options = new() { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
             JsonTypeInfo typeInfo = JsonTypeInfo.CreateJsonTypeInfo(typeof(MyClass), options);
             CreatePropertyAndCheckOptions(options, typeInfo);
 
@@ -26,9 +26,6 @@ namespace System.Text.Json.Serialization.Tests
             CreatePropertyAndCheckOptions(options, typeInfo);
 
             typeInfo = options.TypeInfoResolver.GetTypeInfo(typeof(MyClass), options);
-            CreatePropertyAndCheckOptions(options, typeInfo);
-
-            typeInfo = options.GetTypeInfo(typeof(MyClass));
             CreatePropertyAndCheckOptions(options, typeInfo);
 
             static void CreatePropertyAndCheckOptions(JsonSerializerOptions expectedOptions, JsonTypeInfo typeInfo)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NullableTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NullableTests.cs
@@ -439,5 +439,34 @@ namespace System.Text.Json.Serialization.Tests
             public int? Age { get; set; }
             public DateTime? Birthday { get; set; }
         }
+
+        [Fact]
+        public static void RecursiveNullableStruct_Roundtrip()
+        {
+            var value = new RecursiveNullableStruct
+            {
+                Next = new RecursiveNullableStruct?[]
+                {
+                    new()
+                    {
+                        Next = new RecursiveNullableStruct?[]
+                        {
+                            null
+                        }
+                    }
+                }
+            };
+
+            string json = JsonSerializer.Serialize(value);
+            Assert.Equal("""{"Next":[{"Next":[null]}]}""", json);
+            value = JsonSerializer.Deserialize<RecursiveNullableStruct>(json);
+            string roundtripJson = JsonSerializer.Serialize(value);
+            Assert.Equal(roundtripJson, json);
+        }
+
+        public struct RecursiveNullableStruct
+        {
+            public RecursiveNullableStruct?[] Next { get; set; } 
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -9,7 +8,6 @@ using System.Text.Encodings.Web;
 using System.Text.Json.Serialization.Metadata;
 using System.Text.Json.Tests;
 using System.Text.Unicode;
-using System.Threading;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
@@ -450,6 +448,7 @@ namespace System.Text.Json.Serialization.Tests
                 // Default converters have not been rooted yet
                 Assert.Null(context.GetTypeInfo(typeof(MyClass)));
                 Assert.Throws<NotSupportedException>(() => context.Options.GetConverter(typeof(MyClass)));
+                Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(unsupportedValue, context.Options));
 
                 // Root converters process-wide using a default options instance
                 var options = new JsonSerializerOptions();
@@ -459,6 +458,7 @@ namespace System.Text.Json.Serialization.Tests
                 // We still can't resolve metadata for MyClass or get a converter using the rooted converters.
                 Assert.Null(context.GetTypeInfo(typeof(MyClass)));
                 Assert.Throws<NotSupportedException>(() => context.Options.GetConverter(typeof(MyClass)));
+                Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(unsupportedValue, context.Options));
 
             }).Dispose();
         }
@@ -557,6 +557,23 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new CustomConverterTests.LongArrayConverter());
             GenericConverterTestHelper<long[]>("LongArrayConverter", new long[] { 1, 2, 3, 4 }, "\"1,2,3,4\"", options);
+        }
+
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int[]))]
+        [InlineData(typeof(Poco))]
+        [InlineData(typeof(Dictionary<int, string>))]
+        public static void Options_GetConverter_CustomResolver_DoesNotReturnConverterForUnsupportedType(Type type)
+        {
+            var options = new JsonSerializerOptions { TypeInfoResolver = new NullResolver() };
+            Assert.Throws<NotSupportedException>(() => options.GetConverter(type));
+        }
+
+        public class NullResolver : IJsonTypeInfoResolver
+        {
+            public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options) => null;
         }
 
         private static void GenericConverterTestHelper<T>(string converterName, object objectValue, string stringValue, JsonSerializerOptions options, bool nullOptionOkay = true)


### PR DESCRIPTION
Contributes to #71714 by removing fallback to the reflection converters for any resolver other than the default reflection-based resolver. More specifically this change:

* Makes contract resolvers the only source of truth when it comes to determining converters for types or properties.
* The reflection-based converter factories are only consulted by `DefaultContractResolver` (and `JsonSerializerOptions.GetConverter` whenever a resolver is left unspecified for backward compatibility purposes).
* Makes converter resolution for `JsonPropertyInfo` explicitly lazy unless the `JsonTypeInfo` for the declared type has already been cached.
* Changes the behavior of `JsonSerializerOptions.GetConverter` for options instances tied to `JsonSerializerContext`: the method will throw `NotSupportedException` for any type not explicitly supported by the context and will not query the reflection-based converter factories. This change is inline with the proposal in #71714.
* Adds test coverage for recursive types containing `Nullable<T>` and F# optionals: types whose converters perform eager resolution for the converters of their element types.

Fix #71714.