### PR TITLE
[iOS] Use different tvOS helix queue for PR's

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -120,9 +120,9 @@ jobs:
     # tvOS devices
     - ${{ if in(parameters.platform, 'tvOS_arm64') }}:
       # split traffic for PR's and rolling builds
-      - ${{ if and(ne(parameters.jobParameters.isExtraPlatforms, true), ne(parameters.jobParameters.isExtraPlatforms, 'True')) }}:
+      - ${{ if ne(parameters.jobParameters.isExtraPlatforms, true) }}:
         - OSX.1015.Amd64.AppleTV.Open
-      - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.isExtraPlatforms, 'True')) }}:
+      - ${{ if eq(parameters.jobParameters.isExtraPlatforms, true) }}:
         - OSX.1100.Amd64.AppleTV.Open
 
     # windows x64

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -119,7 +119,11 @@ jobs:
 
     # tvOS devices
     - ${{ if in(parameters.platform, 'tvOS_arm64') }}:
-      - OSX.1015.Amd64.AppleTV.Open
+      # split traffic for PR's and rolling builds
+      - ${{ if eq(variables['isNotExtraPlatformsBuild'], true) }}:
+        - OSX.1015.Amd64.AppleTV.Open
+      - ${{ if ne(variables['isExtraPlatformsBuild'], true) }}:
+        - OSX.1100.Amd64.AppleTV.Open
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -122,7 +122,7 @@ jobs:
       # split traffic for PR's and rolling builds
       - ${{ if eq(variables['isNotExtraPlatformsBuild'], true) }}:
         - OSX.1015.Amd64.AppleTV.Open
-      - ${{ if ne(variables['isExtraPlatformsBuild'], true) }}:
+      - ${{ if eq(variables['isExtraPlatformsBuild'], true) }}:
         - OSX.1100.Amd64.AppleTV.Open
 
     # windows x64

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -120,9 +120,9 @@ jobs:
     # tvOS devices
     - ${{ if in(parameters.platform, 'tvOS_arm64') }}:
       # split traffic for PR's and rolling builds
-      - ${{ if eq(variables['isNotExtraPlatformsBuild'], true) }}:
+      - ${{ if and(ne(parameters.jobParameters.isExtraPlatforms, true), ne(parameters.jobParameters.isExtraPlatforms, 'True')) }}:
         - OSX.1015.Amd64.AppleTV.Open
-      - ${{ if eq(variables['isExtraPlatformsBuild'], true) }}:
+      - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.isExtraPlatforms, 'True')) }}:
         - OSX.1100.Amd64.AppleTV.Open
 
     # windows x64

--- a/eng/pipelines/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/runtime-extra-platforms-other.yml
@@ -228,6 +228,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       nameSuffix: AllSubsets_Mono
+      isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true $(_runSmokeTestsOnlyArg) /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=true /p:BuildDarwinFrameworks=true
       timeoutInMinutes: 180
       condition: >-


### PR DESCRIPTION
Up until now, we have used a single tvOS queue for all pipelines. This has lead to frequent timeouts because there simply aren't enough devices to handle spikes in traffic. We will now make use of two queues, one for runtime (PR's) and one for runtime-extra-platforms (scheduled jobs, manual runs). Since we are only running System.Runtime tests on PR's, we should see PR timeouts much less.