### PR TITLE
Disabling Linux Bionic tests that fail on staging - #72256 follow up.

### DIFF
--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.TarEntry.ExtractToFile.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.TarEntry.ExtractToFile.Tests.Unix.cs
@@ -9,8 +9,8 @@ namespace System.Formats.Tar.Tests
 {
     public partial class TarReader_TarEntry_ExtractToFile_Tests : TarTestsBase
     {
-        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.tvOS & ~TestPlatforms.LinuxBionic)] // https://github.com/dotnet/runtime/issues/68360
-        [ConditionalFact(nameof(IsUnixButNotSuperUser))]
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.tvOS)] // https://github.com/dotnet/runtime/issues/68360
+        [ConditionalFact(nameof(IsUnixButNotSuperUser), nameof(IsNotLinuxBionic))]
         public void SpecialFile_Unelevated_Throws()
         {
             using TempDirectory root = new TempDirectory();

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.TarEntry.ExtractToFileAsync.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.TarEntry.ExtractToFileAsync.Tests.Unix.cs
@@ -9,8 +9,8 @@ namespace System.Formats.Tar.Tests
 {
     public partial class TarReader_TarEntry_ExtractToFileAsync_Tests : TarTestsBase
     {
-        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.tvOS & ~TestPlatforms.LinuxBionic)] // https://github.com/dotnet/runtime/issues/68360
-        [ConditionalFact(nameof(IsUnixButNotSuperUser))]
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.tvOS)] // https://github.com/dotnet/runtime/issues/68360
+        [ConditionalFact(nameof(IsUnixButNotSuperUser), nameof(IsNotLinuxBionic))]
         public async Task SpecialFile_Unelevated_Throws_Async()
         {
             using (TempDirectory root = new TempDirectory())

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -103,6 +103,8 @@ namespace System.Formats.Tar.Tests
 
         protected static bool IsUnixButNotSuperUser => !PlatformDetection.IsWindows && !PlatformDetection.IsSuperUser;
 
+        protected static bool IsNotLinuxBionic => !PlatformDetection.IsLinuxBionic;
+
         protected static string GetTestCaseUnarchivedFolderPath(string testCaseName) =>
             Path.Join(Directory.GetCurrentDirectory(), "unarchived", testCaseName);
 


### PR DESCRIPTION
Follow-up PR for https://github.com/dotnet/runtime/pull/72256. Some tests got disabled in the previous PR, this one disables `SpecialFile_Unelevated_Throws` and `SpecialFile_Unelevated_Throws_Async`, too.

Connected issue: https://github.com/dotnet/runtime/issues/68360.