### PR TITLE
Make PhysicalFileProvider polling more resilient to IO exceptions

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/FileSystemInfoHelper.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/FileSystemInfoHelper.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Extensions.FileProviders.Physical
                         return targetInfo.LastWriteTimeUtc;
                     }
                 }
-                catch (FileNotFoundException)
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                 {
-                    // The file ceased to exist between LinkTarget and ResolveLinkTarget.
+                    // The target or the link ceased to exist between LinkTarget and ResolveLinkTarget.
                 }
 
                 return DateTime.MinValue;

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.netcoreapp.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.netcoreapp.cs
@@ -107,16 +107,11 @@ namespace Microsoft.Extensions.FileProviders
 
             // Act - Change link target to file 2.
             File.Delete(linkPath);
-            try
-            {
-                File.CreateSymbolicLink(linkPath, file2Path);
+            File.CreateSymbolicLink(linkPath, file2Path);
 
-                // Assert - It should report the change regardless of the timestamp being older.
-                Assert.True(await tcs.Task,
-                    $"Change event was not raised - current time: {DateTime.UtcNow:O}, file1 LastWriteTimeUtc: {File.GetLastWriteTimeUtc(file1Path):O}, file2 LastWriteTime: {File.GetLastWriteTimeUtc(file2Path):O}.");
-            }
-            // https://github.com/dotnet/runtime/issues/56810
-            catch (UnauthorizedAccessException) { }
+            // Assert - It should report the change regardless of the timestamp being older.
+            Assert.True(await tcs.Task,
+                $"Change event was not raised - current time: {DateTime.UtcNow:O}, file1 LastWriteTimeUtc: {File.GetLastWriteTimeUtc(file1Path):O}, file2 LastWriteTime: {File.GetLastWriteTimeUtc(file2Path):O}.");
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsSymLinkSupported))]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/71003
Fixes https://github.com/dotnet/runtime/issues/56810