### PR TITLE
[QUIC] Listener AcceptConnectionAsync propagates errors from failed handshake

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -66,7 +66,7 @@ public sealed partial class QuicListener : IAsyncDisposable
     /// <summary>
     /// Handle to MsQuic listener object.
     /// </summary>
-    private MsQuicContextSafeHandle _handle;
+    private readonly MsQuicContextSafeHandle _handle;
 
     /// <summary>
     /// Set to non-zero once disposed. Prevents double and/or concurrent disposal.
@@ -152,6 +152,9 @@ public sealed partial class QuicListener : IAsyncDisposable
     /// <remarks>
     /// Note that <see cref="QuicListener" /> doesn't have a mechanism to report inbound connections that fail the handshake process.
     /// Such connections are only logged by the listener and never surfaced on the outside.
+    ///
+    /// Propagates exceptions from <see cref="QuicListenerOptions.ConnectionOptionsCallback"/>, including validation errors from misconfigured <see cref="QuicServerConnectionOptions"/>, e.g. <see cref="ArgumentException"/>.
+    /// Also propagates exceptions from failed connection handshake, e.g. <see cref="AuthenticationException"/>, <see cref="QuicException"/>.
     /// </remarks>
     /// <returns>A task that will contain a fully connected <see cref="QuicConnection" /> which successfully finished the handshake and is ready to be used.</returns>
     public async ValueTask<QuicConnection> AcceptConnectionAsync(CancellationToken cancellationToken = default)
@@ -165,14 +168,7 @@ public sealed partial class QuicListener : IAsyncDisposable
                 PendingConnection pendingConnection = await _acceptQueue.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
                 await using (pendingConnection.ConfigureAwait(false))
                 {
-                    QuicConnection? connection = await pendingConnection.FinishHandshakeAsync(cancellationToken).ConfigureAwait(false);
-                    // Handshake failed, discard this connection and try to get another from the queue.
-                    if (connection is null)
-                    {
-                        continue;
-                    }
-
-                    return connection;
+                    return await pendingConnection.FinishHandshakeAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -163,13 +163,10 @@ public sealed partial class QuicListener : IAsyncDisposable
 
         try
         {
-            while (true)
+            PendingConnection pendingConnection = await _acceptQueue.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            await using (pendingConnection.ConfigureAwait(false))
             {
-                PendingConnection pendingConnection = await _acceptQueue.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-                await using (pendingConnection.ConfigureAwait(false))
-                {
-                    return await pendingConnection.FinishHandshakeAsync(cancellationToken).ConfigureAwait(false);
-                }
+                return await pendingConnection.FinishHandshakeAsync(cancellationToken).ConfigureAwait(false);
             }
         }
         catch (ChannelClosedException ex) when (ex.InnerException is not null)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -27,7 +27,7 @@ public sealed partial class QuicStream
     /// <summary>
     /// Handle to MsQuic connection object.
     /// </summary>
-    private MsQuicContextSafeHandle _handle;
+    private readonly MsQuicContextSafeHandle _handle;
 
     /// <summary>
     /// Set to non-zero once disposed. Prevents double and/or concurrent disposal.

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicCipherSuitesPolicyTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicCipherSuitesPolicyTests.cs
@@ -71,7 +71,7 @@ namespace System.Net.Quic.Tests
         [Fact]
         public async Task MismatchedCipherPolicies_ConnectAsync_ThrowsQuicException()
         {
-            await Assert.ThrowsAnyAsync<QuicException>(() => TestConnection(
+            await Assert.ThrowsAsync<QuicException>(() => TestConnection(
                new CipherSuitesPolicy(new[] { TlsCipherSuite.TLS_AES_128_GCM_SHA256 }),
                new CipherSuitesPolicy(new[] { TlsCipherSuite.TLS_AES_256_GCM_SHA384 })
             ));

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -600,7 +600,7 @@ namespace System.Net.Quic.Tests
                 // (CloseAsync may be processed before OpenStreamAsync as it is scheduled to the front of the operation queue)
                 // To be revisited once we standartize on exceptions.
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/55619")]
-                await Assert.ThrowsAnyAsync<QuicException>(() => waitTask.AsTask().WaitAsync(TimeSpan.FromSeconds(3)));
+                await Assert.ThrowsAsync<QuicException>(() => waitTask.AsTask().WaitAsync(TimeSpan.FromSeconds(3)));
             }
             else
             {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -73,12 +73,12 @@ namespace System.Net.Quic.Tests
                     // (CloseAsync may be processed before OpenStreamAsync as it is scheduled to the front of the operation queue)
                     // To be revisited once we standartize on exceptions.
                     // [ActiveIssue("https://github.com/dotnet/runtime/issues/55619")]
-                    await Assert.ThrowsAnyAsync<QuicException>(() => connectTask);
+                    await Assert.ThrowsAsync<QuicException>(() => connectTask);
 
                     // Subsequent attempts should fail
                     // TODO: Which exception is correct?
                     await AssertThrowsQuicExceptionAsync(QuicError.OperationAborted, async () => await serverConnection.AcceptInboundStreamAsync());
-                    await Assert.ThrowsAnyAsync<QuicException>(() => OpenAndUseStreamAsync(serverConnection));
+                    await Assert.ThrowsAsync<QuicException>(() => OpenAndUseStreamAsync(serverConnection));
                 });
         }
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -55,5 +55,34 @@ namespace System.Net.Quic.Tests
                 await using QuicConnection clientConnection = await clientStreamTask;
             }).WaitAsync(TimeSpan.FromSeconds(6));
         }
+
+        [Fact]
+        public async Task AcceptConnectionAsync_InvalidConnectionOptions_Throws()
+        {
+            QuicListenerOptions listenerOptions = CreateQuicListenerOptions();
+            // Do not set any options, which should throw an argument exception from accept.
+            listenerOptions.ConnectionOptionsCallback = (_, _, _) => ValueTask.FromResult(new QuicServerConnectionOptions());
+            await using QuicListener listener = await CreateQuicListener(listenerOptions);
+
+            ValueTask<QuicConnection> connectTask = CreateQuicConnection(listener.LocalEndPoint);
+            await Assert.ThrowsAnyAsync<ArgumentException>(async () => await listener.AcceptConnectionAsync());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task AcceptConnectionAsync_ThrowingOptionsCallback_Throws(bool useFromException)
+        {
+            const string expectedMessage = "Expected Message";
+
+            QuicListenerOptions listenerOptions = CreateQuicListenerOptions();
+            // Throw an exception, which should throw the same from accept.
+            listenerOptions.ConnectionOptionsCallback = (_, _, _) => useFromException ? ValueTask.FromException<QuicServerConnectionOptions>(new Exception(expectedMessage)) : throw new Exception(expectedMessage);
+            await using QuicListener listener = await CreateQuicListener(listenerOptions);
+
+            ValueTask<QuicConnection> connectTask = CreateQuicConnection(listener.LocalEndPoint);
+            Exception exception = await Assert.ThrowsAsync<Exception>(async () => await listener.AcceptConnectionAsync());
+            Assert.Equal(expectedMessage, exception.Message);
+        }
     }
 }


### PR DESCRIPTION
If there was a validation error with `QuicServerConnectionOptions` or a failure during `ConnectionOptionsCallback` or a handshake failure, it will no get propagated from `AcceptConnectionAsync`. Originally, that error would get just logged and swallowed, so that if listener user made a mistake they would have a hard time diagnosing it.

Fixes #72160