### PR TITLE
Native AOT runtime changes for multiple package conflict

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.props
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Sdk.targets
+Microsoft.NET.ILCompiler.props
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -11,7 +11,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project>
 
-  <!-- Only import the build props if the NativeAot package isn't referenced via NuGet. -->
-  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.DotNet.ILCompiler.targets" Condition="'$(PublishAot)' == 'true'"/>
-
+  <PropertyGroup>
+    <!-- N.B. The ILLinkTargetsPath is used as a sentinel to indicate a version of this file has already been imported. It will also be the path
+         used to import the targets later in the SDK. -->
+    <ILCompilerTargetsPath>$(MSBuildThisFileDirectory)Microsoft.DotNet.ILCompiler.targets</ILCompilerTargetsPath>
+  </PropertyGroup>
 </Project>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.props
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Microsoft.NET.ILCompiler.props
+Microsoft.DotNet.ILCompiler.props
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -12,7 +12,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project>
 
   <PropertyGroup>
-    <!-- N.B. The ILLinkTargetsPath is used as a sentinel to indicate a version of this file has already been imported. It will also be the path
+    <!-- N.B. The ILCompilerTargetsPath is used as a sentinel to indicate a version of this file has already been imported. It will also be the path
          used to import the targets later in the SDK. -->
     <ILCompilerTargetsPath>$(MSBuildThisFileDirectory)Microsoft.DotNet.ILCompiler.targets</ILCompilerTargetsPath>
   </PropertyGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
@@ -42,20 +42,20 @@
   <!-- Locate the runtime package according to the current target runtime -->
   <Target Name="ImportRuntimeIlcPackageTarget" Condition="'$(BuildingFrameworkLibrary)' != 'true' AND $(IlcCalledViaPackage) == 'true'" DependsOnTargets="$(ImportRuntimeIlcPackageTargetDependsOn)" BeforeTargets="Publish">
     <!-- This targets file is imported by the SDK when the PublishAot property is set. SDK resolves runtime package paths differently-->
-    <Error Condition="'@(ResolvedILCompilerPack)' == '' AND '$(PublishAot)' == 'true'" Text="The ResolvedILCompilerPack ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
+    <Error Condition="'@(ResolvedILCompilerPack)' == '' AND '$(AotRuntimePackageLoadedViaSDK)' == 'true'" Text="The ResolvedILCompilerPack ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
     <!-- NativeAOT runtime pack assemblies need to be defined to avoid the default CoreCLR implementations being set as compiler inputs -->
-    <Error Condition="'@(PackageDefinitions)' == '' AND '$(PublishAot)' != 'true'" Text="The PackageDefinitions ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
+    <Error Condition="'@(PackageDefinitions)' == '' AND '$(AotRuntimePackageLoadedViaSDK)' != 'true'" Text="The PackageDefinitions ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
 
 
     <!-- This targets file is imported by the SDK when the PublishAot property is set. Use the SDK runtime package resolve property to set  down stream properties -->
-    <PropertyGroup Condition="'$(PublishAot)' == 'true'">
+    <PropertyGroup Condition="'$(AotRuntimePackageLoadedViaSDK)' == 'true'">
       <RuntimePackagePath>@(ResolvedILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
       <IlcHostPackagePath>@(ResolvedILCompilerPack->'%(PackageDirectory)')</IlcHostPackagePath>
       <IlcPath>>@(ResolvedILCompilerPack->'%(PackageDirectory)')</IlcPath>
     </PropertyGroup>
 
     <!-- Use the non-SDK runtime package resolve property to set down stream properties if SDK is not involved -->
-    <PropertyGroup Condition="'$(PublishAot)' != 'true'">
+    <PropertyGroup Condition="'$(AotRuntimePackageLoadedViaSDK)' != 'true'">
       <RuntimePackagePath Condition="'%(PackageDefinitions.Name)' == '$(RuntimeIlcPackageName)'">%(PackageDefinitions.ResolvedPath)</RuntimePackagePath>
       <IlcHostPackagePath Condition="'%(PackageDefinitions.Name)' == '$(IlcHostPackageName)'">%(PackageDefinitions.ResolvedPath)</IlcHostPackagePath>
     </PropertyGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
@@ -41,20 +41,20 @@
 
   <!-- Locate the runtime package according to the current target runtime -->
   <Target Name="ImportRuntimeIlcPackageTarget" Condition="'$(BuildingFrameworkLibrary)' != 'true' AND $(IlcCalledViaPackage) == 'true'" DependsOnTargets="$(ImportRuntimeIlcPackageTargetDependsOn)" BeforeTargets="Publish">
-    <!-- This targets file is imported by the SDK when the PublishAot property is set. SDK resolves runtime package paths differently-->
+    <!-- This targets file is imported by the SDK when the AotRuntimePackageLoadedViaSDK property is set. SDK resolves runtime package paths differently-->
     <Error Condition="'@(ResolvedILCompilerPack)' == '' AND '$(AotRuntimePackageLoadedViaSDK)' == 'true'" Text="The ResolvedILCompilerPack ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
     <!-- NativeAOT runtime pack assemblies need to be defined to avoid the default CoreCLR implementations being set as compiler inputs -->
     <Error Condition="'@(PackageDefinitions)' == '' AND '$(AotRuntimePackageLoadedViaSDK)' != 'true'" Text="The PackageDefinitions ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
 
 
-    <!-- This targets file is imported by the SDK when the PublishAot property is set. Use the SDK runtime package resolve property to set  down stream properties -->
+    <!-- This targets file is imported by the SDK when the AotRuntimePackageLoadedViaSDK property is set. Use the SDK runtime package resolve property to set  down stream properties -->
     <PropertyGroup Condition="'$(AotRuntimePackageLoadedViaSDK)' == 'true'">
       <RuntimePackagePath>@(ResolvedILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
       <IlcHostPackagePath>@(ResolvedILCompilerPack->'%(PackageDirectory)')</IlcHostPackagePath>
       <IlcPath>>@(ResolvedILCompilerPack->'%(PackageDirectory)')</IlcPath>
     </PropertyGroup>
 
-    <!-- Use the non-SDK runtime package resolve property to set down stream properties if SDK is not involved -->
+    <!-- Use the non-SDK runtime package resolve property to set down stream properties if there is an explicit reference in the project -->
     <PropertyGroup Condition="'$(AotRuntimePackageLoadedViaSDK)' != 'true'">
       <RuntimePackagePath Condition="'%(PackageDefinitions.Name)' == '$(RuntimeIlcPackageName)'">%(PackageDefinitions.ResolvedPath)</RuntimePackagePath>
       <IlcHostPackagePath Condition="'%(PackageDefinitions.Name)' == '$(IlcHostPackageName)'">%(PackageDefinitions.ResolvedPath)</IlcHostPackagePath>

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -20,7 +20,7 @@
     <ItemGroup>
       <File Include="$(CoreCLRBuildIntegrationDir)*" TargetPath="build" />
       <File Include="$(CoreCLRILCompilerDir)netstandard\*" TargetPath="tools/netstandard" />
-      <File Include="sdk\Sdk.targets" TargetPath="Sdk" />
+      <File Include="sdk\Sdk.props" TargetPath="Sdk" />
     </ItemGroup>
   </Target>
 

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/sdk/Sdk.props
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/sdk/Sdk.props
@@ -1,0 +1,22 @@
+<!--
+***********************************************************************************************
+Sdk.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project>
+
+  <!-- Set a flag to indicate that aot packages are loaded via SDK  -->
+  <PropertyGroup>
+    <AotRuntimePackageLoadedViaSDK Condition="'$(ILCompilerTargetsPath)'== ''">true</AotRuntimePackageLoadedViaSDK>
+  </PropertyGroup>
+
+  <!-- Only import the build props if the NativeAot package isn't referenced via NuGet. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.DotNet.ILCompiler.props" Condition="'$(PublishAot)' == 'true' and '$(ILCompilerTargetsPath)' == ''" />
+
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/26268 where currently adding a ILCompiler package reference creates an application that doesn't work. We want to support this scenario where we expect developers to get the latest ILCompiler package (rather than use the SDK one, which can be a little older) when publishing, for example to pick a fix that is not yet present in the SDK. 

Some notes

- The fix is going to be in the SDK (https://github.com/dotnet/sdk/pull/26652) but requires these changes. The SDK PR will be in draft form until these changes are merged and flow into SDK. It is important to validate that the fix works due to the delay in syncing
- There are 2 packages that are affected: `microsoft.dotnet.ilcompiler `deals primarily with setting up properties and targets and is handled similar to the way the linker manages conflicts with package references (see https://github.com/dotnet/sdk/pull/25993 and https://github.com/dotnet/linker/pull/2837)

> 1. SDK-ONLY: In the SDK, import the `ILCompiler` package, `Sdk.props` from `Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props`

> 2. SDK-ONLY: `ILCompiler's Sdk.props` will only import `Microsoft.DotNet.ILCompiler.props` from the `ILCompiler` package build directory if a sentinel, `ILCompilerTargetsPath`, is not set. The SDK will also set a flag, `AotRuntimePackageLoadedViaSDK`, to indicate that the SDK has loaded the `ILCompiler `package if the sentinel is not previously set.

> 3. Both SDK and Nuget: `Microsoft.DotNet.ILCompiler.props` contains a sentinel, `ILCompilerTargetsPath`, that sets the path to `Microsoft.DotNet.ILCompiler.targets`. We assume that if there is an explicit package reference to the `ILCompiler` package, Nuget will set this sentinel and SDK will honor that. If there is no explicit package reference, then the SDK will set the sentinel

> 4. There will be only one path, the sentinel path, that will be used to set necessary properties and targets when there are multiple references to the `ILCompiler` package with this approach. We want to use the explicit package reference if the developer expresses the intent. `Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets` will load this sentinel and will honor the explicit package reference path if one is present.

- The platform specific package (for example, `runtime.win-x64.microsoft.dotnet.ilcompiler` for the windows package) that contains ilc tool and runtime assets. The [package reference path](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets#L43-L63) is now set based on a flag that gets sets if the SDK package is the only one used. Otherwise, the Nuget package one that comes from the explicit package reference in the app will be picked.
- The publish AOT mechanism has evolved over the time and needs to be cleaned up. Issue #72415 tracks this and should be done as a high priority since following the current code is painful


> 1. The original code was added to only support explicit package references

> 2. SDK support was added for `PublishAot` with backward compatibility support for the explicit package reference without the SDK path (for a short period)

> 3. This feature adds support to adding explicit package reference with SDK `PublishAot`.  We are not planning to support the explicit package reference without the SDK path.