### PR TITLE
[wasm] Fix failing CI test, and misc fixes

### DIFF
--- a/src/mono/wasm/host/ConsoleLoggerExtensions.cs
+++ b/src/mono/wasm/host/ConsoleLoggerExtensions.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.WebAssembly.AppHost;
+
+internal static class ConsoleLoggerExtensions
+{
+    public static ILoggingBuilder AddPassThroughConsole(this ILoggingBuilder builder) =>
+            builder
+                .AddConsole(options => options.FormatterName = nameof(PassThroughConsoleFormatter))
+                .AddConsoleFormatter<PassThroughConsoleFormatter, PassThroughConsoleFormatterOptions>();
+
+    public static ILoggingBuilder AddPassThroughConsole(
+        this ILoggingBuilder builder, Action<PassThroughConsoleFormatterOptions> configure) =>
+            builder
+                .AddConsole(options => options.FormatterName = nameof(PassThroughConsoleFormatter))
+                .AddConsoleFormatter<PassThroughConsoleFormatter, PassThroughConsoleFormatterOptions>(configure);
+}

--- a/src/mono/wasm/host/CustomOptions.cs
+++ b/src/mono/wasm/host/CustomOptions.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Microsoft.Extensions.Logging.Console;
+
+namespace Microsoft.WebAssembly.AppHost;
+internal sealed class PassThroughConsoleFormatterOptions : ConsoleFormatterOptions
+{
+    public string Prefix = string.Empty;
+}

--- a/src/mono/wasm/host/JSEngineHost.cs
+++ b/src/mono/wasm/host/JSEngineHost.cs
@@ -48,13 +48,21 @@ internal sealed class JSEngineHost
             _ => throw new CommandLineException($"Unsupported engine {_args.Host}")
         };
 
+        string? engineBinaryPath;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             if (engineBinary.Equals("node"))
-                engineBinary = FindEngineInPath(engineBinary + ".exe"); // NodeJS ships as .exe rather than .cmd
+                engineBinaryPath = FindEngineInPath(engineBinary + ".exe"); // NodeJS ships as .exe rather than .cmd
             else
-                engineBinary = FindEngineInPath(engineBinary + ".cmd");
+                engineBinaryPath = FindEngineInPath(engineBinary + ".cmd");
         }
+        else
+        {
+            engineBinaryPath = FindEngineInPath(engineBinary);
+        }
+
+        if (engineBinaryPath is null)
+            throw new CommandLineException($"Cannot find host {engineBinary} in PATH");
 
         if (_args.CommonConfig.Debugging)
             throw new CommandLineException($"Debugging not supported with {_args.Host}");
@@ -99,7 +107,7 @@ internal sealed class JSEngineHost
         return exitCode;
     }
 
-    private static string FindEngineInPath(string engineBinary)
+    private static string? FindEngineInPath(string engineBinary)
     {
         if (File.Exists(engineBinary) || Path.IsPathRooted(engineBinary))
             return engineBinary;
@@ -116,6 +124,6 @@ internal sealed class JSEngineHost
                 return fullPath;
         }
 
-        return engineBinary;
+        return null;
     }
 }

--- a/src/mono/wasm/host/Program.cs
+++ b/src/mono/wasm/host/Program.cs
@@ -30,15 +30,12 @@ public class WasmAppHost
 
         using CancellationTokenSource cts = new();
         ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
-            builder.AddSimpleConsole(options =>
-            {
-                options.SingleLine = true;
-                options.TimestampFormat = "[HH:mm:ss] ";
-            })
-            .AddFilter("DevToolsProxy", LogLevel.Information)
-            .AddFilter("FirefoxMonoProxy", LogLevel.Information)
-            .AddFilter("host", LogLevel.Trace)
-            .AddFilter(null, LogLevel.Warning));
+            builder
+                .AddPassThroughConsole()
+                .AddFilter("DevToolsProxy", LogLevel.Information)
+                .AddFilter("FirefoxMonoProxy", LogLevel.Information)
+                .AddFilter("host", LogLevel.Trace)
+                .AddFilter(null, LogLevel.Warning));
 
         ILogger logger = loggerFactory.CreateLogger("host");
         try

--- a/src/mono/wasm/host/SimpleConsoleFormatter.cs
+++ b/src/mono/wasm/host/SimpleConsoleFormatter.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.WebAssembly.AppHost;
+
+internal sealed class PassThroughConsoleFormatter : ConsoleFormatter, IDisposable
+{
+    private readonly IDisposable? _optionsReloadToken;
+    private PassThroughConsoleFormatterOptions? _formatterOptions;
+
+    public PassThroughConsoleFormatter(IOptionsMonitor<PassThroughConsoleFormatterOptions> options)
+        : base("PassThroughConsoleFormatter") =>
+        (_optionsReloadToken, _formatterOptions) =
+            (options.OnChange((options, _) => ReloadLoggerOptions(options)), options.CurrentValue);
+
+    private void ReloadLoggerOptions(PassThroughConsoleFormatterOptions options) => _formatterOptions = options;
+
+    public override void Write<TState>(
+        in LogEntry<TState> logEntry,
+        IExternalScopeProvider? scopeProvider,
+        TextWriter textWriter)
+    {
+        string? message =
+            logEntry.Formatter?.Invoke(
+                logEntry.State, logEntry.Exception);
+
+        if (message is null)
+        {
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(_formatterOptions!.Prefix))
+            textWriter.Write(_formatterOptions!.Prefix);
+        textWriter.WriteLine(message);
+    }
+
+    public void Dispose() => _optionsReloadToken?.Dispose();
+}

--- a/src/mono/wasm/host/Utils.cs
+++ b/src/mono/wasm/host/Utils.cs
@@ -52,6 +52,8 @@ public class Utils
             process.BeginErrorReadLine();
 
         await process.WaitForExitAsync();
+        // Ensure all async handlers have been called
+        process.WaitForExit();
         return process.ExitCode;
     }
 }

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -941,7 +941,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
             if (exitCode != 0)
             {
-                Log.LogError($"Precompiling failed for {assembly}.{Environment.NewLine}{output}");
+                Log.LogError($"Precompiling failed for {assembly} with exit code {exitCode}.{Environment.NewLine}{output}");
                 return false;
             }
 

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Workload.Build.Tasks
                                                     debugMessageImportance: MessageImportance.High);
             if (exitCode != 0)
             {
-                Log.LogError($"workload install failed: {output}");
+                Log.LogError($"workload install failed with exit code {exitCode}: {output}");
 
                 foreach (string dir in Directory.EnumerateDirectories(Path.Combine(SdkDir, "sdk-manifests"), "*", SearchOption.AllDirectories))
                     Log.LogMessage(MessageImportance.Low, $"\t{Path.Combine(SdkDir, "sdk-manifests", dir)}");


### PR DESCRIPTION
`WasmAppHost`:
- use a custom console logger to remove logger prefixes from output
- Find the js engine to run, so a useful, and clean error can be emitted
- Ensure that all process output handlers have run, before exiting

MSBuild tasks:
- Emit exit code from `MonoAOTCompiler`, and `EmccCompile` tasks when the process fails. Useful when looking at logs.

Fixes https://github.com/dotnet/runtime/issues/71887 .