### PR TITLE
fix assert in ssl options clone

### DIFF
--- a/src/libraries/Common/src/System/Net/Security/CertificateHelper.cs
+++ b/src/libraries/Common/src/System/Net/Security/CertificateHelper.cs
@@ -13,9 +13,9 @@ namespace System.Net.Security
     {
         private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
 
-        internal static X509Certificate2? GetEligibleClientCertificate(X509CertificateCollection candidateCerts)
+        internal static X509Certificate2? GetEligibleClientCertificate(X509CertificateCollection? candidateCerts)
         {
-            if (candidateCerts.Count == 0)
+            if (candidateCerts == null || candidateCerts.Count == 0)
             {
                 return null;
             }
@@ -26,9 +26,9 @@ namespace System.Net.Security
             return GetEligibleClientCertificate(certs);
         }
 
-        internal static X509Certificate2? GetEligibleClientCertificate(X509Certificate2Collection candidateCerts)
+        internal static X509Certificate2? GetEligibleClientCertificate(X509Certificate2Collection? candidateCerts)
         {
-            if (candidateCerts.Count == 0)
+            if (candidateCerts == null || candidateCerts.Count == 0)
             {
                 return null;
             }

--- a/src/libraries/Common/src/System/Net/Security/SslClientAuthenticationOptionsExtensions.cs
+++ b/src/libraries/Common/src/System/Net/Security/SslClientAuthenticationOptionsExtensions.cs
@@ -14,8 +14,6 @@ namespace System.Net.Security
     {
         public static SslClientAuthenticationOptions ShallowClone(this SslClientAuthenticationOptions options)
         {
-            var cc = options.ClientCertificates;
-
             var clone = new SslClientAuthenticationOptions()
             {
                 AllowRenegotiation = options.AllowRenegotiation,
@@ -72,7 +70,6 @@ namespace System.Net.Security
                 }
             }
 #endif
-            Debug.Assert(cc == options.ClientCertificates);
 
             return clone;
         }

--- a/src/libraries/Common/src/System/Net/Security/SslClientAuthenticationOptionsExtensions.cs
+++ b/src/libraries/Common/src/System/Net/Security/SslClientAuthenticationOptionsExtensions.cs
@@ -14,11 +14,14 @@ namespace System.Net.Security
     {
         public static SslClientAuthenticationOptions ShallowClone(this SslClientAuthenticationOptions options)
         {
+            var cc = options.ClientCertificates;
+
             var clone = new SslClientAuthenticationOptions()
             {
                 AllowRenegotiation = options.AllowRenegotiation,
                 ApplicationProtocols = options.ApplicationProtocols != null ? new List<SslApplicationProtocol>(options.ApplicationProtocols) : null,
                 CertificateRevocationCheckMode = options.CertificateRevocationCheckMode,
+                CertificateChainPolicy = options.CertificateChainPolicy,
                 CipherSuitesPolicy = options.CipherSuitesPolicy,
                 ClientCertificates = options.ClientCertificates,
                 EnabledSslProtocols = options.EnabledSslProtocols,
@@ -69,6 +72,7 @@ namespace System.Net.Security
                 }
             }
 #endif
+            Debug.Assert(cc == options.ClientCertificates);
 
             return clone;
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -222,7 +222,7 @@ namespace System.Net.Http
 #else
                         ThrowForModifiedManagedSslOptionsIfStarted();
                         _clientCertificateOptions = value;
-                        _underlyingHandler.SslOptions.LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => CertificateHelper.GetEligibleClientCertificate(ClientCertificates)!;
+                        _underlyingHandler.SslOptions.LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => CertificateHelper.GetEligibleClientCertificate(_underlyingHandler.SslOptions.ClientCertificates)!;
 #endif
                         break;
 


### PR DESCRIPTION
fixes #71233

The assert we are hitting was added to detect cases when we add new property but we fail to update the clone method. 
(it failed that purpose and I added the new missing CertificateChainPolicy as well) 
However, in this case it fails because the given `SslClientAuthenticationOptions` is being modified while cloned.
While the underlying issue existed for a while I think the recent failures are triggered by #70716.
Registered LocalCertificateSelectionCallback will access Handler's `ClientCertificates` and that will trigger 
```c#
return _underlyingHandler.SslOptions.ClientCertificates ??
                (_underlyingHandler.SslOptions.ClientCertificates = new X509CertificateCollection());
```

The tests (like SendMoreThanStreamLimitRequestsConcurrently_LastWaits)  triggering the assert use `Parallel.For` to blast bunch of requests, each racing the initialization in chain setup and modifying ClientCertificates from `null` to empty collection. 

This fix is to use underlying object without attempt to initialize it and guarding against `null` in `GetEligibleClientCertificate`.


