### PR TITLE
Do not assume return type ABIs match in `RETURN(CALL)`

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10966,7 +10966,7 @@ GenTree* Compiler::impFixupStructReturnType(GenTree*                 op,
             return op;
         }
 
-        if (op->gtOper == GT_CALL)
+        if (op->IsCall() && (op->AsCall()->GetUnmanagedCallConv() == unmgdCallConv))
         {
             return op;
         }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72265/Runtime_72265.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72265/Runtime_72265.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+unsafe class Runtime_72265
+{
+    private static int Main()
+    {
+        var unmanaged = ((delegate* unmanaged<StructWithIndex>)&GetStructUnmanaged)();
+        var managed = GetStructManaged();
+
+        return !unmanaged.Equals(managed) ? 101 : 100;
+    }
+
+    [UnmanagedCallersOnly]
+    private static StructWithIndex GetStructUnmanaged()
+    {
+        return GetStructManaged();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static StructWithIndex GetStructManaged() => new StructWithIndex { Index = 10, Value = 11 };
+
+    struct StructWithIndex
+    {
+        public int Index;
+        public int Value;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72265/Runtime_72265.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72265/Runtime_72265.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1959,6 +1959,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_34587/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_72265/**">
+            <Issue>https://github.com/dotnet/runtime/issues/72016</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/VS-ia64-JIT/V1.2-M02/b10828/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
If they do not, which is approximated via the calling convention check in this change, let the "spill" path take care of things.

Fixes #72265.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1883890&view=ms.vss-build-web.run-extensions-tab).