### PR TITLE
Improve reliability of some SafeHandle creations

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Dsa.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Dsa.cs
@@ -192,7 +192,9 @@ namespace System.Security.Cryptography
         {
             Debug.Assert(handle != IntPtr.Zero);
 
-            return new SafeDsaHandle(Interop.JObjectLifetime.NewGlobalReference(handle));
+            var duplicate = new SafeDsaHandle();
+            duplicate.SetHandle(Interop.JObjectLifetime.NewGlobalReference(handle));
+            return duplicate;
         }
 
         internal override SafeDsaHandle DuplicateHandle() => DuplicateHandle(DangerousGetHandle());

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509.cs
@@ -47,14 +47,26 @@ internal static partial class Interop
                 throw new CryptographicException();
 
             IntPtr[] ptrs = new IntPtr[size];
-            ret = X509DecodeCollection(ref buf, data.Length, ptrs, ref size);
-            if (ret != SUCCESS)
-                throw new CryptographicException();
-
             SafeX509Handle[] handles = new SafeX509Handle[ptrs.Length];
             for (var i = 0; i < handles.Length; i++)
             {
-                handles[i] = new SafeX509Handle(ptrs[i]);
+                handles[i] = new SafeX509Handle();
+            }
+
+            ret = X509DecodeCollection(ref buf, data.Length, ptrs, ref size);
+            if (ret != SUCCESS)
+            {
+                foreach (SafeX509Handle handle in handles)
+                {
+                    handle.Dispose();
+                }
+
+                throw new CryptographicException();
+            }
+
+            for (var i = 0; i < handles.Length; i++)
+            {
+                Marshal.InitHandle(handles[i], ptrs[i]);
             }
 
             return handles;

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegConnectRegistry.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegConnectRegistry.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
         [LibraryImport(Libraries.Advapi32, EntryPoint = "RegConnectRegistryW", StringMarshalling = StringMarshalling.Utf16)]
         internal static partial int RegConnectRegistry(
             string machineName,
-            SafeRegistryHandle key,
+            IntPtr key,
             out SafeRegistryHandle result);
     }
 }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeCertContextHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeCertContextHandle.cs
@@ -33,8 +33,6 @@ namespace Microsoft.Win32.SafeHandles
             SetHandle(_parent.handle);
         }
 
-        internal new void SetHandle(IntPtr handle) => base.SetHandle(handle);
-
         protected override bool ReleaseHandle()
         {
             if (_parent != null)

--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.Windows.cs
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.Windows.cs
@@ -220,8 +220,7 @@ namespace Microsoft.Win32
             }
 
             // connect to the specified remote registry
-            int ret = Interop.Advapi32.RegConnectRegistry(machineName, new SafeRegistryHandle(new IntPtr((int)hKey), false), out SafeRegistryHandle foreignHKey);
-
+            int ret = Interop.Advapi32.RegConnectRegistry(machineName, new IntPtr((int)hKey), out SafeRegistryHandle foreignHKey);
             if (ret == 0 && !foreignHKey.IsInvalid)
             {
                 RegistryKey key = new RegistryKey(foreignHKey, true, false, true, ((IntPtr)hKey) == HKEY_PERFORMANCE_DATA, view);

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceDataRegistryKey.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceDataRegistryKey.cs
@@ -24,8 +24,7 @@ namespace System.Diagnostics
         public static PerformanceDataRegistryKey OpenRemoteBaseKey(string machineName)
         {
             // connect to the specified remote registry
-            int ret = Interop.Advapi32.RegConnectRegistry(machineName, new SafeRegistryHandle(new IntPtr(PerformanceData), ownsHandle: false), out SafeRegistryHandle foreignHKey);
-
+            int ret = Interop.Advapi32.RegConnectRegistry(machineName, new IntPtr(PerformanceData), out SafeRegistryHandle foreignHKey);
             if (ret == 0 && !foreignHKey.IsInvalid)
             {
                 return new PerformanceDataRegistryKey(foreignHKey);

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Unix.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Unix.cs
@@ -164,15 +164,20 @@ namespace System.Net.NetworkInformation
         {
             Debug.Assert(Monitor.IsEntered(s_gate));
             Debug.Assert(Socket == null, "Socket is not null, must close existing socket before opening another.");
+
+            var sh = new SafeSocketHandle();
+
             IntPtr newSocket;
             Interop.Error result = Interop.Sys.CreateNetworkChangeListenerSocket(&newSocket);
             if (result != Interop.Error.SUCCESS)
             {
                 string message = Interop.Sys.GetLastErrorInfo().GetErrorMessage();
+                sh.Dispose();
                 throw new NetworkInformationException(message);
             }
 
-            Socket = new Socket(new SafeSocketHandle(newSocket, ownsHandle: true));
+            Marshal.InitHandle(sh, newSocket);
+            Socket = new Socket(sh);
 
             // Don't capture ExecutionContext.
             ThreadPool.UnsafeQueueUserWorkItem(

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -40,10 +40,10 @@ namespace System.Net.Sockets
         {
             Interop.Winsock.EnsureInitialized();
 
-            IntPtr handle = Interop.Winsock.WSASocketW(addressFamily, socketType, protocolType, IntPtr.Zero, 0, Interop.Winsock.SocketConstructorFlags.WSA_FLAG_OVERLAPPED |
-                                                                                                                Interop.Winsock.SocketConstructorFlags.WSA_FLAG_NO_HANDLE_INHERIT);
+            socket = new SafeSocketHandle();
+            Marshal.InitHandle(socket, Interop.Winsock.WSASocketW(addressFamily, socketType, protocolType, IntPtr.Zero, 0, Interop.Winsock.SocketConstructorFlags.WSA_FLAG_OVERLAPPED |
+                                                                                                                Interop.Winsock.SocketConstructorFlags.WSA_FLAG_NO_HANDLE_INHERIT));
 
-            socket = new SafeSocketHandle(handle, ownsHandle: true);
             if (socket.IsInvalid)
             {
                 SocketError error = GetLastSocketError();
@@ -72,22 +72,22 @@ namespace System.Net.Sockets
 
             fixed (byte* protocolInfoBytes = socketInformation.ProtocolInformation)
             {
+                socket = new SafeSocketHandle();
+
                 // Sockets are non-inheritable in .NET Core.
                 // Handle properties like HANDLE_FLAG_INHERIT are not cloned with socket duplication, therefore
                 // we need to disable handle inheritance when constructing the new socket handle from Protocol Info.
                 // Additionally, it looks like WSA_FLAG_NO_HANDLE_INHERIT has no effect when being used with the Protocol Info
                 // variant of WSASocketW, so it is being passed to that call only for consistency.
                 // Inheritance is being disabled with SetHandleInformation(...) after the WSASocketW call.
-                IntPtr handle = Interop.Winsock.WSASocketW(
+                Marshal.InitHandle(socket, Interop.Winsock.WSASocketW(
                     (AddressFamily)(-1),
                     (SocketType)(-1),
                     (ProtocolType)(-1),
                     (IntPtr)protocolInfoBytes,
                     0,
                     Interop.Winsock.SocketConstructorFlags.WSA_FLAG_OVERLAPPED |
-                    Interop.Winsock.SocketConstructorFlags.WSA_FLAG_NO_HANDLE_INHERIT);
-
-                socket = new SafeSocketHandle(handle, ownsHandle: true);
+                    Interop.Winsock.SocketConstructorFlags.WSA_FLAG_NO_HANDLE_INHERIT));
 
                 if (socket.IsInvalid)
                 {
@@ -178,9 +178,9 @@ namespace System.Net.Sockets
 
         public static SocketError Accept(SafeSocketHandle listenSocket, byte[] socketAddress, ref int socketAddressSize, out SafeSocketHandle socket)
         {
-            IntPtr handle = Interop.Winsock.accept(listenSocket, socketAddress, ref socketAddressSize);
+            socket = new SafeSocketHandle();
+            Marshal.InitHandle(socket, Interop.Winsock.accept(listenSocket, socketAddress, ref socketAddressSize));
 
-            socket = new SafeSocketHandle(handle, ownsHandle: true);
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, socket);
 
             return socket.IsInvalid ? GetLastSocketError() : SocketError.Success;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Threading

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
@@ -145,6 +145,8 @@ namespace System.Threading
 
         private static SafeWaitHandle NewHandle(WaitableObject waitableObject)
         {
+            var safeWaitHandle = new SafeWaitHandle();
+
             IntPtr handle = IntPtr.Zero;
             try
             {
@@ -158,19 +160,8 @@ namespace System.Threading
                 }
             }
 
-            SafeWaitHandle? safeWaitHandle = null;
-            try
-            {
-                safeWaitHandle = new SafeWaitHandle(handle, ownsHandle: true);
-                return safeWaitHandle;
-            }
-            finally
-            {
-                if (safeWaitHandle == null)
-                {
-                    HandleManager.DeleteHandle(handle);
-                }
-            }
+            Marshal.InitHandle(safeWaitHandle, handle);
+            return safeWaitHandle;
         }
 
         public static SafeWaitHandle NewEvent(bool initiallySignaled, EventResetMode resetMode)

--- a/src/libraries/System.Runtime/tests/Microsoft/Win32/SafeHandles/SafeHandleZeroOrMinusOneIsInvalid.cs
+++ b/src/libraries/System.Runtime/tests/Microsoft/Win32/SafeHandles/SafeHandleZeroOrMinusOneIsInvalid.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 using Xunit;
 
@@ -12,11 +13,14 @@ public static class SafeHandleZeroOrMinusOneIsInvalidTests
     {
         var sh = new TestSafeHandleMinusOneIsInvalid();
         Assert.True(sh.IsInvalid);
-        sh.SetHandle(new IntPtr(-2));
+
+        Marshal.InitHandle(sh, -2);
         Assert.False(sh.IsInvalid);
-        sh.SetHandle(new IntPtr(-1));
+
+        Marshal.InitHandle(sh, -1);
         Assert.True(sh.IsInvalid);
-        sh.SetHandle(IntPtr.Zero);
+
+        Marshal.InitHandle(sh, 0);
         Assert.False(sh.IsInvalid);
     }
 
@@ -25,13 +29,17 @@ public static class SafeHandleZeroOrMinusOneIsInvalidTests
     {
         var sh = new TestSafeHandleZeroOrMinusOneIsInvalid();
         Assert.True(sh.IsInvalid);
-        sh.SetHandle(new IntPtr(-2));
+
+        Marshal.InitHandle(sh, -2);
         Assert.False(sh.IsInvalid);
-        sh.SetHandle(new IntPtr(-1));
+
+        Marshal.InitHandle(sh, -1);
         Assert.True(sh.IsInvalid);
-        sh.SetHandle(IntPtr.Zero);
+
+        Marshal.InitHandle(sh, 0);
         Assert.True(sh.IsInvalid);
-        sh.SetHandle(new IntPtr(1));
+
+        Marshal.InitHandle(sh, 1);
         Assert.False(sh.IsInvalid);
     }
 
@@ -42,7 +50,6 @@ public static class SafeHandleZeroOrMinusOneIsInvalidTests
         }
 
         protected override bool ReleaseHandle() => true;
-        public new void SetHandle(IntPtr handle) => base.SetHandle(handle);
     }
 
     private class TestSafeHandleZeroOrMinusOneIsInvalid : SafeHandleZeroOrMinusOneIsInvalid
@@ -52,6 +59,5 @@ public static class SafeHandleZeroOrMinusOneIsInvalidTests
         }
 
         protected override bool ReleaseHandle() => true;
-        public new void SetHandle(IntPtr handle) => base.SetHandle(handle);
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/Microsoft/Win32/SafeHandles/NCryptSafeHandles.cs
+++ b/src/libraries/System.Security.Cryptography/src/Microsoft/Win32/SafeHandles/NCryptSafeHandles.cs
@@ -383,15 +383,6 @@ namespace Microsoft.Win32.SafeHandles
             return Duplicate<SafeNCryptProviderHandle>();
         }
 
-        internal void SetHandleValue(IntPtr newHandleValue)
-        {
-            Debug.Assert(newHandleValue != IntPtr.Zero);
-            Debug.Assert(!IsClosed);
-            Debug.Assert(handle == IntPtr.Zero);
-
-            SetHandle(newHandleValue);
-        }
-
         protected override bool ReleaseNativeHandle()
         {
             return ReleaseNativeWithNCryptFreeObject();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKey.OpenHandle.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKey.OpenHandle.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Microsoft.Win32.SafeHandles;
 
@@ -34,7 +35,7 @@ namespace System.Security.Cryptography
                 // Get a handle to the key's provider.
                 providerHandle = new SafeNCryptProviderHandle();
                 IntPtr rawProviderHandle = keyHandle.GetPropertyAsIntPtr(KeyPropertyName.ProviderHandle, CngPropertyOptions.None);
-                providerHandle.SetHandleValue(rawProviderHandle);
+                Marshal.InitHandle(providerHandle, rawProviderHandle);
 
                 // If we're wrapping a handle to an ephemeral key, we need to make sure that IsEphemeral is
                 // set up to return true.  In the case that the handle is for an ephemeral key that was created

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
@@ -25,7 +25,8 @@ namespace System.Security.Cryptography.X509Certificates
             if (handle == IntPtr.Zero)
                 throw new ArgumentException(SR.Arg_InvalidHandle, nameof(handle));
 
-            var newHandle = new SafeX509Handle(Interop.JObjectLifetime.NewGlobalReference(handle));
+            var newHandle = new SafeX509Handle();
+            Marshal.InitHandle(newHandle, Interop.JObjectLifetime.NewGlobalReference(handle));
             return new AndroidCertificatePal(newHandle);
         }
 
@@ -41,7 +42,8 @@ namespace System.Security.Cryptography.X509Certificates
                 return certPal.CopyWithPrivateKeyHandle(certPal.PrivateKeyHandle.DuplicateHandle());
             }
 
-            SafeX509Handle handle = new SafeX509Handle(Interop.JObjectLifetime.NewGlobalReference(certPal.Handle));
+            var handle = new SafeX509Handle();
+            Marshal.InitHandle(handle, Interop.JObjectLifetime.NewGlobalReference(certPal.Handle));
             return new AndroidCertificatePal(handle);
         }
 
@@ -523,7 +525,8 @@ namespace System.Security.Cryptography.X509Certificates
         private ICertificatePal CopyWithPrivateKeyHandle(SafeKeyHandle privateKey)
         {
             // Add a global reference to the underlying cert object.
-            SafeX509Handle handle = new SafeX509Handle(Interop.JObjectLifetime.NewGlobalReference(Handle));
+            var handle = new SafeX509Handle();
+            Marshal.InitHandle(handle, Interop.JObjectLifetime.NewGlobalReference(Handle));
             return new AndroidCertificatePal(handle, privateKey);
         }
     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/WindowsInterop.crypt32.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/WindowsInterop.crypt32.cs
@@ -69,7 +69,7 @@ internal static partial class Interop
                 pPrevCertContext = pCertContext.Disconnect();
             }
 
-            pCertContext.SetHandle((IntPtr)Crypt32.CertEnumCertificatesInStore(hCertStore, pPrevCertContext));
+            Marshal.InitHandle(pCertContext, (IntPtr)Crypt32.CertEnumCertificatesInStore(hCertStore, pPrevCertContext));
 
             if (!pCertContext.IsInvalid)
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Android.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Android.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Formats.Asn1;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Asn1;
 
@@ -43,7 +44,8 @@ namespace System.Security.Cryptography.X509Certificates
                     case Oids.Dsa:
                         if (certificatePal != null)
                         {
-                            var handle = new SafeDsaHandle(GetPublicKey(certificatePal, Interop.AndroidCrypto.PAL_KeyAlgorithm.DSA));
+                            var handle = new SafeDsaHandle();
+                            Marshal.InitHandle(handle, GetPublicKey(certificatePal, Interop.AndroidCrypto.PAL_KeyAlgorithm.DSA));
                             return new DSAImplementation.DSAAndroid(handle);
                         }
                         else
@@ -53,7 +55,8 @@ namespace System.Security.Cryptography.X509Certificates
                     case Oids.Rsa:
                         if (certificatePal != null)
                         {
-                            var handle = new SafeRsaHandle(GetPublicKey(certificatePal, Interop.AndroidCrypto.PAL_KeyAlgorithm.RSA));
+                            var handle = new SafeRsaHandle();
+                            Marshal.InitHandle(handle, GetPublicKey(certificatePal, Interop.AndroidCrypto.PAL_KeyAlgorithm.RSA));
                             return new RSAImplementation.RSAAndroid(handle);
                         }
                         else
@@ -111,7 +114,9 @@ namespace System.Security.Cryptography.X509Certificates
 
             private static SafeEcKeyHandle DecodeECPublicKey(ICertificatePal pal)
             {
-                return new SafeEcKeyHandle(GetPublicKey(pal, Interop.AndroidCrypto.PAL_KeyAlgorithm.EC));
+                var handle = new SafeEcKeyHandle();
+                Marshal.InitHandle(handle, GetPublicKey(pal, Interop.AndroidCrypto.PAL_KeyAlgorithm.EC));
+                return handle;
             }
 
             private static IntPtr GetPublicKey(ICertificatePal pal, Interop.AndroidCrypto.PAL_KeyAlgorithm algorithm)

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
@@ -625,15 +625,10 @@ namespace System.ServiceProcess
 
         private static SafeServiceHandle GetDataBaseHandleWithAccess(string machineName, int serviceControlManagerAccess)
         {
-            SafeServiceHandle? databaseHandle;
-            if (machineName.Equals(DefaultMachineName) || machineName.Length == 0)
-            {
-                databaseHandle = new SafeServiceHandle(Interop.Advapi32.OpenSCManager(null, null, serviceControlManagerAccess));
-            }
-            else
-            {
-                databaseHandle = new SafeServiceHandle(Interop.Advapi32.OpenSCManager(machineName, null, serviceControlManagerAccess));
-            }
+            var databaseHandle = new SafeServiceHandle();
+            Marshal.InitHandle(databaseHandle, machineName.Equals(DefaultMachineName) || machineName.Length == 0 ?
+                Interop.Advapi32.OpenSCManager(null, null, serviceControlManagerAccess) :
+                Interop.Advapi32.OpenSCManager(machineName, null, serviceControlManagerAccess));
 
             if (databaseHandle.IsInvalid)
             {
@@ -684,7 +679,8 @@ namespace System.ServiceProcess
         {
             GetDataBaseHandleWithConnectAccess();
 
-            var serviceHandle = new SafeServiceHandle(Interop.Advapi32.OpenService(_serviceManagerHandle, ServiceName, desiredAccess));
+            var serviceHandle = new SafeServiceHandle();
+            Marshal.InitHandle(serviceHandle, Interop.Advapi32.OpenService(_serviceManagerHandle, ServiceName, desiredAccess));
             if (serviceHandle.IsInvalid)
             {
                 Exception inner = new Win32Exception();


### PR DESCRIPTION
Use the new Marshal.InitHandle to support creating the SafeHandle instance before the native call and then storing the handle after, as is done implicitly as part of interop calls that return SafeHandles.  Also replace some existing such SetHandle methods with Marshal.InitHandle.