### PR TITLE
Fix Wbitwise-instead-of-logical in native tests

### DIFF
--- a/src/tests/Common/Platform/platformdefines.cpp
+++ b/src/tests/Common/Platform/platformdefines.cpp
@@ -142,13 +142,13 @@ error_t TP_getenv_s(size_t* pReturnValue, LPWSTR buffer, size_t sizeInWords, LPC
     if (NULL == pReturnValue || NULL == varname) return 1;
 
 #ifdef WINDOWS
-    
+
      size_t  returnValue;
      WCHAR   buf[100];
      if( 0 != _wgetenv_s(&returnValue, buf, 100, varname) || returnValue<=0 )
         return 2;
-    
-    
+
+
     TP_scpy_s(buffer, sizeInWords, (LPWSTR)buf);
 #else
     LPSTR pRet;
@@ -337,13 +337,13 @@ HRESULT ULongLongToULong(ULONGLONG ullOperand, ULONG* pulResult)
 {
     HRESULT hr = INTSAFE_E_ARITHMETIC_OVERFLOW;
     *pulResult = ULONG_ERROR;
-    
+
     if (ullOperand <= UINT32_MAX)
     {
         *pulResult = (ULONG)ullOperand;
         hr = S_OK;
     }
-    
+
     return hr;
 }
 
@@ -357,16 +357,16 @@ HRESULT ULongAdd(ULONG ulAugend, ULONG ulAddend,ULONG* pulResult)
         *pulResult = (ulAugend + ulAddend);
         hr = S_OK;
     }
-    
+
     return hr;
 }
 
 HRESULT ULongMult(ULONG ulMultiplicand, ULONG ulMultiplier, ULONG* pulResult)
 {
     ULONGLONG ull64Result = UInt32x32To64(ulMultiplicand, ulMultiplier);
-    
+
     return ULongLongToULong(ull64Result, pulResult);
-}     
+}
 
 HRESULT CbSysStringSize(ULONG cchSize, BOOL isByteLen, ULONG *result)
 {
@@ -388,7 +388,7 @@ HRESULT CbSysStringSize(ULONG cchSize, BOOL isByteLen, ULONG *result)
     else
     {
         ULONG temp = 0; // should not use in-place addition in ULongAdd
-        if (SUCCEEDED(ULongMult(cchSize, sizeof(WCHAR), &temp)) &
+        if (SUCCEEDED(ULongMult(cchSize, sizeof(WCHAR), &temp)) &&
             SUCCEEDED(ULongAdd(temp, constant, result)))
         {
             *result = *result & ~WIN32_ALLOC_ALIGN;
@@ -400,7 +400,7 @@ HRESULT CbSysStringSize(ULONG cchSize, BOOL isByteLen, ULONG *result)
 
 BSTR TP_SysAllocString(LPCWSTR psz)
 {
-#ifdef WINDOWS    
+#ifdef WINDOWS
     return SysAllocString(psz);
 #else
     if(psz == NULL)
@@ -422,7 +422,7 @@ BSTR CoreClrBStrAlloc(LPCWSTR psz, size_t len)
 
 #if defined(HOST_64BIT)
       // NOTE: There are some apps which peek back 4 bytes to look at the size of the BSTR. So, in case of 64-bit code,
-      // we need to ensure that the BSTR length can be found by looking one DWORD before the BSTR pointer. 
+      // we need to ensure that the BSTR length can be found by looking one DWORD before the BSTR pointer.
       *(DWORD_PTR *)bstr = (DWORD_PTR) 0;
       bstr = (BSTR) ((char *) bstr + sizeof (DWORD));
 #endif
@@ -437,12 +437,12 @@ BSTR CoreClrBStrAlloc(LPCWSTR psz, size_t len)
       bstr[len] = '\0'; // always 0 terminate
     }
 
-    return bstr; 
+    return bstr;
 }
 
 BSTR CoreClrBStrAlloc(LPCSTR psz, size_t len)
 {
-#ifdef WINDOWS    
+#ifdef WINDOWS
     return SysAllocStringByteLen(psz, (UINT)len);
 #else
     BSTR bstr;
@@ -472,25 +472,25 @@ BSTR CoreClrBStrAlloc(LPCSTR psz, size_t len)
     }
 
     return bstr;
-#endif    
+#endif
 }
 
 void CoreClrBStrFree(BSTR bstr)
 {
-#ifdef WINDOWS    
+#ifdef WINDOWS
     return SysFreeString(bstr);
 #else
     if (bstr == NULL)
       return;
-    CoreClrFree((BYTE *)bstr - sizeof(DWORD_PTR));  
-#endif    
+    CoreClrFree((BYTE *)bstr - sizeof(DWORD_PTR));
+#endif
 }
 
 size_t TP_SysStringByteLen(BSTR bstr)
 {
-#ifdef WINDOWS    
+#ifdef WINDOWS
     return SysStringByteLen(bstr);
-#else   
+#else
     if(bstr == NULL)
       return 0;
     int32_t * p32 = (int32_t *) bstr;
@@ -500,7 +500,7 @@ size_t TP_SysStringByteLen(BSTR bstr)
     //std::cout << p32 << p32_1 << endl;
     //std::cout << d32 << d32_1 << endl;
     return (unsigned int)(((DWORD *)bstr)[-1]);
-#endif    
+#endif
 }
 
 size_t TP_SysStringLen(BSTR bstr)
@@ -517,7 +517,7 @@ size_t TP_SysStringLen(BSTR bstr)
 size_t TP_strncpy_s(char* strDest, size_t numberOfElements, const char *strSource, size_t count)
 {
     // NOTE: Need to pass count + 1 since strncpy_s does not count null,
-    // while snprintf does. 
+    // while snprintf does.
     return snprintf(strDest, count + 1, "%s", strSource);
 }
 


### PR DESCRIPTION
Running `src/tests/build.sh` with clang 15 was raising an error `Wbitwise-instead-of-logical` on line 391 due to the use of `&` instead of `&&` in `if` condition.

Also cleaned up trailing whitespaces from this file while at it.