### PR TITLE
Include EventLog.Messages in WindowsDesktop pack

### DIFF
--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <IsShipping>false</IsShipping>
@@ -6,7 +6,7 @@
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>true</IncludeBuildOutput>
-    <!-- Enable when the package shipped with NET6. -->
+    <!-- Enable when PackageValidation supports comparing multiple assemblies. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <PackageDescription>Internal transport package to provide windowsdesktop with the assemblies from dotnet/runtime that make up the Microsoft.WindowsDesktop.App shared framework.</PackageDescription>
     <!-- Reference elements are missing from the nuspec: https://github.com/NuGet/Home/issues/8684. -->
@@ -16,6 +16,13 @@
   <ItemGroup>
     <!-- Requires Private=true to calculate ReferenceCopyLocalPaths items.
          ReferringTargetFramework is set to $(NetCoreAppCurrent)-windows so that we pack the Windows specific implementation assemblies -->
-    <ProjectReference Include="@(WindowsDesktopCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj')" ReferringTargetFramework="$(NetCoreAppCurrent)-windows" PrivateAssets="all" Pack="true" Private="true" IncludeReferenceAssemblyInPackage="true" />
+    <ProjectReference Include="@(WindowsDesktopCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj');
+                               $(LibrariesProjectRoot)System.Diagnostics.EventLog\src\Messages\System.Diagnostics.EventLog.Messages.csproj"
+                      Exclude="$(LibrariesProjectRoot)System.Diagnostics.EventLog.Messages\src\System.Diagnostics.EventLog.Messages.csproj"
+                      ReferringTargetFramework="$(NetCoreAppCurrent)-windows"
+                      PrivateAssets="all"
+                      Pack="true"
+                      Private="true"
+                      IncludeReferenceAssemblyInPackage="true" />
   </ItemGroup>
 </Project>

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -24,5 +24,8 @@
                       Pack="true"
                       Private="true"
                       IncludeReferenceAssemblyInPackage="true" />
+    <!-- Messages is an implementation only assembly. -->
+    <ProjectReference Update="$(LibrariesProjectRoot)System.Diagnostics.EventLog\src\Messages\System.Diagnostics.EventLog.Messages.csproj"
+                      IncludeReferenceAssemblyInPackage="false" />
   </ItemGroup>
 </Project>

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -18,14 +18,10 @@
          ReferringTargetFramework is set to $(NetCoreAppCurrent)-windows so that we pack the Windows specific implementation assemblies -->
     <ProjectReference Include="@(WindowsDesktopCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj');
                                $(LibrariesProjectRoot)System.Diagnostics.EventLog\src\Messages\System.Diagnostics.EventLog.Messages.csproj"
-                      Exclude="$(LibrariesProjectRoot)System.Diagnostics.EventLog.Messages\src\System.Diagnostics.EventLog.Messages.csproj"
                       ReferringTargetFramework="$(NetCoreAppCurrent)-windows"
                       PrivateAssets="all"
                       Pack="true"
                       Private="true"
                       IncludeReferenceAssemblyInPackage="true" />
-    <!-- Messages is an implementation only assembly. -->
-    <ProjectReference Update="$(LibrariesProjectRoot)System.Diagnostics.EventLog\src\Messages\System.Diagnostics.EventLog.Messages.csproj"
-                      IncludeReferenceAssemblyInPackage="false" />
   </ItemGroup>
 </Project>

--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -232,6 +232,7 @@
       System.CodeDom;
       System.Configuration.ConfigurationManager;
       System.Diagnostics.EventLog;
+      System.Diagnostics.EventLog.Messages;
       System.Diagnostics.PerformanceCounter;
       System.DirectoryServices;
       System.Drawing.Common;

--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -232,7 +232,6 @@
       System.CodeDom;
       System.Configuration.ConfigurationManager;
       System.Diagnostics.EventLog;
-      System.Diagnostics.EventLog.Messages;
       System.Diagnostics.PerformanceCounter;
       System.DirectoryServices;
       System.Drawing.Common;


### PR DESCRIPTION
Contributes to (fixes?) https://github.com/dotnet/runtime/issues/72245

The System.Diagnostics.EventLog.Messages assembly is missing from the WindowsDesktop transport package. Adding it to the package and also making sure that it gets the right assembly version in servicing by adding it to the NetCoreAppLibrary.props file.

I verified that the assembly is now part of the package.