### PR TITLE
Remove unnecessary call to Path.GetTempPath

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -271,8 +271,6 @@ namespace System.Diagnostics
                     {
                         if (s_symbolFilePath == null)
                         {
-                            Path.GetTempPath();
-
                             try
                             {
                                 s_symbolFilePath = Path.GetTempFileName();


### PR DESCRIPTION
This line was leftover after https://github.com/dotnet/runtime/commit/6de7147b9266d7730b0d73ba67632b0c198cb11e.