### PR TITLE
[QUIC] API changes follow up

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -42,6 +42,13 @@ internal static class MsQuicConfiguration
             {
                 certificate = selectedCertificate;
             }
+            else
+            {
+                if (NetEventSource.Log.IsEnabled())
+                {
+                    NetEventSource.Info(options, $"'{certificate}' not selected because it doesn't have a private key.");
+                }
+            }
         }
         else if (authenticationOptions.ClientCertificates != null)
         {
@@ -51,6 +58,13 @@ internal static class MsQuicConfiguration
                 {
                     certificate = clientCertificate;
                     break;
+                }
+                else
+                {
+                    if (NetEventSource.Log.IsEnabled())
+                    {
+                        NetEventSource.Info(options, $"'{certificate}' not selected because it doesn't have a private key.");
+                    }
                 }
             }
         }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ValueTaskSource.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ValueTaskSource.cs
@@ -35,9 +35,22 @@ internal sealed class ValueTaskSource : IValueTaskSource
         _keepAlive = default;
     }
 
+    /// <summary>
+    /// Returns <c>true</c> is this task source was completed, i.e. <see cref="TrySetResult"/> or <see cref="TrySetException(Exception)"/> was called.
+    /// </summary>
     public bool IsCompleted => (State)Volatile.Read(ref Unsafe.As<State, byte>(ref _state)) == State.Completed;
+    /// <summary>
+    /// Returns <c>true</c> is this task source was completed successfully, i.e. <see cref="TrySetResult"/> was called and set the result.
+    /// </summary>
     public bool IsCompletedSuccessfully => IsCompleted && _valueTaskSource.GetStatus(_valueTaskSource.Version) == ValueTaskSourceStatus.Succeeded;
 
+    /// <summary>
+    /// Tries to transition from <see cref="State.None"/> to <see cref="State.Awaiting"/>. Only the first call is able to do that so the result can be used to determine whether to invoke an operation or not.
+    /// </summary>
+    /// <param name="valueTask">A value task representing the result. In case this method returns <c>false</c>, it'll still contain a value task that'll get set with the original operation.</param>
+    /// <param name="keepAlive">An object to hold during a P/Invoke call. It'll get release with setting the result/exception.</param>
+    /// <param name="cancellationToken">A cancellation token which might cancel the value task.</param>
+    /// <returns><c>true</c> if this is the first call; otherwise, <c>false</c>.</returns>
     public bool TryInitialize(out ValueTask valueTask, object? keepAlive = null, CancellationToken cancellationToken = default)
     {
         lock (this)
@@ -53,8 +66,8 @@ internal sealed class ValueTaskSource : IValueTaskSource
                 {
                     _cancellationRegistration = cancellationToken.UnsafeRegister(static (obj, cancellationToken) =>
                     {
-                        ValueTaskSource parent = (ValueTaskSource)obj!;
-                        parent.TrySetException(new OperationCanceledException(cancellationToken));
+                        ValueTaskSource thisRef = (ValueTaskSource)obj!;
+                        thisRef.TrySetException(new OperationCanceledException(cancellationToken));
                     }, this);
                 }
             }
@@ -134,11 +147,20 @@ internal sealed class ValueTaskSource : IValueTaskSource
         }
     }
 
+    /// <summary>
+    /// Tries to transition from <see cref="State.Awaiting"/> to <see cref="State.Completed"/>. Only the first call is able to do that.
+    /// </summary>
+    /// <returns><c>true</c> if this is the first call that set the result; otherwise, <c>false</c>.</returns>
     public bool TrySetResult()
     {
         return TryComplete(null);
     }
 
+    /// <summary>
+    /// Tries to transition from <see cref="State.Awaiting"/> to <see cref="State.Completed"/>. Only the first call is able to do that.
+    /// </summary>
+    /// <param name="exception">The exception to set as a result of the value task.</param>
+    /// <returns><c>true</c> if this is the first call that set the result; otherwise, <c>false</c>.</returns>
     public bool TrySetException(Exception exception)
     {
         return TryComplete(exception);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -34,9 +34,6 @@ namespace System.Net.Quic;
 ///
 /// Each connection can then open outbound stream: <see cref="QuicConnection.OpenOutboundStreamAsync(QuicStreamType, CancellationToken)" />,
 /// or accept an inbound stream: <see cref="QuicConnection.AcceptInboundStreamAsync(CancellationToken)" />.
-///
-/// After all the streams have been finished, connection should be properly closed with an application code: <see cref="CloseAsync(long, CancellationToken)" />.
-/// If not, the connection will not send the peer information about being closed and the peer's connection will have to wait on its idle timeout.
 /// </remarks>
 public sealed partial class QuicConnection : IAsyncDisposable
 {
@@ -177,6 +174,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// </summary>
     public SslApplicationProtocol NegotiatedApplicationProtocol => _negotiatedApplicationProtocol;
 
+    /// <inheritdoc cref="ToString"/>
     public override string ToString() => _handle.ToString();
 
     /// <summary>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
@@ -37,6 +37,7 @@ public abstract class QuicConnectionOptions
 
     /// <summary>
     /// Error code used when the stream needs to abort read or write side of the stream internally.
+    /// This property is mandatory and not setting it will result in validation error when establishing a connection.
     /// </summary>
     // QUIC doesn't allow negative value: https://www.rfc-editor.org/rfc/rfc9000.html#integer-encoding
     // We can safely use this to distinguish if user provided value during validation.
@@ -44,8 +45,11 @@ public abstract class QuicConnectionOptions
 
     /// <summary>
     /// Error code used for <see cref="QuicConnection.CloseAsync(long, Threading.CancellationToken)"/> when the connection gets disposed.
-    /// To use different close error code, call  <see cref="QuicConnection.CloseAsync(long, Threading.CancellationToken)"/> explicitly before disposing.
+    /// This property is mandatory and not setting it will result in validation error when establishing a connection.
     /// </summary>
+    /// <remarks>
+    /// To use different close error code, call  <see cref="QuicConnection.CloseAsync(long, Threading.CancellationToken)"/> explicitly before disposing.
+    /// </remarks>
     // QUIC doesn't allow negative value: https://www.rfc-editor.org/rfc/rfc9000.html#integer-encoding
     // We can safely use this to distinguish if user provided value during validation.
     public long DefaultCloseErrorCode { get; set; } = -1;
@@ -95,11 +99,13 @@ public sealed class QuicClientConnectionOptions : QuicConnectionOptions
 
     /// <summary>
     /// Client authentication options to use when establishing a new connection.
+    /// This property is mandatory and not setting it will result in validation error when establishing a connection.
     /// </summary>
     public SslClientAuthenticationOptions ClientAuthenticationOptions { get; set; } = null!;
 
     /// <summary>
     /// The remote endpoint to connect to. May be both <see cref="DnsEndPoint"/>, which will get resolved to an IP before connecting, or directly <see cref="IPEndPoint"/>.
+    /// This property is mandatory and not setting it will result in validation error when establishing a connection.
     /// </summary>
     public EndPoint RemoteEndPoint { get; set; } = null!;
 
@@ -144,6 +150,7 @@ public sealed class QuicServerConnectionOptions : QuicConnectionOptions
 
     /// <summary>
     /// Server authentication options to use when accepting a new connection.
+    /// This property is mandatory and not setting it will result in validation error when establishing a connection.
     /// </summary>
     public SslServerAuthenticationOptions ServerAuthenticationOptions { get; set; } = null!;
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -93,6 +93,7 @@ public sealed partial class QuicListener : IAsyncDisposable
     /// </summary>
     public IPEndPoint LocalEndPoint { get; }
 
+    /// <inheritdoc cref="ToString"/>
     public override string ToString() => _handle.ToString();
 
     /// <summary>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListenerOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListenerOptions.cs
@@ -15,11 +15,13 @@ public sealed class QuicListenerOptions
 {
     /// <summary>
     /// The endpoint to listen on.
+    /// This property is mandatory and not setting it will result in validation error when starting the listener.
     /// </summary>
     public IPEndPoint ListenEndPoint { get; set; } = null!;
 
     /// <summary>
     /// List of application protocols which the listener will accept. At least one must be specified.
+    /// This property is mandatory and not setting it will result in validation error when starting the listener.
     /// </summary>
     public List<SslApplicationProtocol> ApplicationProtocols { get; set; } = null!;
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.Stream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.Stream.cs
@@ -59,7 +59,7 @@ public partial class QuicStream : Stream
     }
 
     // Read boilerplate.
-    public override bool CanRead => Volatile.Read(ref _disposed) == 0 && _canRead;
+    public override bool CanRead => Volatile.Read(ref _disposed) == 0 && _canRead && !_receiveTcs.IsCompleted;
     public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
         => TaskToApm.Begin(ReadAsync(buffer, offset, count, default), callback, state);
     public override int EndRead(IAsyncResult asyncResult)
@@ -108,7 +108,7 @@ public partial class QuicStream : Stream
     }
 
     // Write boilerplate.
-    public override bool CanWrite => Volatile.Read(ref _disposed) == 0 && _canWrite;
+    public override bool CanWrite => Volatile.Read(ref _disposed) == 0 && _canWrite && !_sendTcs.IsCompleted;
     public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
         => TaskToApm.Begin(WriteAsync(buffer, offset, count, default), callback, state);
     public override void EndWrite(IAsyncResult asyncResult)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.Stream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.Stream.cs
@@ -59,7 +59,7 @@ public partial class QuicStream : Stream
     }
 
     // Read boilerplate.
-    public override bool CanRead => Volatile.Read(ref _disposed) == 0 && _canRead && !_receiveTcs.IsCompleted;
+    public override bool CanRead => Volatile.Read(ref _disposed) == 0 && _canRead;
     public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
         => TaskToApm.Begin(ReadAsync(buffer, offset, count, default), callback, state);
     public override int EndRead(IAsyncResult asyncResult)
@@ -108,7 +108,7 @@ public partial class QuicStream : Stream
     }
 
     // Write boilerplate.
-    public override bool CanWrite => Volatile.Read(ref _disposed) == 0 && _canWrite && !_sendTcs.IsCompleted;
+    public override bool CanWrite => Volatile.Read(ref _disposed) == 0 && _canWrite;
     public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
         => TaskToApm.Begin(WriteAsync(buffer, offset, count, default), callback, state);
     public override void EndWrite(IAsyncResult asyncResult)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -327,6 +327,8 @@ public sealed partial class QuicStream
 
 
     /// <inheritdoc cref="WriteAsync(System.ReadOnlyMemory{byte},System.Threading.CancellationToken)"/>
+    /// <param name="buffer">The region of memory to write data from.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
     /// <param name="completeWrites">Notifies the peer about gracefully closing the write side, i.e.: sends FIN flag with the data.</param>
     public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, bool completeWrites, CancellationToken cancellationToken = default)
     {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -9,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Quic;
 using static System.Net.Quic.MsQuicHelpers;
-using static System.Net.Quic.QuicDefaults;
 using static Microsoft.Quic.MsQuic;
 
 using START_COMPLETE = Microsoft.Quic.QUIC_STREAM_EVENT._Anonymous_e__Union._START_COMPLETE_e__Struct;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -22,6 +22,37 @@ using SHUTDOWN_COMPLETE = Microsoft.Quic.QUIC_STREAM_EVENT._Anonymous_e__Union._
 
 namespace System.Net.Quic;
 
+/// <summary>
+/// Represents a QUIC stream, see <see href="https://www.rfc-editor.org/rfc/rfc9000.html#name-streams">RFC 9000: Streams</see> for more details.
+/// <see cref="QuicStream" /> can be <see cref="QuicStreamType.Unidirectional">unidirectional</see>, i.e.: write-only for the opening side,
+/// or <see cref="QuicStreamType.Bidirectional">bidirectional</see> which allows both side to write.
+/// </summary>
+/// <remarks>
+/// <see cref="QuicStream"/> can be used in a same way as any other <see cref="Stream"/>.
+/// Apart from stream API, <see cref="QuicStream"/> also exposes QUIC specific features:
+/// <list type="bullet">
+/// <item>
+/// <term><see cref="WriteAsync(System.ReadOnlyMemory{byte},bool,System.Threading.CancellationToken)"/></term>
+/// <description>Allows to close the writing side of the stream as a single operation with the write itself.</description>
+/// </item>
+/// <item>
+/// <term><see cref="CompleteWrites"/></term>
+/// <description>Close the writing side of the stream.</description>
+/// </item>
+/// <item>
+/// <term><see cref="Abort"/></term>
+/// <description>Aborts either the writing or the reading side of the stream.</description>
+/// </item>
+/// <item>
+/// <term><see cref="WritesClosed"/></term>
+/// <description>A <see cref="Task"/> that will get completed when the stream writing side has been closed (gracefully or abortively).</description>
+/// </item>
+/// <item>
+/// <term><see cref="ReadsClosed"/></term>
+/// <description>A <see cref="Task"/> that will get completed when the stream reading side has been closed (gracefully or abortively).</description>
+/// </item>
+/// </list>
+/// </remarks>
 public sealed partial class QuicStream
 {
     /// <summary>
@@ -89,10 +120,24 @@ public sealed partial class QuicStream
     /// </summary>
     public QuicStreamType Type => _type;
 
+    /// <summary>
+    /// A <see cref="Task"/> that will get completed once reading side has been closed.
+    /// Which might be by reading till end of stream (<see cref="ReadAsync(System.Memory{byte},System.Threading.CancellationToken)"/> will return <c>0</c>),
+    /// or when <see cref="Abort"/> for <see cref="QuicAbortDirection.Read"/> is called,
+    /// or when the peer called <see cref="Abort"/> for <see cref="QuicAbortDirection.Write"/>.
+    /// </summary>
     public Task ReadsClosed => _receiveTcs.GetFinalTask();
 
+    /// <summary>
+    /// A <see cref="Task"/> that will get completed once writing side has been closed.
+    /// Which might be by closing the write side via <see cref="CompleteWrites"/>
+    /// or <see cref="WriteAsync(System.ReadOnlyMemory{byte},bool,System.Threading.CancellationToken)"/> with <c>completeWrites: true</c> and getting acknowledgement from the peer for it,
+    /// or when <see cref="Abort"/> for <see cref="QuicAbortDirection.Write"/> is called,
+    /// or when the peer called <see cref="Abort"/> for <see cref="QuicAbortDirection.Read"/>.
+    /// </summary>
     public Task WritesClosed => _sendTcs.GetFinalTask();
 
+    /// <inheritdoc cref="ToString"/>
     public override string ToString() => _handle.ToString();
 
     /// <summary>
@@ -175,6 +220,13 @@ public sealed partial class QuicStream
         _startedTcs.TrySetResult();
     }
 
+    /// <summary>
+    /// Starts the stream, but doesn't send anything to the peer yet.
+    /// If no more concurrent streams can be opened at the moment, the operation will wait until it can,
+    /// either by closing some existing streams or receiving more available stream ids from the peer.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>An asynchronous task that completes with the opened <see cref="QuicStream" />.</returns>
     internal ValueTask StartAsync(CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
@@ -197,6 +249,7 @@ public sealed partial class QuicStream
         return valueTask;
     }
 
+    /// <inheritdoc cref="ReadAsync(System.Memory{byte},System.Threading.CancellationToken)"/>
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
@@ -270,9 +323,13 @@ public sealed partial class QuicStream
         return totalCopied;
     }
 
+    /// <inheritdoc cref="WriteAsync(System.ReadOnlyMemory{byte},System.Threading.CancellationToken)"/>
     public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         => WriteAsync(buffer, completeWrites: false, cancellationToken);
 
+
+    /// <inheritdoc cref="WriteAsync(System.ReadOnlyMemory{byte},System.Threading.CancellationToken)"/>
+    /// <param name="completeWrites">Notifies the peer about gracefully closing the write side, i.e.: sends FIN flag with the data.</param>
     public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, bool completeWrites, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
@@ -347,7 +404,15 @@ public sealed partial class QuicStream
         return valueTask;
     }
 
-
+    /// <summary>
+    /// Aborts either <see cref="QuicAbortDirection.Read">reading</see>, <see cref="QuicAbortDirection.Write">writing</see> or <see cref="QuicAbortDirection.Both">both</see> sides of the stream.
+    /// </summary>
+    /// <remarks>
+    /// Corresponds to <see href="https://www.rfc-editor.org/rfc/rfc9000.html#frame-stop-sending">STOP_SENDING</see>
+    /// and <see href="https://www.rfc-editor.org/rfc/rfc9000.html#frame-reset-stream">RESET_STREAM</see> QUIC frames.
+    /// </remarks>
+    /// <param name="abortDirection">The direction of the stream to abort.</param>
+    /// <param name="errorCode">The error code with which to abort the stream, this value is application protocol (layer above QUIC) dependent.</param>
     public void Abort(QuicAbortDirection abortDirection, long errorCode)
     {
         if (_disposed == 1)
@@ -387,6 +452,13 @@ public sealed partial class QuicStream
         }
     }
 
+    /// <summary>
+    /// Gracefully completes the writing side of the stream.
+    /// Equivalent to using <see cref="WriteAsync(System.ReadOnlyMemory{byte},bool,System.Threading.CancellationToken)"/> with <c>completeWrites: true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Corresponds to an empty <see href="https://www.rfc-editor.org/rfc/rfc9000.html#frame-stream">STREAM</see> frame with <c>FIN</c> flag set to <c>true</c>.
+    /// </remarks>
     public void CompleteWrites()
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
@@ -547,7 +619,7 @@ public sealed partial class QuicStream
     }
 
     /// <summary>
-    /// If the read side is not fully consumed, i.e.: <see cref="ReadsClosed"/> is completed and/or <see cref="ReadAsync(Memory{byte}, CancellationToken)"/> returned <c>0</c>,
+    /// If the read side is not fully consumed, i.e.: <see cref="ReadsClosed"/> is not completed and/or <see cref="ReadAsync(Memory{byte}, CancellationToken)"/> hasn't returned <c>0</c>,
     /// dispose will abort the read side with provided <see cref="QuicConnectionOptions.DefaultStreamErrorCode"/>.
     /// If the write side hasn't been closed, it'll be closed gracefully as if <see cref="CompleteWrites"/> was called.
     /// Finally, all resources associated with the stream will be released.

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -701,14 +701,14 @@ namespace System.Net.Quic.Tests
                 },
                 async serverStream =>
                 {
-                    var writeCompletionTask = ReleaseOnWriteCompletionAsync();
+                    var writesClosedTask = ReleaseOnWritesClosedAsync();
 
                     int received = await serverStream.ReadAsync(new byte[1]);
                     Assert.Equal(1, received);
                     received = await serverStream.ReadAsync(new byte[1]);
                     Assert.Equal(0, received);
 
-                    Assert.False(writeCompletionTask.IsCompleted, "Server is still writing.");
+                    Assert.False(writesClosedTask.IsCompleted, "Server is still writing.");
 
                     // Tell client that data has been read and it can abort its reads.
                     sem.Release();
@@ -716,9 +716,9 @@ namespace System.Net.Quic.Tests
                     long sendAbortErrorCode = await waitForAbortTcs.Task;
                     Assert.Equal(ExpectedErrorCode, sendAbortErrorCode);
 
-                    await writeCompletionTask;
+                    await writesClosedTask;
 
-                    async ValueTask ReleaseOnWriteCompletionAsync()
+                    async ValueTask ReleaseOnWritesClosedAsync()
                     {
                         try
                         {
@@ -764,7 +764,7 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        public async Task WaitForWriteCompletionAsync_ServerWriteAborted_Throws()
+        public async Task WaitForWritesClosedAsync_ServerWriteAborted_Throws()
         {
             const int ExpectedErrorCode = 0xfffffff;
             SemaphoreSlim sem = new SemaphoreSlim(0);
@@ -779,27 +779,27 @@ namespace System.Net.Quic.Tests
                 },
                 async serverStream =>
                 {
-                    var writeCompletionTask = ReleaseOnWriteCompletionAsync();
+                    var writesClosedTask = ReleaseOnWritesClosedAsync();
 
                     int received = await serverStream.ReadAsync(new byte[1]);
                     Assert.Equal(1, received);
                     received = await serverStream.ReadAsync(new byte[1]);
                     Assert.Equal(0, received);
 
-                    Assert.False(writeCompletionTask.IsCompleted, "Server is still writing.");
+                    Assert.False(writesClosedTask.IsCompleted, "Server is still writing.");
 
                     serverStream.Abort(QuicAbortDirection.Write, ExpectedErrorCode);
                     sem.Release();
 
                     await waitForAbortTcs.Task;
-                    await writeCompletionTask;
+                    await writesClosedTask;
 
-                    async ValueTask ReleaseOnWriteCompletionAsync()
+                    async ValueTask ReleaseOnWritesClosedAsync()
                     {
                         try
                         {
                             await serverStream.WritesClosed;
-                            waitForAbortTcs.SetException(new Exception("WaitForWriteCompletionAsync didn't throw stream aborted."));
+                            waitForAbortTcs.SetException(new Exception("WaitForWriteCompletionAsync didn't throw operation aborted."));
                         }
                         catch (QuicException ex) when (ex.QuicError == QuicError.OperationAborted)
                         {
@@ -814,7 +814,157 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        public async Task WaitForWriteCompletionAsync_ServerShutdown_Success()
+        public async Task WaitForReadsClosedAsync_ServerReadAborted_Throws()
+        {
+            const int ExpectedErrorCode = 0xfffffff;
+            SemaphoreSlim sem = new SemaphoreSlim(0);
+
+            TaskCompletionSource waitForAbortTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            await RunBidirectionalClientServer(
+                async clientStream =>
+                {
+                    Assert.Equal(1, await clientStream.ReadAsync(new byte[1]));
+                    await clientStream.ReadsClosed;
+                    Assert.Equal(0, await clientStream.ReadAsync(new byte[1]));
+                    await sem.WaitAsync();
+                },
+                async serverStream =>
+                {
+                    var readsClosedTask = ReleaseOnReadsClosedAsync();
+
+                    await serverStream.WriteAsync(new byte[1], completeWrites: true);
+                    await serverStream.WritesClosed;
+
+                    Assert.False(readsClosedTask.IsCompleted, "Server is still reading.");
+
+                    serverStream.Abort(QuicAbortDirection.Read, ExpectedErrorCode);
+                    sem.Release();
+
+                    await waitForAbortTcs.Task;
+                    await readsClosedTask;
+
+                    async ValueTask ReleaseOnReadsClosedAsync()
+                    {
+                        try
+                        {
+                            await serverStream.ReadsClosed;
+                            waitForAbortTcs.SetException(new Exception("ReadsClosed didn't throw operation aborted."));
+                        }
+                        catch (QuicException ex) when (ex.QuicError == QuicError.OperationAborted)
+                        {
+                            waitForAbortTcs.SetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            waitForAbortTcs.SetException(ex);
+                        }
+                    };
+                });
+        }
+
+        [Fact]
+        public async Task WaitForWritesClosedAsync_ClientReadAborted_Throws()
+        {
+            const int ExpectedErrorCode = 0xfffffff;
+            SemaphoreSlim sem = new SemaphoreSlim(0);
+
+            TaskCompletionSource waitForAbortTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            await RunBidirectionalClientServer(
+                async clientStream =>
+                {
+                    await clientStream.WriteAsync(new byte[1], completeWrites: true);
+                    await sem.WaitAsync();
+                    clientStream.Abort(QuicAbortDirection.Read, ExpectedErrorCode);
+                },
+                async serverStream =>
+                {
+                    var writesClosedTask = ReleaseOnWritesClosedAsync();
+
+                    int received = await serverStream.ReadAsync(new byte[1]);
+                    Assert.Equal(1, received);
+                    received = await serverStream.ReadAsync(new byte[1]);
+                    Assert.Equal(0, received);
+
+                    Assert.False(writesClosedTask.IsCompleted, "Server is still writing.");
+
+                    sem.Release();
+
+                    await waitForAbortTcs.Task;
+                    await writesClosedTask;
+
+                    async ValueTask ReleaseOnWritesClosedAsync()
+                    {
+                        try
+                        {
+                            await serverStream.WritesClosed;
+                            waitForAbortTcs.SetException(new Exception("WritesClosed didn't throw stream aborted."));
+                        }
+                        catch (QuicException ex) when (ex.QuicError == QuicError.StreamAborted && ex.ApplicationErrorCode == ExpectedErrorCode)
+                        {
+                            waitForAbortTcs.SetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            waitForAbortTcs.SetException(ex);
+                        }
+                    };
+                });
+        }
+
+        [Fact]
+        public async Task WaitForReadsClosedAsync_ClientWriteAborted_Throws()
+        {
+            const int ExpectedErrorCode = 0xfffffff;
+            SemaphoreSlim sem = new SemaphoreSlim(0);
+
+            TaskCompletionSource waitForAbortTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            await RunBidirectionalClientServer(
+                async clientStream =>
+                {
+                    Assert.Equal(1, await clientStream.ReadAsync(new byte[1]));
+                    await clientStream.ReadsClosed;
+                    Assert.Equal(0, await clientStream.ReadAsync(new byte[1]));
+                    await sem.WaitAsync();
+                    clientStream.Abort(QuicAbortDirection.Write, ExpectedErrorCode);
+                },
+                async serverStream =>
+                {
+                    var readsClosedTask = ReleaseOnReadsClosedAsync();
+
+                    await serverStream.WriteAsync(new byte[1], completeWrites: true);
+                    await serverStream.WritesClosed;
+
+                    Assert.False(readsClosedTask.IsCompleted, "Server is still reading.");
+
+                    sem.Release();
+
+                    await waitForAbortTcs.Task;
+                    await readsClosedTask;
+
+                    async ValueTask ReleaseOnReadsClosedAsync()
+                    {
+                        try
+                        {
+                            await serverStream.ReadsClosed;
+                            waitForAbortTcs.SetException(new Exception("ReadsClosed didn't throw stream aborted."));
+                        }
+                        catch (QuicException ex) when (ex.QuicError == QuicError.StreamAborted && ex.ApplicationErrorCode == ExpectedErrorCode)
+                        {
+                            waitForAbortTcs.SetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            waitForAbortTcs.SetException(ex);
+                        }
+                    };
+                });
+        }
+
+        [Fact]
+        public async Task WaitForWritesClosedAsync_ServerShutdown_Success()
         {
             await RunBidirectionalClientServer(
                 async clientStream =>
@@ -829,7 +979,7 @@ namespace System.Net.Quic.Tests
                 },
                 async serverStream =>
                 {
-                    var writeCompletionTask = serverStream.WritesClosed;
+                    var writesClosedTask = serverStream.WritesClosed;
 
                     int received = await serverStream.ReadAsync(new byte[1]);
                     Assert.Equal(1, received);
@@ -838,16 +988,51 @@ namespace System.Net.Quic.Tests
 
                     await serverStream.WriteAsync(new byte[1]);
 
-                    Assert.False(writeCompletionTask.IsCompleted, "Server is still writing.");
+                    Assert.False(writesClosedTask.IsCompleted, "Server is still writing.");
 
                     serverStream.CompleteWrites();
 
-                    await writeCompletionTask;
+                    await writesClosedTask;
+                });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WaitForReadsClosedAsync_ClientCompleteWrites_Success(bool extraCall)
+        {
+            await RunBidirectionalClientServer(
+                async clientStream =>
+                {
+                    Assert.Equal(1, await clientStream.ReadAsync(new byte[1]));
+                    await clientStream.ReadsClosed;
+                    Assert.Equal(0, await clientStream.ReadAsync(new byte[1]));
+
+                    await clientStream.WriteAsync(new byte[1], completeWrites: !extraCall);
+                    if (extraCall)
+                    {
+                        clientStream.CompleteWrites();
+                    }
+                },
+                async serverStream =>
+                {
+                    var readsClosedTask = serverStream.ReadsClosed;
+
+                    await serverStream.WriteAsync(new byte[1], completeWrites: true);
+                    await serverStream.WritesClosed;
+
+                    Assert.False(readsClosedTask.IsCompleted, "Server is still reading.");
+
+                    var readCount = await serverStream.ReadAsync(new byte[1]);
+                    Assert.Equal(1, readCount);
+                    readCount = await serverStream.ReadAsync(new byte[1]);
+                    Assert.Equal(0, readCount);
+                    Assert.True(readsClosedTask.IsCompletedSuccessfully);
                 });
         }
 
         [Fact]
-        public async Task WaitForWriteCompletionAsync_GracefulShutdown_Success()
+        public async Task WaitForWritesClosedAsync_GracefulShutdown_Success()
         {
             await RunBidirectionalClientServer(
                 async clientStream =>
@@ -862,23 +1047,53 @@ namespace System.Net.Quic.Tests
                 },
                 async serverStream =>
                 {
-                    var writeCompletionTask = serverStream.WritesClosed;
+                    var writesClosedTask = serverStream.WritesClosed;
 
                     int received = await serverStream.ReadAsync(new byte[1]);
                     Assert.Equal(1, received);
                     received = await serverStream.ReadAsync(new byte[1]);
                     Assert.Equal(0, received);
 
-                    Assert.False(writeCompletionTask.IsCompleted, "Server is still writing.");
+                    Assert.False(writesClosedTask.IsCompleted, "Server is still writing.");
 
                     await serverStream.WriteAsync(new byte[1], completeWrites: true);
 
-                    await writeCompletionTask;
+                    await writesClosedTask;
                 });
         }
 
         [Fact]
-        public async Task WaitForWriteCompletionAsync_ConnectionClosed_Throws()
+        public async Task WaitForReadsClosedAsync_GracefulShutdown_Success()
+        {
+            await RunBidirectionalClientServer(
+                async clientStream =>
+                {
+                    Assert.Equal(1, await clientStream.ReadAsync(new byte[1]));
+                    await clientStream.ReadsClosed;
+                    Assert.Equal(0, await clientStream.ReadAsync(new byte[1]));
+
+                    await clientStream.WriteAsync(new byte[1]);
+                    // Let DisposeAsync gracefully shutdown the write side.
+                },
+                async serverStream =>
+                {
+                    var readsClosedTask = serverStream.ReadsClosed;
+
+                    await serverStream.WriteAsync(new byte[1], completeWrites: true);
+                    await serverStream.WritesClosed;
+
+                    Assert.False(readsClosedTask.IsCompleted, "Server is still reading.");
+
+                    var readCount = await serverStream.ReadAsync(new byte[1]);
+                    Assert.Equal(1, readCount);
+                    readCount = await serverStream.ReadAsync(new byte[1]);
+                    Assert.Equal(0, readCount);
+                    Assert.True(readsClosedTask.IsCompletedSuccessfully);
+                });
+        }
+
+        [Fact]
+        public async Task WaitForWritesClosedAsync_ConnectionClosed_Throws()
         {
             const int ExpectedErrorCode = 0xfffffff;
 
@@ -890,7 +1105,7 @@ namespace System.Net.Quic.Tests
                 {
                     await using QuicStream stream = await connection.AcceptInboundStreamAsync();
 
-                    var writeCompletionTask = ReleaseOnWriteCompletionAsync();
+                    var writesClosedTask = ReleaseOnWritesClosedAsync();
 
                     int received = await stream.ReadAsync(new byte[1]);
                     Assert.Equal(1, received);
@@ -903,14 +1118,14 @@ namespace System.Net.Quic.Tests
                     long closeErrorCode = await waitForAbortTcs.Task;
                     Assert.Equal(ExpectedErrorCode, closeErrorCode);
 
-                    await writeCompletionTask;
+                    await writesClosedTask;
 
-                    async ValueTask ReleaseOnWriteCompletionAsync()
+                    async ValueTask ReleaseOnWritesClosedAsync()
                     {
                         try
                         {
                             await stream.WritesClosed;
-                            waitForAbortTcs.SetException(new Exception("WaitForWriteCompletionAsync didn't throw connection aborted."));
+                            waitForAbortTcs.SetException(new Exception("WritesClosed didn't throw connection aborted."));
                         }
                         catch (QuicException ex) when (ex.QuicError == QuicError.ConnectionAborted)
                         {
@@ -927,6 +1142,64 @@ namespace System.Net.Quic.Tests
                     await stream.WritesClosed;
 
                     // Wait for the server to read data before closing the connection
+                    await sem.WaitAsync();
+
+                    await connection.CloseAsync(ExpectedErrorCode);
+                }
+            );
+        }
+
+        [Fact]
+        public async Task WaitForReadsClosedAsync_ConnectionClosed_Throws()
+        {
+            const int ExpectedErrorCode = 0xfffffff;
+
+            using SemaphoreSlim sem = new SemaphoreSlim(0);
+            TaskCompletionSource<long> waitForAbortTcs = new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            await RunClientServer(
+                serverFunction: async connection =>
+                {
+                    await using QuicStream stream = await connection.AcceptInboundStreamAsync();
+
+                    var readsClosedTask = ReleaseOnReadsClosedAsync();
+
+                    await stream.WriteAsync(new byte[1], completeWrites: true);
+
+                    // Signal that the server has read data
+                    sem.Release();
+
+                    long closeErrorCode = await waitForAbortTcs.Task;
+                    Assert.Equal(ExpectedErrorCode, closeErrorCode);
+
+                    await readsClosedTask;
+
+                    async ValueTask ReleaseOnReadsClosedAsync()
+                    {
+                        try
+                        {
+                            await stream.ReadsClosed;
+                            waitForAbortTcs.SetException(new Exception("ReadsClosed didn't throw connection aborted."));
+                        }
+                        catch (QuicException ex) when (ex.QuicError == QuicError.ConnectionAborted)
+                        {
+                            waitForAbortTcs.SetResult(ex.ApplicationErrorCode.Value);
+                            QuicException readEx = await Assert.ThrowsAsync<QuicException>(async () => await stream.ReadAsync(new byte[1]));
+                            Assert.Equal(ex, readEx);
+                        }
+                    };
+                },
+                clientFunction: async connection =>
+                {
+                    await using QuicStream stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+
+                    await stream.WriteAsync(new byte[1]);
+
+                    Assert.Equal(1, await stream.ReadAsync(new byte[1]));
+                    await stream.ReadsClosed;
+                    Assert.Equal(0, await stream.ReadAsync(new byte[1]));
+
+                    // Wait for the server to write data before closing the connection
                     await sem.WaitAsync();
 
                     await connection.CloseAsync(ExpectedErrorCode);


### PR DESCRIPTION
- `ResettableValueTaskSource` now propagates exceptions immediately from `GetResult`. I.e.: if it gets set successfully without `final` (via e.g. RECEIVE) and then with exception with `final` (via `AbortRead`) it'll report the exception from the abort. cc @CarnaViire 
- Added comments for `QuicStream` and both task sources
- Added some more tests (for `RemoteCertificate`, for `Task` properties of `QuicStream`)

Fixes #72027