### PR TITLE
Do not run pipelines on .devcontainer changes

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -9,6 +9,7 @@ trigger:
     - src/libraries/System.Private.CoreLib/*
     exclude:
     - '**.md'
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -10,6 +10,7 @@ trigger:
     - src/libraries/System.Private.CoreLib/*
     exclude:
     - '**.md'
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -9,6 +9,7 @@ trigger:
     - src/libraries/System.Private.CoreLib/*
     exclude:
     - '**.md'
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -16,6 +16,7 @@ pr:
     - eng/pipelines/global-build.yml
     exclude:
     - '**.md'
+    - .devcontainer/*
     - .github/*
     - docs/*
     - eng/pipelines/coreclr/*.*

--- a/eng/pipelines/runtime-cet.yml
+++ b/eng/pipelines/runtime-cet.yml
@@ -13,6 +13,7 @@ pr:
     exclude:
     - /**/*.md
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -12,6 +12,7 @@ trigger:
     exclude:
     - '**.md'
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT
@@ -37,6 +38,7 @@ pr:
     exclude:
     - '**.md'
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/runtime-llvm.yml
+++ b/eng/pipelines/runtime-llvm.yml
@@ -14,6 +14,7 @@ trigger:
     exclude:
     - '**.md'
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT
@@ -40,6 +41,7 @@ pr:
     exclude:
     - '**.md'
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -11,6 +11,7 @@ trigger:
     - docs/manpages/*
     exclude:
     - '**.md'
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/runtime-richnav.yml
+++ b/eng/pipelines/runtime-richnav.yml
@@ -10,6 +10,7 @@ trigger:
     exclude:
     - '**.md'
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -13,6 +13,7 @@ trigger:
     exclude:
     - '**.md'
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT
@@ -39,6 +40,7 @@ pr:
     exclude:
     - '**.md'
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -14,6 +14,7 @@ trigger:
     exclude:
     - '**.md'
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT
@@ -40,6 +41,7 @@ pr:
     exclude:
     - '**.md'
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -14,6 +14,7 @@ trigger:
     exclude:
     - '**.md'
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT
@@ -31,6 +32,7 @@ pr:
     exclude:
     - '**.md'
     - eng/Version.Details.xml
+    - .devcontainer/*
     - .github/*
     - docs/*
     - LICENSE.TXT


### PR DESCRIPTION
As observed in https://github.com/dotnet/runtime/pull/72287, changing files in `.devcontainer` should not have any material impact on the build or CI. These files are used entirely for GitHub Codespaces, so it should be treated similarly as the `.github` directory.