### PR TITLE
[wasm] separate PromiseController<T> from cancellation

### DIFF
--- a/src/mono/wasm/runtime/cancelable-promise.ts
+++ b/src/mono/wasm/runtime/cancelable-promise.ts
@@ -4,9 +4,9 @@
 import { _lookup_js_owned_object } from "./gc-handles";
 import { TaskCallbackHolder } from "./marshal-to-cs";
 import { mono_assert, GCHandle } from "./types";
+import { createPromiseController, getPromiseController, ControllablePromise, assertIsControllablePromise } from "./promise-controller";
 
 export const _are_promises_supported = ((typeof Promise === "object") || (typeof Promise === "function")) && (typeof Promise.resolve === "function");
-export const promise_control_symbol = Symbol.for("wasm promise_control");
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function isThenable(js_obj: any): boolean {
@@ -16,48 +16,8 @@ export function isThenable(js_obj: any): boolean {
         ((typeof js_obj === "object" || typeof js_obj === "function") && typeof js_obj.then === "function");
 }
 
-export interface PromiseControl {
-    isDone: boolean;
-    resolve: (data?: any) => void;
-    reject: (reason: any) => void;
-    promise: Promise<any>;
-}
-
-export function create_cancelable_promise(afterResolve?: () => void, afterReject?: () => void): {
-    promise: Promise<any>, promise_control: PromiseControl
-} {
-    let promise_control: PromiseControl = <any>null;
-    const promise = new Promise(function (resolve, reject) {
-        promise_control = {
-            promise: <any>null,
-            isDone: false,
-            resolve: (data: any) => {
-                if (!promise_control!.isDone) {
-                    promise_control!.isDone = true;
-                    resolve(data);
-                    if (afterResolve) {
-                        afterResolve();
-                    }
-                }
-            },
-            reject: (reason: any) => {
-                if (!promise_control!.isDone) {
-                    promise_control!.isDone = true;
-                    reject(reason);
-                    if (afterReject) {
-                        afterReject();
-                    }
-                }
-            }
-        };
-    });
-    promise_control.promise = promise;
-    (<any>promise)[promise_control_symbol] = promise_control;
-    return { promise, promise_control: promise_control! };
-}
-
-export function wrap_as_cancelable_promise<T>(fn: () => Promise<T>): Promise<T> {
-    const { promise, promise_control } = create_cancelable_promise();
+export function wrap_as_cancelable_promise<T>(fn: () => Promise<T>): ControllablePromise<T> {
+    const { promise, promise_control } = createPromiseController<T>();
     const inner = fn();
     inner.then((data) => promise_control.resolve(data)).catch((reason) => promise_control.reject(reason));
     return promise;
@@ -69,8 +29,8 @@ export function mono_wasm_cancel_promise(task_holder_gc_handle: GCHandle): void 
 
     const promise = holder.promise;
     mono_assert(!!promise, () => `Expected Promise for GCHandle ${task_holder_gc_handle}`);
-    const promise_control = (<any>promise)[promise_control_symbol];
-    mono_assert(!!promise_control, () => `Expected promise_control for GCHandle ${task_holder_gc_handle}`);
+    assertIsControllablePromise(promise);
+    const promise_control = getPromiseController(promise);
     promise_control.reject("OperationCanceledException");
 }
 

--- a/src/mono/wasm/runtime/corebindings.ts
+++ b/src/mono/wasm/runtime/corebindings.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { JSHandle, GCHandle, MonoObjectRef } from "./types";
-import { PromiseControl } from "./cancelable-promise";
+import { PromiseController } from "./promise-controller";
 import { runtimeHelpers } from "./imports";
 
 // TODO replace all of this with [JSExport]
@@ -47,8 +47,8 @@ export interface t_CSwraps {
     _set_tcs_failure(gcHandle: GCHandle, result: string): void
     _get_tcs_task_ref(gcHandle: GCHandle, result: MonoObjectRef): void;
     _task_from_result_ref(value: any, result: MonoObjectRef): void;
-    // FIXME: PromiseControl is a JS object so we can't pass an address directly
-    _setup_js_cont_ref(task: MonoObjectRef, continuation: PromiseControl): void;
+    // FIXME: PromiseController is a JS object so we can't pass an address directly
+    _setup_js_cont_ref(task: MonoObjectRef, continuation: PromiseController): void;
 
     _object_to_string_ref(obj: MonoObjectRef): string;
     _get_date_value_ref(obj: MonoObjectRef): number;

--- a/src/mono/wasm/runtime/corebindings.ts
+++ b/src/mono/wasm/runtime/corebindings.ts
@@ -47,7 +47,6 @@ export interface t_CSwraps {
     _set_tcs_failure(gcHandle: GCHandle, result: string): void
     _get_tcs_task_ref(gcHandle: GCHandle, result: MonoObjectRef): void;
     _task_from_result_ref(value: any, result: MonoObjectRef): void;
-    // FIXME: PromiseController is a JS object so we can't pass an address directly
     _setup_js_cont_ref(task: MonoObjectRef, continuation: PromiseController): void;
 
     _object_to_string_ref(obj: MonoObjectRef): string;

--- a/src/mono/wasm/runtime/cs-to-js.ts
+++ b/src/mono/wasm/runtime/cs-to-js.ts
@@ -14,10 +14,11 @@ import cwraps from "./cwraps";
 import { get_js_owned_object_by_gc_handle_ref, js_owned_gc_handle_symbol, mono_wasm_get_jsobj_from_js_handle, mono_wasm_get_js_handle, setup_managed_proxy, teardown_managed_proxy, _lookup_js_owned_object } from "./gc-handles";
 import { mono_method_get_call_signature_ref, call_method_ref, wrap_error_root } from "./method-calls";
 import { js_to_mono_obj_root } from "./js-to-cs";
-import { _are_promises_supported, create_cancelable_promise } from "./cancelable-promise";
+import { _are_promises_supported } from "./cancelable-promise";
 import { getU32, getI32, getF32, getF64 } from "./memory";
 import { Int32Ptr, VoidPtr } from "./types/emscripten";
 import { ManagedObject } from "./marshal";
+import { createPromiseController } from "./promise-controller";
 
 const delegate_invoke_symbol = Symbol.for("wasm delegate_invoke");
 const delegate_invoke_signature_symbol = Symbol.for("wasm delegate_invoke_signature");
@@ -297,7 +298,7 @@ function _unbox_task_root_as_promise(root: WasmRoot<MonoObject>) {
     if (!result) {
         const explicitFinalization = () => teardown_managed_proxy(result, gc_handle);
 
-        const { promise, promise_control } = create_cancelable_promise(explicitFinalization, explicitFinalization);
+        const { promise, promise_control } = createPromiseController(explicitFinalization, explicitFinalization);
 
         // note that we do not implement promise/task roundtrip
         // With more complexity we could recover original instance when this promise is marshaled back to C#.

--- a/src/mono/wasm/runtime/promise-controller.ts
+++ b/src/mono/wasm/runtime/promise-controller.ts
@@ -34,7 +34,7 @@ export function createPromiseController<T>(afterResolve?: () => void, afterRejec
     const promise = new Promise<T>(function (resolve, reject) {
         promise_control = {
             isDone: false,
-            promise: promise,
+            promise: null as unknown as Promise<T>,
             resolve: (data: T | PromiseLike<T>) => {
                 if (!promise_control!.isDone) {
                     promise_control!.isDone = true;
@@ -55,6 +55,7 @@ export function createPromiseController<T>(afterResolve?: () => void, afterRejec
             }
         };
     });
+    (<any>promise_control).promise = promise;
     const controllablePromise = promise as ControllablePromise<T>;
     controllablePromise[promise_control_symbol] = promise_control;
     return { promise: controllablePromise, promise_control: promise_control };

--- a/src/mono/wasm/runtime/promise-controller.ts
+++ b/src/mono/wasm/runtime/promise-controller.ts
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+import {
+    mono_assert
+} from "./types";
+
+/// a unique symbol used to mark a promise as controllable
+export const promise_control_symbol = Symbol.for("wasm promise_control");
+
+/// A PromiseController encapsulates a Promise together with easy access to its resolve and reject functions.
+/// It's a bit like a TaskCompletionSource in .NET
+export interface PromiseController<T = any> {
+    isDone: boolean;
+    readonly promise: Promise<T>;
+    resolve: (value: T | PromiseLike<T>) => void;
+    reject: (reason?: any) => void;
+}
+
+/// A Promise<T> with a controller attached
+export interface ControllablePromise<T = any> extends Promise<T> {
+    [promise_control_symbol]: PromiseController<T>;
+}
+
+/// Just a pair of a promise and its controller
+export interface PromiseAndController<T> {
+    promise: ControllablePromise<T>;
+    promise_control: PromiseController<T>;
+}
+
+/// Creates a new promise together with a controller that can be used to resolve or reject that promise.
+/// Optionally takes callbacks to be called immediately after a promise is resolved or rejected.
+export function createPromiseController<T>(afterResolve?: () => void, afterReject?: () => void): PromiseAndController<T> {
+    let promise_control: PromiseController<T> = null as unknown as PromiseController<T>;
+    const promise = new Promise<T>(function (resolve, reject) {
+        promise_control = {
+            isDone: false,
+            promise: promise,
+            resolve: (data: T | PromiseLike<T>) => {
+                if (!promise_control!.isDone) {
+                    promise_control!.isDone = true;
+                    resolve(data);
+                    if (afterResolve) {
+                        afterResolve();
+                    }
+                }
+            },
+            reject: (reason: any) => {
+                if (!promise_control!.isDone) {
+                    promise_control!.isDone = true;
+                    reject(reason);
+                    if (afterReject) {
+                        afterReject();
+                    }
+                }
+            }
+        };
+    });
+    const controllablePromise = promise as ControllablePromise<T>;
+    controllablePromise[promise_control_symbol] = promise_control;
+    return { promise: controllablePromise, promise_control: promise_control };
+}
+
+export function getPromiseController<T>(promise: ControllablePromise<T>): PromiseController<T>;
+export function getPromiseController<T>(promise: Promise<T>): PromiseController<T> | undefined {
+    return (promise as ControllablePromise<T>)[promise_control_symbol];
+}
+
+export function isControllablePromise<T>(promise: Promise<T>): promise is ControllablePromise<T> {
+    return (promise as ControllablePromise<T>)[promise_control_symbol] !== undefined;
+}
+
+export function assertIsControllablePromise<T>(promise: Promise<T>): asserts promise is ControllablePromise<T> {
+    mono_assert(isControllablePromise(promise), "Promise is not controllable");
+}


### PR DESCRIPTION
make `PromiseController<T>` into a general purpose intrenal utility for our TS code, that's separate from cancellation