### PR TITLE
[QUIC] Fixed disabled receives if buffer gets drained before RECEIVE returns

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ReceiveBuffers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ReceiveBuffers.cs
@@ -28,6 +28,14 @@ internal struct ReceiveBuffers
         }
     }
 
+    public bool HasCapacity()
+    {
+        lock (_syncRoot)
+        {
+            return _buffer.ActiveMemory.Length < MaxBufferedBytes;
+        }
+    }
+
     public int CopyFrom(ReadOnlySpan<QUIC_BUFFER> quicBuffers, int totalLength, bool final)
     {
         lock (_syncRoot)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -509,7 +509,7 @@ public sealed partial class QuicStream
         _receiveTcs.TrySetResult();
 
         data.TotalBufferLength = totalCopied;
-        return _receiveBuffers.HasCapacity() ? QUIC_STATUS_CONTINUE : QUIC_STATUS_SUCCESS;
+        return (_receiveBuffers.HasCapacity() && Interlocked.CompareExchange(ref _receivedNeedsEnable, 0, 1) == 1) ? QUIC_STATUS_CONTINUE : QUIC_STATUS_SUCCESS;
     }
     private unsafe int HandleEventSendComplete(ref SEND_COMPLETE data)
     {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -509,7 +509,7 @@ public sealed partial class QuicStream
         _receiveTcs.TrySetResult();
 
         data.TotalBufferLength = totalCopied;
-        return QUIC_STATUS_SUCCESS;
+        return _receiveBuffers.HasCapacity() ? QUIC_STATUS_CONTINUE : QUIC_STATUS_SUCCESS;
     }
     private unsafe int HandleEventSendComplete(ref SEND_COMPLETE data)
     {


### PR DESCRIPTION
Root cause: we're reading in a tight loop, so when RECEIVE event arrived, we'd copy some data (based on buffer capacity) and return SUCCESS with partial receive. But the reading loop thread was faster and it would drain the buffer before the event handler returned to MsQuic. Now we have `ReadAsync` waiting on the `_receiveTcs` (waiting on another RECEIVE event) and MsQuic waiting on `StreamReceiveSetEnabled` since we did partial data receive.

The fix: check if the receive buffer has a capacity (i.e.: someone read from it in the mean time) and if so immediately re-enable receives with `QUIC_STATUS_CONTINUE` 

Interestingly, this manifested only on Windows, so I ran the offending test in a tight loop for ~10 minutes without any failures (normally it'd manifest in less than 1 minute).

Fixes #72196
Fixes #72422