### PR TITLE
Apply a variant of the visitor pattern for reflection-based generic type instantiation.

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -263,6 +263,7 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionEmitCachingMemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionEmitMemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionMemberAccessor.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\TypeWitness.cs" />
     <Compile Include="System\Text\Json\Serialization\MetadataPropertyName.cs" />
     <Compile Include="System\Text\Json\Serialization\PreserveReferenceHandler.cs" />
     <Compile Include="System\Text\Json\Serialization\PreserveReferenceResolver.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
@@ -3,8 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-using System.Runtime.ExceptionServices;
+using System.Text.Json.Reflection;
 using System.Threading;
 
 namespace System.Text.Json.Serialization.Metadata
@@ -36,6 +35,10 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
         /// <inheritdoc/>
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "The ctor is marked RequiresUnreferencedCode.")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "The ctor is marked RequiresDynamicCode.")]
         public virtual JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
         {
             if (type == null)
@@ -64,36 +67,23 @@ namespace System.Text.Json.Serialization.Metadata
             return typeInfo;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "The ctor is marked RequiresUnreferencedCode.")]
-        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-            Justification = "The ctor is marked RequiresDynamicCode.")]
-        private JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options)
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        private static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options)
         {
-            MethodInfo methodInfo = typeof(DefaultJsonTypeInfoResolver).GetMethod(nameof(CreateReflectionJsonTypeInfo), BindingFlags.NonPublic | BindingFlags.Static)!;
-#if NETCOREAPP
-            return (JsonTypeInfo)methodInfo.MakeGenericMethod(type).Invoke(null, BindingFlags.NonPublic | BindingFlags.DoNotWrapExceptions, null, new[] { options }, null)!;
-#else
-            try
-            {
-                return (JsonTypeInfo)methodInfo.MakeGenericMethod(type).Invoke(null, new[] { options })!;
-            }
-            catch (TargetInvocationException ex)
-            {
-                // Some of the validation is done during construction (i.e. validity of JsonConverter, inner types etc.)
-                // therefore we need to unwrap TargetInvocationException for better user experience
-                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                throw null!;
-            }
-#endif
+            return ReflectionJsonTypeInfoBuilder.Instance.Visit(type, options);
         }
 
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        private static JsonTypeInfo<T> CreateReflectionJsonTypeInfo<T>(JsonSerializerOptions options)
+        private sealed class ReflectionJsonTypeInfoBuilder : ITypeVisitor<JsonSerializerOptions, JsonTypeInfo>
         {
-            JsonConverter converter = GetConverterForType(typeof(T), options);
-            return new ReflectionJsonTypeInfo<T>(converter, options);
+            public static ReflectionJsonTypeInfoBuilder Instance { get; } = new();
+            public JsonTypeInfo Visit<T>(JsonSerializerOptions options)
+            {
+                JsonConverter converter = GetConverterForType(typeof(T), options);
+                return new ReflectionJsonTypeInfo<T>(converter, options);
+            }
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/TypeWitness.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/TypeWitness.cs
@@ -8,7 +8,7 @@ namespace System.Text.Json.Reflection
     /// <summary>
     /// Encapsulates a generic type parameter that can be unpacked on-demand using a generic visitor,
     /// encoding an existential type. Can use reflection to instantiate type parameters that are not known at compile time.
-    /// Uses concepts taken from https://www.microsoft.com/en-us/research/publication/generalized-algebraic-data-types-and-object-oriented-programming/
+    /// Uses concepts taken from https://www.microsoft.com/research/publication/generalized-algebraic-data-types-and-object-oriented-programming/
     /// </summary>
     internal abstract class TypeWitness
     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/TypeWitness.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/TypeWitness.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Text.Json.Reflection
+{
+    /// <summary>
+    /// Encapsulates a generic type parameter that can be unpacked on-demand using a generic visitor,
+    /// encoding an existential type. Can use reflection to instantiate type parameters that are not known at compile time.
+    /// Uses concepts taken from https://www.microsoft.com/en-us/research/publication/generalized-algebraic-data-types-and-object-oriented-programming/
+    /// </summary>
+    internal abstract class TypeWitness
+    {
+        public abstract Type Type { get; }
+        public abstract TResult Accept<TState, TResult>(ITypeVisitor<TState, TResult> builder, TState state);
+
+        [RequiresUnreferencedCode("Uses Type.MakeGenericType to instantiate a generic TypeWitness<T> using reflection.")]
+        [RequiresDynamicCode("Uses Type.MakeGenericType to instantiate a generic TypeWitness<T> using reflection.")]
+        public static TypeWitness Create(Type type) => (TypeWitness)Activator.CreateInstance(typeof(TypeWitness<>).MakeGenericType(type))!;
+    }
+
+    internal sealed class TypeWitness<T> : TypeWitness
+    {
+        public override Type Type => typeof(T);
+        public override TResult Accept<TState, TResult>(ITypeVisitor<TState, TResult> builder, TState state)
+            => builder.Visit<T>(state);
+    }
+
+    /// <summary>
+    /// Given a <typeparamref name="TState" /> input, visits the generic parameter of a
+    /// <see cref="TypeWitness{T}"/> and returns a <typeparamref name="TResult" /> output.
+    /// </summary>
+    internal interface ITypeVisitor<TState, TResult>
+    {
+        TResult Visit<T>(TState state);
+    }
+
+    internal static class TypeVisitorExtensions
+    {
+        [RequiresUnreferencedCode("Uses Type.MakeGenericType to instantiate a generic TypeWitness<T> using reflection.")]
+        [RequiresDynamicCode("Uses Type.MakeGenericType to instantiate a generic TypeWitness<T> using reflection.")]
+        public static TResult Visit<TState, TResult>(this ITypeVisitor<TState, TResult> visitor, Type type, TState state)
+            => TypeWitness.Create(type).Accept(visitor, state);
+    }
+}


### PR DESCRIPTION
The System.Text.Json default metadata resolver has been using reflection to instantiate some of its generic metadata types such as `JsonTypeInfo<T>` and `JsonPropertyInfo<T>`. This of course is necessary since the value of `T` cannot be statically determined in most cases. 

This PR updates some of the existing reflection-based generic type instantiation logic so that type parameter reification concerns are delegated to a "type witness", and any domain-specific metadata instantiation is performed via a generic visitor that is accepted by the witness. This approach has a few benefits:

1. Makes the metadata layer more amenable to refactoring: constructors are not invoked via reflection and any parameter mismatches are caught at compile time.
2. Avoids `TargetInvocationException` being surfaced to the user.
3. Records [nice performance gains](https://gist.github.com/eiriktsarpalis/77d97083e500da339935f1acc428d383) compared to `System.Activator` or direct `MethodInfo` invocation on the micro level.

cc @stephentoub @GrabYourPitchforks @jkotas for feedback.