### PR TITLE
Refactor `SymbolicRegexRunnerFactory`'s representation of the minterm set's type.

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Debug.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Debug.cs
@@ -22,7 +22,7 @@ namespace System.Text.RegularExpressions
                 throw new NotSupportedException();
             }
 
-            srmFactory._matcher.SaveDGML(writer, maxLabelLength);
+            srmFactory.Matcher.SaveDGML(writer, maxLabelLength);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace System.Text.RegularExpressions
                 throw new NotSupportedException();
             }
 
-            return srmFactory._matcher.SampleMatches(k, randomseed);
+            return srmFactory.Matcher.SampleMatches(k, randomseed);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace System.Text.RegularExpressions
                 throw new NotSupportedException();
             }
 
-            srmFactory._matcher.Explore(includeDotStarred, includeReverse, includeOriginal, exploreDfa, exploreNfa);
+            srmFactory.Matcher.Explore(includeDotStarred, includeReverse, includeOriginal, exploreDfa, exploreNfa);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -98,7 +98,7 @@ namespace System.Text.RegularExpressions
             if ((options & RegexOptions.NonBacktracking) != 0)
             {
                 // If we're in non-backtracking mode, create the appropriate factory.
-                factory = new SymbolicRegexRunnerFactory(tree, options, matchTimeout);
+                factory = SymbolicRegexRunnerFactory.Create(tree, options, matchTimeout);
             }
             else
             {


### PR DESCRIPTION
`SymbolicRegexRunnerFactory` became an abstract class with only a `SymbolicRegexMatcher` property for debug purposes.
The factory's implementation was moved to a subclass that is generic over `TSet`, avoiding type checks at match time, and streamlining the generic parameter's flow.