### PR TITLE
Limit core-count of fankkuch benchmark code

### DIFF
--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/fannkuch-redux/fannkuch-redux-5.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/fannkuch-redux/fannkuch-redux-5.cs
@@ -116,7 +116,11 @@ namespace BenchmarksGame
             var factn = 1;
             for (int i = 1; i < fact.Length; i++) { fact[i] = factn *= i; }
 
-            int nTasks = Environment.ProcessorCount;
+            // For n == 7 and nTasks > 8, the algorithm returns chkSum != 228
+            // Hence, we restrict the processor count to 8 to get consistency on
+            // all the hardwares.
+            // See https://github.com/dotnet/runtime/issues/67157
+            int nTasks = Math.Min(Environment.ProcessorCount, 8);
             chkSums = new int[nTasks];
             maxFlips = new int[nTasks];
             int taskSize = factn / nTasks;

--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/fannkuch-redux/fannkuch-redux-9.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/fannkuch-redux/fannkuch-redux-9.cs
@@ -164,7 +164,11 @@ namespace BenchmarksGame
                 fact[i] = fact[i - 1] * i;
             }
 
-            var PC = Environment.ProcessorCount;
+            // For n == 7 and nTasks > 8, the algorithm returns chkSum != 228
+            // Hence, we restrict the processor count to 8 to get consistency on
+            // all the hardwares.
+            // See https://github.com/dotnet/runtime/issues/67157
+            var PC = Math.Min(Environment.ProcessorCount, 8);
             taskCount = n > 11 ? fact[n] / (9 * 8 * 7 * 6 * 5 * 4 * 3 * 2) : PC;
             int taskSize = fact[n] / taskCount;
             chkSums = new int[PC];


### PR DESCRIPTION
No. of parallel tasks greater than 8 leads to different results by fankkuch algorithm than what we expect. Just limit the process count to 8.

Fixes: https://github.com/dotnet/runtime/issues/67157