### PR TITLE
Avoid adding an HttpClient.Timeout message to ConnectTimeout exceptions

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -606,7 +606,7 @@ namespace System.Net.Http
                 }
                 else if (cts.IsCancellationRequested && !pendingRequestsCts.IsCancellationRequested)
                 {
-                    // If this exception is for cancellation, but cancellation wasn't requested, either by the caller's token or by the pending requests source,
+                    // If the linked cancellation token source was canceled, but cancellation wasn't requested, either by the caller's token or by the pending requests source,
                     // the only other cause could be a timeout.  Treat it as such.
 
                     // cancellationToken could have been triggered right after we checked it, but before we checked the cts.

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -825,6 +825,22 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        public async Task UnknownOperationCanceledException_NotWrappedInATimeoutException()
+        {
+            using var client = new HttpClient(new CustomResponseHandler((request, cancellation) =>
+            {
+                throw new OperationCanceledException("Foo");
+            }));
+            client.Timeout = TimeSpan.FromSeconds(42);
+
+            OperationCanceledException e = await Assert.ThrowsAsync<OperationCanceledException>(() => client.GetAsync(CreateFakeUri()));
+
+            Assert.Null(e.InnerException);
+            Assert.Equal("Foo", e.Message);
+            Assert.DoesNotContain("42", e.ToString());
+        }
+
+        [Fact]
         public void DefaultProxy_SetNull_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => HttpClient.DefaultProxy = null);


### PR DESCRIPTION
Fixes #67505