### PR TITLE
Add CancellationToken-accepting overloads for SendPingAsync

### DIFF
--- a/src/libraries/System.Net.Ping/ref/System.Net.Ping.cs
+++ b/src/libraries/System.Net.Ping/ref/System.Net.Ping.cs
@@ -62,10 +62,12 @@ namespace System.Net.NetworkInformation
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(System.Net.IPAddress address, int timeout) { throw null; }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(System.Net.IPAddress address, int timeout, byte[] buffer) { throw null; }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(System.Net.IPAddress address, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions? options) { throw null; }
+        public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(System.Net.IPAddress address, System.TimeSpan timeout, byte[]? buffer = null, System.Net.NetworkInformation.PingOptions? options = null, System.Threading.CancellationToken cancellationToken = default) { throw null; }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(string hostNameOrAddress) { throw null; }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(string hostNameOrAddress, int timeout) { throw null; }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer) { throw null; }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions? options) { throw null; }
+        public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(string hostNameOrAddress, System.TimeSpan timeout, byte[]? buffer = null, System.Net.NetworkInformation.PingOptions? options = null, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
     public partial class PingCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
     {

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.OSX.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.OSX.cs
@@ -22,17 +22,7 @@ namespace System.Net.NetworkInformation
         private static PingReply SendPingCore(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
             => SendIcmpEchoRequestOverRawSocket(address, buffer, timeout, options);
 
-        private async Task<PingReply> SendPingAsyncCore(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
-        {
-            Task<PingReply> t = SendIcmpEchoRequestOverRawSocketAsync(address, buffer, timeout, options);
-            PingReply reply = await t.ConfigureAwait(false);
-
-            if (_canceled)
-            {
-                throw new OperationCanceledException();
-            }
-
-            return reply;
-        }
+        private Task<PingReply> SendPingAsyncCore(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
+            => SendIcmpEchoRequestOverRawSocketAsync(address, buffer, timeout, options);
     }
 }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
@@ -73,33 +73,29 @@ namespace System.Net.NetworkInformation
 
         private async Task<PingReply> SendWithPingUtilityAsync(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
         {
-            using (Process p = GetPingProcess(address, buffer, timeout, options))
+            CancellationToken timeoutOrCancellationToken = _timeoutOrCancellationSource!.Token;
+
+            using Process pingProcess = GetPingProcess(address, buffer, timeout, options);
+            pingProcess.Start();
+
+            try
             {
-                var processCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                p.EnableRaisingEvents = true;
-                p.Exited += (s, e) => processCompletion.SetResult();
-                p.Start();
+                await pingProcess.WaitForExitAsync(timeoutOrCancellationToken).ConfigureAwait(false);
 
-                try
+                string stdout = await pingProcess.StandardOutput.ReadToEndAsync(timeoutOrCancellationToken).ConfigureAwait(false);
+                return ParsePingUtilityOutput(address, pingProcess.ExitCode, stdout);
+            }
+            catch when (timeoutOrCancellationToken.IsCancellationRequested)
+            {
+                if (!pingProcess.HasExited)
                 {
-                    await processCompletion.Task.WaitAsync(TimeSpan.FromMilliseconds(timeout)).ConfigureAwait(false);
+                    pingProcess.Kill();
                 }
-                catch (TimeoutException)
+                if (_canceled)
                 {
-                    p.Kill();
-                    return CreatePingReply(IPStatus.TimedOut);
+                    throw;
                 }
-
-                try
-                {
-                    string stdout = await p.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
-                    return ParsePingUtilityOutput(address, p.ExitCode, stdout);
-                }
-                catch (Exception)
-                {
-                    // If the standard output cannot be successfully parsed, throw a generic PingException.
-                    throw new PingException(SR.net_ping);
-                }
+                return CreatePingReply(IPStatus.TimedOut);
             }
         }
 

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
@@ -278,14 +278,14 @@ namespace System.Net.NetworkInformation
 
         private async Task<PingReply> SendIcmpEchoRequestOverRawSocketAsync(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
         {
-            CancellationToken timeoutOrCancellationToken = _timeoutOrCancellationSource!.Token;
-
             SocketConfig socketConfig = GetSocketConfig(address, buffer, timeout, options);
             using Socket socket = GetRawSocket(socketConfig);
             int ipHeaderLength = socketConfig.IsIpv4 ? MinIpHeaderLengthInBytes : 0;
 
             try
             {
+                CancellationToken timeoutOrCancellationToken = _timeoutOrCancellationSource!.Token;
+
                 await socket.SendToAsync(
                     socketConfig.SendBuffer.AsMemory(),
                     SocketFlags.None,

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -27,20 +27,11 @@ namespace System.Net.NetworkInformation
             return reply;
         }
 
-        private async Task<PingReply> SendPingAsyncCore(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
+        private Task<PingReply> SendPingAsyncCore(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
         {
-            Task<PingReply> t = RawSocketPermissions.CanUseRawSockets(address.AddressFamily) ?
+            return RawSocketPermissions.CanUseRawSockets(address.AddressFamily) ?
                     SendIcmpEchoRequestOverRawSocketAsync(address, buffer, timeout, options) :
                     SendWithPingUtilityAsync(address, buffer, timeout, options);
-
-            PingReply reply = await t.ConfigureAwait(false);
-
-            if (_canceled)
-            {
-                throw new OperationCanceledException();
-            }
-
-            return reply;
         }
     }
 }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
@@ -136,7 +136,6 @@ namespace System.Net.NetworkInformation
             }
         }
 
-        // Cancels pending async requests, closes the handles.
         private void InternalDispose()
         {
             _disposeRequested = true;
@@ -488,6 +487,8 @@ namespace System.Net.NetworkInformation
                 IPAddress address = await getAddress(getAddressArg, _timeoutOrCancellationSource.Token).ConfigureAwait(false);
 
                 Task<PingReply> pingTask = SendPingAsyncCore(address, buffer, timeout, options);
+                // Note: we set the cancellation-based timeout only after resolving the address and initiating the ping with the
+                // intent that the timeout applies solely to the ping operation rather than to any setup steps.
                 _timeoutOrCancellationSource.CancelAfter(timeout);
                 return await pingTask.ConfigureAwait(false);
             }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -77,6 +78,7 @@ namespace System.Net.NetworkInformation
             ObjectDisposedException.ThrowIf(_disposeRequested, this);
         }
 
+        [MemberNotNull(nameof(_timeoutOrCancellationSource))]
         private void CheckStart()
         {
             int currentStatus;
@@ -481,9 +483,9 @@ namespace System.Net.NetworkInformation
             CheckStart();
             try
             {
-                using CancellationTokenRegistration _ = cancellationToken.Register(static state => ((Ping)state!).SetCanceled(), this);
+                using CancellationTokenRegistration _ = cancellationToken.UnsafeRegister(static state => ((Ping)state!).SetCanceled(), this);
 
-                IPAddress address = await getAddress(getAddressArg, _timeoutOrCancellationSource!.Token).ConfigureAwait(false);
+                IPAddress address = await getAddress(getAddressArg, _timeoutOrCancellationSource.Token).ConfigureAwait(false);
 
                 Task<PingReply> pingTask = SendPingAsyncCore(address, buffer, timeout, options);
                 _timeoutOrCancellationSource.CancelAfter(timeout);


### PR DESCRIPTION
Provides "true" cancellation for async ping methods using either a token or
the existing SendAsyncCancel() API.

Fix #67260