### PR TITLE
Update NuGet reference versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -144,8 +144,8 @@
     <DNNEVersion>1.0.27</DNNEVersion>
     <MicrosoftBuildVersion>16.10.0</MicrosoftBuildVersion>
     <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildTasksCoreVersion>
-    <NugetProjectModelVersion>5.8.0</NugetProjectModelVersion>
-    <NugetPackagingVersion>5.8.0</NugetPackagingVersion>
+    <NugetProjectModelVersion>6.2.1</NugetProjectModelVersion>
+    <NugetPackagingVersion>6.2.1</NugetPackagingVersion>
     <!-- Testing -->
     <MicrosoftNETCoreCoreDisToolsVersion>1.1.0</MicrosoftNETCoreCoreDisToolsVersion>
     <MicrosoftNETTestSdkVersion>16.9.0-preview-20201201-01</MicrosoftNETTestSdkVersion>

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/SerializableAssembly.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/SerializableAssembly.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="14.3.0">
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
These references were still pulling in Newtonsoft.Json 9.0.1 causing
governance problems.

Also update a Microsoft.Build.Tasks.Core reference to use our defined
property for it.