### PR TITLE
JIT: Avoid using type info from GDV guesses during import

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17496,10 +17496,12 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
                     break;
                 }
             }
-            if (call->IsInlineCandidate())
+            if (call->IsInlineCandidate() && !call->IsGuardedDevirtualizationCandidate())
             {
                 // For inline candidates, we've already cached the return
-                // type class handle in the inline info.
+                // type class handle in the inline info (for GDV candidates,
+                // this data is valid only for a correct guess, so we cannot
+                // use it).
                 InlineCandidateInfo* inlInfo = call->gtInlineCandidateInfo;
                 assert(inlInfo != nullptr);
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72363/Runtime_72363.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72363/Runtime_72363.cs
@@ -44,7 +44,7 @@ public class Runtime_72363
 
 public interface IFace<out T>
 {
-    abstract T Foo();
+    T Foo();
 }
 
 public class ListImpl : IFace<List<int>>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72363/Runtime_72363.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72363/Runtime_72363.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+public class Runtime_72363
+{
+    public static int Main()
+    {
+        var bi = new ListImpl();
+        for (int i = 0; i < 100; i++)
+        {
+            Check(bi);
+
+            if (i > 30 && i < 40)
+            {
+                Thread.Sleep(10);
+            }
+        }
+
+        if (Check(new StringImpl()))
+        {
+            Console.WriteLine("FAIL: A string is not an IList<int>!");
+            return -1;
+        }
+
+        Console.WriteLine("PASS");
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Check(IFace<object> i)
+    {
+        // We would use type information about the GDV guess here to optimize.
+        if (i.Foo() is IList<int>)
+            return true;
+
+        return false;
+    }
+}
+
+public interface IFace<out T>
+{
+    abstract T Foo();
+}
+
+public class ListImpl : IFace<List<int>>
+{
+    public List<int> Foo()
+    {
+        return new List<int> { 10 };
+    }
+}
+
+public class StringImpl : IFace<string>
+{
+    public string Foo()
+    {
+        return "Hello, world!";
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72363/Runtime_72363.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72363/Runtime_72363.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_TieredCompilation=1
+set COMPlus_TieredPGO=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_TieredCompilation=1
+export COMPlus_TieredPGO=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
We can only use this type information after they have been expanded and
if we are on the happy path.

Fix #72363