### PR TITLE
Fix System.IO.FileSystem.DisabledFileLocking.Tests with NativeAOT

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/DisabledFileLockingTests/System.IO.FileSystem.DisabledFileLocking.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/DisabledFileLockingTests/System.IO.FileSystem.DisabledFileLocking.Tests.csproj
@@ -33,4 +33,7 @@
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)StreamConformanceTests\StreamConformanceTests.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.IO.DisableFileLocking" Value="true" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.FileSystem/tests/DisabledFileLockingTests/runtimeconfig.template.json
+++ b/src/libraries/System.IO.FileSystem/tests/DisabledFileLockingTests/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-    "configProperties": {
-        "System.IO.DisableFileLocking": true
-    }
-}


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/72310 tracks supporting runtimeconfig.template.json. Use the MSBuild property instead as that one works.