### PR TITLE
Always generate metadata for dynamic methods

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -4767,15 +4767,6 @@ void ReflectionModule::CaptureModuleMetaDataToMemory()
     }
     CONTRACTL_END;
 
-    // If a debugger is attached, then the CLR will still send ClassLoad notifications for dynamic modules,
-    // which mean we still need to keep the metadata available. This is the same as Whidbey.
-    // An alternative (and better) design would be to suppress ClassLoad notifications too, but then we'd
-    // need some way of sending a "catchup" notification to the debugger after we re-enable notifications.
-    if (!CORDebuggerAttached())
-    {
-        return;
-    }
-
     // Do not release the emitter. This is a weak reference.
     IMetaDataEmit *pEmitter = this->GetEmitter();
     _ASSERTE(pEmitter != NULL);


### PR DESCRIPTION

Fixes #62977

> This is an unintended side effect of #57069. As it stands now we won't generate metadata for dynamic modules unless a debugger is attached. Before that change we would bail from `ReflectionModule::CaptureModuleMetaDataToMemory` only if `IsMetadataCaptureSuppressed() && !CORDebuggerAttached()`, `IsMetadataCaptureSuppressed()` was only true in one case, when we were importing a COM type lib. But, when the import was done it would turn suppression off and we would generate the metadata then.

> https://github.com/dotnet/runtime/blob/3dc99e900b46eff4900ca46a63ba7da963271d10/src/coreclr/vm/ceeload.cpp#L12688-L12691

> After the change we always bail unconditionally if no debugger is attached, and there is no code to update it when a debugger attaches later.

> https://github.com/dotnet/runtime/blob/50fa756a2f1020bd21b8e72e5750d307e38d72e0/src/coreclr/vm/ceeload.cpp#L4774-L4777

> The fix here is to delete the early out, since the COM typelib code was removed as part of the same effort. This will revert us to the previous behavior.

_Originally posted by @davmason in https://github.com/dotnet/runtime/issues/62977#issuecomment-1186149824_

