### PR TITLE
Differentiate "BinaryFormatter disabled" error messages

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Formatters/src/Resources/Strings.resx
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/Resources/Strings.resx
@@ -249,4 +249,7 @@
   <data name="BinaryFormatter_SerializationDisallowed" xml:space="preserve">
     <value>BinaryFormatter serialization and deserialization are disabled within this application. See https://aka.ms/binaryformatter for more information.</value>
   </data>
+  <data name="BinaryFormatter_SerializationNotSupportedOnThisPlatform" xml:space="preserve">
+    <value>BinaryFormatter serialization and deserialization are not supported on this platform. See https://aka.ms/binaryformatter for more information.</value>
+  </data>
 </root>

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.PlatformNotSupported.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.PlatformNotSupported.cs
@@ -11,11 +11,11 @@ namespace System.Runtime.Serialization.Formatters.Binary
         [Obsolete(Obsoletions.BinaryFormatterMessage, DiagnosticId = Obsoletions.BinaryFormatterDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [RequiresUnreferencedCode(IFormatter.RequiresUnreferencedCodeMessage)]
         public object Deserialize(Stream serializationStream)
-            => throw new PlatformNotSupportedException(SR.BinaryFormatter_SerializationDisallowed);
+            => throw new PlatformNotSupportedException(SR.BinaryFormatter_SerializationNotSupportedOnThisPlatform);
 
         [Obsolete(Obsoletions.BinaryFormatterMessage, DiagnosticId = Obsoletions.BinaryFormatterDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [RequiresUnreferencedCode(IFormatter.RequiresUnreferencedCodeMessage)]
         public void Serialize(Stream serializationStream, object graph)
-            => throw new PlatformNotSupportedException(SR.BinaryFormatter_SerializationDisallowed);
+            => throw new PlatformNotSupportedException(SR.BinaryFormatter_SerializationNotSupportedOnThisPlatform);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/68723.

Improves the error message text when `BinaryFormatter` throws an "I'm disallowed!" exception at runtime. It's subtle, but I'm hoping the language distinction of "disabled" vs. "not supported" will help alleviate some of the confusion.

* `NotSupportedException` _("disabled within this application")_ - BF is disabled by app / host policy but can be reenabled.
* `PlatformNotSupportedException` _("not supported on this platform")_ - BF is simply not supported on this platform and there is no way to enable it.

I'll send a separate PR to the docs repo updating the landing page (https://aka.ms/binaryformatter) to clarify this differentiation as well.