### PR TITLE
Allocate MsQuicSafeHandle._traceId lazily

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
@@ -56,29 +56,37 @@ internal static class MsQuicHelpers
     }
 
     internal static unsafe T GetMsQuicParameter<T>(MsQuicSafeHandle handle, uint parameter)
-        where T: unmanaged
+        where T : unmanaged
     {
         T value;
         uint length = (uint)sizeof(T);
 
-        ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->GetParam(
+        int status = MsQuicApi.Api.ApiTable->GetParam(
             handle.QuicHandle,
             parameter,
             &length,
-            (byte*)&value),
-            $"GetParam({handle}, {parameter}) failed");
+            (byte*)&value);
+
+        if (StatusFailed(status))
+        {
+            throw ThrowHelper.GetExceptionForMsQuicStatus(status, $"GetParam({handle}, {parameter}) failed");
+        }
 
         return value;
     }
 
     internal static unsafe void SetMsQuicParameter<T>(MsQuicSafeHandle handle, uint parameter, T value)
-        where T: unmanaged
+        where T : unmanaged
     {
-        ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->SetParam(
+        int status = MsQuicApi.Api.ApiTable->SetParam(
             handle.QuicHandle,
             parameter,
             (uint)sizeof(T),
-            (byte*)&value),
-            $"SetParam({handle}, {parameter}) failed");
+            (byte*)&value);
+
+        if (StatusFailed(status))
+        {
+            throw ThrowHelper.GetExceptionForMsQuicStatus(status, $"SetParam({handle}, {parameter}) failed");
+        }
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicSafeHandle.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicSafeHandle.cs
@@ -20,7 +20,8 @@ internal unsafe class MsQuicSafeHandle : SafeHandle
     };
 
     private readonly delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void> _releaseAction;
-    private readonly string _traceId;
+    private string? _traceId;
+    private SafeHandleType _type;
 
     public override bool IsInvalid => handle == IntPtr.Zero;
 
@@ -30,7 +31,7 @@ internal unsafe class MsQuicSafeHandle : SafeHandle
         : base((IntPtr)handle, ownsHandle: true)
     {
         _releaseAction = releaseAction;
-        _traceId = $"[{s_typeName[(int)safeHandleType]}][0x{DangerousGetHandle():X11}]";
+        _type = safeHandleType;
 
         if (NetEventSource.Log.IsEnabled())
         {
@@ -51,7 +52,7 @@ internal unsafe class MsQuicSafeHandle : SafeHandle
         return true;
     }
 
-    public override string ToString() => _traceId;
+    public override string ToString() => _traceId ??= $"[{s_typeName[(int)_type]}][0x{DangerousGetHandle():X11}]";
 }
 
 internal enum SafeHandleType


### PR DESCRIPTION
Closes #71935.

I tried running it in our benchmarks via Crank but I have not observed any significant perf difference.

I also put a breakpoint in the ToString() of the `MsQuicSafeHandle` to really check that we don't force the allocation anywhere.