### PR TITLE
[wasm] Fix perf pipeline builds

### DIFF
--- a/src/mono/wasm/build/WasmApp.InTree.props
+++ b/src/mono/wasm/build/WasmApp.InTree.props
@@ -9,7 +9,7 @@
     <EMSDK_PATH Condition="'$(EMSDK_PATH)' == '' and '$(MonoProjectRoot)' != ''">$([MSBuild]::NormalizeDirectory($(MonoProjectRoot), 'wasm', 'emsdk'))</EMSDK_PATH>
     <RunAOTCompilation Condition="'$(RunAOTCompilation)' == ''">false</RunAOTCompilation>
     <PublishTrimmed>true</PublishTrimmed>
-    <TrimMode>link</TrimMode>
+    <TrimMode>partial</TrimMode>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
   <!-- This is temporary hack for https://github.com/dotnet/runtime/issues/61294 -->

--- a/src/mono/wasm/build/WasmApp.LocalBuild.targets
+++ b/src/mono/wasm/build/WasmApp.LocalBuild.targets
@@ -26,7 +26,7 @@
 
   <PropertyGroup>
     <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">true</PublishTrimmed>
-    <TrimMode>link</TrimMode>
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -106,6 +106,7 @@
     <WasmGenerateAppBundle Condition="'$(WasmGenerateAppBundle)' == '' and '$(OutputType)' != 'Library'">true</WasmGenerateAppBundle>
     <WasmGenerateAppBundle Condition="'$(WasmGenerateAppBundle)' == ''">false</WasmGenerateAppBundle>
     <UseAppHost>false</UseAppHost>
+    <TrimMode Condition="'$(TrimMode)' == ''">partial</TrimMode>
 
     <!-- Temporarily `false`, till sdk gets a fix for supporting the new file -->
     <WasmEmitSymbolMap Condition="'$(WasmEmitSymbolMap)' == '' and '$(RunAOTCompilation)' != 'true'">false</WasmEmitSymbolMap>


### PR DESCRIPTION
Perf pipeline builds broke recently as detailed in https://github.com/dotnet/runtime/issues/72104, and https://github.com/dotnet/runtime/issues/72105 . AOT builds broke because il-linking would result in 10 assemblies, instead of 145! This was because the default is `TrimMode=full` now.

- The fix is to set `TrimMode=`partial` to opt-in to the older `link` behavior`.
- The `TrimMode` values changed in https://github.com/dotnet/sdk/pull/26246 .

Note: This restores the old behavior. But we want to eventually enable `TrimMode=full`.

Fixes https://github.com/dotnet/runtime/issues/72104
Fixes https://github.com/dotnet/runtime/issues/72105