### PR TITLE
port BitArray.And, Or, Xor and Not to Vector<T>

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Collections/src/System/Collections/BitArray.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 using System.Runtime.Intrinsics.Arm;
+using System.Numerics;
 
 namespace System.Collections
 {
@@ -119,9 +120,7 @@ namespace System.Collections
         }
 
         private const uint Vector128ByteCount = 16;
-        private const uint Vector128IntCount = 4;
         private const uint Vector256ByteCount = 32;
-        private const uint Vector256IntCount = 8;
         public unsafe BitArray(bool[] values)
         {
             ArgumentNullException.ThrowIfNull(values);
@@ -338,25 +337,14 @@ namespace System.Collections
                 case 0: goto Done;
             }
 
-            uint i = 0;
+            int i = 0;
 
-            ref int left = ref MemoryMarshal.GetArrayDataReference<int>(thisArray);
-            ref int right = ref MemoryMarshal.GetArrayDataReference<int>(valueArray);
-
-            if (Vector256.IsHardwareAccelerated)
+            if (Vector.IsHardwareAccelerated)
             {
-                for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
+                for (; i < (uint)count - (Vector<int>.Count - 1u); i += Vector<int>.Count)
                 {
-                    Vector256<int> result = Vector256.LoadUnsafe(ref left, i) & Vector256.LoadUnsafe(ref right, i);
-                    result.StoreUnsafe(ref left, i);
-                }
-            }
-            else if (Vector128.IsHardwareAccelerated)
-            {
-                for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                {
-                    Vector128<int> result = Vector128.LoadUnsafe(ref left, i) & Vector128.LoadUnsafe(ref right, i);
-                    result.StoreUnsafe(ref left, i);
+                    Vector<int> result = new Vector<int>(thisArray, i) & new Vector<int>(valueArray, i);
+                    result.CopyTo(thisArray, i);
                 }
             }
 
@@ -404,25 +392,14 @@ namespace System.Collections
                 case 0: goto Done;
             }
 
-            uint i = 0;
+            int i = 0;
 
-            ref int left = ref MemoryMarshal.GetArrayDataReference<int>(thisArray);
-            ref int right = ref MemoryMarshal.GetArrayDataReference<int>(valueArray);
-
-            if (Vector256.IsHardwareAccelerated)
+            if (Vector.IsHardwareAccelerated)
             {
-                for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
+                for (; i < (uint)count - (Vector<int>.Count - 1u); i += Vector<int>.Count)
                 {
-                    Vector256<int> result = Vector256.LoadUnsafe(ref left, i) | Vector256.LoadUnsafe(ref right, i);
-                    result.StoreUnsafe(ref left, i);
-                }
-            }
-            else if (Vector128.IsHardwareAccelerated)
-            {
-                for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                {
-                    Vector128<int> result = Vector128.LoadUnsafe(ref left, i) | Vector128.LoadUnsafe(ref right, i);
-                    result.StoreUnsafe(ref left, i);
+                    Vector<int> result = new Vector<int>(thisArray, i) | new Vector<int>(valueArray, i);
+                    result.CopyTo(thisArray, i);
                 }
             }
 
@@ -470,25 +447,14 @@ namespace System.Collections
                 case 0: goto Done;
             }
 
-            uint i = 0;
+            int i = 0;
 
-            ref int left = ref MemoryMarshal.GetArrayDataReference<int>(thisArray);
-            ref int right = ref MemoryMarshal.GetArrayDataReference<int>(valueArray);
-
-            if (Vector256.IsHardwareAccelerated)
+            if (Vector.IsHardwareAccelerated)
             {
-                for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
+                for (; i < (uint)count - (Vector<int>.Count - 1u); i += Vector<int>.Count)
                 {
-                    Vector256<int> result = Vector256.LoadUnsafe(ref left, i) ^ Vector256.LoadUnsafe(ref right, i);
-                    result.StoreUnsafe(ref left, i);
-                }
-            }
-            else if (Vector128.IsHardwareAccelerated)
-            {
-                for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                {
-                    Vector128<int> result = Vector128.LoadUnsafe(ref left, i) ^ Vector128.LoadUnsafe(ref right, i);
-                    result.StoreUnsafe(ref left, i);
+                    Vector<int> result = new Vector<int>(thisArray, i) ^ new Vector<int>(valueArray, i);
+                    result.CopyTo(thisArray, i);
                 }
             }
 
@@ -529,24 +495,14 @@ namespace System.Collections
                 case 0: goto Done;
             }
 
-            uint i = 0;
+            int i = 0;
 
-            ref int value = ref MemoryMarshal.GetArrayDataReference<int>(thisArray);
-
-            if (Vector256.IsHardwareAccelerated)
+            if (Vector.IsHardwareAccelerated)
             {
-                for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
+                for (; i < (uint)count - (Vector<int>.Count - 1u); i += Vector<int>.Count)
                 {
-                    Vector256<int> result = ~Vector256.LoadUnsafe(ref value, i);
-                    result.StoreUnsafe(ref value, i);
-                }
-            }
-            else if (Vector128.IsHardwareAccelerated)
-            {
-                for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                {
-                    Vector128<int> result = ~Vector128.LoadUnsafe(ref value, i);
-                    result.StoreUnsafe(ref value, i);
+                    Vector<int> result = ~new Vector<int>(thisArray, i);
+                    result.CopyTo(thisArray, i);
                 }
             }
 

--- a/src/libraries/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Collections/src/System/Collections/BitArray.cs
@@ -341,10 +341,13 @@ namespace System.Collections
 
             if (Vector.IsHardwareAccelerated)
             {
-                for (; i < (uint)count - (Vector<int>.Count - 1u); i += Vector<int>.Count)
+                fixed (int* pThisBuffer = thisArray)
+                fixed (int* pValueBuffer = valueArray)
                 {
-                    Vector<int> result = new Vector<int>(thisArray, i) & new Vector<int>(valueArray, i);
-                    result.CopyTo(thisArray, i);
+                    for (; i <= (uint)count - Vector<int>.Count; i += Vector<int>.Count)
+                    {
+                        Unsafe.WriteUnaligned(pThisBuffer + i, Unsafe.ReadUnaligned<Vector<int>>(pThisBuffer + i) & Unsafe.ReadUnaligned<Vector<int>>(pValueBuffer + i));
+                    }
                 }
             }
 
@@ -394,12 +397,12 @@ namespace System.Collections
 
             int i = 0;
 
-            if (Vector.IsHardwareAccelerated)
+            fixed (int* pThisBuffer = thisArray)
+            fixed (int* pValueBuffer = valueArray)
             {
-                for (; i < (uint)count - (Vector<int>.Count - 1u); i += Vector<int>.Count)
+                for (; i <= (uint)count - Vector<int>.Count; i += Vector<int>.Count)
                 {
-                    Vector<int> result = new Vector<int>(thisArray, i) | new Vector<int>(valueArray, i);
-                    result.CopyTo(thisArray, i);
+                    Unsafe.WriteUnaligned(pThisBuffer + i, Unsafe.ReadUnaligned<Vector<int>>(pThisBuffer + i) | Unsafe.ReadUnaligned<Vector<int>>(pValueBuffer + i));
                 }
             }
 
@@ -449,12 +452,12 @@ namespace System.Collections
 
             int i = 0;
 
-            if (Vector.IsHardwareAccelerated)
+            fixed (int* pThisBuffer = thisArray)
+            fixed (int* pValueBuffer = valueArray)
             {
-                for (; i < (uint)count - (Vector<int>.Count - 1u); i += Vector<int>.Count)
+                for (; i <= (uint)count - Vector<int>.Count; i += Vector<int>.Count)
                 {
-                    Vector<int> result = new Vector<int>(thisArray, i) ^ new Vector<int>(valueArray, i);
-                    result.CopyTo(thisArray, i);
+                    Unsafe.WriteUnaligned(pThisBuffer + i, Unsafe.ReadUnaligned<Vector<int>>(pThisBuffer + i) ^ Unsafe.ReadUnaligned<Vector<int>>(pValueBuffer + i));
                 }
             }
 
@@ -497,12 +500,11 @@ namespace System.Collections
 
             int i = 0;
 
-            if (Vector.IsHardwareAccelerated)
+            fixed (int* pThisBuffer = thisArray)
             {
-                for (; i < (uint)count - (Vector<int>.Count - 1u); i += Vector<int>.Count)
+                for (; i <= (uint)count - Vector<int>.Count; i += Vector<int>.Count)
                 {
-                    Vector<int> result = ~new Vector<int>(thisArray, i);
-                    result.CopyTo(thisArray, i);
+                    Unsafe.WriteUnaligned(pThisBuffer + i, ~Unsafe.ReadUnaligned<Vector<int>>(pThisBuffer + i));
                 }
             }
 


### PR DESCRIPTION
I started the learning process by porting very simple `BitArray` APIs: And, Or, Xor and Not.

To my surprise, there is a notable regression:

### x64

<details>

```ini
BenchmarkDotNet=v0.13.1.1799-nightly, OS=Windows 11 (10.0.22000.795/21H2)
AMD Ryzen Threadripper PRO 3945WX 12-Cores, 1 CPU, 24 logical and 12 physical cores
.NET SDK=7.0.100-preview.6.22352.1
  [Host]     : .NET 7.0.0 (7.0.22.32404), X64 RyuJIT
```

|      Method |             Toolchain | Size |       Mean | Ratio |
|------------ |---------------------- |----- |-----------:|------:|
| BitArrayNot |       \PR\corerun.exe |    4 |  0.8868 ns |  1.52 |
| BitArrayNot | \baseline\corerun.exe |    4 |  0.5938 ns |  1.00 |
|             |                       |      |            |       |
| BitArrayAnd |       \PR\corerun.exe |    4 |  1.8233 ns |  0.95 |
| BitArrayAnd | \baseline\corerun.exe |    4 |  1.9173 ns |  1.00 |
|             |                       |      |            |       |
|  BitArrayOr |       \PR\corerun.exe |    4 |  1.8242 ns |  0.92 |
|  BitArrayOr | \baseline\corerun.exe |    4 |  1.9889 ns |  1.00 |
|             |                       |      |            |       |
| BitArrayXor |       \PR\corerun.exe |    4 |  1.8429 ns |  0.93 |
| BitArrayXor | \baseline\corerun.exe |    4 |  1.9822 ns |  1.00 |
|             |                       |      |            |       |
| BitArrayNot |       \PR\corerun.exe |  512 | 11.4026 ns |  1.80 |
| BitArrayNot | \baseline\corerun.exe |  512 |  6.3584 ns |  1.00 |
|             |                       |      |            |       |
| BitArrayAnd |       \PR\corerun.exe |  512 | 14.6244 ns |  1.57 |
| BitArrayAnd | \baseline\corerun.exe |  512 |  9.2924 ns |  1.00 |
|             |                       |      |            |       |
|  BitArrayOr |       \PR\corerun.exe |  512 | 14.7221 ns |  1.58 |
|  BitArrayOr | \baseline\corerun.exe |  512 |  9.3151 ns |  1.00 |
|             |                       |      |            |       |
| BitArrayXor |       \PR\corerun.exe |  512 | 14.7987 ns |  1.59 |
| BitArrayXor | \baseline\corerun.exe |  512 |  9.2756 ns |  1.00 |


The assembly diff for `Not` can be found [here](https://www.diffchecker.com/wujjY8Wk)

</details>

### arm64

<details>

```ini
BenchmarkDotNet=v0.13.1.1786-nightly, OS=ubuntu 20.04
Unknown processor
.NET SDK=7.0.100-rc.1.22368.24
  [Host]     : .NET 7.0.0 (7.0.22.36704), Arm64 RyuJIT
```

|      Method |         Toolchain | Size |      Mean | Ratio |
|------------ |------------------ |----- |----------:|------:|
| BitArrayNot |       /PR/corerun |    4 |  6.358 ns |  0.88 |
| BitArrayNot | /baseline/corerun |    4 |  7.202 ns |  1.00 |
|             |                   |      |           |       |
| BitArrayAnd |       /PR/corerun |    4 | 11.824 ns |  1.00 |
| BitArrayAnd | /baseline/corerun |    4 | 11.820 ns |  1.00 |
|             |                   |      |           |       |
|  BitArrayOr |       /PR/corerun |    4 | 11.889 ns |  1.01 |
|  BitArrayOr | /baseline/corerun |    4 | 11.816 ns |  1.00 |
|             |                   |      |           |       |
| BitArrayXor |       /PR/corerun |    4 | 11.815 ns |  1.01 |
| BitArrayXor | /baseline/corerun |    4 | 11.708 ns |  1.00 |
|             |                   |      |           |       |
| BitArrayNot |       /PR/corerun |  512 | 75.451 ns |  1.94 |
| BitArrayNot | /baseline/corerun |  512 | 39.403 ns |  1.00 |
|             |                   |      |           |       |
| BitArrayAnd |       /PR/corerun |  512 | 95.542 ns |  1.84 |
| BitArrayAnd | /baseline/corerun |  512 | 51.936 ns |  1.00 |
|             |                   |      |           |       |
|  BitArrayOr |       /PR/corerun |  512 | 95.537 ns |  1.86 |
|  BitArrayOr | /baseline/corerun |  512 | 51.505 ns |  1.00 |
|             |                   |      |           |       |
| BitArrayXor |       /PR/corerun |  512 | 94.904 ns |  1.83 |
| BitArrayXor | /baseline/corerun |  512 | 51.989 ns |  1.00 |

</details>

@tannergooding I don't want to merge this PR as is, but rather find out whether I am doing everything right and what could be done to close the gap.

cc @stephentoub 