### PR TITLE
Generate fewer type loader templates

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
@@ -199,18 +199,7 @@ namespace ILCompiler
                 if ((pair.Value & MetadataCategory.RuntimeMapping) != 0)
                 {
                     FieldDesc field = pair.Key;
-
-                    // We only care about static fields at this point. Instance fields don't need
-                    // runtime artifacts generated in the image.
-                    if (field.IsStatic && !field.IsLiteral)
-                    {
-                        if (field.IsThreadStatic)
-                            rootProvider.RootThreadStaticBaseForType(field.OwningType, reason);
-                        else if (field.HasGCStaticBase)
-                            rootProvider.RootGCStaticBaseForType(field.OwningType, reason);
-                        else
-                            rootProvider.RootNonGCStaticBaseForType(field.OwningType, reason);
-                    }
+                    rootProvider.AddReflectionRoot(field, reason);
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -666,5 +666,11 @@ namespace ILCompiler
                 result = comparer.Compare(Method, other.Method);
             return result;
         }
+        public override bool Equals(object obj) =>
+            obj is ConstrainedCallInfo other
+            && ConstrainedType == other.ConstrainedType
+            && Method == other.Method;
+
+        public override int GetHashCode() => HashCode.Combine(ConstrainedType, Method);
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -862,6 +862,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             _method = method;
             Debug.Assert(method.HasInstantiation);
+            Debug.Assert(!method.IsGenericMethodDefinition);
             Debug.Assert(method.IsCanonicalMethod(CanonicalFormKind.Any));
             Debug.Assert(method.GetCanonMethodTarget(CanonicalFormKind.Specific) == method, "Assert that the canonical method passed in is in standard canonical form");
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -347,6 +347,7 @@ namespace ILCompiler
                 }
 
                 GenericMethodsTemplateMap.GetTemplateMethodDependencies(ref dependencies, factory, method);
+                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, method.OwningType);
             }
         }
 
@@ -360,6 +361,12 @@ namespace ILCompiler
             if ((category & MetadataCategory.Description) != 0)
             {
                 GetMetadataDependenciesDueToReflectability(ref dependencies, factory, field);
+            }
+
+            if ((category & MetadataCategory.RuntimeMapping) != 0)
+            {
+                TypeDesc owningCanonicalType = field.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific);
+                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, owningCanonicalType);
             }
         }
 
@@ -395,8 +402,6 @@ namespace ILCompiler
             {
                 GetMetadataDependenciesDueToReflectability(ref dependencies, factory, type);
             }
-
-            GetDependenciesDueToEETypePresence(ref dependencies, factory, type);
         }
 
         protected virtual void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
@@ -404,11 +409,6 @@ namespace ILCompiler
             // MetadataManagers can override this to provide additional dependencies caused by the emission of metadata
             // (E.g. dependencies caused by the type having custom attributes applied to it: making sure we compile the attribute constructor
             // and property setters)
-        }
-
-        protected virtual void GetDependenciesDueToEETypePresence(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
-        {
-            // MetadataManagers can override this to provide additional dependencies caused by the emission of an MethodTable.
         }
 
         public virtual void GetConditionalDependenciesDueToEETypePresence(ref CombinedDependencyList dependencies, NodeFactory factory, TypeDesc type)
@@ -466,7 +466,6 @@ namespace ILCompiler
                 ExactMethodInstantiationsNode.GetExactMethodInstantiationDependenciesForMethod(ref dependencies, factory, method);
             }
 
-            GetDependenciesDueToTemplateTypeLoader(ref dependencies, factory, method);
             GetDependenciesDueToMethodCodePresenceInternal(ref dependencies, factory, method, methodIL);
         }
 
@@ -480,21 +479,6 @@ namespace ILCompiler
         {
             // MetadataManagers can override this to provide additional dependencies caused by the presence of
             // method code.
-        }
-
-        private void GetDependenciesDueToTemplateTypeLoader(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
-        {
-            // TODO-SIZE: this is overly generous in the templates we create
-            if (_blockingPolicy is FullyBlockedMetadataBlockingPolicy)
-                return;
-
-            TypeDesc owningTemplateType = method.OwningType;
-
-            // Unboxing and Instantiating stubs use a different type as their template
-            if (factory.TypeSystemContext.IsSpecialUnboxingThunk(method))
-                owningTemplateType = factory.TypeSystemContext.GetTargetOfSpecialUnboxingThunk(method).OwningType;
-
-            GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, owningTemplateType);
         }
 
         protected virtual void GetDependenciesDueToMethodCodePresenceInternal(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, MethodIL methodIL)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -345,6 +345,8 @@ namespace ILCompiler
 
                     ReflectionInvokeSupportDependencyAlgorithm.GetDependenciesFromParamsArray(ref dependencies, factory, method);
                 }
+
+                GenericMethodsTemplateMap.GetTemplateMethodDependencies(ref dependencies, factory, method);
             }
         }
 
@@ -486,20 +488,13 @@ namespace ILCompiler
             if (_blockingPolicy is FullyBlockedMetadataBlockingPolicy)
                 return;
 
-            if (method.HasInstantiation)
-            {
-                GenericMethodsTemplateMap.GetTemplateMethodDependencies(ref dependencies, factory, method);
-            }
-            else
-            {
-                TypeDesc owningTemplateType = method.OwningType;
+            TypeDesc owningTemplateType = method.OwningType;
 
-                // Unboxing and Instantiating stubs use a different type as their template
-                if (factory.TypeSystemContext.IsSpecialUnboxingThunk(method))
-                    owningTemplateType = factory.TypeSystemContext.GetTargetOfSpecialUnboxingThunk(method).OwningType;
+            // Unboxing and Instantiating stubs use a different type as their template
+            if (factory.TypeSystemContext.IsSpecialUnboxingThunk(method))
+                owningTemplateType = factory.TypeSystemContext.GetTargetOfSpecialUnboxingThunk(method).OwningType;
 
-                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, owningTemplateType);
-            }
+            GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, owningTemplateType);
         }
 
         protected virtual void GetDependenciesDueToMethodCodePresenceInternal(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, MethodIL methodIL)


### PR DESCRIPTION
"Type loader template" is a data structure the AOT compiler can generate to enable runtime-loading of new generic types.

For example, if a user does `typeof(Foo<>).MakeGenericType(typeof(object))` at runtime and we didn't pregenerate a `MethodTable` for `Foo<object>`, but we do have a type loader template for `Foo<__Canon>`, we can create `Foo<object>` `MethodTable` at runtime.

The rule for when to make a type loader template in the AOT compiler was simple - if a `MethodTable` for a type was created and the type has a canonical form, create a template. This works but produces a lot more templates than needed.

With this I'm restricting type loader template generation to when we have reflectable methods or fields on a type. There's little point in creating a template for things that are not visible to reflection.

Reduces the number of type loader templates in a hello world to a half, resulting in 50 kB savings. There's opportunity to save the other half too. The logic that ensures virtual methods have the same reflectability might be a bit over-aggressive and it's causing us to go from "`object.GetHashCode` needs to be reflectable" to "`Dictionary.GetHashCode` needs to be reflectable" to "`Dictionary` needs a type loader template".

Cc @dotnet/ilc-contrib 