### PR TITLE
[wasm] Move interop project refs to common place

### DIFF
--- a/src/mono/sample/wasm/Directory.Build.props
+++ b/src/mono/sample/wasm/Directory.Build.props
@@ -28,6 +28,11 @@
     <WasmEmitSymbolMap>true</WasmEmitSymbolMap>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj" OutputItemTpe="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj" OutputItemType="Analyzer" ReferencOutputAssembly="false" />
+  </ItemGroup>
+
   <!-- Import late, so properties like $(ArtifactsBinDir) are set -->
   <Import Project="$(MonoProjectRoot)wasm\build\WasmApp.InTree.props" />
 </Project>

--- a/src/mono/sample/wasm/browser-bench/Console/Wasm.Console.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Console/Wasm.Console.Bench.Sample.csproj
@@ -20,7 +20,5 @@
     <Compile Include="../*.cs" />
     <Compile Remove="../Browser.cs" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -14,8 +14,6 @@
     <WasmExtraFilesToDeploy Include="frame-main.js" />
     <WasmExtraFilesToDeploy Include="style.css" />
     <Compile Remove="Console/Console.cs" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/mono/sample/wasm/browser/Wasm.Browser.ES6.Sample.csproj
+++ b/src/mono/sample/wasm/browser/Wasm.Browser.ES6.Sample.csproj
@@ -10,8 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <WasmExtraFilesToDeploy Include="index.html" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <PropertyGroup>
     <_SampleProject>Wasm.Browser.ES6.Sample.csproj</_SampleProject>


### PR DESCRIPTION
So that all the wasm samples have access to the new interop