### PR TITLE
draft(not ready for review): Don't add extra `0` when formatting BigInteger to hex

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -927,10 +927,14 @@ namespace System.Numerics
                 if (head < 0x08 || clearHighF)
                 {
                     // {0xF8-0xFF} print as {8-F}
-                    // {0x00-0x07} print as {0-7}
-                    sb.Append(head < 10 ?
-                        (char)(head + '0') :
-                        format == 'X' ? (char)((head & 0xF) - 10 + 'A') : (char)((head & 0xF) - 10 + 'a'));
+                    // {0x01-0x07} print as {1-7}
+                    if (head > 0)
+                    {
+                        sb.Append(head < 10 ?
+                            (char)(head + '0') :
+                            format == 'X' ? (char)((head & 0xF) - 10 + 'A') : (char)((head & 0xF) - 10 + 'a'));
+                    }
+
                     cur--;
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/72426

Draft to see if this breaks something. Otherwise, I'll add a test.