### PR TITLE
Fix finalized SafeHandles in System.Security.Cryptography on Linux

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.EcKey.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.EcKey.cs
@@ -103,6 +103,7 @@ namespace System.Security.Cryptography
 
             if (!Interop.AndroidCrypto.EcKeyUpRef(handle))
             {
+                safeHandle.Dispose();
                 throw new CryptographicException();
             }
 

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Rsa.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Rsa.cs
@@ -236,6 +236,7 @@ namespace System.Security.Cryptography
 
             if (!Interop.AndroidCrypto.RsaUpRef(handle))
             {
+                safeHandle.Dispose();
                 throw new CryptographicException();
             }
 

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
@@ -125,36 +125,38 @@ internal static partial class Interop
                     out qy_bn, out qy_cb,
                     out d_bn_not_owned, out d_cb);
 
-                if (rc == -1)
-                {
-                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
-                }
-                else if (rc != 1)
-                {
-                    throw Interop.Crypto.CreateOpenSslCryptographicException();
-                }
-
                 using (qx_bn)
                 using (qy_bn)
-                using (d_bn = new SafeBignumHandle(d_bn_not_owned, false))
                 {
-                    // Match Windows semantics where qx, qy, and d have same length
-                    int keySizeBits = EcKeyGetSize(key);
-                    int expectedSize = (keySizeBits + 7) / 8;
-                    int cbKey = GetMax(qx_cb, qy_cb, d_cb);
-
-                    Debug.Assert(
-                        cbKey <= expectedSize,
-                        $"Expected output size was {expectedSize}, which a parameter exceeded. qx={qx_cb}, qy={qy_cb}, d={d_cb}");
-
-                    cbKey = GetMax(cbKey, expectedSize);
-
-                    parameters.Q = new ECPoint
+                    if (rc == -1)
                     {
-                        X = Crypto.ExtractBignum(qx_bn, cbKey),
-                        Y = Crypto.ExtractBignum(qy_bn, cbKey)
-                    };
-                    parameters.D = d_cb == 0 ? null : Crypto.ExtractBignum(d_bn, cbKey);
+                        throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                    }
+                    else if (rc != 1)
+                    {
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
+                    }
+
+                    using (d_bn = new SafeBignumHandle(d_bn_not_owned, false))
+                    {
+                        // Match Windows semantics where qx, qy, and d have same length
+                        int keySizeBits = EcKeyGetSize(key);
+                        int expectedSize = (keySizeBits + 7) / 8;
+                        int cbKey = GetMax(qx_cb, qy_cb, d_cb);
+
+                        Debug.Assert(
+                            cbKey <= expectedSize,
+                            $"Expected output size was {expectedSize}, which a parameter exceeded. qx={qx_cb}, qy={qy_cb}, d={d_cb}");
+
+                        cbKey = GetMax(cbKey, expectedSize);
+
+                        parameters.Q = new ECPoint
+                        {
+                            X = Crypto.ExtractBignum(qx_bn, cbKey),
+                            Y = Crypto.ExtractBignum(qy_bn, cbKey)
+                        };
+                        parameters.D = d_cb == 0 ? null : Crypto.ExtractBignum(d_bn, cbKey);
+                    }
                 }
             }
             finally
@@ -212,15 +214,6 @@ internal static partial class Interop
                     out cofactor_bn, out cofactor_cb,
                     out seed_bn, out seed_cb);
 
-                if (rc == -1)
-                {
-                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
-                }
-                else if (rc != 1)
-                {
-                    throw Interop.Crypto.CreateOpenSslCryptographicException();
-                }
-
                 using (qx_bn)
                 using (qy_bn)
                 using (p_bn)
@@ -231,62 +224,73 @@ internal static partial class Interop
                 using (order_bn)
                 using (cofactor_bn)
                 using (seed_bn)
-                using (var d_h = new SafeBignumHandle(d_bn_not_owned, false))
                 {
-                    int cbFieldLength;
-                    int pFieldLength;
-                    if (curveType == ECCurve.ECCurveType.Characteristic2)
+                    if (rc == -1)
                     {
-                        // Match Windows semantics where a,b,gx,gy,qx,qy have same length
-                        // Treat length of m separately as it is not tied to other fields for Char2 (Char2 not supported by Windows)
-                        cbFieldLength = GetMax(new[] { a_cb, b_cb, gx_cb, gy_cb, qx_cb, qy_cb });
-                        pFieldLength = p_cb;
+                        throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
                     }
-                    else
+                    else if (rc != 1)
                     {
-                        // Match Windows semantics where p,a,b,gx,gy,qx,qy have same length
-                        cbFieldLength = GetMax(new[] { p_cb, a_cb, b_cb, gx_cb, gy_cb, qx_cb, qy_cb });
-                        pFieldLength = cbFieldLength;
+                        throw Interop.Crypto.CreateOpenSslCryptographicException();
                     }
 
-                    // Match Windows semantics where order and d have same length
-                    int cbSubgroupOrder = GetMax(order_cb, d_cb);
-
-                    // Copy values to ECParameters
-                    ECParameters parameters = default;
-                    parameters.Q = new ECPoint
+                    using (var d_h = new SafeBignumHandle(d_bn_not_owned, false))
                     {
-                        X = Crypto.ExtractBignum(qx_bn, cbFieldLength),
-                        Y = Crypto.ExtractBignum(qy_bn, cbFieldLength)
-                    };
-                    parameters.D = d_cb == 0 ? null : Crypto.ExtractBignum(d_h, cbSubgroupOrder);
+                        int cbFieldLength;
+                        int pFieldLength;
+                        if (curveType == ECCurve.ECCurveType.Characteristic2)
+                        {
+                            // Match Windows semantics where a,b,gx,gy,qx,qy have same length
+                            // Treat length of m separately as it is not tied to other fields for Char2 (Char2 not supported by Windows)
+                            cbFieldLength = GetMax(new[] { a_cb, b_cb, gx_cb, gy_cb, qx_cb, qy_cb });
+                            pFieldLength = p_cb;
+                        }
+                        else
+                        {
+                            // Match Windows semantics where p,a,b,gx,gy,qx,qy have same length
+                            cbFieldLength = GetMax(new[] { p_cb, a_cb, b_cb, gx_cb, gy_cb, qx_cb, qy_cb });
+                            pFieldLength = cbFieldLength;
+                        }
 
-                    var curve = parameters.Curve;
-                    curve.CurveType = curveType;
-                    curve.A = Crypto.ExtractBignum(a_bn, cbFieldLength)!;
-                    curve.B = Crypto.ExtractBignum(b_bn, cbFieldLength)!;
-                    curve.G = new ECPoint
-                    {
-                        X = Crypto.ExtractBignum(gx_bn, cbFieldLength),
-                        Y = Crypto.ExtractBignum(gy_bn, cbFieldLength)
-                    };
-                    curve.Order = Crypto.ExtractBignum(order_bn, cbSubgroupOrder)!;
+                        // Match Windows semantics where order and d have same length
+                        int cbSubgroupOrder = GetMax(order_cb, d_cb);
 
-                    if (curveType == ECCurve.ECCurveType.Characteristic2)
-                    {
-                        curve.Polynomial = Crypto.ExtractBignum(p_bn, pFieldLength)!;
+                        // Copy values to ECParameters
+                        ECParameters parameters = default;
+                        parameters.Q = new ECPoint
+                        {
+                            X = Crypto.ExtractBignum(qx_bn, cbFieldLength),
+                            Y = Crypto.ExtractBignum(qy_bn, cbFieldLength)
+                        };
+                        parameters.D = d_cb == 0 ? null : Crypto.ExtractBignum(d_h, cbSubgroupOrder);
+
+                        var curve = parameters.Curve;
+                        curve.CurveType = curveType;
+                        curve.A = Crypto.ExtractBignum(a_bn, cbFieldLength)!;
+                        curve.B = Crypto.ExtractBignum(b_bn, cbFieldLength)!;
+                        curve.G = new ECPoint
+                        {
+                            X = Crypto.ExtractBignum(gx_bn, cbFieldLength),
+                            Y = Crypto.ExtractBignum(gy_bn, cbFieldLength)
+                        };
+                        curve.Order = Crypto.ExtractBignum(order_bn, cbSubgroupOrder)!;
+
+                        if (curveType == ECCurve.ECCurveType.Characteristic2)
+                        {
+                            curve.Polynomial = Crypto.ExtractBignum(p_bn, pFieldLength)!;
+                        }
+                        else
+                        {
+                            curve.Prime = Crypto.ExtractBignum(p_bn, pFieldLength)!;
+                        }
+
+                        // Optional parameters
+                        curve.Cofactor = cofactor_cb == 0 ? null : Crypto.ExtractBignum(cofactor_bn, cofactor_cb);
+                        curve.Seed = seed_cb == 0 ? null : Crypto.ExtractBignum(seed_bn, seed_cb);
+
+                        parameters.Curve = curve;
+                        return parameters;
                     }
-                    else
-                    {
-                        curve.Prime = Crypto.ExtractBignum(p_bn, pFieldLength)!;
-                    }
-
-                    // Optional parameters
-                    curve.Cofactor = cofactor_cb == 0 ? null : Crypto.ExtractBignum(cofactor_bn, cofactor_cb);
-                    curve.Seed = seed_cb == 0 ? null : Crypto.ExtractBignum(seed_bn, seed_cb);
-
-                    parameters.Curve = curve;
-                    return parameters;
                 }
             }
             finally

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeDsaHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeDsaHandle.Unix.cs
@@ -37,7 +37,9 @@ namespace Microsoft.Win32.SafeHandles
 
             if (!Interop.Crypto.DsaUpRef(handle))
             {
-                throw Interop.Crypto.CreateOpenSslCryptographicException();
+                Exception e = Interop.Crypto.CreateOpenSslCryptographicException();
+                safeHandle.Dispose();
+                throw e;
             }
 
             safeHandle.SetHandle(handle);

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEcKeyHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEcKeyHandle.Unix.cs
@@ -37,7 +37,9 @@ namespace Microsoft.Win32.SafeHandles
 
             if (!Interop.Crypto.EcKeyUpRef(handle))
             {
-                throw Interop.Crypto.CreateOpenSslCryptographicException();
+                Exception e = Interop.Crypto.CreateOpenSslCryptographicException();
+                safeHandle.Dispose();
+                throw e;
             }
 
             safeHandle.SetHandle(handle);

--- a/src/libraries/Common/src/System/Security/Cryptography/DSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAAndroid.cs
@@ -381,6 +381,7 @@ namespace System.Security.Cryptography
                 // with the already loaded key.
                 ForceSetKeySize(BitsPerByte * Interop.AndroidCrypto.DsaKeySize(newKey));
 
+                FreeKey();
                 _key = new Lazy<SafeDsaHandle>(newKey);
             }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -373,6 +373,7 @@ namespace System.Security.Cryptography
             // with the already loaded key.
             ForceSetKeySize(BitsPerByte * Interop.Crypto.DsaKeySize(newKey));
 
+            FreeKey();
             _key = new Lazy<SafeDsaHandle>(newKey);
         }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
@@ -95,7 +95,9 @@ namespace System.Security.Cryptography
             get
             {
                 ThrowIfDisposed();
-                return new ECDiffieHellmanOpenSslPublicKey(_key.UpRefKeyHandle());
+
+                using SafeEvpPKeyHandle handle = _key.UpRefKeyHandle();
+                return new ECDiffieHellmanOpenSslPublicKey(handle);
             }
         }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
@@ -96,8 +96,10 @@ namespace System.Security.Cryptography
             {
                 ThrowIfDisposed();
 
-                using SafeEvpPKeyHandle handle = _key.UpRefKeyHandle();
-                return new ECDiffieHellmanOpenSslPublicKey(handle);
+                using (SafeEvpPKeyHandle handle = _key.UpRefKeyHandle())
+                {
+                    return new ECDiffieHellmanOpenSslPublicKey(handle);
+                }
             }
         }
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDhKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDhKeyFileTests.cs
@@ -16,15 +16,19 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         protected override Func<ECDiffieHellman, byte[]> PublicKeyWriteArrayFunc { get; } =
             key =>
             {
-                using ECDiffieHellmanPublicKey publicKey = key.PublicKey;
-                return publicKey.ExportSubjectPublicKeyInfo();
+                using (ECDiffieHellmanPublicKey publicKey = key.PublicKey)
+                {
+                    return publicKey.ExportSubjectPublicKeyInfo();
+                }
             };
 
         protected override WriteKeyToSpanFunc PublicKeyWriteSpanFunc { get; } =
             (ECDiffieHellman key, Span<byte> destination, out int bytesWritten) =>
             {
-                using ECDiffieHellmanPublicKey publicKey = key.PublicKey;
-                return publicKey.TryExportSubjectPublicKeyInfo(destination, out bytesWritten);
+                using (ECDiffieHellmanPublicKey publicKey = key.PublicKey)
+                {
+                    return publicKey.TryExportSubjectPublicKeyInfo(destination, out bytesWritten);
+                }
             };
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDhKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDhKeyFileTests.cs
@@ -14,10 +14,17 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         protected override void Exercise(ECDiffieHellman key) => key.Exercise();
 
         protected override Func<ECDiffieHellman, byte[]> PublicKeyWriteArrayFunc { get; } =
-            key => key.PublicKey.ExportSubjectPublicKeyInfo();
+            key =>
+            {
+                using ECDiffieHellmanPublicKey publicKey = key.PublicKey;
+                return publicKey.ExportSubjectPublicKeyInfo();
+            };
 
         protected override WriteKeyToSpanFunc PublicKeyWriteSpanFunc { get; } =
             (ECDiffieHellman key, Span<byte> destination, out int bytesWritten) =>
-                key.PublicKey.TryExportSubjectPublicKeyInfo(destination, out bytesWritten);
+            {
+                using ECDiffieHellmanPublicKey publicKey = key.PublicKey;
+                return publicKey.TryExportSubjectPublicKeyInfo(destination, out bytesWritten);
+            };
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.cs
@@ -168,6 +168,8 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
                     key.KeySize = 384;
                     key.ExportParameters(false);
                 });
+
+            pubKey.Dispose();
         }
 
 #if NETCOREAPP


### PR DESCRIPTION
While there may be more (probably are), this fixes the ~300 logged during running the System.Security.Cryptography tests.