### PR TITLE
Fix singlefilehost build with clang 15

### DIFF
--- a/src/native/corehost/fxr/sdk_resolver.cpp
+++ b/src/native/corehost/fxr/sdk_resolver.cpp
@@ -34,7 +34,7 @@ sdk_resolver::sdk_resolver(bool allow_prerelease) :
 }
 
 sdk_resolver::sdk_resolver(fx_ver_t version, sdk_roll_forward_policy roll_forward, bool allow_prerelease) :
-    requested_version(move(version)),
+    requested_version(std::move(version)),
     roll_forward(roll_forward),
     allow_prerelease(allow_prerelease)
 {
@@ -353,7 +353,7 @@ bool sdk_resolver::parse_global_file(pal::string_t global_file_path)
         }
     }
 
-    global_file = move(global_file_path);
+    global_file = std::move(global_file_path);
     return true;
 }
 
@@ -467,7 +467,7 @@ bool sdk_resolver::resolve_sdk_path_and_version(const pal::string_t& dir, pal::s
         if (pal::directory_exists(probe_path))
         {
             trace::verbose(_X("Found requested SDK directory [%s]"), probe_path.c_str());
-            sdk_path = move(probe_path);
+            sdk_path = std::move(probe_path);
             resolved_version = requested_version;
 
             // The SDK path has been resolved
@@ -519,7 +519,7 @@ bool sdk_resolver::resolve_sdk_path_and_version(const pal::string_t& dir, pal::s
 
         changed = true;
         resolved_version = ver;
-        resolved_version_str = move(version);
+        resolved_version_str = std::move(version);
     }
 
     if (changed)


### PR DESCRIPTION
With clang 15 beta (which is in PATH by default on one of the https://gitpod.io template I'm using) throws the following error:

```
  [ 98%] Building CXX object Corehost.Static/CMakeFiles/singlefilehost.dir/runtime/src/native/corehost/fxr/sdk_resolver.cpp.o
  /runtime/src/native/corehost/fxr/sdk_resolver.cpp:37:23: error: unqualified call to std::move [-Werror,-Wunqualified-std-cast-call]
      requested_version(move(version)),
                        ^
                        std::
  /runtime/src/native/corehost/fxr/sdk_resolver.cpp:356:19: error: unqualified call to std::move [-Werror,-Wunqualified-std-cast-call]
      global_file = move(global_file_path);
                    ^
                    std::
  /runtime/src/native/corehost/fxr/sdk_resolver.cpp:470:24: error: unqualified call to std::move [-Werror,-Wunqualified-std-cast-call]
              sdk_path = move(probe_path);
                         ^
                         std::
  /runtime/src/native/corehost/fxr/sdk_resolver.cpp:522:32: error: unqualified call to std::move [-Werror,-Wunqualified-std-cast-call]
          resolved_version_str = move(version);
                                 ^
                                 std::
  4 errors generated.
  make[2]: *** [Corehost.Static/CMakeFiles/singlefilehost.dir/build.make:272: Corehost.Static/CMakeFiles/singlefilehost.dir/runtime/src/native/corehost/fxr/sdk_resolver.cpp.o] Error 1
  make[1]: *** [CMakeFiles/Makefile2:1936: Corehost.Static/CMakeFiles/singlefilehost.dir/all] Error 2
  make: *** [Makefile:136: all] Error 2
  /runtime/src/coreclr
  Failed to build "CoreCLR component".
```

According to the schedule at https://llvm.org, clang 15 rc1 will be released in last week of July and final in first week of September. So it is better to fix this minor issue now before 7.0 RC1 snap.