### PR TITLE
Support OpenSSL-based MsQuic on Windows

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -51,6 +51,8 @@ internal sealed unsafe class MsQuicApi
 
     internal static bool IsQuicSupported { get; }
 
+    internal static bool UsesSChannelBackend { get; }
+
     internal static bool Tls13ServerMayBeDisabled { get; }
     internal static bool Tls13ClientMayBeDisabled { get; }
 
@@ -102,6 +104,12 @@ internal sealed unsafe class MsQuicApi
                                     NetEventSource.Info(null, $"Incompatible MsQuic library version '{version}', expecting '{MsQuicVersion}'");
                                 }
                             }
+
+                            // Assume SChanel is being used on windows and query for the actual provider from the library
+                            QUIC_TLS_PROVIDER provider = OperatingSystem.IsWindows() ? QUIC_TLS_PROVIDER.SCHANNEL : QUIC_TLS_PROVIDER.OPENSSL;
+                            size = sizeof(QUIC_TLS_PROVIDER);
+                            apiTable->GetParam(null, QUIC_PARAM_GLOBAL_TLS_PROVIDER, &size, &provider);
+                            UsesSChannelBackend = provider == QUIC_TLS_PROVIDER.SCHANNEL;
                         }
                     }
                 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -103,8 +103,8 @@ internal sealed unsafe class MsQuicApi
                                     return;
                                 }
 
-                                Tls13ServerMayBeDisabled = IsTls13Disabled(true);
-                                Tls13ClientMayBeDisabled = IsTls13Disabled(false);
+                                Tls13ServerMayBeDisabled = IsTls13Disabled(isServer: true);
+                                Tls13ClientMayBeDisabled = IsTls13Disabled(isServer: false);
                             }
 
                             Api = new MsQuicApi(apiTable);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -23,7 +23,7 @@ internal static class MsQuicConfiguration
         flags |= QUIC_CREDENTIAL_FLAGS.CLIENT;
         flags |= QUIC_CREDENTIAL_FLAGS.INDICATE_CERTIFICATE_RECEIVED;
         flags |= QUIC_CREDENTIAL_FLAGS.NO_CERTIFICATE_VALIDATION;
-        if (OperatingSystem.IsWindows())
+        if (MsQuicApi.UsesSChannelBackend)
         {
             flags |= QUIC_CREDENTIAL_FLAGS.USE_SUPPLIED_CREDENTIALS;
         }
@@ -131,7 +131,7 @@ internal static class MsQuicConfiguration
         try
         {
             QUIC_CREDENTIAL_CONFIG config = new QUIC_CREDENTIAL_CONFIG { Flags = flags };
-            config.Flags |= (OperatingSystem.IsWindows() ? QUIC_CREDENTIAL_FLAGS.NONE : QUIC_CREDENTIAL_FLAGS.USE_PORTABLE_CERTIFICATES);
+            config.Flags |= (MsQuicApi.UsesSChannelBackend ? QUIC_CREDENTIAL_FLAGS.NONE : QUIC_CREDENTIAL_FLAGS.USE_PORTABLE_CERTIFICATES);
 
             if (cipherSuitesPolicy != null)
             {
@@ -145,7 +145,7 @@ internal static class MsQuicConfiguration
                 config.Type = QUIC_CREDENTIAL_TYPE.NONE;
                 status = MsQuicApi.Api.ApiTable->ConfigurationLoadCredential(configurationHandle.QuicHandle, &config);
             }
-            else if (OperatingSystem.IsWindows())
+            else if (MsQuicApi.UsesSChannelBackend)
             {
                 config.Type = QUIC_CREDENTIAL_TYPE.CERTIFICATE_CONTEXT;
                 config.CertificateContext = (void*)certificate.Handle;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
@@ -68,7 +68,7 @@ public partial class QuicConnection
                 chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
                 chain.ChainPolicy.ApplicationPolicy.Add(_isClient ? s_serverAuthOid : s_clientAuthOid);
 
-                if (OperatingSystem.IsWindows())
+                if (MsQuicApi.UsesSChannelBackend)
                 {
                     certificate = new X509Certificate2((IntPtr)certificatePtr);
                 }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -204,7 +204,7 @@ namespace System.Net.Security.Tests
             if (PlatformDetection.IsWindows)
             {
                 X509Certificate2 ephemeral = endEntity;
-                endEntity = new X509Certificate2(endEntity.Export(X509ContentType.Pfx));
+                endEntity = new X509Certificate2(endEntity.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
                 ephemeral.Dispose();
             }
 


### PR DESCRIPTION
Closes #69978.

While not officially supported, it is not hard for us to support QUIC on older Windows version via OpenSSL-based build of MsQuic.

The only limitation now is that the `X509Certificate2` instances must have exportable private keys (i.e. passing `X509KeyStorageFlags.Exportable` to ctor).