### PR TITLE
[release/6.0][mono] add 400 band workloads

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,7 +9,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-emsdk -->
-    <add key="darc-pub-dotnet-emsdk-52e9452" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-52e9452f/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-1026ad5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-1026ad55/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-wcf -->
     <!--  End: Package sources from dotnet-wcf -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -20,6 +20,10 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>1026ad55ddb8587bf68829d3f5e8abafa65548fe</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.400" Version="6.0.8">
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+      <Sha>1026ad55ddb8587bf68829d3f5e8abafa65548fe</Sha>
+    </Dependency>
     <Dependency Name="System.ServiceModel.Primitives" Version="4.9.0">
       <Uri>https://github.com/dotnet/wcf</Uri>
       <Sha>04c3656e0325277aefa18378f24238d39b259222</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,17 +8,17 @@
       <Uri>https://github.com/dotnet/msquic</Uri>
       <Sha>98129287d56a5e0348c291ce4260e630b4aa510d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="6.0.4">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="6.0.8">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>52e9452f82e26f9fcae791e84c082ae22f1ef66f</Sha>
+      <Sha>1026ad55ddb8587bf68829d3f5e8abafa65548fe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.200" Version="6.0.4">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.200" Version="6.0.8">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>52e9452f82e26f9fcae791e84c082ae22f1ef66f</Sha>
+      <Sha>1026ad55ddb8587bf68829d3f5e8abafa65548fe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.4">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.8">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>52e9452f82e26f9fcae791e84c082ae22f1ef66f</Sha>
+      <Sha>1026ad55ddb8587bf68829d3f5e8abafa65548fe</Sha>
     </Dependency>
     <Dependency Name="System.ServiceModel.Primitives" Version="4.9.0">
       <Uri>https://github.com/dotnet/wcf</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,7 @@
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>8</PatchVersion>
-    <SdkBandVersion>6.0.300</SdkBandVersion>
+    <SdkBandVersion>6.0.400</SdkBandVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
@@ -25,7 +25,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- The bands we want to produce workload manifests for -->
-    <WorkloadSdkBandVersions Include="6.0.100;6.0.200;6.0.300" />
+    <WorkloadSdkBandVersions Include="6.0.100;6.0.200;6.0.300;6.0.400" />
   </ItemGroup>
   <PropertyGroup>
     <!-- For source generator support we need to target multiple versions of Rolsyn in order to be able to run on older versions of Roslyn -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -150,7 +150,7 @@
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
-    <SdkVersionForWorkloadTesting>6.0.400</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>6.0.400-rtm.22371.2</SdkVersionForWorkloadTesting>
     <SdkChannelForWorkloadTesting>6.0.4xx</SdkChannelForWorkloadTesting>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20211019.1</MicrosoftPrivateIntellisenseVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -151,6 +151,7 @@
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
     <SdkVersionForWorkloadTesting>6.0.400</SdkVersionForWorkloadTesting>
+    <SdkChannelForWorkloadTesting>6.0.4xx</SdkChannelForWorkloadTesting>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20211019.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -170,9 +170,9 @@
     <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.21416.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.21416.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
     <!-- emscripten / Node -->
-    <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60100Version>
-    <MicrosoftNETWorkloadEmscriptenManifest60200Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60200Version>
-    <MicrosoftNETWorkloadEmscriptenManifest60300Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60300Version>
+    <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.8</MicrosoftNETWorkloadEmscriptenManifest60100Version>
+    <MicrosoftNETWorkloadEmscriptenManifest60200Version>6.0.8</MicrosoftNETWorkloadEmscriptenManifest60200Version>
+    <MicrosoftNETWorkloadEmscriptenManifest60300Version>6.0.8</MicrosoftNETWorkloadEmscriptenManifest60300Version>
     <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</MicrosoftNETRuntimeEmscriptenVersion>
     <!-- workloads -->
     <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -150,7 +150,7 @@
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
-    <SdkVersionForWorkloadTesting>6.0.300-preview.22159.1</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>6.0.400</SdkVersionForWorkloadTesting>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20211019.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
@@ -173,7 +173,9 @@
     <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.8</MicrosoftNETWorkloadEmscriptenManifest60100Version>
     <MicrosoftNETWorkloadEmscriptenManifest60200Version>6.0.8</MicrosoftNETWorkloadEmscriptenManifest60200Version>
     <MicrosoftNETWorkloadEmscriptenManifest60300Version>6.0.8</MicrosoftNETWorkloadEmscriptenManifest60300Version>
+    <MicrosoftNETWorkloadEmscriptenManifest60400Version>6.0.8</MicrosoftNETWorkloadEmscriptenManifest60400Version>
     <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</MicrosoftNETRuntimeEmscriptenVersion>
+
     <!-- workloads -->
     <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>
     <WixPackageVersion>1.0.0-v3.14.0.5722</WixPackageVersion>

--- a/src/libraries/workloads-testing.targets
+++ b/src/libraries/workloads-testing.targets
@@ -38,7 +38,21 @@
       <_DotNetInstallScriptName Condition=" $([MSBuild]::IsOSPlatform('windows'))">dotnet-install.ps1</_DotNetInstallScriptName>
 
       <_DotNetInstallScriptPath>$(ArtifactsObjDir)$(_DotNetInstallScriptName)</_DotNetInstallScriptPath>
-     </PropertyGroup>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(SdkVersionForWorkloadTesting)' != ''">
+      <_DotNetInstallCommand Condition="!$([MSBuild]::IsOSPlatform('windows'))"
+              >$(_DotNetInstallScriptPath) -i $(SdkWithNoWorkloadForTestingPath) -v $(SdkVersionForWorkloadTesting)</_DotNetInstallCommand>
+      <_DotNetInstallCommand Condition="$([MSBuild]::IsOSPlatform('windows'))"
+              >$(_DotNetInstallScriptPath) -InstallDir $(SdkWithNoWorkloadForTestingPath) -Version $(SdkVersionForWorkloadTesting)</_DotNetInstallCommand>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(SdkVersionForWorkloadTesting)' == ''">
+      <_DotNetInstallCommand Condition="!$([MSBuild]::IsOSPlatform('windows'))"
+              >$(_DotNetInstallScriptPath) -i $(SdkWithNoWorkloadForTestingPath) -q daily -c $(SdkChannelForWorkloadTesting)</_DotNetInstallCommand>
+      <_DotNetInstallCommand Condition="$([MSBuild]::IsOSPlatform('windows'))"
+              >$(_DotNetInstallScriptPath) -InstallDir $(SdkWithNoWorkloadForTestingPath) -Quality daily -Channel $(SdkChannelForWorkloadTesting)</_DotNetInstallCommand>
+    </PropertyGroup>
 
     <DownloadFile SourceUrl="https://dot.net/v1/$(_DotNetInstallScriptName)"
                   DestinationFolder="$(ArtifactsObjDir)"
@@ -47,10 +61,10 @@
 
     <Exec Condition="!$([MSBuild]::IsOSPlatform('windows'))"
           IgnoreStandardErrorWarningFormat="true"
-          Command="chmod +x $(_DotNetInstallScriptPath); $(_DotNetInstallScriptPath) -i $(SdkWithNoWorkloadForTestingPath) -v $(SdkVersionForWorkloadTesting)" />
+          Command="chmod +x $(_DotNetInstallScriptPath); $(_DotNetInstallCommand)" />
 
     <Exec Condition="$([MSBuild]::IsOSPlatform('windows'))"
-          Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallScriptPath) -InstallDir $(SdkWithNoWorkloadForTestingPath) -Version $(SdkVersionForWorkloadTesting)"' />
+          Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallCommand)"' />
 
     <WriteLinesToFile File="$(SdkWithNoWorkloadStampPath)" Lines="" Overwrite="true" />
   </Target>


### PR DESCRIPTION
this is to work around the broken sdk workload band install logic that has since been fixed, if it ships after August servicing we'll need to bump the runtime version.