### PR TITLE
[RateLimiting] Add statistics API

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.Typeforwards.netcoreapp.cs
+++ b/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.Typeforwards.netcoreapp.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// The compiler emits a reference to the internal copy of this type in our non-NETCoreApp assembly
+// so we must include a forward to be compatible with libraries compiled against non-NETCoreApp System.Threading.RateLimiting
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsExternalInit))]

--- a/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
+++ b/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
@@ -14,7 +14,7 @@ namespace System.Threading.RateLimiting
         protected override System.Threading.RateLimiting.RateLimitLease AttemptAcquireCore(int permitCount) { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
-        public override int GetAvailablePermits() { throw null; }
+        public override System.Threading.RateLimiting.RateLimiterStatistics? GetStatistics() { throw null; }
     }
     public sealed partial class ConcurrencyLimiterOptions
     {
@@ -33,7 +33,7 @@ namespace System.Threading.RateLimiting
         protected override System.Threading.RateLimiting.RateLimitLease AttemptAcquireCore(int requestCount) { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
-        public override int GetAvailablePermits() { throw null; }
+        public override System.Threading.RateLimiting.RateLimiterStatistics? GetStatistics() { throw null; }
         public override bool TryReplenish() { throw null; }
     }
     public sealed partial class FixedWindowRateLimiterOptions
@@ -78,7 +78,7 @@ namespace System.Threading.RateLimiting
         protected virtual void Dispose(bool disposing) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
-        public abstract int GetAvailablePermits(TResource resource);
+        public abstract System.Threading.RateLimiting.RateLimiterStatistics? GetStatistics(TResource resource);
         public System.Threading.RateLimiting.PartitionedRateLimiter<TOuter> WithTranslatedKey<TOuter>(System.Func<TOuter, TResource> keyAdapter, bool leaveOpen) { throw null; }
     }
     public enum QueueProcessingOrder
@@ -98,7 +98,15 @@ namespace System.Threading.RateLimiting
         protected virtual void Dispose(bool disposing) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
-        public abstract int GetAvailablePermits();
+        public abstract System.Threading.RateLimiting.RateLimiterStatistics? GetStatistics();
+    }
+    public partial class RateLimiterStatistics
+    {
+        public RateLimiterStatistics() { }
+        public long CurrentAvailablePermits { get { throw null; } set { } }
+        public long CurrentQueuedCount { get { throw null; } set { } }
+        public long TotalFailedLeases { get { throw null; } set { } }
+        public long TotalSuccessfulLeases { get { throw null; } set { } }
     }
     public abstract partial class RateLimitLease : System.IDisposable
     {
@@ -146,7 +154,7 @@ namespace System.Threading.RateLimiting
         protected override System.Threading.RateLimiting.RateLimitLease AttemptAcquireCore(int requestCount) { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
-        public override int GetAvailablePermits() { throw null; }
+        public override System.Threading.RateLimiting.RateLimiterStatistics? GetStatistics() { throw null; }
         public override bool TryReplenish() { throw null; }
     }
     public sealed partial class SlidingWindowRateLimiterOptions
@@ -169,7 +177,7 @@ namespace System.Threading.RateLimiting
         protected override System.Threading.RateLimiting.RateLimitLease AttemptAcquireCore(int tokenCount) { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
-        public override int GetAvailablePermits() { throw null; }
+        public override System.Threading.RateLimiting.RateLimiterStatistics? GetStatistics() { throw null; }
         public override bool TryReplenish() { throw null; }
     }
     public sealed partial class TokenBucketRateLimiterOptions

--- a/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.csproj
+++ b/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
   </PropertyGroup>
@@ -7,7 +7,11 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\ref\Microsoft.Bcl.AsyncInterfaces.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="System.Threading.RateLimiting.cs" />
+    <Compile Include="System.Threading.RateLimiting.Typeforwards.netcoreapp.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'"
+          Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
+++ b/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
@@ -27,12 +27,14 @@ System.Threading.RateLimiting.RateLimitLease</PackageDescription>
     <Compile Include="System\Threading\RateLimiting\PartitionedRateLimiter.T.cs" />
     <Compile Include="System\Threading\RateLimiting\QueueProcessingOrder.cs" />
     <Compile Include="System\Threading\RateLimiting\RateLimiter.cs" />
+    <Compile Include="System\Threading\RateLimiting\RateLimiterStatistics.cs" />
     <Compile Include="System\Threading\RateLimiting\RateLimitLease.cs" />
     <Compile Include="System\Threading\RateLimiting\RateLimitPartition.cs" />
     <Compile Include="System\Threading\RateLimiting\RateLimitPartition.T.cs" />
     <Compile Include="System\Threading\RateLimiting\ReplenishingRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\SlidingWindowRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\SlidingWindowRateLimiterOptions.cs" />
+    <Compile Include="System\Threading\RateLimiting\System.Threading.RateLimiting.Typeforwards.netcoreapp.cs" />
     <Compile Include="System\Threading\RateLimiting\TimerAwaitable.cs" />
     <Compile Include="System\Threading\RateLimiting\TokenBucketRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\TokenBucketRateLimiterOptions.cs" />
@@ -43,5 +45,10 @@ System.Threading.RateLimiting.RateLimitLease</PackageDescription>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\src\Microsoft.Bcl.AsyncInterfaces.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Remove="System\Threading\RateLimiting\System.Threading.RateLimiting.Typeforwards.netcoreapp.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
@@ -29,7 +29,7 @@ namespace System.Threading.RateLimiting
             long lowestAvailablePermits = long.MaxValue;
             long currentQueuedCount = 0;
             long totalFailedLeases = 0;
-            long totalSuccessfulLeases = 0;
+            long innerMostSuccessfulLeases = 0;
             foreach (PartitionedRateLimiter<TResource> limiter in _limiters)
             {
                 if (limiter.GetStatistics(resource) is { } statistics)
@@ -40,7 +40,7 @@ namespace System.Threading.RateLimiting
                     }
                     currentQueuedCount += statistics.CurrentQueuedCount;
                     totalFailedLeases += statistics.TotalFailedLeases;
-                    totalSuccessfulLeases += statistics.TotalSuccessfulLeases;
+                    innerMostSuccessfulLeases = statistics.TotalSuccessfulLeases;
                 }
             }
             return new RateLimiterStatistics()
@@ -48,7 +48,7 @@ namespace System.Threading.RateLimiting
                 CurrentAvailablePermits = lowestAvailablePermits,
                 CurrentQueuedCount = currentQueuedCount,
                 TotalFailedLeases = totalFailedLeases,
-                TotalSuccessfulLeases = totalSuccessfulLeases,
+                TotalSuccessfulLeases = innerMostSuccessfulLeases,
             };
         }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
@@ -27,7 +27,7 @@ namespace System.Threading.RateLimiting
         {
             ThrowIfDisposed();
             long lowestAvailablePermits = long.MaxValue;
-            long lowestQueuedCount = long.MaxValue;
+            long currentQueuedCount = 0;
             long totalFailedLeases = 0;
             long totalSuccessfulLeases = 0;
             foreach (PartitionedRateLimiter<TResource> limiter in _limiters)
@@ -38,10 +38,7 @@ namespace System.Threading.RateLimiting
                     {
                         lowestAvailablePermits = statistics.CurrentAvailablePermits;
                     }
-                    if (statistics.CurrentQueuedCount < lowestQueuedCount)
-                    {
-                        lowestQueuedCount = statistics.CurrentQueuedCount;
-                    }
+                    currentQueuedCount += statistics.CurrentQueuedCount;
                     totalFailedLeases += statistics.TotalFailedLeases;
                     totalSuccessfulLeases += statistics.TotalSuccessfulLeases;
                 }
@@ -49,7 +46,7 @@ namespace System.Threading.RateLimiting
             return new RateLimiterStatistics()
             {
                 CurrentAvailablePermits = lowestAvailablePermits,
-                CurrentQueuedCount = lowestQueuedCount,
+                CurrentQueuedCount = currentQueuedCount,
                 TotalFailedLeases = totalFailedLeases,
                 TotalSuccessfulLeases = totalSuccessfulLeases,
             };

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -67,6 +67,7 @@ namespace System.Threading.RateLimiting
         /// <inheritdoc/>
         public override RateLimiterStatistics? GetStatistics()
         {
+            ThrowIfDisposed();
             return new RateLimiterStatistics()
             {
                 CurrentAvailablePermits = _permitCount,

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -92,8 +92,10 @@ namespace System.Threading.RateLimiting
             {
                 if (_permitCount > 0)
                 {
+                    Interlocked.Increment(ref _successfulLeasesCount);
                     return SuccessfulLease;
                 }
+                Interlocked.Increment(ref _failedLeasesCount);
                 return FailedLease;
             }
 
@@ -125,6 +127,7 @@ namespace System.Threading.RateLimiting
             // Return SuccessfulLease if requestedCount is 0 and resources are available
             if (permitCount == 0 && _permitCount > 0 && !_disposed)
             {
+                Interlocked.Increment(ref _successfulLeasesCount);
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
@@ -196,6 +199,7 @@ namespace System.Threading.RateLimiting
             {
                 if (permitCount == 0)
                 {
+                    Interlocked.Increment(ref _successfulLeasesCount);
                     // Edge case where the check before the lock showed 0 available permits but when we got the lock some permits were now available
                     lease = SuccessfulLease;
                     return true;
@@ -259,10 +263,7 @@ namespace System.Threading.RateLimiting
                         }
                         else
                         {
-                            if (nextPendingRequest.Count != 0)
-                            {
-                                Interlocked.Increment(ref _successfulLeasesCount);
-                            }
+                            Interlocked.Increment(ref _successfulLeasesCount);
                         }
                         nextPendingRequest.CancellationTokenRegistration.Dispose();
                         Debug.Assert(_queueCount >= 0);

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
@@ -65,9 +65,9 @@ namespace System.Threading.RateLimiting
             _timer.Dispose();
         }
 
-        public override int GetAvailablePermits(TResource resource)
+        public override RateLimiterStatistics? GetStatistics(TResource resource)
         {
-            return GetRateLimiter(resource).GetAvailablePermits();
+            return GetRateLimiter(resource).GetStatistics();
         }
 
         protected override RateLimitLease AttemptAcquireCore(TResource resource, int permitCount)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -112,9 +112,11 @@ namespace System.Threading.RateLimiting
                 // Requests will be allowed if the total served request is less than the max allowed requests (permit limit).
                 if (_requestCount > 0)
                 {
+                    Interlocked.Increment(ref _successfulLeasesCount);
                     return SuccessfulLease;
                 }
 
+                Interlocked.Increment(ref _failedLeasesCount);
                 return CreateFailedWindowLease(requestCount);
             }
 
@@ -144,6 +146,7 @@ namespace System.Threading.RateLimiting
             // Return SuccessfulAcquisition if requestCount is 0 and resources are available
             if (requestCount == 0 && _requestCount > 0)
             {
+                Interlocked.Increment(ref _successfulLeasesCount);
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
@@ -222,6 +225,7 @@ namespace System.Threading.RateLimiting
             {
                 if (requestCount == 0)
                 {
+                    Interlocked.Increment(ref _successfulLeasesCount);
                     // Edge case where the check before the lock showed 0 available permit counters but when we got the lock, some permits were now available
                     lease = SuccessfulLease;
                     return true;
@@ -335,10 +339,7 @@ namespace System.Threading.RateLimiting
                         }
                         else
                         {
-                            if (nextPendingRequest.Count != 0)
-                            {
-                                Interlocked.Increment(ref _successfulLeasesCount);
-                            }
+                            Interlocked.Increment(ref _successfulLeasesCount);
                         }
                         nextPendingRequest.CancellationTokenRegistration.Dispose();
                         Debug.Assert(_queueCount >= 0);

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -19,6 +19,9 @@ namespace System.Threading.RateLimiting
         private long? _idleSince;
         private bool _disposed;
 
+        private long _failedLeasesCount;
+        private long _successfulLeasesCount;
+
         private readonly Timer? _renewTimer;
         private readonly FixedWindowRateLimiterOptions _options;
         private readonly Deque<RequestRegistration> _queue = new Deque<RequestRegistration>();
@@ -81,7 +84,16 @@ namespace System.Threading.RateLimiting
         }
 
         /// <inheritdoc/>
-        public override int GetAvailablePermits() => _requestCount;
+        public override RateLimiterStatistics? GetStatistics()
+        {
+            return new RateLimiterStatistics()
+            {
+                CurrentAvailablePermits = _requestCount,
+                CurrentQueuedCount = _queueCount,
+                TotalFailedLeases = Interlocked.Read(ref _failedLeasesCount),
+                TotalSuccessfulLeases = Interlocked.Read(ref _successfulLeasesCount),
+            };
+        }
 
         /// <inheritdoc/>
         protected override RateLimitLease AttemptAcquireCore(int requestCount)
@@ -113,6 +125,7 @@ namespace System.Threading.RateLimiting
                     return lease;
                 }
 
+                Interlocked.Increment(ref _failedLeasesCount);
                 return CreateFailedWindowLease(requestCount);
             }
         }
@@ -157,11 +170,16 @@ namespace System.Threading.RateLimiting
                             {
                                 _queueCount += oldestRequest.Count;
                             }
+                            else
+                            {
+                                Interlocked.Increment(ref _failedLeasesCount);
+                            }
                         }
                         while (_options.QueueLimit - _queueCount < requestCount);
                     }
                     else
                     {
+                        Interlocked.Increment(ref _failedLeasesCount);
                         // Don't queue if queue limit reached and QueueProcessingOrder is OldestFirst
                         return new ValueTask<RateLimitLease>(CreateFailedWindowLease(requestCount));
                     }
@@ -216,6 +234,7 @@ namespace System.Threading.RateLimiting
                     _idleSince = null;
                     _requestCount -= requestCount;
                     Debug.Assert(_requestCount >= 0);
+                    Interlocked.Increment(ref _successfulLeasesCount);
                     lease = SuccessfulLease;
                     return true;
                 }
@@ -313,6 +332,13 @@ namespace System.Threading.RateLimiting
                             _requestCount += nextPendingRequest.Count;
                             // Updating queue count is handled by the cancellation code
                             _queueCount += nextPendingRequest.Count;
+                        }
+                        else
+                        {
+                            if (nextPendingRequest.Count != 0)
+                            {
+                                Interlocked.Increment(ref _successfulLeasesCount);
+                            }
                         }
                         nextPendingRequest.CancellationTokenRegistration.Dispose();
                         Debug.Assert(_queueCount >= 0);

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -86,6 +86,7 @@ namespace System.Threading.RateLimiting
         /// <inheritdoc/>
         public override RateLimiterStatistics? GetStatistics()
         {
+            ThrowIfDisposed();
             return new RateLimiterStatistics()
             {
                 CurrentAvailablePermits = _requestCount,

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
@@ -9,29 +9,35 @@ namespace System.Threading.RateLimiting
     internal sealed class NoopLimiter : RateLimiter
     {
         private static readonly RateLimitLease _lease = new NoopLease();
-        private static readonly RateLimiterStatistics _stats = new RateLimiterStatistics()
-        {
-            CurrentAvailablePermits = long.MaxValue,
-            CurrentQueuedCount = 0,
-            TotalFailedLeases = 0,
-            TotalSuccessfulLeases = 0,
-        };
 
-        private NoopLimiter() { }
+        private long _totalSuccessfulLeases;
 
-        public static NoopLimiter Instance { get; } = new NoopLimiter();
+        public NoopLimiter() { }
 
         public override TimeSpan? IdleDuration => null;
 
         public override RateLimiterStatistics? GetStatistics()
         {
-            return _stats;
+            return new RateLimiterStatistics()
+            {
+                CurrentAvailablePermits = long.MaxValue,
+                CurrentQueuedCount = 0,
+                TotalFailedLeases = 0,
+                TotalSuccessfulLeases = Interlocked.Read(ref _totalSuccessfulLeases)
+            };
         }
 
-        protected override RateLimitLease AttemptAcquireCore(int permitCount) => _lease;
+        protected override RateLimitLease AttemptAcquireCore(int permitCount)
+        {
+            Interlocked.Increment(ref _totalSuccessfulLeases);
+            return _lease;
+        }
 
         protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
-            => new ValueTask<RateLimitLease>(_lease);
+        {
+            Interlocked.Increment(ref _totalSuccessfulLeases);
+            return new ValueTask<RateLimitLease>(_lease);
+        }
 
         private sealed class NoopLease : RateLimitLease
         {

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
@@ -9,6 +9,13 @@ namespace System.Threading.RateLimiting
     internal sealed class NoopLimiter : RateLimiter
     {
         private static readonly RateLimitLease _lease = new NoopLease();
+        private static readonly RateLimiterStatistics _stats = new RateLimiterStatistics()
+        {
+            CurrentAvailablePermits = long.MaxValue,
+            CurrentQueuedCount = 0,
+            TotalFailedLeases = 0,
+            TotalSuccessfulLeases = 0,
+        };
 
         private NoopLimiter() { }
 
@@ -16,7 +23,10 @@ namespace System.Threading.RateLimiting
 
         public override TimeSpan? IdleDuration => null;
 
-        public override int GetAvailablePermits() => int.MaxValue;
+        public override RateLimiterStatistics? GetStatistics()
+        {
+            return _stats;
+        }
 
         protected override RateLimitLease AttemptAcquireCore(int permitCount) => _lease;
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
@@ -126,16 +126,14 @@ namespace System.Threading.RateLimiting
         /// </summary>
         /// <typeparam name="TOuter">The type to translate into <typeparamref name="TResource"/>.</typeparam>
         /// <param name="keyAdapter">The function to be called every time a <typeparamref name="TOuter"/> is passed to
-        /// PartitionedRateLimiter&lt;TOuter&gt;.Acquire(TOuter, int) or PartitionedRateLimiter&lt;TOuter&gt;.WaitAsync(TOuter, int, CancellationToken).</param>
-        /// <remarks><paramref name="keyAdapter"/> should be implemented in a thread-safe way.
+        /// PartitionedRateLimiter&lt;TOuter&gt;.Acquire(TOuter, int) or PartitionedRateLimiter&lt;TOuter&gt;.WaitAsync(TOuter, int, CancellationToken).
+        /// <para />
+        /// <remarks><paramref name="keyAdapter"/> should be implemented in a thread-safe way.</remarks></param>
         /// <param name="leaveOpen">Specifies whether the returned <see cref="PartitionedRateLimiter{TOuter}"/> will dispose the wrapped <see cref="PartitionedRateLimiter{TResource}"/>.</param>
         /// <returns>A new PartitionedRateLimiter&lt;TOuter&gt; that translates <typeparamref name="TOuter"/>
         /// to <typeparamref name="TResource"/> and calls the inner <see cref="PartitionedRateLimiter{TResource}"/>.</returns>
         public PartitionedRateLimiter<TOuter> WithTranslatedKey<TOuter>(Func<TOuter, TResource> keyAdapter, bool leaveOpen)
         {
-            // REVIEW: Do we want to have an option to dispose the inner limiter?
-            // Should the default be to dispose the inner limiter and have an option to not dispose it?
-            // See Stream wrappers like SslStream for prior-art
             return new TranslatingLimiter<TResource, TOuter>(this, keyAdapter, leaveOpen);
         }
     }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
@@ -127,8 +127,8 @@ namespace System.Threading.RateLimiting
         /// <typeparam name="TOuter">The type to translate into <typeparamref name="TResource"/>.</typeparam>
         /// <param name="keyAdapter">The function to be called every time a <typeparamref name="TOuter"/> is passed to
         /// PartitionedRateLimiter&lt;TOuter&gt;.Acquire(TOuter, int) or PartitionedRateLimiter&lt;TOuter&gt;.WaitAsync(TOuter, int, CancellationToken).</param>
+        /// <remarks><paramref name="keyAdapter"/> should be implemented in a thread-safe way.
         /// <param name="leaveOpen">Specifies whether the returned <see cref="PartitionedRateLimiter{TOuter}"/> will dispose the wrapped <see cref="PartitionedRateLimiter{TResource}"/>.</param>
-        /// <remarks><see cref="PartitionedRateLimiter{TResource}.Dispose()"/> or <see cref="PartitionedRateLimiter{TResource}.DisposeAsync()"/> does not dispose the wrapped <see cref="PartitionedRateLimiter{TResource}"/>.</remarks>
         /// <returns>A new PartitionedRateLimiter&lt;TOuter&gt; that translates <typeparamref name="TOuter"/>
         /// to <typeparamref name="TResource"/> and calls the inner <see cref="PartitionedRateLimiter{TResource}"/>.</returns>
         public PartitionedRateLimiter<TOuter> WithTranslatedKey<TOuter>(Func<TOuter, TResource> keyAdapter, bool leaveOpen)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
@@ -12,10 +12,10 @@ namespace System.Threading.RateLimiting
     public abstract class PartitionedRateLimiter<TResource> : IAsyncDisposable, IDisposable
     {
         /// <summary>
-        /// An estimated count of available permits.
+        /// Gets a snapshot of the statistics for the <paramref name="resource"/> if available.
         /// </summary>
-        /// <returns></returns>
-        public abstract int GetAvailablePermits(TResource resource);
+        /// <returns>An instance of <see cref="RateLimiterStatistics"/> containing a snapshot of the statistics for a <paramref name="resource"/>.</returns>
+        public abstract RateLimiterStatistics? GetStatistics(TResource resource);
 
         /// <summary>
         /// Fast synchronous attempt to acquire permits.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
@@ -38,7 +38,8 @@ namespace System.Threading.RateLimiting
         /// Methods on the returned <see cref="PartitionedRateLimiter{TResource}"/> will iterate over the passed in <paramref name="limiters"/> in the order given.
         /// </para>
         /// <para>
-        /// <see cref="PartitionedRateLimiter{TResource}.GetStatistics(TResource)"/> will return the lowest value for <see cref="RateLimiterStatistics.CurrentAvailablePermits"/>
+        /// <see cref="PartitionedRateLimiter{TResource}.GetStatistics(TResource)"/> will return the lowest value for <see cref="RateLimiterStatistics.CurrentAvailablePermits"/>,
+        /// the inner-most limiter's <see cref="RateLimiterStatistics.TotalSuccessfulLeases"/>,
         /// and the aggregate values for the rest of the properties from the <paramref name="limiters"/>.
         /// </para>
         /// <para>

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
@@ -38,8 +38,8 @@ namespace System.Threading.RateLimiting
         /// Methods on the returned <see cref="PartitionedRateLimiter{TResource}"/> will iterate over the passed in <paramref name="limiters"/> in the order given.
         /// </para>
         /// <para>
-        /// <see cref="PartitionedRateLimiter{TResource}.GetStatistics(TResource)"/> will return the lowest values for <see cref="RateLimiterStatistics.CurrentAvailablePermits"/>
-        /// and <see cref="RateLimiterStatistics.CurrentQueuedCount"/> and the aggregate values for the rest of the properties from the <paramref name="limiters"/>.
+        /// <see cref="PartitionedRateLimiter{TResource}.GetStatistics(TResource)"/> will return the lowest value for <see cref="RateLimiterStatistics.CurrentAvailablePermits"/>
+        /// and the aggregate values for the rest of the properties from the <paramref name="limiters"/>.
         /// </para>
         /// <para>
         /// <see cref="RateLimitLease"/>s returned will aggregate metadata and for duplicates use the value of the first lease with the same metadata name.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
@@ -38,7 +38,8 @@ namespace System.Threading.RateLimiting
         /// Methods on the returned <see cref="PartitionedRateLimiter{TResource}"/> will iterate over the passed in <paramref name="limiters"/> in the order given.
         /// </para>
         /// <para>
-        /// <see cref="PartitionedRateLimiter{TResource}.GetAvailablePermits(TResource)"/> will return the lowest value of all the <paramref name="limiters"/>.
+        /// <see cref="PartitionedRateLimiter{TResource}.GetStatistics(TResource)"/> will return the lowest values for <see cref="RateLimiterStatistics.CurrentAvailablePermits"/>
+        /// and <see cref="RateLimiterStatistics.CurrentQueuedCount"/> and the aggregate values for the rest of the properties from the <paramref name="limiters"/>.
         /// </para>
         /// <para>
         /// <see cref="RateLimitLease"/>s returned will aggregate metadata and for duplicates use the value of the first lease with the same metadata name.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.cs
@@ -48,7 +48,7 @@ namespace System.Threading.RateLimiting
         /// <returns></returns>
         public static RateLimitPartition<TKey> GetNoLimiter<TKey>(TKey partitionKey)
         {
-            return Get(partitionKey, _ => NoopLimiter.Instance);
+            return Get(partitionKey, _ => new NoopLimiter());
         }
 
         /// <summary>

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
@@ -11,10 +11,10 @@ namespace System.Threading.RateLimiting
     public abstract class RateLimiter : IAsyncDisposable, IDisposable
     {
         /// <summary>
-        /// An estimated count of available permits.
+        /// Gets a snapshot of the <see cref="RateLimiter"/> statistics if available.
         /// </summary>
-        /// <returns></returns>
-        public abstract int GetAvailablePermits();
+        /// <returns>An instance of <see cref="RateLimiterStatistics"/> containing a snapshot of the <see cref="RateLimiter"/> statistics.</returns>
+        public abstract RateLimiterStatistics? GetStatistics();
 
         /// <summary>
         /// Specifies how long the <see cref="RateLimiter"/> has had all permits available. Used by RateLimiter managers that may want to

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiterStatistics.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiterStatistics.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Threading.RateLimiting
+{
+    /// <summary>
+    /// Snapshot of statistics for a <see cref="RateLimiter"/>.
+    /// </summary>
+    public class RateLimiterStatistics
+    {
+        /// <summary>
+        /// Initializes an instance of <see cref="RateLimiterStatistics"/>.
+        /// </summary>
+        public RateLimiterStatistics() { }
+
+        /// <summary>
+        /// Gets the number of permits currently available for the <see cref="RateLimiter"/>.
+        /// </summary>
+        public long CurrentAvailablePermits { get; init; }
+
+        /// <summary>
+        /// Gets the number of queued permits for the <see cref="RateLimiter"/>.
+        /// </summary>
+        public long CurrentQueuedCount { get; init; }
+
+        /// <summary>
+        /// Gets the total number of failed <see cref="RateLimitLease"/>s returned.
+        /// </summary>
+        public long TotalFailedLeases { get; init; }
+
+        /// <summary>
+        /// Gets the total number of successful <see cref="RateLimitLease"/>s returned.
+        /// </summary>
+        public long TotalSuccessfulLeases { get; init; }
+    }
+}

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -117,9 +117,11 @@ namespace System.Threading.RateLimiting
             {
                 if (_requestCount > 0)
                 {
+                    Interlocked.Increment(ref _successfulLeasesCount);
                     return SuccessfulLease;
                 }
 
+                Interlocked.Increment(ref _failedLeasesCount);
                 return FailedLease;
             }
 
@@ -150,6 +152,7 @@ namespace System.Threading.RateLimiting
             // Return SuccessfulAcquisition if resources are available
             if (requestCount == 0 && _requestCount > 0)
             {
+                Interlocked.Increment(ref _successfulLeasesCount);
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
@@ -219,6 +222,7 @@ namespace System.Threading.RateLimiting
             {
                 if (requestCount == 0)
                 {
+                    Interlocked.Increment(ref _successfulLeasesCount);
                     // Edge case where the check before the lock showed 0 available permits but when we got the lock some permits were now available
                     lease = SuccessfulLease;
                     return true;
@@ -335,10 +339,7 @@ namespace System.Threading.RateLimiting
                         }
                         else
                         {
-                            if (nextPendingRequest.Count != 0)
-                            {
-                                Interlocked.Increment(ref _successfulLeasesCount);
-                            }
+                            Interlocked.Increment(ref _successfulLeasesCount);
                         }
                         nextPendingRequest.CancellationTokenRegistration.Dispose();
                         Debug.Assert(_queueCount >= 0);

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -94,6 +94,7 @@ namespace System.Threading.RateLimiting
         /// <inheritdoc/>
         public override RateLimiterStatistics? GetStatistics()
         {
+            ThrowIfDisposed();
             return new RateLimiterStatistics()
             {
                 CurrentAvailablePermits = _requestCount,

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/System.Threading.RateLimiting.Typeforwards.netcoreapp.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/System.Threading.RateLimiting.Typeforwards.netcoreapp.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// The compiler emits a reference to the internal copy of this type in our non-NETCoreApp assembly
+// so we must include a forward to be compatible with libraries compiled against non-NETCoreApp System.Threading.RateLimiting
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsExternalInit))]

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -111,9 +111,11 @@ namespace System.Threading.RateLimiting
             {
                 if (_tokenCount > 0)
                 {
+                    Interlocked.Increment(ref _successfulLeasesCount);
                     return SuccessfulLease;
                 }
 
+                Interlocked.Increment(ref _failedLeasesCount);
                 return CreateFailedTokenLease(tokenCount);
             }
 
@@ -143,6 +145,7 @@ namespace System.Threading.RateLimiting
             // Return SuccessfulAcquisition if requestedCount is 0 and resources are available
             if (tokenCount == 0 && _tokenCount > 0)
             {
+                Interlocked.Increment(ref _successfulLeasesCount);
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
@@ -224,6 +227,7 @@ namespace System.Threading.RateLimiting
             {
                 if (tokenCount == 0)
                 {
+                    Interlocked.Increment(ref _successfulLeasesCount);
                     // Edge case where the check before the lock showed 0 available permits but when we got the lock some permits were now available
                     lease = SuccessfulLease;
                     return true;
@@ -339,10 +343,7 @@ namespace System.Threading.RateLimiting
                         }
                         else
                         {
-                            if (nextPendingRequest.Count != 0)
-                            {
-                                Interlocked.Increment(ref _successfulLeasesCount);
-                            }
+                            Interlocked.Increment(ref _successfulLeasesCount);
                         }
                         nextPendingRequest.CancellationTokenRegistration.Dispose();
                         Debug.Assert(_queueCount >= 0);

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -88,6 +88,7 @@ namespace System.Threading.RateLimiting
         /// <inheritdoc/>
         public override RateLimiterStatistics? GetStatistics()
         {
+            ThrowIfDisposed();
             return new RateLimiterStatistics()
             {
                 CurrentAvailablePermits = _tokenCount,

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TranslatingLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TranslatingLimiter.cs
@@ -20,11 +20,11 @@ namespace System.Threading.RateLimiting
             _disposeInnerLimiter = !leaveOpen;
         }
 
-        public override int GetAvailablePermits(TResource resource)
+        public override RateLimiterStatistics? GetStatistics(TResource resource)
         {
             ThrowIfDispose();
             TInner key = _keyAdapter(resource);
-            return _innerRateLimiter.GetAvailablePermits(key);
+            return _innerRateLimiter.GetStatistics(key);
         }
 
         protected override RateLimitLease AttemptAcquireCore(TResource resource, int permitCount)

--- a/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
@@ -124,5 +124,8 @@ namespace System.Threading.RateLimiting.Test
 
         [Fact]
         public abstract Task GetStatisticsWithZeroPermitCount();
+
+        [Fact]
+        public abstract void GetStatisticsThrowsAfterDispose();
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
@@ -115,5 +115,11 @@ namespace System.Threading.RateLimiting.Test
 
         [Fact]
         public abstract void IdleDurationUpdatesWhenChangingFromActive();
+
+        [Fact]
+        public abstract void GetStatisticsReturnsNewInstances();
+
+        [Fact]
+        public abstract Task GetStatisticsHasCorrectValues();
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
@@ -121,5 +121,8 @@ namespace System.Threading.RateLimiting.Test
 
         [Fact]
         public abstract Task GetStatisticsHasCorrectValues();
+
+        [Fact]
+        public abstract Task GetStatisticsWithZeroPermitCount();
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
@@ -194,7 +194,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public void GetStatisticsHasCorrectValues()
+        public async Task GetStatisticsHasCorrectValues()
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
@@ -231,7 +231,7 @@ namespace System.Threading.RateLimiting.Tests
 
             Assert.Equal(3, stats.CurrentAvailablePermits);
             Assert.Equal(0, stats.CurrentQueuedCount);
-            Assert.Equal(3, stats.TotalSuccessfulLeases);
+            Assert.Equal(1, stats.TotalSuccessfulLeases);
             Assert.Equal(0, stats.TotalFailedLeases);
 
             var lease2 = chainedLimiter.AttemptAcquire("", 10);
@@ -240,7 +240,7 @@ namespace System.Threading.RateLimiting.Tests
 
             Assert.Equal(3, stats.CurrentAvailablePermits);
             Assert.Equal(0, stats.CurrentQueuedCount);
-            Assert.Equal(5, stats.TotalSuccessfulLeases);
+            Assert.Equal(1, stats.TotalSuccessfulLeases);
             Assert.Equal(1, stats.TotalFailedLeases);
 
             var task = chainedLimiter.AcquireAsync("", 10);
@@ -249,7 +249,18 @@ namespace System.Threading.RateLimiting.Tests
 
             Assert.Equal(2, stats.CurrentAvailablePermits);
             Assert.Equal(10, stats.CurrentQueuedCount);
-            Assert.Equal(7, stats.TotalSuccessfulLeases);
+            Assert.Equal(1, stats.TotalSuccessfulLeases);
+            Assert.Equal(1, stats.TotalFailedLeases);
+
+            lease.Dispose();
+
+            lease = await task;
+            Assert.True(lease.IsAcquired);
+            stats = chainedLimiter.GetStatistics("");
+
+            Assert.Equal(3, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats.CurrentQueuedCount);
+            Assert.Equal(2, stats.TotalSuccessfulLeases);
             Assert.Equal(1, stats.TotalFailedLeases);
         }
 

--- a/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
@@ -52,7 +52,7 @@ namespace System.Threading.RateLimiting.Tests
 
             chainedLimiter.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => chainedLimiter.GetAvailablePermits(""));
+            Assert.Throws<ObjectDisposedException>(() => chainedLimiter.GetStatistics(""));
             Assert.Throws<ObjectDisposedException>(() => chainedLimiter.AttemptAcquire(""));
             await Assert.ThrowsAsync<ObjectDisposedException>(async () => await chainedLimiter.AcquireAsync(""));
         }
@@ -84,13 +84,13 @@ namespace System.Threading.RateLimiting.Tests
 
             await chainedLimiter.DisposeAsync();
 
-            Assert.Throws<ObjectDisposedException>(() => chainedLimiter.GetAvailablePermits(""));
+            Assert.Throws<ObjectDisposedException>(() => chainedLimiter.GetStatistics(""));
             Assert.Throws<ObjectDisposedException>(() => chainedLimiter.AttemptAcquire(""));
             await Assert.ThrowsAsync<ObjectDisposedException>(async () => await chainedLimiter.AcquireAsync(""));
         }
 
         [Fact]
-        public void AvailablePermitsReturnsLowestValue()
+        public void GetStatisticsReturnsLowestOrAggregateValues()
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
@@ -99,7 +99,7 @@ namespace System.Threading.RateLimiting.Tests
                     {
                         PermitLimit = 34,
                         QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                        QueueLimit = 0
+                        QueueLimit = 4
                     });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
@@ -109,7 +109,7 @@ namespace System.Threading.RateLimiting.Tests
                     {
                         PermitLimit = 22,
                         QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                        QueueLimit = 0
+                        QueueLimit = 2
                     });
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
@@ -119,16 +119,21 @@ namespace System.Threading.RateLimiting.Tests
                     {
                         PermitLimit = 13,
                         QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                        QueueLimit = 0
+                        QueueLimit = 10
                     });
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
-            Assert.Equal(13, chainedLimiter.GetAvailablePermits(""));
+
+            var stats = chainedLimiter.GetStatistics("");
+            Assert.Equal(13, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats.CurrentQueuedCount);
+            Assert.Equal(0, stats.TotalFailedLeases);
+            Assert.Equal(0, stats.TotalSuccessfulLeases);
         }
 
         [Fact]
-        public void AvailablePermitsWithSingleLimiterWorks()
+        public void GetStatisticsWithSingleLimiterWorks()
         {
             using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
             {
@@ -142,7 +147,71 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
-            Assert.Equal(34, chainedLimiter.GetAvailablePermits(""));
+
+            var stats = chainedLimiter.GetStatistics("");
+            Assert.Equal(34, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats.CurrentQueuedCount);
+            Assert.Equal(0, stats.TotalFailedLeases);
+            Assert.Equal(0, stats.TotalSuccessfulLeases);
+        }
+
+        [Fact]
+        public void GetStatisticsReturnsNewInstances()
+        {
+            using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(34, QueueProcessingOrder.NewestFirst, 4));
+            });
+            using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(22, QueueProcessingOrder.NewestFirst, 2));
+            });
+            using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(13, QueueProcessingOrder.NewestFirst, 10));
+            });
+
+            using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
+
+            var stats = chainedLimiter.GetStatistics("");
+            var stats2 = chainedLimiter.GetStatistics("");
+            Assert.NotSame(stats, stats2);
+        }
+
+        [Fact]
+        public void GetStatisticsHasCorrectValues()
+        {
+            using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(34, QueueProcessingOrder.NewestFirst, 4));
+            });
+            using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(22, QueueProcessingOrder.NewestFirst, 2));
+            });
+            using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(13, QueueProcessingOrder.NewestFirst, 10));
+            });
+
+            using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
+
+            var lease = chainedLimiter.Acquire("", 10);
+            var stats = chainedLimiter.GetStatistics("");
+
+            Assert.Equal(3, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats.CurrentQueuedCount);
+            Assert.Equal(3, stats.TotalSuccessfulLeases);
+            Assert.Equal(0, stats.TotalFailedLeases);
+
+            var lease2 = chainedLimiter.Acquire("", 10);
+            Assert.False(lease2.IsAcquired);
+            stats = chainedLimiter.GetStatistics("");
+
+            Assert.Equal(3, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats.CurrentQueuedCount);
+            Assert.Equal(5, stats.TotalSuccessfulLeases);
+            Assert.Equal(1, stats.TotalFailedLeases);
         }
 
         [Fact]
@@ -257,12 +326,12 @@ namespace System.Threading.RateLimiting.Tests
             var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.True(lease.IsAcquired);
-            Assert.Equal(0, concurrencyLimiter1.GetAvailablePermits());
-            Assert.Equal(0, concurrencyLimiter2.GetAvailablePermits());
+            Assert.Equal(0, concurrencyLimiter1.GetStatistics().CurrentAvailablePermits);
+            Assert.Equal(0, concurrencyLimiter2.GetStatistics().CurrentAvailablePermits);
 
             lease.Dispose();
-            Assert.Equal(1, concurrencyLimiter1.GetAvailablePermits());
-            Assert.Equal(1, concurrencyLimiter2.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter1.GetStatistics().CurrentAvailablePermits);
+            Assert.Equal(1, concurrencyLimiter2.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -293,12 +362,12 @@ namespace System.Threading.RateLimiting.Tests
             var lease = await chainedLimiter.AcquireAsync("");
 
             Assert.True(lease.IsAcquired);
-            Assert.Equal(0, concurrencyLimiter1.GetAvailablePermits());
-            Assert.Equal(0, concurrencyLimiter2.GetAvailablePermits());
+            Assert.Equal(0, concurrencyLimiter1.GetStatistics().CurrentAvailablePermits);
+            Assert.Equal(0, concurrencyLimiter2.GetStatistics().CurrentAvailablePermits);
 
             lease.Dispose();
-            Assert.Equal(1, concurrencyLimiter1.GetAvailablePermits());
-            Assert.Equal(1, concurrencyLimiter2.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter1.GetStatistics().CurrentAvailablePermits);
+            Assert.Equal(1, concurrencyLimiter2.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -319,10 +388,10 @@ namespace System.Threading.RateLimiting.Tests
             var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.True(lease.IsAcquired);
-            Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(0, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
 
             lease.Dispose();
-            Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -343,10 +412,10 @@ namespace System.Threading.RateLimiting.Tests
             var lease = await chainedLimiter.AcquireAsync("");
 
             Assert.True(lease.IsAcquired);
-            Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(0, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
 
             lease.Dispose();
-            Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -442,7 +511,7 @@ namespace System.Threading.RateLimiting.Tests
             using var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.False(lease.IsAcquired);
-            Assert.Equal(1, concurrencyLimiter1.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter1.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -476,7 +545,7 @@ namespace System.Threading.RateLimiting.Tests
             using var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.False(lease.IsAcquired);
-            Assert.Equal(1, concurrencyLimiter1.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter1.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -499,7 +568,7 @@ namespace System.Threading.RateLimiting.Tests
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
             Assert.Throws<NotImplementedException>(() => chainedLimiter.AttemptAcquire(""));
-            Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -522,7 +591,7 @@ namespace System.Threading.RateLimiting.Tests
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
             await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.AcquireAsync(""));
-            Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -759,12 +828,12 @@ namespace System.Threading.RateLimiting.Tests
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
             var lease = chainedLimiter.AttemptAcquire("");
             Assert.True(lease.IsAcquired);
-            Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(0, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
             var ex = Assert.Throws<AggregateException>(() => lease.Dispose());
             Assert.Single(ex.InnerExceptions);
             Assert.IsType<NotImplementedException>(ex.InnerException);
 
-            Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -788,12 +857,12 @@ namespace System.Threading.RateLimiting.Tests
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
             var lease = await chainedLimiter.AcquireAsync("");
             Assert.True(lease.IsAcquired);
-            Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(0, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
             var ex = Assert.Throws<AggregateException>(() => lease.Dispose());
             Assert.Single(ex.InnerExceptions);
             Assert.IsType<NotImplementedException>(ex.InnerException);
 
-            Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -823,12 +892,12 @@ namespace System.Threading.RateLimiting.Tests
 
             var lease = chainedLimiter.AttemptAcquire("", 3);
             Assert.True(lease.IsAcquired);
-            Assert.Equal(2, concurrencyLimiter1.GetAvailablePermits());
-            Assert.Equal(0, concurrencyLimiter2.GetAvailablePermits());
+            Assert.Equal(2, concurrencyLimiter1.GetStatistics().CurrentAvailablePermits);
+            Assert.Equal(0, concurrencyLimiter2.GetStatistics().CurrentAvailablePermits);
 
             lease.Dispose();
-            Assert.Equal(5, concurrencyLimiter1.GetAvailablePermits());
-            Assert.Equal(3, concurrencyLimiter2.GetAvailablePermits());
+            Assert.Equal(5, concurrencyLimiter1.GetStatistics().CurrentAvailablePermits);
+            Assert.Equal(3, concurrencyLimiter2.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -858,12 +927,12 @@ namespace System.Threading.RateLimiting.Tests
 
             var lease = await chainedLimiter.AcquireAsync("", 3);
             Assert.True(lease.IsAcquired);
-            Assert.Equal(2, concurrencyLimiter1.GetAvailablePermits());
-            Assert.Equal(0, concurrencyLimiter2.GetAvailablePermits());
+            Assert.Equal(2, concurrencyLimiter1.GetStatistics().CurrentAvailablePermits);
+            Assert.Equal(0, concurrencyLimiter2.GetStatistics().CurrentAvailablePermits);
 
             lease.Dispose();
-            Assert.Equal(5, concurrencyLimiter1.GetAvailablePermits());
-            Assert.Equal(3, concurrencyLimiter2.GetAvailablePermits());
+            Assert.Equal(5, concurrencyLimiter1.GetStatistics().CurrentAvailablePermits);
+            Assert.Equal(3, concurrencyLimiter2.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -974,15 +1043,15 @@ namespace System.Threading.RateLimiting.Tests
 
             var lease = chainedLimiter.AttemptAcquire("");
             Assert.True(lease.IsAcquired);
-            Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
 
             var cts = new CancellationTokenSource();
             var task = chainedLimiter.AcquireAsync("", 1, cts.Token);
 
-            Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(0, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
             cts.Cancel();
             await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
-            Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]

--- a/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
@@ -160,15 +160,30 @@ namespace System.Threading.RateLimiting.Tests
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(34, QueueProcessingOrder.NewestFirst, 4));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = 34,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = 4
+                });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(22, QueueProcessingOrder.NewestFirst, 2));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = 22,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = 2
+                });
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(13, QueueProcessingOrder.NewestFirst, 10));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = 13,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = 10
+                });
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
@@ -183,15 +198,30 @@ namespace System.Threading.RateLimiting.Tests
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(34, QueueProcessingOrder.NewestFirst, 4));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = 34,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = 4
+                });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(22, QueueProcessingOrder.NewestFirst, 2));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = 22,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = 2
+                });
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions(13, QueueProcessingOrder.NewestFirst, 10));
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ => new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = 13,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = 10
+                });
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
@@ -211,6 +241,15 @@ namespace System.Threading.RateLimiting.Tests
             Assert.Equal(3, stats.CurrentAvailablePermits);
             Assert.Equal(0, stats.CurrentQueuedCount);
             Assert.Equal(5, stats.TotalSuccessfulLeases);
+            Assert.Equal(1, stats.TotalFailedLeases);
+
+            var task = chainedLimiter.WaitAndAcquireAsync("", 10);
+            Assert.False(task.IsCompleted);
+            stats = chainedLimiter.GetStatistics("");
+
+            Assert.Equal(2, stats.CurrentAvailablePermits);
+            Assert.Equal(10, stats.CurrentQueuedCount);
+            Assert.Equal(7, stats.TotalSuccessfulLeases);
             Assert.Equal(1, stats.TotalFailedLeases);
         }
 

--- a/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
@@ -226,7 +226,7 @@ namespace System.Threading.RateLimiting.Tests
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
 
-            var lease = chainedLimiter.Acquire("", 10);
+            var lease = chainedLimiter.AttemptAcquire("", 10);
             var stats = chainedLimiter.GetStatistics("");
 
             Assert.Equal(3, stats.CurrentAvailablePermits);
@@ -234,7 +234,7 @@ namespace System.Threading.RateLimiting.Tests
             Assert.Equal(3, stats.TotalSuccessfulLeases);
             Assert.Equal(0, stats.TotalFailedLeases);
 
-            var lease2 = chainedLimiter.Acquire("", 10);
+            var lease2 = chainedLimiter.AttemptAcquire("", 10);
             Assert.False(lease2.IsAcquired);
             stats = chainedLimiter.GetStatistics("");
 
@@ -243,7 +243,7 @@ namespace System.Threading.RateLimiting.Tests
             Assert.Equal(5, stats.TotalSuccessfulLeases);
             Assert.Equal(1, stats.TotalFailedLeases);
 
-            var task = chainedLimiter.WaitAndAcquireAsync("", 10);
+            var task = chainedLimiter.AcquireAsync("", 10);
             Assert.False(task.IsCompleted);
             stats = chainedLimiter.GetStatistics("");
 

--- a/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
@@ -808,7 +808,12 @@ namespace System.Threading.RateLimiting.Test
         [Fact]
         public override void GetStatisticsReturnsNewInstances()
         {
-            var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1));
+            var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+            {
+                PermitLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 1
+            });
 
             var stats = limiter.GetStatistics();
             Assert.Equal(1, stats.CurrentAvailablePermits);
@@ -824,7 +829,12 @@ namespace System.Threading.RateLimiting.Test
         [Fact]
         public override async Task GetStatisticsHasCorrectValues()
         {
-            var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions(100, QueueProcessingOrder.OldestFirst, 50));
+            var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+            {
+                PermitLimit = 100,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 50
+            });
 
             var stats = limiter.GetStatistics();
             Assert.Equal(100, stats.CurrentAvailablePermits);
@@ -875,6 +885,37 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(0, stats.CurrentQueuedCount);
             Assert.Equal(2, stats.TotalFailedLeases);
             Assert.Equal(2, stats.TotalSuccessfulLeases);
+        }
+
+        [Fact]
+        public override async Task GetStatisticsWithZeroPermitCount()
+        {
+            var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+            {
+                PermitLimit = 100,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 50
+            });
+            var lease = limiter.Acquire(0);
+            Assert.True(lease.IsAcquired);
+            Assert.Equal(1, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
+
+            lease = await limiter.WaitAndAcquireAsync(0);
+            Assert.True(lease.IsAcquired);
+            Assert.Equal(2, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
+
+            lease = limiter.Acquire(100);
+            Assert.True(lease.IsAcquired);
+            Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
+
+            var lease2 = limiter.Acquire(0);
+            Assert.False(lease2.IsAcquired);
+            Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(1, limiter.GetStatistics().TotalFailedLeases);
+            Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
         }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
@@ -818,7 +818,7 @@ namespace System.Threading.RateLimiting.Test
             var stats = limiter.GetStatistics();
             Assert.Equal(1, stats.CurrentAvailablePermits);
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
 
             var stats2 = limiter.GetStatistics();
             Assert.NotSame(stats, stats2);
@@ -843,7 +843,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(0, stats.TotalSuccessfulLeases);
 
             // success from acquire + available
-            var lease1 = limiter.Acquire(60);
+            var lease1 = limiter.AttemptAcquire(60);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
             Assert.Equal(0, stats.CurrentQueuedCount);
@@ -851,7 +851,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, stats.TotalSuccessfulLeases);
 
             // queue
-            var lease2Task = limiter.WaitAndAcquireAsync(50);
+            var lease2Task = limiter.AcquireAsync(50);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
             Assert.Equal(50, stats.CurrentQueuedCount);
@@ -859,7 +859,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, stats.TotalSuccessfulLeases);
 
             // failure from wait
-            var lease3 = await limiter.WaitAndAcquireAsync(1);
+            var lease3 = await limiter.AcquireAsync(1);
             Assert.False(lease3.IsAcquired);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
@@ -868,7 +868,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, stats.TotalSuccessfulLeases);
 
             // failure from acquire
-            var lease4 = limiter.Acquire(100);
+            var lease4 = limiter.AttemptAcquire(100);
             Assert.False(lease4.IsAcquired);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
@@ -896,22 +896,22 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 50
             });
-            var lease = limiter.Acquire(0);
+            var lease = limiter.AttemptAcquire(0);
             Assert.True(lease.IsAcquired);
             Assert.Equal(1, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
 
-            lease = await limiter.WaitAndAcquireAsync(0);
+            lease = await limiter.AcquireAsync(0);
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
 
-            lease = limiter.Acquire(100);
+            lease = limiter.AttemptAcquire(100);
             Assert.True(lease.IsAcquired);
             Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
 
-            var lease2 = limiter.Acquire(0);
+            var lease2 = limiter.AttemptAcquire(0);
             Assert.False(lease2.IsAcquired);
             Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(1, limiter.GetStatistics().TotalFailedLeases);

--- a/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
@@ -917,5 +917,18 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, limiter.GetStatistics().TotalFailedLeases);
             Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
         }
+
+        [Fact]
+        public override void GetStatisticsThrowsAfterDispose()
+        {
+            var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+            {
+                PermitLimit = 100,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 50
+            });
+            limiter.Dispose();
+            Assert.Throws<ObjectDisposedException>(limiter.GetStatistics);
+        }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
@@ -114,7 +114,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(wait2.IsCompleted);
 
             lease.Dispose();
-            Assert.Equal(0, limiter.GetAvailablePermits());
+            Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
             Assert.True(limiter.TryReplenish());
 
             lease = await wait2;
@@ -150,7 +150,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(wait1.IsCompleted);
 
             lease.Dispose();
-            Assert.Equal(1, limiter.GetAvailablePermits());
+            Assert.Equal(1, limiter.GetStatistics().CurrentAvailablePermits);
             Assert.True(limiter.TryReplenish());
 
             lease = await wait1;
@@ -502,7 +502,7 @@ namespace System.Threading.RateLimiting.Test
             lease.Dispose();
             Assert.True(limiter.TryReplenish());
 
-            Assert.Equal(1, limiter.GetAvailablePermits());
+            Assert.Equal(1, limiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -528,7 +528,7 @@ namespace System.Threading.RateLimiting.Test
             lease.Dispose();
             Assert.True(limiter.TryReplenish());
 
-            Assert.Equal(1, limiter.GetAvailablePermits());
+            Assert.Equal(1, limiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -739,9 +739,9 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.FromSeconds(1),
                 AutoReplenishment = true
             });
-            Assert.Equal(2, limiter.GetAvailablePermits());
+            Assert.Equal(2, limiter.GetStatistics().CurrentAvailablePermits);
             Assert.False(limiter.TryReplenish());
-            Assert.Equal(2, limiter.GetAvailablePermits());
+            Assert.Equal(2, limiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -755,7 +755,7 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.FromMilliseconds(1000),
                 AutoReplenishment = true
             });
-            Assert.Equal(2, limiter.GetAvailablePermits());
+            Assert.Equal(2, limiter.GetStatistics().CurrentAvailablePermits);
             limiter.AttemptAcquire(2);
 
             var lease = await limiter.AcquireAsync(1);
@@ -780,7 +780,7 @@ namespace System.Threading.RateLimiting.Test
             var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
-            Assert.Equal(1, limiter.GetAvailablePermits());
+            Assert.Equal(1, limiter.GetStatistics().CurrentAvailablePermits);
             lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
             Assert.False(wait.IsCompleted);
@@ -1016,6 +1016,78 @@ namespace System.Threading.RateLimiting.Test
 
             // Make sure dispose doesn't have any side-effects when dealing with a canceled queued item
             limiter.Dispose();
+        }
+
+        [Fact]
+        public override void GetStatisticsReturnsNewInstances()
+        {
+            var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1, TimeSpan.Zero, false));
+
+            var stats = limiter.GetStatistics();
+            Assert.Equal(1, stats.CurrentAvailablePermits);
+
+            var lease = limiter.Acquire(1);
+
+            var stats2 = limiter.GetStatistics();
+            Assert.NotSame(stats, stats2);
+            Assert.Equal(1, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats2.CurrentAvailablePermits);
+        }
+
+        [Fact]
+        public override async Task GetStatisticsHasCorrectValues()
+        {
+            var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions(100, QueueProcessingOrder.OldestFirst, 50, TimeSpan.Zero, false));
+
+            var stats = limiter.GetStatistics();
+            Assert.Equal(100, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats.CurrentQueuedCount);
+            Assert.Equal(0, stats.TotalFailedLeases);
+            Assert.Equal(0, stats.TotalSuccessfulLeases);
+
+            // success from acquire + available
+            var lease1 = limiter.Acquire(60);
+            stats = limiter.GetStatistics();
+            Assert.Equal(40, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats.CurrentQueuedCount);
+            Assert.Equal(0, stats.TotalFailedLeases);
+            Assert.Equal(1, stats.TotalSuccessfulLeases);
+
+            // queue
+            var lease2Task = limiter.WaitAndAcquireAsync(50);
+            stats = limiter.GetStatistics();
+            Assert.Equal(40, stats.CurrentAvailablePermits);
+            Assert.Equal(50, stats.CurrentQueuedCount);
+            Assert.Equal(0, stats.TotalFailedLeases);
+            Assert.Equal(1, stats.TotalSuccessfulLeases);
+
+            // failure from wait
+            var lease3 = await limiter.WaitAndAcquireAsync(1);
+            Assert.False(lease3.IsAcquired);
+            stats = limiter.GetStatistics();
+            Assert.Equal(40, stats.CurrentAvailablePermits);
+            Assert.Equal(50, stats.CurrentQueuedCount);
+            Assert.Equal(1, stats.TotalFailedLeases);
+            Assert.Equal(1, stats.TotalSuccessfulLeases);
+
+            // failure from acquire
+            var lease4 = limiter.Acquire(100);
+            Assert.False(lease4.IsAcquired);
+            stats = limiter.GetStatistics();
+            Assert.Equal(40, stats.CurrentAvailablePermits);
+            Assert.Equal(50, stats.CurrentQueuedCount);
+            Assert.Equal(2, stats.TotalFailedLeases);
+            Assert.Equal(1, stats.TotalSuccessfulLeases);
+
+            limiter.TryReplenish();
+            await lease2Task;
+
+            // success from wait + available + queue
+            stats = limiter.GetStatistics();
+            Assert.Equal(50, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats.CurrentQueuedCount);
+            Assert.Equal(2, stats.TotalFailedLeases);
+            Assert.Equal(2, stats.TotalSuccessfulLeases);
         }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
@@ -1136,5 +1136,20 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, limiter.GetStatistics().TotalFailedLeases);
             Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
         }
+
+        [Fact]
+        public override void GetStatisticsThrowsAfterDispose()
+        {
+            var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 100,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 50,
+                Window = TimeSpan.Zero,
+                AutoReplenishment = false
+            });
+            limiter.Dispose();
+            Assert.Throws<ObjectDisposedException>(limiter.GetStatistics);
+        }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
@@ -1021,7 +1021,14 @@ namespace System.Threading.RateLimiting.Test
         [Fact]
         public override void GetStatisticsReturnsNewInstances()
         {
-            var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1, TimeSpan.Zero, false));
+            var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 1,
+                Window = TimeSpan.Zero,
+                AutoReplenishment = false
+            });
 
             var stats = limiter.GetStatistics();
             Assert.Equal(1, stats.CurrentAvailablePermits);
@@ -1037,7 +1044,14 @@ namespace System.Threading.RateLimiting.Test
         [Fact]
         public override async Task GetStatisticsHasCorrectValues()
         {
-            var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions(100, QueueProcessingOrder.OldestFirst, 50, TimeSpan.Zero, false));
+            var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 100,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 50,
+                Window = TimeSpan.Zero,
+                AutoReplenishment = false
+            });
 
             var stats = limiter.GetStatistics();
             Assert.Equal(100, stats.CurrentAvailablePermits);
@@ -1088,6 +1102,39 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(0, stats.CurrentQueuedCount);
             Assert.Equal(2, stats.TotalFailedLeases);
             Assert.Equal(2, stats.TotalSuccessfulLeases);
+        }
+
+        [Fact]
+        public override async Task GetStatisticsWithZeroPermitCount()
+        {
+            var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 100,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 50,
+                Window = TimeSpan.Zero,
+                AutoReplenishment = false
+            });
+            var lease = limiter.Acquire(0);
+            Assert.True(lease.IsAcquired);
+            Assert.Equal(1, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
+
+            lease = await limiter.WaitAndAcquireAsync(0);
+            Assert.True(lease.IsAcquired);
+            Assert.Equal(2, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
+
+            lease = limiter.Acquire(100);
+            Assert.True(lease.IsAcquired);
+            Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
+
+            var lease2 = limiter.Acquire(0);
+            Assert.False(lease2.IsAcquired);
+            Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(1, limiter.GetStatistics().TotalFailedLeases);
+            Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
         }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
@@ -1033,7 +1033,7 @@ namespace System.Threading.RateLimiting.Test
             var stats = limiter.GetStatistics();
             Assert.Equal(1, stats.CurrentAvailablePermits);
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
 
             var stats2 = limiter.GetStatistics();
             Assert.NotSame(stats, stats2);
@@ -1060,7 +1060,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(0, stats.TotalSuccessfulLeases);
 
             // success from acquire + available
-            var lease1 = limiter.Acquire(60);
+            var lease1 = limiter.AttemptAcquire(60);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
             Assert.Equal(0, stats.CurrentQueuedCount);
@@ -1068,7 +1068,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, stats.TotalSuccessfulLeases);
 
             // queue
-            var lease2Task = limiter.WaitAndAcquireAsync(50);
+            var lease2Task = limiter.AcquireAsync(50);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
             Assert.Equal(50, stats.CurrentQueuedCount);
@@ -1076,7 +1076,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, stats.TotalSuccessfulLeases);
 
             // failure from wait
-            var lease3 = await limiter.WaitAndAcquireAsync(1);
+            var lease3 = await limiter.AcquireAsync(1);
             Assert.False(lease3.IsAcquired);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
@@ -1085,7 +1085,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, stats.TotalSuccessfulLeases);
 
             // failure from acquire
-            var lease4 = limiter.Acquire(100);
+            var lease4 = limiter.AttemptAcquire(100);
             Assert.False(lease4.IsAcquired);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
@@ -1115,22 +1115,22 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(0);
+            var lease = limiter.AttemptAcquire(0);
             Assert.True(lease.IsAcquired);
             Assert.Equal(1, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
 
-            lease = await limiter.WaitAndAcquireAsync(0);
+            lease = await limiter.AcquireAsync(0);
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
 
-            lease = limiter.Acquire(100);
+            lease = limiter.AttemptAcquire(100);
             Assert.True(lease.IsAcquired);
             Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
 
-            var lease2 = limiter.Acquire(0);
+            var lease2 = limiter.AttemptAcquire(0);
             Assert.False(lease2.IsAcquired);
             Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(1, limiter.GetStatistics().TotalFailedLeases);

--- a/src/libraries/System.Threading.RateLimiting/tests/Infrastructure/Utils.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/Infrastructure/Utils.cs
@@ -49,20 +49,20 @@ namespace System.Threading.RateLimiting.Tests
 
     internal sealed class NotImplementedPartitionedRateLimiter<T> : PartitionedRateLimiter<T>
     {
-        public override int GetAvailablePermits(T resource) => throw new NotImplementedException();
+        public override RateLimiterStatistics? GetStatistics(T resource) => throw new NotImplementedException();
         protected override RateLimitLease AttemptAcquireCore(T resource, int permitCount) => throw new NotImplementedException();
         protected override ValueTask<RateLimitLease> AcquireAsyncCore(T resource, int permitCount, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 
     internal sealed class TrackingRateLimiter : RateLimiter
     {
-        private int _getAvailablePermitsCallCount;
+        private int _getStatisticsCallCount;
         private int _acquireCallCount;
         private int _waitAsyncCallCount;
         private int _disposeCallCount;
         private int _disposeAsyncCallCount;
 
-        public int GetAvailablePermitsCallCount => _getAvailablePermitsCallCount;
+        public int GetStatisticsCallCount => _getStatisticsCallCount;
         public int AcquireCallCount => _acquireCallCount;
         public int AcquireAsyncCallCount => _waitAsyncCallCount;
         public int DisposeCallCount => _disposeCallCount;
@@ -70,10 +70,10 @@ namespace System.Threading.RateLimiting.Tests
 
         public override TimeSpan? IdleDuration => null;
 
-        public override int GetAvailablePermits()
+        public override RateLimiterStatistics? GetStatistics()
         {
-            Interlocked.Increment(ref _getAvailablePermitsCallCount);
-            return 1;
+            Interlocked.Increment(ref _getStatisticsCallCount);
+            return null;
         }
 
         protected override RateLimitLease AttemptAcquireCore(int permitCount)
@@ -149,7 +149,7 @@ namespace System.Threading.RateLimiting.Tests
     {
         public override TimeSpan? IdleDuration => throw new NotImplementedException();
 
-        public override int GetAvailablePermits() => throw new NotImplementedException();
+        public override RateLimiterStatistics? GetStatistics() => throw new NotImplementedException();
         protected override RateLimitLease AttemptAcquireCore(int permitCount) => throw new NotImplementedException();
         protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
@@ -159,8 +159,8 @@ namespace System.Threading.RateLimiting.Tests
         public Func<TimeSpan?> IdleDurationImpl { get; set; } = () => null;
         public override TimeSpan? IdleDuration => IdleDurationImpl();
 
-        public Func<int> GetAvailablePermitsImpl { get; set; } = () => throw new NotImplementedException();
-        public override int GetAvailablePermits() => GetAvailablePermitsImpl();
+        public Func<RateLimiterStatistics?> GetStatisticsImpl{ get; set; } = () => throw new NotImplementedException();
+        public override RateLimiterStatistics? GetStatistics() => GetStatisticsImpl();
 
         public Func<int, RateLimitLease> AttemptAcquireCoreImpl { get; set; } = _ => new Lease();
         protected override RateLimitLease AttemptAcquireCore(int permitCount) => AttemptAcquireCoreImpl(permitCount);
@@ -189,8 +189,8 @@ namespace System.Threading.RateLimiting.Tests
         public Func<TimeSpan?> IdleDurationImpl { get; set; } = () => null;
         public override TimeSpan? IdleDuration => IdleDurationImpl();
 
-        public Func<int> GetAvailablePermitsImpl { get; set; } = () => throw new NotImplementedException();
-        public override int GetAvailablePermits() => GetAvailablePermitsImpl();
+        public Func<RateLimiterStatistics?> GetStatisticsImpl { get; set; } = () => throw new NotImplementedException();
+        public override RateLimiterStatistics? GetStatistics() => GetStatisticsImpl();
 
         public Func<int, RateLimitLease> AttemptAcquireCoreImpl { get; set; } = _ => new Lease();
         protected override RateLimitLease AttemptAcquireCore(int permitCount) => AttemptAcquireCoreImpl(permitCount);

--- a/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
@@ -61,7 +61,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public void Create_GetAvailablePermitsCallsUnderlyingPartitionsLimiter()
+        public void Create_GetStatisticsCallsUnderlyingPartitionsLimiter()
         {
             var limiterFactory = new TrackingRateLimiterFactory<int>();
             using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
@@ -69,9 +69,9 @@ namespace System.Threading.RateLimiting.Tests
                 return RateLimitPartition.Get(1, key => limiterFactory.GetLimiter(key));
             });
 
-            limiter.GetAvailablePermits("");
+            limiter.GetStatistics("");
             Assert.Equal(1, limiterFactory.Limiters.Count);
-            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.GetAvailablePermitsCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.GetStatisticsCallCount);
         }
 
         [Fact]

--- a/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
@@ -766,13 +766,13 @@ namespace System.Threading.RateLimiting.Tests
                 return i.ToString();
             }, leaveOpen: true);
 
-            Assert.Equal(1, translateLimiter.GetAvailablePermits(1));
+            Assert.Equal(1, translateLimiter.GetStatistics(1).CurrentAvailablePermits);
             Assert.Equal(1, translateCallCount);
 
             var lease = translateLimiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, translateCallCount);
-            Assert.Equal(0, translateLimiter.GetAvailablePermits(1));
+            Assert.Equal(0, translateLimiter.GetStatistics(1).CurrentAvailablePermits);
             Assert.Equal(3, translateCallCount);
 
             var lease2 = limiter.AttemptAcquire("1");
@@ -780,13 +780,13 @@ namespace System.Threading.RateLimiting.Tests
 
             lease.Dispose();
 
-            Assert.Equal(1, translateLimiter.GetAvailablePermits(1));
+            Assert.Equal(1, translateLimiter.GetStatistics(1).CurrentAvailablePermits);
             Assert.Equal(4, translateCallCount);
 
             lease = limiter.AttemptAcquire("1");
             Assert.True(lease.IsAcquired);
 
-            Assert.Equal(0, translateLimiter.GetAvailablePermits(1));
+            Assert.Equal(0, translateLimiter.GetStatistics(1).CurrentAvailablePermits);
             Assert.Equal(5, translateCallCount);
         }
 
@@ -952,6 +952,25 @@ namespace System.Threading.RateLimiting.Tests
 
             Assert.Throws<ObjectDisposedException>(() => limiter.AttemptAcquire("1"));
             Assert.Throws<ObjectDisposedException>(() => translateLimiter.AttemptAcquire(1));
+        }
+
+        [Fact]
+        public void Translate_GetStatisticsCallsUnderlyingLimiter()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.Get(1, key => limiterFactory.GetLimiter(key));
+            });
+
+            var translateLimiter = limiter.WithTranslatedKey<int>(i =>
+            {
+                return i.ToString();
+            }, leaveOpen: false);
+
+            translateLimiter.GetStatistics(1);
+            Assert.Equal(1, limiterFactory.Limiters.Count);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.GetStatisticsCallCount);
         }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/RateLimiterPartitionTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/RateLimiterPartitionTests.cs
@@ -86,7 +86,7 @@ namespace System.Threading.RateLimiting.Tests
             var leaseCount = 0;
             for (var i = 0; i < 134; i++)
             {
-                var lease = limiter.Acquire(i);
+                var lease = limiter.AttemptAcquire(i);
                 Assert.True(lease.IsAcquired);
                 ++leaseCount;
             }
@@ -99,7 +99,7 @@ namespace System.Threading.RateLimiting.Tests
 
             for (var i = 0; i < 165; i++)
             {
-                var wait = limiter.WaitAndAcquireAsync(int.MaxValue);
+                var wait = limiter.AcquireAsync(int.MaxValue);
                 Assert.True(wait.IsCompletedSuccessfully);
                 var lease = await wait;
                 Assert.True(lease.IsAcquired);

--- a/src/libraries/System.Threading.RateLimiting/tests/RateLimiterPartitionTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/RateLimiterPartitionTests.cs
@@ -21,7 +21,7 @@ namespace System.Threading.RateLimiting.Tests
 
             var limiter = partition.Factory(1);
             var concurrencyLimiter = Assert.IsType<ConcurrencyLimiter>(limiter);
-            Assert.Equal(options.PermitLimit, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(options.PermitLimit, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace System.Threading.RateLimiting.Tests
 
             var limiter = partition.Factory(1);
             var tokenBucketLimiter = Assert.IsType<TokenBucketRateLimiter>(limiter);
-            Assert.Equal(options.TokenLimit, tokenBucketLimiter.GetAvailablePermits());
+            Assert.Equal(options.TokenLimit, tokenBucketLimiter.GetStatistics().CurrentAvailablePermits);
             Assert.Equal(options.ReplenishmentPeriod, tokenBucketLimiter.ReplenishmentPeriod);
             Assert.False(tokenBucketLimiter.IsAutoReplenishing);
         }
@@ -53,10 +53,10 @@ namespace System.Threading.RateLimiting.Tests
             var limiter = partition.Factory(1);
 
             // How do we test an internal implementation of a limiter that doesn't limit? Just try some stuff that normal limiters would probably block on and see if it works.
-            var available = limiter.GetAvailablePermits();
+            var available = limiter.GetStatistics().CurrentAvailablePermits;
             var lease = limiter.AttemptAcquire(int.MaxValue);
             Assert.True(lease.IsAcquired);
-            Assert.Equal(available, limiter.GetAvailablePermits());
+            Assert.Equal(available, limiter.GetStatistics().CurrentAvailablePermits);
 
             lease = limiter.AttemptAcquire(int.MaxValue);
             Assert.True(lease.IsAcquired);
@@ -81,7 +81,7 @@ namespace System.Threading.RateLimiting.Tests
 
             var limiter = partition.Factory(1);
             var concurrencyLimiter = Assert.IsType<ConcurrencyLimiter>(limiter);
-            Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
+            Assert.Equal(1, concurrencyLimiter.GetStatistics().CurrentAvailablePermits);
 
             var partition2 = RateLimitPartition.Get(1, key => new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
             {
@@ -94,7 +94,7 @@ namespace System.Threading.RateLimiting.Tests
             }));
             limiter = partition2.Factory(1);
             var tokenBucketLimiter = Assert.IsType<TokenBucketRateLimiter>(limiter);
-            Assert.Equal(1, tokenBucketLimiter.GetAvailablePermits());
+            Assert.Equal(1, tokenBucketLimiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -112,7 +112,7 @@ namespace System.Threading.RateLimiting.Tests
 
             var limiter = partition.Factory(1);
             var fixedWindowLimiter = Assert.IsType<FixedWindowRateLimiter>(limiter);
-            Assert.Equal(options.PermitLimit, fixedWindowLimiter.GetAvailablePermits());
+            Assert.Equal(options.PermitLimit, fixedWindowLimiter.GetStatistics().CurrentAvailablePermits);
             Assert.Equal(options.Window, fixedWindowLimiter.ReplenishmentPeriod);
             Assert.False(fixedWindowLimiter.IsAutoReplenishing);
         }
@@ -133,7 +133,7 @@ namespace System.Threading.RateLimiting.Tests
 
             var limiter = partition.Factory(1);
             var slidingWindowLimiter = Assert.IsType<SlidingWindowRateLimiter>(limiter);
-            Assert.Equal(options.PermitLimit, slidingWindowLimiter.GetAvailablePermits());
+            Assert.Equal(options.PermitLimit, slidingWindowLimiter.GetStatistics().CurrentAvailablePermits);
             Assert.Equal(TimeSpan.FromSeconds(11), slidingWindowLimiter.ReplenishmentPeriod);
             Assert.False(slidingWindowLimiter.IsAutoReplenishing);
         }

--- a/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
@@ -1097,7 +1097,7 @@ namespace System.Threading.RateLimiting.Test
             var stats = limiter.GetStatistics();
             Assert.Equal(1, stats.CurrentAvailablePermits);
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
 
             var stats2 = limiter.GetStatistics();
             Assert.NotSame(stats, stats2);
@@ -1124,14 +1124,14 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(0, stats.TotalFailedLeases);
             Assert.Equal(0, stats.TotalSuccessfulLeases);
 
-            var lease1 = limiter.Acquire(60);
+            var lease1 = limiter.AttemptAcquire(60);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
             Assert.Equal(0, stats.CurrentQueuedCount);
             Assert.Equal(0, stats.TotalFailedLeases);
             Assert.Equal(1, stats.TotalSuccessfulLeases);
 
-            var lease2Task = limiter.WaitAndAcquireAsync(50);
+            var lease2Task = limiter.AcquireAsync(50);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
             Assert.Equal(50, stats.CurrentQueuedCount);
@@ -1140,7 +1140,7 @@ namespace System.Threading.RateLimiting.Test
 
             limiter.TryReplenish();
 
-            var lease3 = await limiter.WaitAndAcquireAsync(1);
+            var lease3 = await limiter.AcquireAsync(1);
             Assert.False(lease3.IsAcquired);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
@@ -1148,7 +1148,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, stats.TotalFailedLeases);
             Assert.Equal(1, stats.TotalSuccessfulLeases);
 
-            var lease4 = limiter.Acquire(100);
+            var lease4 = limiter.AttemptAcquire(100);
             Assert.False(lease4.IsAcquired);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
@@ -1178,22 +1178,22 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 3,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(0);
+            var lease = limiter.AttemptAcquire(0);
             Assert.True(lease.IsAcquired);
             Assert.Equal(1, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
 
-            lease = await limiter.WaitAndAcquireAsync(0);
+            lease = await limiter.AcquireAsync(0);
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
 
-            lease = limiter.Acquire(100);
+            lease = limiter.AttemptAcquire(100);
             Assert.True(lease.IsAcquired);
             Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
 
-            var lease2 = limiter.Acquire(0);
+            var lease2 = limiter.AttemptAcquire(0);
             Assert.False(lease2.IsAcquired);
             Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(1, limiter.GetStatistics().TotalFailedLeases);

--- a/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
@@ -148,7 +148,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.True((await wait3).IsAcquired);
 
             Assert.False((await wait).IsAcquired);
-            Assert.Equal(0, limiter.GetAvailablePermits());
+            Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -182,7 +182,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(wait2.IsCompleted);
 
             lease.Dispose();
-            Assert.Equal(1, limiter.GetAvailablePermits());
+            Assert.Equal(1, limiter.GetStatistics().CurrentAvailablePermits);
             Assert.True(limiter.TryReplenish());
             Assert.True(limiter.TryReplenish());
 
@@ -222,7 +222,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(wait1.IsCompleted);
 
             lease.Dispose();
-            Assert.Equal(1, limiter.GetAvailablePermits());
+            Assert.Equal(1, limiter.GetStatistics().CurrentAvailablePermits);
             Assert.True(limiter.TryReplenish());
             Assert.True(limiter.TryReplenish());
 
@@ -602,7 +602,7 @@ namespace System.Threading.RateLimiting.Test
             lease.Dispose();
             Assert.True(limiter.TryReplenish());
 
-            Assert.Equal(0, limiter.GetAvailablePermits());
+            Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -629,7 +629,7 @@ namespace System.Threading.RateLimiting.Test
             lease.Dispose();
             Assert.True(limiter.TryReplenish());
 
-            Assert.Equal(0, limiter.GetAvailablePermits());
+            Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -662,7 +662,7 @@ namespace System.Threading.RateLimiting.Test
 
             lease = await wait;
             Assert.True(lease.IsAcquired);
-            Assert.Equal(1, limiter.GetAvailablePermits());
+            Assert.Equal(1, limiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -777,9 +777,9 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 1,
                 AutoReplenishment = true
             });
-            Assert.Equal(2, limiter.GetAvailablePermits());
+            Assert.Equal(2, limiter.GetStatistics().CurrentAvailablePermits);
             Assert.False(limiter.TryReplenish());
-            Assert.Equal(2, limiter.GetAvailablePermits());
+            Assert.Equal(2, limiter.GetStatistics().CurrentAvailablePermits);
         }
 
         [Fact]
@@ -794,7 +794,7 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = true
             });
-            Assert.Equal(2, limiter.GetAvailablePermits());
+            Assert.Equal(2, limiter.GetStatistics().CurrentAvailablePermits);
             limiter.AttemptAcquire(2);
 
             var lease = await limiter.AcquireAsync(1);
@@ -820,7 +820,7 @@ namespace System.Threading.RateLimiting.Test
             var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
-            Assert.Equal(1, limiter.GetAvailablePermits());
+            Assert.Equal(1, limiter.GetStatistics().CurrentAvailablePermits);
             lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
             Assert.False(wait.IsCompleted);
@@ -1079,6 +1079,75 @@ namespace System.Threading.RateLimiting.Test
 
             // Make sure dispose doesn't have any side-effects when dealing with a canceled queued item
             limiter.Dispose();
+        }
+
+        [Fact]
+        public override void GetStatisticsReturnsNewInstances()
+        {
+            var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1, TimeSpan.Zero, 2, false));
+
+            var stats = limiter.GetStatistics();
+            Assert.Equal(1, stats.CurrentAvailablePermits);
+
+            var lease = limiter.Acquire(1);
+
+            var stats2 = limiter.GetStatistics();
+            Assert.NotSame(stats, stats2);
+            Assert.Equal(1, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats2.CurrentAvailablePermits);
+        }
+
+        [Fact]
+        public override async Task GetStatisticsHasCorrectValues()
+        {
+            var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(100, QueueProcessingOrder.OldestFirst, 50, TimeSpan.Zero, 2, false));
+
+            var stats = limiter.GetStatistics();
+            Assert.Equal(100, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats.CurrentQueuedCount);
+            Assert.Equal(0, stats.TotalFailedLeases);
+            Assert.Equal(0, stats.TotalSuccessfulLeases);
+
+            var lease1 = limiter.Acquire(60);
+            stats = limiter.GetStatistics();
+            Assert.Equal(40, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats.CurrentQueuedCount);
+            Assert.Equal(0, stats.TotalFailedLeases);
+            Assert.Equal(1, stats.TotalSuccessfulLeases);
+
+            var lease2Task = limiter.WaitAndAcquireAsync(50);
+            stats = limiter.GetStatistics();
+            Assert.Equal(40, stats.CurrentAvailablePermits);
+            Assert.Equal(50, stats.CurrentQueuedCount);
+            Assert.Equal(0, stats.TotalFailedLeases);
+            Assert.Equal(1, stats.TotalSuccessfulLeases);
+
+            limiter.TryReplenish();
+
+            var lease3 = await limiter.WaitAndAcquireAsync(1);
+            Assert.False(lease3.IsAcquired);
+            stats = limiter.GetStatistics();
+            Assert.Equal(40, stats.CurrentAvailablePermits);
+            Assert.Equal(50, stats.CurrentQueuedCount);
+            Assert.Equal(1, stats.TotalFailedLeases);
+            Assert.Equal(1, stats.TotalSuccessfulLeases);
+
+            var lease4 = limiter.Acquire(100);
+            Assert.False(lease4.IsAcquired);
+            stats = limiter.GetStatistics();
+            Assert.Equal(40, stats.CurrentAvailablePermits);
+            Assert.Equal(50, stats.CurrentQueuedCount);
+            Assert.Equal(2, stats.TotalFailedLeases);
+            Assert.Equal(1, stats.TotalSuccessfulLeases);
+
+            limiter.TryReplenish();
+            await lease2Task;
+
+            stats = limiter.GetStatistics();
+            Assert.Equal(50, stats.CurrentAvailablePermits);
+            Assert.Equal(0, stats.CurrentQueuedCount);
+            Assert.Equal(2, stats.TotalFailedLeases);
+            Assert.Equal(2, stats.TotalSuccessfulLeases);
         }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
@@ -1199,5 +1199,21 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, limiter.GetStatistics().TotalFailedLeases);
             Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
         }
+
+        [Fact]
+        public override void GetStatisticsThrowsAfterDispose()
+        {
+            var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
+            {
+                PermitLimit = 100,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 50,
+                Window = TimeSpan.Zero,
+                SegmentsPerWindow = 3,
+                AutoReplenishment = false
+            });
+            limiter.Dispose();
+            Assert.Throws<ObjectDisposedException>(limiter.GetStatistics);
+        }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
@@ -1322,5 +1322,21 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, limiter.GetStatistics().TotalFailedLeases);
             Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
         }
+
+        [Fact]
+        public override void GetStatisticsThrowsAfterDispose()
+        {
+            var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = 100,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 50,
+                ReplenishmentPeriod = TimeSpan.Zero,
+                TokensPerPeriod = 30,
+                AutoReplenishment = false
+            });
+            limiter.Dispose();
+            Assert.Throws<ObjectDisposedException>(limiter.GetStatistics);
+        }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
@@ -1222,7 +1222,7 @@ namespace System.Threading.RateLimiting.Test
             var stats = limiter.GetStatistics();
             Assert.Equal(1, stats.CurrentAvailablePermits);
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
 
             var stats2 = limiter.GetStatistics();
             Assert.NotSame(stats, stats2);
@@ -1249,21 +1249,21 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(0, stats.TotalFailedLeases);
             Assert.Equal(0, stats.TotalSuccessfulLeases);
 
-            var lease1 = limiter.Acquire(60);
+            var lease1 = limiter.AttemptAcquire(60);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
             Assert.Equal(0, stats.CurrentQueuedCount);
             Assert.Equal(0, stats.TotalFailedLeases);
             Assert.Equal(1, stats.TotalSuccessfulLeases);
 
-            var lease2Task = limiter.WaitAndAcquireAsync(50);
+            var lease2Task = limiter.AcquireAsync(50);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
             Assert.Equal(50, stats.CurrentQueuedCount);
             Assert.Equal(0, stats.TotalFailedLeases);
             Assert.Equal(1, stats.TotalSuccessfulLeases);
 
-            var lease3 = await limiter.WaitAndAcquireAsync(1);
+            var lease3 = await limiter.AcquireAsync(1);
             Assert.False(lease3.IsAcquired);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
@@ -1271,7 +1271,7 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(1, stats.TotalFailedLeases);
             Assert.Equal(1, stats.TotalSuccessfulLeases);
 
-            var lease4 = limiter.Acquire(100);
+            var lease4 = limiter.AttemptAcquire(100);
             Assert.False(lease4.IsAcquired);
             stats = limiter.GetStatistics();
             Assert.Equal(40, stats.CurrentAvailablePermits);
@@ -1301,22 +1301,22 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 30,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(0);
+            var lease = limiter.AttemptAcquire(0);
             Assert.True(lease.IsAcquired);
             Assert.Equal(1, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
 
-            lease = await limiter.WaitAndAcquireAsync(0);
+            lease = await limiter.AcquireAsync(0);
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
 
-            lease = limiter.Acquire(100);
+            lease = limiter.AttemptAcquire(100);
             Assert.True(lease.IsAcquired);
             Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
 
-            var lease2 = limiter.Acquire(0);
+            var lease2 = limiter.AttemptAcquire(0);
             Assert.False(lease2.IsAcquired);
             Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
             Assert.Equal(1, limiter.GetStatistics().TotalFailedLeases);

--- a/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
@@ -1209,7 +1209,15 @@ namespace System.Threading.RateLimiting.Test
         [Fact]
         public override void GetStatisticsReturnsNewInstances()
         {
-            var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1, TimeSpan.Zero, 2, false));
+            var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 1,
+                ReplenishmentPeriod = TimeSpan.Zero,
+                TokensPerPeriod = 2,
+                AutoReplenishment = false
+            });
 
             var stats = limiter.GetStatistics();
             Assert.Equal(1, stats.CurrentAvailablePermits);
@@ -1225,7 +1233,15 @@ namespace System.Threading.RateLimiting.Test
         [Fact]
         public override async Task GetStatisticsHasCorrectValues()
         {
-            var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(100, QueueProcessingOrder.OldestFirst, 50, TimeSpan.Zero, 30, false));
+            var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = 100,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 50,
+                ReplenishmentPeriod = TimeSpan.Zero,
+                TokensPerPeriod = 30,
+                AutoReplenishment = false
+            });
 
             var stats = limiter.GetStatistics();
             Assert.Equal(100, stats.CurrentAvailablePermits);
@@ -1271,6 +1287,40 @@ namespace System.Threading.RateLimiting.Test
             Assert.Equal(0, stats.CurrentQueuedCount);
             Assert.Equal(2, stats.TotalFailedLeases);
             Assert.Equal(2, stats.TotalSuccessfulLeases);
+        }
+
+        [Fact]
+        public override async Task GetStatisticsWithZeroPermitCount()
+        {
+            var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = 100,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 50,
+                ReplenishmentPeriod = TimeSpan.Zero,
+                TokensPerPeriod = 30,
+                AutoReplenishment = false
+            });
+            var lease = limiter.Acquire(0);
+            Assert.True(lease.IsAcquired);
+            Assert.Equal(1, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
+
+            lease = await limiter.WaitAndAcquireAsync(0);
+            Assert.True(lease.IsAcquired);
+            Assert.Equal(2, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(100, limiter.GetStatistics().CurrentAvailablePermits);
+
+            lease = limiter.Acquire(100);
+            Assert.True(lease.IsAcquired);
+            Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
+
+            var lease2 = limiter.Acquire(0);
+            Assert.False(lease2.IsAcquired);
+            Assert.Equal(3, limiter.GetStatistics().TotalSuccessfulLeases);
+            Assert.Equal(1, limiter.GetStatistics().TotalFailedLeases);
+            Assert.Equal(0, limiter.GetStatistics().CurrentAvailablePermits);
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/71804

I could be convinced that the chained rate limiter should use the largest queue count instead of the smallest.

Also, the NoopLimiter could technically keep track of the successful leases and update the stats for that property.