### PR TITLE
Make `Enum.GetValues` AOT-safe

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -91,24 +91,14 @@ namespace System
             }
         }
 
-        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload instead.")]
         public sealed override Array GetEnumValues()
         {
             if (!IsActualEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
 
-            Array values = Enum.GetEnumInfo(this).ValuesAsUnderlyingType;
-            int count = values.Length;
-            // Without universal shared generics, chances are slim that we'll have the appropriate
-            // array type available. Offer an escape hatch that avoids a MissingMetadataException
-            // at the cost of a small appcompat risk.
-            Array result;
-            if (AppContext.TryGetSwitch("Switch.System.Enum.RelaxedGetValues", out bool isRelaxed) && isRelaxed)
-                result = Array.CreateInstance(Enum.InternalGetUnderlyingType(this), count);
-            else
-                result = Array.CreateInstance(this, count);
-            Array.Copy(values, result, values.Length);
-            return result;
+            // Compat: we should be returning SomeInt32Enum[]. Instead we return Int32[].
+            // This is a tradeoff since SomeInt32Enum[] type might not have been pregenerated.
+            return (Array)Enum.GetEnumInfo(this).ValuesAsUnderlyingType.Clone();
         }
 
         internal bool IsActualEnum

--- a/src/libraries/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
+++ b/src/libraries/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
@@ -225,7 +225,7 @@ namespace System.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public virtual void ICollection_NonGeneric_CopyTo_ArrayOfEnumType(int count)
         {
-            Array enumArr = Enum.GetValues(typeof(EnumerableType));
+            Array enumArr = Enum.GetValues<EnumerableType>();
             if (count > 0 && count < enumArr.Length)
             {
                 ICollection collection = NonGenericICollectionFactory(count);

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -175,6 +175,23 @@ namespace System
             }
         }
 
+        private static volatile Tuple<bool> s_lazyEnumGetValuesReturnsEnumArray;
+        public static bool EnumGetValuesReturnsEnumArray
+        {
+            get
+            {
+                if (s_lazyEnumGetValuesReturnsEnumArray == null)
+                {
+                    bool enumGetValuesReturnsEnumArray = Enum.GetValues(typeof(TestEnum)).GetType() == typeof(TestEnum[]);
+                    s_lazyEnumGetValuesReturnsEnumArray = Tuple.Create<bool>(enumGetValuesReturnsEnumArray);
+                }
+                return s_lazyEnumGetValuesReturnsEnumArray.Item1;
+            }
+        }
+        enum TestEnum { }
+
+        public static bool EnumGetValuesReturnsUnderlyingTypeArray => !EnumGetValuesReturnsEnumArray;
+
         private static volatile Tuple<bool> s_lazyMetadataTokensSupported;
         public static bool IsMetadataTokenSupported
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -315,7 +315,6 @@ namespace System
             (TEnum[])GetValues(typeof(TEnum));
 #endif
 
-        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload instead.")]
         public static Array GetValues(Type enumType)
         {
             ArgumentNullException.ThrowIfNull(enumType);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureType.cs
@@ -99,7 +99,6 @@ namespace System.Reflection
         public sealed override string GetEnumName(object value) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override string[] GetEnumNames() => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override Type GetEnumUnderlyingType() => throw new NotSupportedException(SR.NotSupported_SignatureType);
-        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use Enum.GetValues<TEnum> instead.")]
         public sealed override Array GetEnumValues() => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override Guid GUID => throw new NotSupportedException(SR.NotSupported_SignatureType);
         protected sealed override TypeCode GetTypeCodeImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -118,7 +118,6 @@ namespace System
             return new ReadOnlySpan<string>(ret).ToArray();
         }
 
-        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload instead.")]
         public override Array GetEnumValues()
         {
             if (!IsActualEnum)

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -515,7 +515,6 @@ namespace System
             return fields[0].FieldType;
         }
 
-        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use Enum.GetValues<TEnum> instead.")]
         public virtual Array GetEnumValues()
         {
             if (!IsEnum)

--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -454,6 +454,13 @@ namespace System.Reflection.Tests
 
         private static void GetEnumValues(Type enumType, Array expected)
         {
+            if (!PlatformDetection.EnumGetValuesReturnsEnumArray)
+            {
+                // Change the array to underlying type array if GetValues doesn't return Enum[] but int[]
+                Array newExpected = Array.CreateInstance(Enum.GetUnderlyingType(enumType), expected.Length);
+                Array.Copy(expected, newExpected, expected.Length);
+                expected = newExpected;
+            }
             Assert.Equal(expected, enumType.GetTypeInfo().GetEnumValues());
         }
 

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2312,7 +2312,6 @@ namespace System
         public static string[] GetNames<TEnum>() where TEnum: struct, System.Enum { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
         public static System.Type GetUnderlyingType(System.Type enumType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload instead.")]
         public static System.Array GetValues(System.Type enumType) { throw null; }
         public static TEnum[] GetValues<TEnum>() where TEnum : struct, System.Enum { throw null; }
         public bool HasFlag(System.Enum flag) { throw null; }
@@ -5860,7 +5859,6 @@ namespace System
         public virtual string? GetEnumName(object value) { throw null; }
         public virtual string[] GetEnumNames() { throw null; }
         public virtual System.Type GetEnumUnderlyingType() { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use Enum.GetValues<TEnum> instead.")]
         public virtual System.Array GetEnumValues() { throw null; }
         [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]
         public System.Reflection.EventInfo? GetEvent(string name) { throw null; }

--- a/src/libraries/System.Runtime/tests/System/EnumTests.cs
+++ b/src/libraries/System.Runtime/tests/System/EnumTests.cs
@@ -1454,11 +1454,49 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentException>("enumType", () => Enum.GetNames(enumType));
         }
 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.EnumGetValuesReturnsUnderlyingTypeArray))]
+        public void GetValues_CheckArrayType_UnderlyingType()
+        {
+            Assert.Equal(typeof(sbyte[]), Enum.GetValues(typeof(SByteEnum)).GetType());
+            Assert.Equal(typeof(byte[]), Enum.GetValues(typeof(ByteEnum)).GetType());
+            Assert.Equal(typeof(short[]), Enum.GetValues(typeof(Int16Enum)).GetType());
+            Assert.Equal(typeof(ushort[]), Enum.GetValues(typeof(UInt16Enum)).GetType());
+            Assert.Equal(typeof(int[]), Enum.GetValues(typeof(Int32Enum)).GetType());
+            Assert.Equal(typeof(uint[]), Enum.GetValues(typeof(UInt32Enum)).GetType());
+            Assert.Equal(typeof(long[]), Enum.GetValues(typeof(Int64Enum)).GetType());
+            Assert.Equal(typeof(ulong[]), Enum.GetValues(typeof(UInt64Enum)).GetType());
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.EnumGetValuesReturnsEnumArray))]
+        public void GetValues_CheckArrayType_EnumType()
+        {
+            Assert.Equal(typeof(SByteEnum[]), Enum.GetValues(typeof(SByteEnum)).GetType());
+            Assert.Equal(typeof(ByteEnum[]), Enum.GetValues(typeof(ByteEnum)).GetType());
+            Assert.Equal(typeof(Int16Enum[]), Enum.GetValues(typeof(Int16Enum)).GetType());
+            Assert.Equal(typeof(UInt16Enum[]), Enum.GetValues(typeof(UInt16Enum)).GetType());
+            Assert.Equal(typeof(Int32Enum[]), Enum.GetValues(typeof(Int32Enum)).GetType());
+            Assert.Equal(typeof(UInt32Enum[]), Enum.GetValues(typeof(UInt32Enum)).GetType());
+            Assert.Equal(typeof(Int64Enum[]), Enum.GetValues(typeof(Int64Enum)).GetType());
+            Assert.Equal(typeof(UInt64Enum[]), Enum.GetValues(typeof(UInt64Enum)).GetType());
+        }
+
+        private static T[] TransformEnumArray<T>(T[] array) where T : struct, Enum
+        {
+            if (!PlatformDetection.EnumGetValuesReturnsEnumArray)
+            {
+                // Change the array to underlying type array if GetValues doesn't return Enum[] but int[]
+                Array newArray = Array.CreateInstance(Enum.GetUnderlyingType(typeof(T)), array.Length);
+                Array.Copy(array, newArray, array.Length);
+                array = (T[])newArray;
+            }
+            return array;
+        }
+
         [Fact]
         public void GetValues_InvokeSimpleEnumEnum_ReturnsExpected()
         {
             var expected = new SimpleEnum[] { SimpleEnum.Red, SimpleEnum.Blue, SimpleEnum.Green, SimpleEnum.Green_a, SimpleEnum.Green_b, SimpleEnum.B };
-            Assert.Equal(expected, Enum.GetValues(typeof(SimpleEnum)));
+            Assert.Equal(TransformEnumArray(expected), Enum.GetValues(typeof(SimpleEnum)));
             Assert.NotSame(Enum.GetValues(typeof(SimpleEnum)), Enum.GetValues(typeof(SimpleEnum)));
             Assert.Equal(expected, Enum.GetValues<SimpleEnum>());
         }
@@ -1467,7 +1505,7 @@ namespace System.Tests
         public void GetValues_InvokeSByteEnum_ReturnsExpected()
         {
             var expected = new SByteEnum[] { SByteEnum.One, SByteEnum.Two, SByteEnum.Max, SByteEnum.Min };
-            Assert.Equal(expected, Enum.GetValues(typeof(SByteEnum)));
+            Assert.Equal(TransformEnumArray(expected), Enum.GetValues(typeof(SByteEnum)));
             Assert.NotSame(Enum.GetValues(typeof(SByteEnum)), Enum.GetValues(typeof(SByteEnum)));
             Assert.Equal(expected, Enum.GetValues<SByteEnum>());
         }
@@ -1476,7 +1514,7 @@ namespace System.Tests
         public void GetValues_InvokeByteEnum_ReturnsExpected()
         {
             var expected = new ByteEnum[] { ByteEnum.Min, ByteEnum.One, ByteEnum.Two, ByteEnum.Max };
-            Assert.Equal(expected, Enum.GetValues(typeof(ByteEnum)));
+            Assert.Equal(TransformEnumArray(expected), Enum.GetValues(typeof(ByteEnum)));
             Assert.NotSame(Enum.GetValues(typeof(ByteEnum)), Enum.GetValues(typeof(ByteEnum)));
             Assert.Equal(expected, Enum.GetValues<ByteEnum>());
         }
@@ -1485,7 +1523,7 @@ namespace System.Tests
         public void GetValues_InvokeInt16Enum_ReturnsExpected()
         {
             var expected = new Int16Enum[] { Int16Enum.One, Int16Enum.Two, Int16Enum.Max, Int16Enum.Min };
-            Assert.Equal(expected, Enum.GetValues(typeof(Int16Enum)));
+            Assert.Equal(TransformEnumArray(expected), Enum.GetValues(typeof(Int16Enum)));
             Assert.NotSame(Enum.GetValues(typeof(Int16Enum)), Enum.GetValues(typeof(Int16Enum)));
             Assert.Equal(expected, Enum.GetValues<Int16Enum>());
         }
@@ -1494,7 +1532,7 @@ namespace System.Tests
         public void GetValues_InvokeUInt16Enum_ReturnsExpected()
         {
             var expected = new UInt16Enum[] { UInt16Enum.Min, UInt16Enum.One, UInt16Enum.Two, UInt16Enum.Max };
-            Assert.Equal(expected, Enum.GetValues(typeof(UInt16Enum)));
+            Assert.Equal(TransformEnumArray(expected), Enum.GetValues(typeof(UInt16Enum)));
             Assert.NotSame(Enum.GetValues(typeof(UInt16Enum)), Enum.GetValues(typeof(UInt16Enum)));
             Assert.Equal(expected, Enum.GetValues<UInt16Enum>());
         }
@@ -1503,7 +1541,7 @@ namespace System.Tests
         public void GetValues_InvokeInt32Enum_ReturnsExpected()
         {
             var expected = new Int32Enum[] { Int32Enum.One, Int32Enum.Two, Int32Enum.Max, Int32Enum.Min };
-            Assert.Equal(expected, Enum.GetValues(typeof(Int32Enum)));
+            Assert.Equal(TransformEnumArray(expected), Enum.GetValues(typeof(Int32Enum)));
             Assert.NotSame(Enum.GetValues(typeof(Int32Enum)), Enum.GetValues(typeof(Int32Enum)));
             Assert.Equal(expected, Enum.GetValues<Int32Enum>());
         }
@@ -1512,7 +1550,7 @@ namespace System.Tests
         public void GetValues_InvokeUInt32Enum_ReturnsExpected()
         {
             var expected = new UInt32Enum[] { UInt32Enum.Min, UInt32Enum.One, UInt32Enum.Two, UInt32Enum.Max };
-            Assert.Equal(expected, Enum.GetValues(typeof(UInt32Enum)));
+            Assert.Equal(TransformEnumArray(expected), Enum.GetValues(typeof(UInt32Enum)));
             Assert.NotSame(Enum.GetValues(typeof(UInt32Enum)), Enum.GetValues(typeof(UInt32Enum)));
             Assert.Equal(expected, Enum.GetValues<UInt32Enum>());
         }
@@ -1521,7 +1559,7 @@ namespace System.Tests
         public void GetValues_InvokeInt64Enum_ReturnsExpected()
         {
             var expected = new Int64Enum[] { Int64Enum.One, Int64Enum.Two, Int64Enum.Max, Int64Enum.Min };
-            Assert.Equal(expected, Enum.GetValues(typeof(Int64Enum)));
+            Assert.Equal(TransformEnumArray(expected), Enum.GetValues(typeof(Int64Enum)));
             Assert.NotSame(Enum.GetValues(typeof(Int64Enum)), Enum.GetValues(typeof(Int64Enum)));
             Assert.Equal(expected, Enum.GetValues<Int64Enum>());
         }
@@ -1530,7 +1568,7 @@ namespace System.Tests
         public void GetValues_InvokeUInt64Enum_ReturnsExpected()
         {
             var expected = new UInt64Enum[] { UInt64Enum.Min, UInt64Enum.One, UInt64Enum.Two, UInt64Enum.Max };
-            Assert.Equal(expected, Enum.GetValues(typeof(UInt64Enum)));
+            Assert.Equal(TransformEnumArray(expected), Enum.GetValues(typeof(UInt64Enum)));
             Assert.NotSame(Enum.GetValues(typeof(UInt64Enum)), Enum.GetValues(typeof(UInt64Enum)));
             Assert.Equal(expected, Enum.GetValues<UInt64Enum>());
         }

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -1430,7 +1430,7 @@ internal static class ReflectionTest
 
             Console.WriteLine("Enum.GetValues");
             {
-                if (Enum.GetValues(typeof(Mine)).GetType().GetElementType() != typeof(Mine))
+                if (Enum.GetValues(typeof(Mine)) is not Mine[])
                     throw new Exception("GetValues");
             }
 


### PR DESCRIPTION
...at the cost of a small compat break. We return `int[]` instead of `SomeInt32Enum[]`.

Fixes #72140.

We can also delete intrinsic handling of `Enum.GetValues` in dataflow analysis but I don't want to conflict with Vitek's #71485 right now.

Cc @dotnet/ilc-contrib