### PR TITLE
Fixing the per object hard limit support for regions

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -29956,7 +29956,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
                             if (oh == soh)
                             {
-                                heap_segment* freeable = freeable_soh_segment;
+                                heap_segment* freeable = hp->freeable_soh_segment;
                                 while (freeable)
                                 {
                                     committed += (heap_segment_committed (freeable) - get_region_start (freeable));
@@ -29965,7 +29965,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
                             }
                             else
                             {
-                                heap_segment* freeable = freeable_uoh_segment;
+                                heap_segment* freeable = hp->freeable_uoh_segment;
                                 while (freeable)
                                 {
                                     if (heap_segment_oh (freeable) == oh)

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -242,7 +242,7 @@ gc_oh_num gen_to_oh(int gen)
             return gc_oh_num::poh;
         default:
             assert(false);
-            return gc_oh_num::none;
+            return gc_oh_num::unknown;
     }
 }
 
@@ -5628,7 +5628,7 @@ gc_heap::soh_get_segment_to_expand()
 heap_segment*
 gc_heap::get_segment (size_t size, gc_oh_num oh)
 {
-    assert(oh < total_oh_count);
+    assert(oh != gc_oh_num::unknown);
     BOOL uoh_p = (oh == gc_oh_num::loh) || (oh == gc_oh_num::poh);
     if (heap_hard_limit)
         return NULL;
@@ -44051,8 +44051,6 @@ HRESULT GCHeap::Initialize()
 {
     HRESULT hr = S_OK;
 
-    memset (gc_heap::committed_by_oh, 0, sizeof (gc_heap::committed_by_oh));
-
     qpf = (uint64_t)GCToOSInterface::QueryPerformanceFrequency();
     qpf_ms = 1000.0 / (double)qpf;
     qpf_us = 1000.0 * 1000.0 / (double)qpf;
@@ -44078,6 +44076,8 @@ HRESULT GCHeap::Initialize()
     gc_heap::heap_hard_limit_oh[soh] = (size_t)GCConfig::GetGCHeapHardLimitSOH();
     gc_heap::heap_hard_limit_oh[loh] = (size_t)GCConfig::GetGCHeapHardLimitLOH();
     gc_heap::heap_hard_limit_oh[poh] = (size_t)GCConfig::GetGCHeapHardLimitPOH();
+
+    memset (gc_heap::committed_by_oh, 0, sizeof (gc_heap::committed_by_oh));
 
     gc_heap::use_large_pages_p = GCConfig::GetGCLargePages();
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -419,8 +419,10 @@ enum gc_oh_num
     soh = 0,
     loh = 1,
     poh = 2,
-    none = 3,
-    total_oh_count = 4
+    free = 3,
+    none = 4,
+    total_oh_count = 3,
+    total_bucket_count = 5
 };
 
 gc_oh_num gen_to_oh (int gen);
@@ -1296,7 +1298,7 @@ public:
     PER_HEAP
     void verify_free_lists();
     PER_HEAP
-    void verify_regions (int gen_number, bool can_verify_gen_num, bool can_verify_tail);
+    void verify_regions (int gen_number, bool can_verify_gen_num, bool can_verify_tail, size_t& total_committed);
     PER_HEAP
     void verify_regions (bool can_verify_gen_num, bool concurrent_p);
     PER_HEAP_ISOLATED
@@ -3803,7 +3805,7 @@ public:
     gen_to_condemn_tuning gen_to_condemn_reasons;
 
     PER_HEAP
-    size_t etw_allocation_running_amount[gc_oh_num::total_oh_count - 1];
+    size_t etw_allocation_running_amount[gc_oh_num::total_oh_count];
 
     PER_HEAP
     uint64_t total_alloc_bytes_soh;
@@ -4007,7 +4009,7 @@ public:
     size_t heap_hard_limit;
 
     PER_HEAP_ISOLATED
-    size_t heap_hard_limit_oh[total_oh_count - 1];
+    size_t heap_hard_limit_oh[gc_oh_num::total_oh_count];
 
     PER_HEAP_ISOLATED
     CLRCriticalSection check_commit_cs;
@@ -4016,7 +4018,14 @@ public:
     size_t current_total_committed;
 
     PER_HEAP_ISOLATED
-    size_t committed_by_oh[total_oh_count];
+    size_t committed_by_oh[gc_oh_num::total_bucket_count];
+
+#ifdef _DEBUG
+#ifdef MULTIPLE_HEAPS
+    PER_HEAP
+    size_t committed_by_oh_per_heap[gc_oh_num::total_oh_count];
+#endif
+#endif
 
     // This is what GC uses for its own bookkeeping.
     PER_HEAP_ISOLATED
@@ -4818,7 +4827,7 @@ protected:
     size_t num_provisional_triggered;
 
     PER_HEAP
-    size_t allocated_since_last_gc[gc_oh_num::total_oh_count - 1];
+    size_t allocated_since_last_gc[gc_oh_num::total_oh_count];
 
 #ifdef BACKGROUND_GC
     PER_HEAP_ISOLATED

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -419,7 +419,7 @@ enum gc_oh_num
     soh = 0,
     loh = 1,
     poh = 2,
-    none = -1,
+    unknown = -1,
 };
 
 const int total_oh_count = gc_oh_num::poh + 1;

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -419,11 +419,13 @@ enum gc_oh_num
     soh = 0,
     loh = 1,
     poh = 2,
-    free = 3,
-    none = 4,
-    total_oh_count = 3,
-    total_bucket_count = 5
+    none = -1,
 };
+
+const int total_oh_count = gc_oh_num::poh + 1;
+const int recorded_committed_free_bucket = total_oh_count;
+const int recorded_committed_bookkeeping_bucket = recorded_committed_free_bucket + 1;
+const int recorded_committed_bucket_counts = recorded_committed_bookkeeping_bucket + 1;
 
 gc_oh_num gen_to_oh (int gen);
 
@@ -1298,7 +1300,7 @@ public:
     PER_HEAP
     void verify_free_lists();
     PER_HEAP
-    void verify_regions (int gen_number, bool can_verify_gen_num, bool can_verify_tail, size_t& total_committed);
+    void verify_regions (int gen_number, bool can_verify_gen_num, bool can_verify_tail, size_t* p_total_committed = nullptr);
     PER_HEAP
     void verify_regions (bool can_verify_gen_num, bool concurrent_p);
     PER_HEAP_ISOLATED
@@ -2035,9 +2037,9 @@ protected:
     PER_HEAP_ISOLATED
     bool virtual_alloc_commit_for_heap (void* addr, size_t size, int h_number);
     PER_HEAP_ISOLATED
-    bool virtual_commit (void* address, size_t size, gc_oh_num oh, int h_number=-1, bool* hard_limit_exceeded_p=NULL);
+    bool virtual_commit (void* address, size_t size, int bucket, int h_number=-1, bool* hard_limit_exceeded_p=NULL);
     PER_HEAP_ISOLATED
-    bool virtual_decommit (void* address, size_t size, gc_oh_num oh, int h_number=-1);
+    bool virtual_decommit (void* address, size_t size, int bucket, int h_number=-1);
     PER_HEAP_ISOLATED
     void virtual_free (void* add, size_t size, heap_segment* sg=NULL);
     PER_HEAP
@@ -3805,7 +3807,7 @@ public:
     gen_to_condemn_tuning gen_to_condemn_reasons;
 
     PER_HEAP
-    size_t etw_allocation_running_amount[gc_oh_num::total_oh_count];
+    size_t etw_allocation_running_amount[total_oh_count];
 
     PER_HEAP
     uint64_t total_alloc_bytes_soh;
@@ -4009,7 +4011,7 @@ public:
     size_t heap_hard_limit;
 
     PER_HEAP_ISOLATED
-    size_t heap_hard_limit_oh[gc_oh_num::total_oh_count];
+    size_t heap_hard_limit_oh[total_oh_count];
 
     PER_HEAP_ISOLATED
     CLRCriticalSection check_commit_cs;
@@ -4018,14 +4020,12 @@ public:
     size_t current_total_committed;
 
     PER_HEAP_ISOLATED
-    size_t committed_by_oh[gc_oh_num::total_bucket_count];
+    size_t committed_by_oh[recorded_committed_bucket_counts];
 
-#ifdef _DEBUG
-#ifdef MULTIPLE_HEAPS
+#if defined (_DEBUG) && defined (MULTIPLE_HEAPS)
     PER_HEAP
-    size_t committed_by_oh_per_heap[gc_oh_num::total_oh_count];
-#endif
-#endif
+    size_t committed_by_oh_per_heap[total_oh_count];
+#endif // _DEBUG && MULTIPLE_HEAPS
 
     // This is what GC uses for its own bookkeeping.
     PER_HEAP_ISOLATED
@@ -4827,7 +4827,7 @@ protected:
     size_t num_provisional_triggered;
 
     PER_HEAP
-    size_t allocated_since_last_gc[gc_oh_num::total_oh_count];
+    size_t allocated_since_last_gc[total_oh_count];
 
 #ifdef BACKGROUND_GC
     PER_HEAP_ISOLATED


### PR DESCRIPTION
Fixes #71790
Fixes https://github.com/dotnet/runtime/issues/36828

In regions, we can move regions from/to free lists, so just keeping track of the commits for which object-heap during commit/decommit time is no longer enough, we also need to update our accounting when we move them around.

This change created a new bucket for free, that counts the committed memory in the region free lists.

Much of the diff is a refactoring that change the value of `total_oh_count` from `4` to `3`, which is more correct IMO. Many lines were doing `-1` which is no longer needed.

The `commit-accounting` logging statements are intentionally structured so that they can be used to reconstruct the committed region ranges if we have all of them. These can be useful for future tooling purposes (e.g. creating an animated map of how the regions evolves over time)