### PR TITLE
Do not use the string bit vector in regexes, if it's all ones or all zeroes.

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -4506,9 +4506,7 @@ namespace System.Text.RegularExpressions.Generator
                 // (In the future, we could possibly extend the rm.Analysis to produce a known
                 // lower-bound and compare against that rather than always using 128 as the
                 // pivot point.)
-                return negate ?
-                    $"((ch = {chExpr}) < 128 || !RegexRunner.CharInClass((char)ch, {Literal(charClass)}))" :
-                    $"((ch = {chExpr}) >= 128 && RegexRunner.CharInClass((char)ch, {Literal(charClass)}))";
+                return EmitContainsNoAscii();
             }
 
             if (analysis.AllAsciiContained)
@@ -4516,9 +4514,7 @@ namespace System.Text.RegularExpressions.Generator
                 // We determined that every ASCII character is in the class, for example
                 // if the class were the negated example from case 1 above:
                 // [^\p{IsGreek}\p{IsGreekExtended}].
-                return negate ?
-                    $"((ch = {chExpr}) >= 128 && !RegexRunner.CharInClass((char)ch, {Literal(charClass)}))" :
-                    $"((ch = {chExpr}) < 128 || RegexRunner.CharInClass((char)ch, {Literal(charClass)}))";
+                return EmitAllAsciiContained();
             }
 
             // Now, our big hammer is to generate a lookup table that lets us quickly index by character into a yes/no
@@ -4547,6 +4543,15 @@ namespace System.Text.RegularExpressions.Generator
                     }
                 }
             });
+
+            // There's a chance that the class contains either no ASCII characters or all of them,
+            // and the analysis could not find it (for example if the class has a subtraction).
+            // We optimize away the bit vector in these trivial cases.
+            switch (bitVectorString)
+            {
+                case "\0\0\0\0\0\0\0\0": return EmitContainsNoAscii();
+                case "\uffff\uffff\uffff\uffff\uffff\uffff\uffff\uffff": return EmitAllAsciiContained();
+            }
 
             // We determined that the character class may contain ASCII, so we
             // output the lookup against the lookup table.
@@ -4577,6 +4582,20 @@ namespace System.Text.RegularExpressions.Generator
             return negate ?
                 $"((ch = {chExpr}) < 128 ? ({Literal(bitVectorString)}[ch >> 4] & (1 << (ch & 0xF))) == 0 : !RegexRunner.CharInClass((char)ch, {Literal(charClass)}))" :
                 $"((ch = {chExpr}) < 128 ? ({Literal(bitVectorString)}[ch >> 4] & (1 << (ch & 0xF))) != 0 : RegexRunner.CharInClass((char)ch, {Literal(charClass)}))";
+
+            string EmitContainsNoAscii()
+            {
+                return negate ?
+                    $"((ch = {chExpr}) < 128 || !RegexRunner.CharInClass((char)ch, {Literal(charClass)}))" :
+                    $"((ch = {chExpr}) >= 128 && RegexRunner.CharInClass((char)ch, {Literal(charClass)}))";
+            }
+
+            string EmitAllAsciiContained()
+            {
+                return negate ?
+                    $"((ch = {chExpr}) >= 128 && !RegexRunner.CharInClass((char)ch, {Literal(charClass)}))" :
+                    $"((ch = {chExpr}) < 128 || RegexRunner.CharInClass((char)ch, {Literal(charClass)}))";
+            }
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -5472,14 +5472,8 @@ namespace System.Text.RegularExpressions
             Label doneLabel = DefineLabel();
             Label comparisonLabel = DefineLabel();
 
-            if (analysis.ContainsNoAscii)
+            void EmitContainsNoAscii()
             {
-                // We determined that the character class contains only non-ASCII,
-                // for example if the class were [\u1000-\u2000\u3000-\u4000\u5000-\u6000].
-                // (In the future, we could possibly extend the analysis to produce a known
-                // lower-bound and compare against that rather than always using 128 as the
-                // pivot point.)
-
                 // ch >= 128 && RegexRunner.CharInClass(ch, "...")
                 Ldloc(tempLocal);
                 Ldc(128);
@@ -5491,15 +5485,10 @@ namespace System.Text.RegularExpressions
                 Stloc(resultLocal);
                 MarkLabel(doneLabel);
                 Ldloc(resultLocal);
-                return;
             }
 
-            if (analysis.AllAsciiContained)
+            void EmitAllAsciiContained()
             {
-                // We determined that every ASCII character is in the class, for example
-                // if the class were the negated example from case 1 above:
-                // [^\p{IsGreek}\p{IsGreekExtended}].
-
                 // ch < 128 || RegexRunner.CharInClass(ch, "...")
                 Ldloc(tempLocal);
                 Ldc(128);
@@ -5511,6 +5500,27 @@ namespace System.Text.RegularExpressions
                 Stloc(resultLocal);
                 MarkLabel(doneLabel);
                 Ldloc(resultLocal);
+            }
+
+            if (analysis.ContainsNoAscii)
+            {
+                // We determined that the character class contains only non-ASCII,
+                // for example if the class were [\u1000-\u2000\u3000-\u4000\u5000-\u6000].
+                // (In the future, we could possibly extend the analysis to produce a known
+                // lower-bound and compare against that rather than always using 128 as the
+                // pivot point.)
+
+                EmitContainsNoAscii();
+                return;
+            }
+
+            if (analysis.AllAsciiContained)
+            {
+                // We determined that every ASCII character is in the class, for example
+                // if the class were the negated example from case 1 above:
+                // [^\p{IsGreek}\p{IsGreekExtended}].
+
+                EmitAllAsciiContained();
                 return;
             }
 
@@ -5540,6 +5550,19 @@ namespace System.Text.RegularExpressions
                     }
                 }
             });
+
+            // There's a chance that the class contains either no ASCII characters or all of them,
+            // and the analysis could not find it (for example if the class has a subtraction).
+            // We optimize away the bit vector in these trivial cases.
+            switch (bitVectorString)
+            {
+                case "\0\0\0\0\0\0\0\0":
+                    EmitContainsNoAscii();
+                    return;
+                case "\uffff\uffff\uffff\uffff\uffff\uffff\uffff\uffff":
+                    EmitAllAsciiContained();
+                    return;
+            }
 
             // We determined that the character class may contain ASCII, so we
             // output the lookup against the lookup table.

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Count.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Count.Tests.cs
@@ -75,6 +75,8 @@ namespace System.Text.RegularExpressions.Tests
                 yield return new object[] { engine, @".", "\n\n\n", 0, RegexOptions.None, 0 };
                 yield return new object[] { engine, @".", "\n\n\n", 0, RegexOptions.Singleline, 3 };
 
+                yield return new object[] { engine, @"[а-я-[аeиоуыэюя]]", "спокойной ночи", 0, RegexOptions.None, 8 };
+
                 if (!RegexHelpers.IsNonBacktracking(engine))
                 {
                     // Lookbehinds


### PR DESCRIPTION
Fixes #72312.

When emitting code that matches regex character classes, if all other shortcuts fail, we resort to hardcoding whether ASCII characters belong in the set using a string as a bit vector, and calling `CharInClass` for the other characters. Sometimes, based on `RegexCharClass.Analyze` we determine that the character class contains either all ASCII characters or none of them, and skip the bit vector search.

However these analysis results are not perfect and cannot produce reliable results if for example the character class contains a subtraction. This PR checks the string bit vector after its construction to see if it contains only ones or zeroes and if so, emits code that does not use it.