### PR TITLE
Fix for older version of cmake

### DIFF
--- a/eng/native/configuretools.cmake
+++ b/eng/native/configuretools.cmake
@@ -28,8 +28,8 @@ if(NOT WIN32 AND NOT CLR_CMAKE_TARGET_BROWSER)
       return()
     endif()
 
+    unset(EXEC_LOCATION_${exec} CACHE)
     find_program(EXEC_LOCATION_${exec}
-      NO_CACHE
       NAMES
       "${TOOLSET_PREFIX}${exec}${CLR_CMAKE_COMPILER_FILE_NAME_VERSION}"
       "${TOOLSET_PREFIX}${exec}")


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/72250 was about supporting the older llvm-toolchain. This PR is about supporting the older cmake version. Turned out `NO_CACHE` was introduced in cmake 3.21 and some CI legs use the older version (I was testing it on 3.24).

cc @hoyosjs, @agocke, @janvorli, I opened this PR so it can be included in .NET 7 RC1. It also unblocked #71725, but that PR has some other (deref and nuget packaging related) issue, which might not make it in .NET 7.