### PR TITLE
Block SaveWmfAsPngDoesntChangeImageBoundaries

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
@@ -790,7 +790,7 @@ namespace System.Drawing.Tests
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "In .NET Framework we use GDI 1.0")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72165", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/69471"))]
         public void SaveWmfAsPngDoesntChangeImageBoundaries()
         {
             if (PlatformDetection.IsWindows7)

--- a/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
@@ -790,7 +790,7 @@ namespace System.Drawing.Tests
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "In .NET Framework we use GDI 1.0")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69471", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version22000OrGreater))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/69471")]
         public void SaveWmfAsPngDoesntChangeImageBoundaries()
         {
             if (PlatformDetection.IsWindows7)

--- a/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
@@ -790,7 +790,7 @@ namespace System.Drawing.Tests
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "In .NET Framework we use GDI 1.0")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69471"))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/69471", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version22000OrGreater))]
         public void SaveWmfAsPngDoesntChangeImageBoundaries()
         {
             if (PlatformDetection.IsWindows7)


### PR DESCRIPTION
People keep running into this locally and I almost spent time investigating this as my own regression.