### PR TITLE
Rename --instructionset to --instruction-set in ilc

### DIFF
--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -147,7 +147,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
 #pragma warning(pop)
 #endif
     {
-        printf("\nMicrosoft (R) .NET IL Assembler version " CLR_PRODUCT_VERSION);
+        printf("\n.NET IL Assembler version " CLR_PRODUCT_VERSION);
         printf("\n%S\n\n", VER_LEGALCOPYRIGHT_LOGO_STR_L);
         goto PrintUsageAndExit;
 
@@ -630,7 +630,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                 //======================================================================
                 if(bLogo)
                 {
-                    printf("\nMicrosoft (R) .NET IL Assembler.  Version " CLR_PRODUCT_VERSION);
+                    printf("\n.NET IL Assembler.  Version " CLR_PRODUCT_VERSION);
                     printf("\n%S", VER_LEGALCOPYRIGHT_LOGO_STR_L);
                 }
 

--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -7029,7 +7029,7 @@ void DumpPreamble()
     else if(g_fDumpRTF)
     {
     }
-    sprintf_s(szString,SZSTRING_SIZE,"//  Microsoft (R) .NET IL Disassembler.  Version " CLR_PRODUCT_VERSION);
+    sprintf_s(szString,SZSTRING_SIZE,"//  .NET IL Disassembler.  Version " CLR_PRODUCT_VERSION);
     printLine(g_pFile,COMMENT(szString));
     if(g_fDumpHTML)
     {

--- a/src/coreclr/ildasm/windasm.cpp
+++ b/src/coreclr/ildasm/windasm.cpp
@@ -93,7 +93,7 @@ FILE* OpenOutput(_In_ __nullterminated const char* szFileName);
 
 void PrintLogo()
 {
-    printf("Microsoft (R) .NET IL Disassembler.  Version " CLR_PRODUCT_VERSION);
+    printf(".NET IL Disassembler.  Version " CLR_PRODUCT_VERSION);
     printf("\n%S\n\n", VER_LEGALCOPYRIGHT_LOGO_STR_L);
 }
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -232,7 +232,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcFoldIdenticalMethodBodies) == 'true'" Include="--methodbodyfolding" />
       <IlcArg Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) == 'Size'" Include="--Os" />
       <IlcArg Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) == 'Speed'" Include="--Ot" />
-      <IlcArg Condition="$(IlcInstructionSet) != ''" Include="--instructionset:$(IlcInstructionSet)" />
+      <IlcArg Condition="$(IlcInstructionSet) != ''" Include="--instruction-set:$(IlcInstructionSet)" />
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--reflectiondata:none" />
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--feature:System.Collections.Generic.DefaultComparers=false" />
       <IlcArg Condition="$(IlcSingleThreaded) == 'true'" Include="--parallelism:1" />

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -110,7 +110,7 @@ namespace ILCompiler
         private void Help(string helpText)
         {
             Console.WriteLine();
-            Console.Write("Microsoft (R) .NET Native IL Compiler");
+            Console.Write(".NET Native IL Compiler");
             Console.Write(" ");
             Console.Write(typeof(Program).GetTypeInfo().Assembly.GetName().Version);
             Console.WriteLine();
@@ -215,7 +215,7 @@ namespace ILCompiler
                 syntax.DefineOptionList("feature", ref _featureSwitches, "Feature switches to apply (format: 'Namespace.Name=[true|false]'");
                 syntax.DefineOptionList("runtimeopt", ref _runtimeOptions, "Runtime options to set");
                 syntax.DefineOption("parallelism", ref _parallelism, "Maximum number of threads to use during compilation");
-                syntax.DefineOption("instructionset", ref _instructionSet, "Instruction set to allow or disallow");
+                syntax.DefineOption("instruction-set", ref _instructionSet, "Instruction set to allow or disallow");
                 syntax.DefineOption("guard", ref _guard, "Enable mitigations. Options: 'cf': CFG (Control Flow Guard, Windows only)");
                 syntax.DefineOption("preinitstatics", ref _preinitStatics, "Interpret static constructors at compile time if possible (implied by -O)");
                 syntax.DefineOption("nopreinitstatics", ref _noPreinitStatics, "Do not interpret static constructors at compile time");

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64NonVex.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64NonVex.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <IlcArg Include="--instructionset:sse4.2" />
+    <IlcArg Include="--instruction-set:sse4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <IlcArg Include="--instructionset:avx2" />
+    <IlcArg Include="--instruction-set:avx2" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Crossgen2 uses `--instruction-set` argument, while ilc has `--instructionset`, and the command description in ilc (`src/coreclr/tools/aot/ILCompiler/Program.cs` at line 276 and 309) refer to it as `--instruction-set`. This PR aligns the argument name to hyphenated form.

Also removed `Microsoft (R)` from tools' banners.

Context: https://github.com/dotnet/runtime/pull/72082#issuecomment-1186263715