### PR TITLE
Enable CopyConstructorMarshaler test after #71792 fix

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -363,9 +363,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer/*">
             <Issue>https://github.com/dotnet/runtime/issues/11360</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler/*">
-            <Issue>https://github.com/dotnet/runtime/issues/67372</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XUnitTestBinBase)/JIT/Directed/callconv/ThisCall/ThisCallTest/*">
             <Issue>Native member function calling conventions not supported on Windows ARM32.</Issue>
         </ExcludeList>


### PR DESCRIPTION
#71792 fixed the issue so re-enable the test.

Closes: https://github.com/dotnet/runtime/issues/67372