### PR TITLE
Remove wrong cgroups assert

### DIFF
--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -128,7 +128,6 @@ private:
             case TMPFS_MAGIC: return 1;
             case CGROUP2_SUPER_MAGIC: return 2;
             default:
-                assert(!"Unexpected file system type for /sys/fs/cgroup");
                 return 0;
         }
 #endif

--- a/src/coreclr/nativeaot/Runtime/unix/cgroup.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/cgroup.cpp
@@ -105,7 +105,6 @@ private:
             case TMPFS_MAGIC: return 1;
             case CGROUP2_SUPER_MAGIC: return 2;
             default:
-                assert(!"Unexpected file system type for /sys/fs/cgroup");
                 return 0;
         }
 #endif

--- a/src/coreclr/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/pal/src/misc/cgroup.cpp
@@ -138,7 +138,6 @@ private:
             case TMPFS_MAGIC: return 1;
             case CGROUP2_SUPER_MAGIC: return 2;
             default:
-                _ASSERTE(!"Unexpected file system type for /sys/fs/cgroup");
                 return 0;
         }
 #endif


### PR DESCRIPTION
When detecting the current cgroup version on Linux, checked and
debug builds assert when the filesystem type of /sys/fs/cgroup is
neither TMPFS_MAGIC nor CGROUP2_SUPER_MAGIC. This change removes
the assert and considers it as "no cgroup support". This is the case 
e.g. in chroot environment.
Release builds already have this behavior.

Close #62960