### PR TITLE
Fix CompressionLevel.Optimal for Brotli

### DIFF
--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliStream.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliStream.cs
@@ -33,12 +33,21 @@ namespace System.IO.Compression
             {
                 case CompressionMode.Compress:
                     if (!stream.CanWrite)
+                    {
                         throw new ArgumentException(SR.Stream_FalseCanWrite, nameof(stream));
+                    }
+
+                    _encoder.SetQuality(BrotliUtils.Quality_Default);
+                    _encoder.SetWindow(BrotliUtils.WindowBits_Default);
                     break;
+
                 case CompressionMode.Decompress:
                     if (!stream.CanRead)
+                    {
                         throw new ArgumentException(SR.Stream_FalseCanRead, nameof(stream));
+                    }
                     break;
+
                 default:
                     throw new ArgumentException(SR.ArgumentOutOfRange_Enum, nameof(mode));
             }

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliUtils.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliUtils.cs
@@ -9,16 +9,16 @@ namespace System.IO.Compression
         public const int WindowBits_Default = 22;
         public const int WindowBits_Max = 24;
         public const int Quality_Min = 0;
-        public const int Quality_Default = 11;
+        public const int Quality_Default = 4;
         public const int Quality_Max = 11;
         public const int MaxInputSize = int.MaxValue - 515; // 515 is the max compressed extra bytes
 
         internal static int GetQualityFromCompressionLevel(CompressionLevel compressionLevel) =>
             compressionLevel switch
             {
-                CompressionLevel.Optimal => Quality_Default,
                 CompressionLevel.NoCompression => Quality_Min,
                 CompressionLevel.Fastest => 1,
+                CompressionLevel.Optimal => Quality_Default,
                 CompressionLevel.SmallestSize => Quality_Max,
                 _ => throw new ArgumentException(SR.ArgumentOutOfRange_Enum, nameof(compressionLevel))
             };

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
@@ -17,6 +17,7 @@ namespace System.IO.Compression
         /// <param name="stream">The stream to compress.</param>
         /// <param name="compressionLevel">One of the enumeration values that indicates whether to emphasize speed or compression efficiency when compressing the stream.</param>
         public BrotliStream(Stream stream, CompressionLevel compressionLevel) : this(stream, compressionLevel, leaveOpen: false) { }
+
         /// <summary>Initializes a new instance of the <see cref="System.IO.Compression.BrotliStream" /> class by using the specified stream and compression level, and optionally leaves the stream open.</summary>
         /// <param name="stream">The stream to compress.</param>
         /// <param name="compressionLevel">One of the enumeration values that indicates whether to emphasize speed or compression efficiency when compressing the stream.</param>


### PR DESCRIPTION
The intent of `CompressionLevel.Optimal` is to be a balanced tradeoff between compression ratio and speed:
```C#
        /// <summary>
        /// The compression operation should balance compression speed and output size.
        /// </summary>
        Optimal = 0,
```
but whereas `DeflateStream`, `GZipStream`, and `ZLibStream` all treat `Optimal` as such (using zlib's default setting for such a balanced tradeoff), `BrotliStream` treats `Optimal` the same as maximum compression, which is very slow.  Especially now that maximum compression is expressible as `CompressionLevel.SmallestSize`, it's even more valuable for `Optimal` to represent that balanced tradeoff.  Based on a variety of sources around the net and some local testing, I've changed the `Optimal` value from 11 to 4; I've also changed the default used when no level is set to be `Optimal` (e.g. `new BrotliStream(..., CompressionMode.Compress)`.  This is also more important now that we've fixed the argument validation bug that allowed arbitrary numerical values to be passed through unvalidated (`DeflateStream`, `GZipStream`, and `ZLibStream` all properly validated already).

Fixes https://github.com/dotnet/runtime/issues/46595
Fixes https://github.com/dotnet/runtime/issues/64185
Fixes https://github.com/dotnet/runtime/issues/72220

For reference, here are local measurements of time and size to compress each of our test files in runtime-assets using this PR.  Prior to this PR, the Optimal values matched the SmallestSize values.  This is based on writing in 1K chunks.

|                                                                    | Level         | Time (s) | Size (b) |
| ------------------------------------------------------------------ | ------------- | -------- | -------- |
| UncompressedTestFiles\\alice29.txt                                 | NoCompression | 2.6293   | 91874    |
| UncompressedTestFiles\\alice29.txt                                 | Fastest       | 2.3388   | 87269    |
| UncompressedTestFiles\\alice29.txt                                 | Optimal       | 3.8406   | 54467    |
| UncompressedTestFiles\\alice29.txt                                 | SmallestSize  | 199.6285 | 46006    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\asyoulik.txt                                | NoCompression | 2.2171   | 80887    |
| UncompressedTestFiles\\asyoulik.txt                                | Fastest       | 1.9447   | 76373    |
| UncompressedTestFiles\\asyoulik.txt                                | Optimal       | 3.2476   | 49477    |
| UncompressedTestFiles\\asyoulik.txt                                | SmallestSize  | 159.8074 | 42712    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\cp.html                                     | NoCompression | 0.4428   | 14479    |
| UncompressedTestFiles\\cp.html                                     | Fastest       | 0.4035   | 13662    |
| UncompressedTestFiles\\cp.html                                     | Optimal       | 0.7788   | 8103     |
| UncompressedTestFiles\\cp.html                                     | SmallestSize  | 27.4777  | 6894     |
|                                                                    |               |          |          |
| UncompressedTestFiles\\fields.c                                    | NoCompression | 0.221    | 5837     |
| UncompressedTestFiles\\fields.c                                    | Fastest       | 0.1894   | 5381     |
| UncompressedTestFiles\\fields.c                                    | Optimal       | 0.5744   | 3278     |
| UncompressedTestFiles\\fields.c                                    | SmallestSize  | 13.1068  | 2717     |
|                                                                    |               |          |          |
| UncompressedTestFiles\\grammar.lsp                                 | NoCompression | 0.0761   | 1850     |
| UncompressedTestFiles\\grammar.lsp                                 | Fastest       | 0.0695   | 1685     |
| UncompressedTestFiles\\grammar.lsp                                 | Optimal       | 0.3753   | 1258     |
| UncompressedTestFiles\\grammar.lsp                                 | SmallestSize  | 5.3079   | 1124     |
|                                                                    |               |          |          |
| UncompressedTestFiles\\kennedy.xls                                 | NoCompression | 15.0624  | 301536   |
| UncompressedTestFiles\\kennedy.xls                                 | Fastest       | 11.645   | 240138   |
| UncompressedTestFiles\\kennedy.xls                                 | Optimal       | 14.4044  | 113871   |
| UncompressedTestFiles\\kennedy.xls                                 | SmallestSize  | 2060.26  | 61498    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\lcet10.txt                                  | NoCompression | 7.4125   | 256153   |
| UncompressedTestFiles\\lcet10.txt                                  | Fastest       | 6.6139   | 242587   |
| UncompressedTestFiles\\lcet10.txt                                  | Optimal       | 9.3937   | 139527   |
| UncompressedTestFiles\\lcet10.txt                                  | SmallestSize  | 641.716  | 112264   |
|                                                                    |               |          |          |
| UncompressedTestFiles\\plrabn12.txt                                | NoCompression | 8.1206   | 303822   |
| UncompressedTestFiles\\plrabn12.txt                                | Fastest       | 9.1307   | 288300   |
| UncompressedTestFiles\\plrabn12.txt                                | Optimal       | 11.9471  | 191916   |
| UncompressedTestFiles\\plrabn12.txt                                | SmallestSize  | 718.69   | 162585   |
|                                                                    |               |          |          |
| UncompressedTestFiles\\ptt5                                        | NoCompression | 7.3581   | 103527   |
| UncompressedTestFiles\\ptt5                                        | Fastest       | 6.0247   | 86790    |
| UncompressedTestFiles\\ptt5                                        | Optimal       | 5.5391   | 53295    |
| UncompressedTestFiles\\ptt5                                        | SmallestSize  | 888.7847 | 40939    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\sum                                         | NoCompression | 0.7669   | 22063    |
| UncompressedTestFiles\\sum                                         | Fastest       | 0.6608   | 20398    |
| UncompressedTestFiles\\sum                                         | Optimal       | 1.222    | 12547    |
| UncompressedTestFiles\\sum                                         | SmallestSize  | 46.2843  | 10144    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\TestDocument.doc                            | NoCompression | 0.7481   | 20406    |
| UncompressedTestFiles\\TestDocument.doc                            | Fastest       | 0.6388   | 19006    |
| UncompressedTestFiles\\TestDocument.doc                            | Optimal       | 1.1753   | 6301     |
| UncompressedTestFiles\\TestDocument.doc                            | SmallestSize  | 27.2491  | 5651     |
|                                                                    |               |          |          |
| UncompressedTestFiles\\TestDocument.docx                           | NoCompression | 0.357    | 15453    |
| UncompressedTestFiles\\TestDocument.docx                           | Fastest       | 0.3097   | 15121    |
| UncompressedTestFiles\\TestDocument.docx                           | Optimal       | 0.9365   | 12600    |
| UncompressedTestFiles\\TestDocument.docx                           | SmallestSize  | 30.7547  | 12176    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\TestDocument.pdf                            | NoCompression | 2.3971   | 120365   |
| UncompressedTestFiles\\TestDocument.pdf                            | Fastest       | 2.073    | 119868   |
| UncompressedTestFiles\\TestDocument.pdf                            | Optimal       | 2.2002   | 115862   |
| UncompressedTestFiles\\TestDocument.pdf                            | SmallestSize  | 463.0941 | 114601   |
|                                                                    |               |          |          |
| UncompressedTestFiles\\TestDocument.txt                            | NoCompression | 0.3534   | 12592    |
| UncompressedTestFiles\\TestDocument.txt                            | Fastest       | 0.3298   | 11885    |
| UncompressedTestFiles\\TestDocument.txt                            | Optimal       | 0.4199   | 609      |
| UncompressedTestFiles\\TestDocument.txt                            | SmallestSize  | 3.4359   | 458      |
|                                                                    |               |          |          |
| UncompressedTestFiles\\xargs.1                                     | NoCompression | 0.0925   | 2611     |
| UncompressedTestFiles\\xargs.1                                     | Fastest       | 0.0777   | 2429     |
| UncompressedTestFiles\\xargs.1                                     | Optimal       | 0.4027   | 1760     |
| UncompressedTestFiles\\xargs.1                                     | SmallestSize  | 6.5394   | 1464     |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\10x10y                      | NoCompression | 0.0308   | 24       |
| UncompressedTestFiles\\GoogleTestData\\10x10y                      | Fastest       | 0.01     | 22       |
| UncompressedTestFiles\\GoogleTestData\\10x10y                      | Optimal       | 0.0441   | 12       |
| UncompressedTestFiles\\GoogleTestData\\10x10y                      | SmallestSize  | 0.5027   | 12       |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\64x                         | NoCompression | 0.013    | 66       |
| UncompressedTestFiles\\GoogleTestData\\64x                         | Fastest       | 0.0092   | 19       |
| UncompressedTestFiles\\GoogleTestData\\64x                         | Optimal       | 0.0332   | 10       |
| UncompressedTestFiles\\GoogleTestData\\64x                         | SmallestSize  | 0.5038   | 11       |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\backward65536               | NoCompression | 0.5267   | 3056     |
| UncompressedTestFiles\\GoogleTestData\\backward65536               | Fastest       | 0.3252   | 1248     |
| UncompressedTestFiles\\GoogleTestData\\backward65536               | Optimal       | 0.521    | 19       |
| UncompressedTestFiles\\GoogleTestData\\backward65536               | SmallestSize  | 9.8462   | 20       |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\compressed\_file            | NoCompression | 0.93     | 50244    |
| UncompressedTestFiles\\GoogleTestData\\compressed\_file            | Fastest       | 0.8197   | 50244    |
| UncompressedTestFiles\\GoogleTestData\\compressed\_file            | Optimal       | 0.5494   | 50100    |
| UncompressedTestFiles\\GoogleTestData\\compressed\_file            | SmallestSize  | 13.0755  | 50100    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\compressed\_repeated        | NoCompression | 2.3233   | 104448   |
| UncompressedTestFiles\\GoogleTestData\\compressed\_repeated        | Fastest       | 1.8912   | 103315   |
| UncompressedTestFiles\\GoogleTestData\\compressed\_repeated        | Optimal       | 1.2824   | 50445    |
| UncompressedTestFiles\\GoogleTestData\\compressed\_repeated        | SmallestSize  | 142.3112 | 50156    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\empty                       | NoCompression | 0.0047   | 1        |
| UncompressedTestFiles\\GoogleTestData\\empty                       | Fastest       | 0.0046   | 1        |
| UncompressedTestFiles\\GoogleTestData\\empty                       | Optimal       | 0.0119   | 1        |
| UncompressedTestFiles\\GoogleTestData\\empty                       | SmallestSize  | 0.2414   | 1        |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\mapsdatazrh                 | NoCompression | 6.3617   | 248411   |
| UncompressedTestFiles\\GoogleTestData\\mapsdatazrh                 | Fastest       | 5.5249   | 237599   |
| UncompressedTestFiles\\GoogleTestData\\mapsdatazrh                 | Optimal       | 5.3991   | 172914   |
| UncompressedTestFiles\\GoogleTestData\\mapsdatazrh                 | SmallestSize  | 579.1282 | 159339   |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\monkey                      | NoCompression | 0.0186   | 535      |
| UncompressedTestFiles\\GoogleTestData\\monkey                      | Fastest       | 0.018    | 464      |
| UncompressedTestFiles\\GoogleTestData\\monkey                      | Optimal       | 0.2497   | 447      |
| UncompressedTestFiles\\GoogleTestData\\monkey                      | SmallestSize  | 1.5155   | 405      |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\plrabn12.txt                | NoCompression | 7.7685   | 303822   |
| UncompressedTestFiles\\GoogleTestData\\plrabn12.txt                | Fastest       | 6.9209   | 288300   |
| UncompressedTestFiles\\GoogleTestData\\plrabn12.txt                | Optimal       | 11.8668  | 191916   |
| UncompressedTestFiles\\GoogleTestData\\plrabn12.txt                | SmallestSize  | 663.7283 | 162585   |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\quickfox                    | NoCompression | 0.0145   | 47       |
| UncompressedTestFiles\\GoogleTestData\\quickfox                    | Fastest       | 0.0114   | 47       |
| UncompressedTestFiles\\GoogleTestData\\quickfox                    | Optimal       | 0.117    | 47       |
| UncompressedTestFiles\\GoogleTestData\\quickfox                    | SmallestSize  | 0.6283   | 47       |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\quickfox\_repeated          | NoCompression | 1.4822   | 15256    |
| UncompressedTestFiles\\GoogleTestData\\quickfox\_repeated          | Fastest       | 1.0156   | 10737    |
| UncompressedTestFiles\\GoogleTestData\\quickfox\_repeated          | Optimal       | 1.0473   | 52       |
| UncompressedTestFiles\\GoogleTestData\\quickfox\_repeated          | SmallestSize  | 10.472   | 57       |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\random\_org\_10k.bin        | NoCompression | 0.2042   | 10031    |
| UncompressedTestFiles\\GoogleTestData\\random\_org\_10k.bin        | Fastest       | 0.1747   | 10031    |
| UncompressedTestFiles\\GoogleTestData\\random\_org\_10k.bin        | Optimal       | 0.3997   | 10004    |
| UncompressedTestFiles\\GoogleTestData\\random\_org\_10k.bin        | SmallestSize  | 16.7305  | 10004    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\ukkonooa                    | NoCompression | 0.0256   | 123      |
| UncompressedTestFiles\\GoogleTestData\\ukkonooa                    | Fastest       | 0.0124   | 84       |
| UncompressedTestFiles\\GoogleTestData\\ukkonooa                    | Optimal       | 0.1321   | 62       |
| UncompressedTestFiles\\GoogleTestData\\ukkonooa                    | SmallestSize  | 0.7021   | 81       |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\x                           | NoCompression | 0.0125   | 5        |
| UncompressedTestFiles\\GoogleTestData\\x                           | Fastest       | 0.0077   | 5        |
| UncompressedTestFiles\\GoogleTestData\\x                           | Optimal       | 0.0209   | 5        |
| UncompressedTestFiles\\GoogleTestData\\x                           | SmallestSize  | 0.1997   | 5        |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\xyzzy                       | NoCompression | 0.012    | 9        |
| UncompressedTestFiles\\GoogleTestData\\xyzzy                       | Fastest       | 0.0127   | 9        |
| UncompressedTestFiles\\GoogleTestData\\xyzzy                       | Optimal       | 0.0341   | 9        |
| UncompressedTestFiles\\GoogleTestData\\xyzzy                       | SmallestSize  | 0.5024   | 9        |
|                                                                    |               |          |          |
| UncompressedTestFiles\\GoogleTestData\\zeros                       | NoCompression | 3.2957   | 11957    |
| UncompressedTestFiles\\GoogleTestData\\zeros                       | Fastest       | 1.2054   | 4897     |
| UncompressedTestFiles\\GoogleTestData\\zeros                       | Optimal       | 1.5983   | 13       |
| UncompressedTestFiles\\GoogleTestData\\zeros                       | SmallestSize  | 26.1265  | 14       |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\angular.js                        | NoCompression | 21.7842  | 658201   |
| UncompressedTestFiles\\WebFiles\\angular.js                        | Fastest       | 19.3305  | 616118   |
| UncompressedTestFiles\\WebFiles\\angular.js                        | Optimal       | 20.7139  | 303734   |
| UncompressedTestFiles\\WebFiles\\angular.js                        | SmallestSize  | 1809.499 | 238542   |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\angular.min.js                    | NoCompression | 2.9548   | 101106   |
| UncompressedTestFiles\\WebFiles\\angular.min.js                    | Fastest       | 2.8023   | 94502    |
| UncompressedTestFiles\\WebFiles\\angular.min.js                    | Optimal       | 3.6814   | 59407    |
| UncompressedTestFiles\\WebFiles\\angular.min.js                    | SmallestSize  | 231.552  | 51183    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\broker-config.js                  | NoCompression | 0.2727   | 7693     |
| UncompressedTestFiles\\WebFiles\\broker-config.js                  | Fastest       | 0.2429   | 7180     |
| UncompressedTestFiles\\WebFiles\\broker-config.js                  | Optimal       | 0.5422   | 4019     |
| UncompressedTestFiles\\WebFiles\\broker-config.js                  | SmallestSize  | 15.5805  | 3425     |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\config.js                         | NoCompression | 0.0485   | 1188     |
| UncompressedTestFiles\\WebFiles\\config.js                         | Fastest       | 0.043    | 1111     |
| UncompressedTestFiles\\WebFiles\\config.js                         | Optimal       | 0.3007   | 835      |
| UncompressedTestFiles\\WebFiles\\config.js                         | SmallestSize  | 3.4928   | 714      |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\jquery-3.2.1.js                   | NoCompression | 4.7525   | 154833   |
| UncompressedTestFiles\\WebFiles\\jquery-3.2.1.js                   | Fastest       | 4.2201   | 144873   |
| UncompressedTestFiles\\WebFiles\\jquery-3.2.1.js                   | Optimal       | 5.4571   | 80767    |
| UncompressedTestFiles\\WebFiles\\jquery-3.2.1.js                   | SmallestSize  | 366.0033 | 65996    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\jquery-3.2.1.min.js               | NoCompression | 1.5167   | 53824    |
| UncompressedTestFiles\\WebFiles\\jquery-3.2.1.min.js               | Fastest       | 1.3658   | 50386    |
| UncompressedTestFiles\\WebFiles\\jquery-3.2.1.min.js               | Optimal       | 2.2928   | 31257    |
| UncompressedTestFiles\\WebFiles\\jquery-3.2.1.min.js               | SmallestSize  | 105.1005 | 27233    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\meBoot.min.js                     | NoCompression | 0.3768   | 12442    |
| UncompressedTestFiles\\WebFiles\\meBoot.min.js                     | Fastest       | 0.3303   | 11647    |
| UncompressedTestFiles\\WebFiles\\meBoot.min.js                     | Optimal       | 0.7382   | 7583     |
| UncompressedTestFiles\\WebFiles\\meBoot.min.js                     | SmallestSize  | 24.3661  | 6692     |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\mwf-west-european-default.min.css | NoCompression | 8.6086   | 199372   |
| UncompressedTestFiles\\WebFiles\\mwf-west-european-default.min.css | Fastest       | 7.2527   | 181110   |
| UncompressedTestFiles\\WebFiles\\mwf-west-european-default.min.css | Optimal       | 6.3795   | 67306    |
| UncompressedTestFiles\\WebFiles\\mwf-west-european-default.min.css | SmallestSize  | 724.5991 | 50550    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\MWFMDL2.woff                      | NoCompression | 0.2132   | 10958    |
| UncompressedTestFiles\\WebFiles\\MWFMDL2.woff                      | Fastest       | 0.1978   | 10932    |
| UncompressedTestFiles\\WebFiles\\MWFMDL2.woff                      | Optimal       | 0.4329   | 10850    |
| UncompressedTestFiles\\WebFiles\\MWFMDL2.woff                      | SmallestSize  | 22.3428  | 10764    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\style.css                         | NoCompression | 0.0831   | 2266     |
| UncompressedTestFiles\\WebFiles\\style.css                         | Fastest       | 0.0738   | 2080     |
| UncompressedTestFiles\\WebFiles\\style.css                         | Optimal       | 0.3723   | 1173     |
| UncompressedTestFiles\\WebFiles\\style.css                         | SmallestSize  | 5.5696   | 1019     |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\uhf-west-european-default.min.css | NoCompression | 1.8925   | 41797    |
| UncompressedTestFiles\\WebFiles\\uhf-west-european-default.min.css | Fastest       | 1.566    | 37828    |
| UncompressedTestFiles\\WebFiles\\uhf-west-european-default.min.css | Optimal       | 1.635    | 15212    |
| UncompressedTestFiles\\WebFiles\\uhf-west-european-default.min.css | SmallestSize  | 142.875  | 12063    |
|                                                                    |               |          |          |
| UncompressedTestFiles\\WebFiles\\www.reddit.com6.23.2017.har       | NoCompression | 70.7763  | 2444920  |
| UncompressedTestFiles\\WebFiles\\www.reddit.com6.23.2017.har       | Fastest       | 61.9193  | 2284328  |
| UncompressedTestFiles\\WebFiles\\www.reddit.com6.23.2017.har       | Optimal       | 61.9911  | 1102579  |
| UncompressedTestFiles\\WebFiles\\www.reddit.com6.23.2017.har       | SmallestSize  | 5652.197 | 924534   |