### PR TITLE
Revert "Support OpenSSL-based MsQuic on Windows (#72262)"

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -51,13 +51,27 @@ internal sealed unsafe class MsQuicApi
 
     internal static bool IsQuicSupported { get; }
 
-    internal static bool UsesSChannelBackend { get; }
-
     internal static bool Tls13ServerMayBeDisabled { get; }
     internal static bool Tls13ClientMayBeDisabled { get; }
 
     static MsQuicApi()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            if (!IsWindowsVersionSupported())
+            {
+                if (NetEventSource.Log.IsEnabled())
+                {
+                    NetEventSource.Info(null, $"Current Windows version ({Environment.OSVersion}) is not supported by QUIC. Minimal supported version is {MinWindowsVersion}");
+                }
+
+                return;
+            }
+
+            Tls13ServerMayBeDisabled = IsTls13Disabled(true);
+            Tls13ClientMayBeDisabled = IsTls13Disabled(false);
+        }
+
         IntPtr msQuicHandle;
         if (NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle) ||
             NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle))
@@ -76,39 +90,18 @@ internal sealed unsafe class MsQuicApi
                         if (StatusSucceeded(apiTable->GetParam(null, QUIC_PARAM_GLOBAL_LIBRARY_VERSION, &size, libVersion)))
                         {
                             var version = new Version((int)libVersion[0], (int)libVersion[1], (int)libVersion[2], (int)libVersion[3]);
-                            if (version < MsQuicVersion)
+                            if (version >= MsQuicVersion)
+                            {
+                                Api = new MsQuicApi(apiTable);
+                                IsQuicSupported = true;
+                            }
+                            else
                             {
                                 if (NetEventSource.Log.IsEnabled())
                                 {
                                     NetEventSource.Info(null, $"Incompatible MsQuic library version '{version}', expecting '{MsQuicVersion}'");
                                 }
-                                return;
                             }
-
-                            // Assume SChanel is being used on windows and query for the actual provider from the library
-                            QUIC_TLS_PROVIDER provider = OperatingSystem.IsWindows() ? QUIC_TLS_PROVIDER.SCHANNEL : QUIC_TLS_PROVIDER.OPENSSL;
-                            size = sizeof(QUIC_TLS_PROVIDER);
-                            apiTable->GetParam(null, QUIC_PARAM_GLOBAL_TLS_PROVIDER, &size, &provider);
-                            UsesSChannelBackend = provider == QUIC_TLS_PROVIDER.SCHANNEL;
-
-                            if (UsesSChannelBackend)
-                            {
-                                if (!IsWindowsVersionSupported())
-                                {
-                                    if (NetEventSource.Log.IsEnabled())
-                                    {
-                                        NetEventSource.Info(null, $"Current Windows version ({Environment.OSVersion}) is not supported by QUIC. Minimal supported version is {MinWindowsVersion}");
-                                    }
-
-                                    return;
-                                }
-
-                                Tls13ServerMayBeDisabled = IsTls13Disabled(isServer: true);
-                                Tls13ClientMayBeDisabled = IsTls13Disabled(isServer: false);
-                            }
-
-                            Api = new MsQuicApi(apiTable);
-                            IsQuicSupported = true;
                         }
                     }
                 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -23,7 +23,7 @@ internal static class MsQuicConfiguration
         flags |= QUIC_CREDENTIAL_FLAGS.CLIENT;
         flags |= QUIC_CREDENTIAL_FLAGS.INDICATE_CERTIFICATE_RECEIVED;
         flags |= QUIC_CREDENTIAL_FLAGS.NO_CERTIFICATE_VALIDATION;
-        if (MsQuicApi.UsesSChannelBackend)
+        if (OperatingSystem.IsWindows())
         {
             flags |= QUIC_CREDENTIAL_FLAGS.USE_SUPPLIED_CREDENTIALS;
         }
@@ -145,7 +145,7 @@ internal static class MsQuicConfiguration
         try
         {
             QUIC_CREDENTIAL_CONFIG config = new QUIC_CREDENTIAL_CONFIG { Flags = flags };
-            config.Flags |= (MsQuicApi.UsesSChannelBackend ? QUIC_CREDENTIAL_FLAGS.NONE : QUIC_CREDENTIAL_FLAGS.USE_PORTABLE_CERTIFICATES);
+            config.Flags |= (OperatingSystem.IsWindows() ? QUIC_CREDENTIAL_FLAGS.NONE : QUIC_CREDENTIAL_FLAGS.USE_PORTABLE_CERTIFICATES);
 
             if (cipherSuitesPolicy != null)
             {
@@ -159,7 +159,7 @@ internal static class MsQuicConfiguration
                 config.Type = QUIC_CREDENTIAL_TYPE.NONE;
                 status = MsQuicApi.Api.ApiTable->ConfigurationLoadCredential(configurationHandle.QuicHandle, &config);
             }
-            else if (MsQuicApi.UsesSChannelBackend)
+            else if (OperatingSystem.IsWindows())
             {
                 config.Type = QUIC_CREDENTIAL_TYPE.CERTIFICATE_CONTEXT;
                 config.CertificateContext = (void*)certificate.Handle;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
@@ -69,7 +69,7 @@ public partial class QuicConnection
                     chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
                     chain.ChainPolicy.ApplicationPolicy.Add(_isClient ? s_serverAuthOid : s_clientAuthOid);
 
-                    if (MsQuicApi.UsesSChannelBackend)
+                    if (OperatingSystem.IsWindows())
                     {
                         result = new X509Certificate2((IntPtr)certificatePtr);
                     }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -206,7 +206,7 @@ namespace System.Net.Security.Tests
             if (PlatformDetection.IsWindows)
             {
                 X509Certificate2 ephemeral = endEntity;
-                endEntity = new X509Certificate2(endEntity.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+                endEntity = new X509Certificate2(endEntity.Export(X509ContentType.Pfx));
                 ephemeral.Dispose();
             }
 


### PR DESCRIPTION
This reverts commit 3e5f0c1a62be4f6aa315443d208b1640799a9deb (PR #72262).

The change has (supposedly) triggered strange native crashes on schannel-unsupported platforms, see #72429. We need to investigate before reintroducing the change.

Closes #72429
Closes #72428