### PR TITLE
Implement `Stream.HasOverridenBeginEndXXX`

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/NativeAotILProvider.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/NativeAotILProvider.cs
@@ -92,6 +92,12 @@ namespace Internal.IL
                         }
                     }
                     break;
+                case "Stream":
+                    {
+                        if (owningType.Namespace == "System.IO")
+                            return StreamIntrinsics.EmitIL(method);
+                    }
+                    break;
             }
 
             return null;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StreamIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StreamIntrinsics.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Provides method bodies for System.IO.Stream intrinsics.
+    /// </summary>
+    public static class StreamIntrinsics
+    {
+        public static MethodIL EmitIL(MethodDesc method)
+        {
+            Debug.Assert(((MetadataType)method.OwningType).Name == "Stream");
+
+            bool isRead = method.Name == "HasOverriddenBeginEndRead";
+            if (!isRead && method.Name != "HasOverriddenBeginEndWrite")
+                return null;
+
+            TypeDesc streamClass = method.OwningType;
+            MethodDesc beginMethod = streamClass.GetMethod(isRead ? "BeginRead" : "BeginWrite", null);
+            MethodDesc endMethod = streamClass.GetMethod(isRead ? "EndRead" : "EndWrite", null);
+
+            ILEmitter emitter = new ILEmitter();
+            ILCodeStream codestream = emitter.NewCodeStream();
+
+            ILCodeLabel lOverriden = emitter.NewCodeLabel();
+
+            ILToken beginMethodToken = emitter.NewToken(beginMethod);
+            codestream.EmitLdArg(0);
+            codestream.Emit(ILOpcode.ldvirtftn, beginMethodToken);
+            codestream.Emit(ILOpcode.ldftn, beginMethodToken);
+            codestream.Emit(ILOpcode.bne_un, lOverriden);
+
+            ILToken endMethodToken = emitter.NewToken(endMethod);
+            codestream.EmitLdArg(0);
+            codestream.Emit(ILOpcode.ldvirtftn, endMethodToken);
+            codestream.Emit(ILOpcode.ldftn, endMethodToken);
+            codestream.Emit(ILOpcode.bne_un, lOverriden);
+
+            codestream.EmitLdc(0);
+            codestream.Emit(ILOpcode.ret);
+
+            codestream.EmitLabel(lOverriden);
+            codestream.EmitLdc(1);
+            codestream.Emit(ILOpcode.ret);
+
+            return emitter.Link(method);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
@@ -166,12 +166,12 @@ namespace ILCompiler.DependencyAnalysis
 
                 case ReadyToRunHelperId.ResolveVirtualFunction:
                     {
-                        // Not tested
-                        encoder.EmitINT3();
-
                         MethodDesc targetMethod = (MethodDesc)Target;
                         if (targetMethod.OwningType.IsInterface)
                         {
+                            // Not tested
+                            encoder.EmitINT3();
+                            
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, factory.InterfaceDispatchCell(targetMethod));
                             encoder.EmitJMP(factory.ExternSymbol("RhpResolveInterfaceMethod"));
                         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -235,6 +235,7 @@
       <Link>IL\Stubs\MethodBaseGetCurrentMethodThunk.Sorting.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\RuntimeHelpersIntrinsics.cs" Link="IL\Stubs\RuntimeHelpersIntrinsics.cs" />
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\StreamIntrinsics.cs" Link="IL\Stubs\StreamIntrinsics.cs" />
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\TypeGetTypeMethodThunk.cs">
       <Link>IL\Stubs\TypeGetTypeMethodThunk.cs</Link>
     </Compile>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -449,17 +449,13 @@ namespace System.IO
             return totalRead;
         }
 
-#if NATIVEAOT // TODO: https://github.com/dotnet/corert/issues/3251
-        private static bool HasOverriddenBeginEndRead() => true;
-
-        private static bool HasOverriddenBeginEndWrite() => true;
-#else
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern bool HasOverriddenBeginEndRead();
 
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern bool HasOverriddenBeginEndWrite();
-#endif
 
         private Task<int> BeginEndReadAsync(byte[] buffer, int offset, int count)
         {
@@ -1227,9 +1223,6 @@ namespace System.IO
 
             public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
             {
-#if NATIVEAOT
-                throw new NotImplementedException(); // TODO: https://github.com/dotnet/corert/issues/3251
-#else
                 bool overridesBeginRead = _stream.HasOverriddenBeginEndRead();
 
                 lock (_stream)
@@ -1244,7 +1237,6 @@ namespace System.IO
                         _stream.BeginRead(buffer, offset, count, callback, state) :
                         _stream.BeginReadInternal(buffer, offset, count, callback, state, serializeAsynchronously: true, apm: true);
                 }
-#endif
             }
 
             public override int EndRead(IAsyncResult asyncResult)
@@ -1302,9 +1294,6 @@ namespace System.IO
 
             public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
             {
-#if NATIVEAOT
-                throw new NotImplementedException(); // TODO: https://github.com/dotnet/corert/issues/3251
-#else
                 bool overridesBeginWrite = _stream.HasOverriddenBeginEndWrite();
 
                 lock (_stream)
@@ -1319,7 +1308,6 @@ namespace System.IO
                         _stream.BeginWrite(buffer, offset, count, callback, state) :
                         _stream.BeginWriteInternal(buffer, offset, count, callback, state, serializeAsynchronously: true, apm: true);
                 }
-#endif
             }
 
             public override void EndWrite(IAsyncResult asyncResult)

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -512,7 +512,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\System.Globalization.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\NlsTests\System.Globalization.Nls.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\CalendarTestWithConfigSwitch\System.Globalization.CalendarsWithConfigSwitch.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO\tests\System.IO.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Queryable\tests\System.Linq.Queryable.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Management\tests\System.Management.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets\tests\System.Net.WebSockets.Tests.csproj" />


### PR DESCRIPTION
Fixes dotnet/corert#3251.

`Stream.HasOverriddenBeginEndRead`/`Stream.HasOverriddenBeginEndWrite` are magic methods that call into the runtime on both CoreCLR and Mono to find out whether `Stream.BeginRead`/`EndRead`/`BeginWrite`/`EndWrite` are overriden on the current class.

Since we don't have a runtime in NativeAOT, implement this in the compiler. The answer to this question is expressible in IL: load function pointer to the method virtually and non-virtually and compare. I'm not calling into `FunctionPointerOps` because I can't imagine a scenario where this wouldn't work, but I can be persuaded to call to `FunctionPointerOps` to do the comparison.

Should make us pass all System.IO libraries tests.

Cc @dotnet/ilc-contrib 