### PR TITLE
Convert tar header struct to class

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
@@ -99,7 +99,7 @@ namespace System.Formats.Tar
         /// <remarks><see cref="GroupName"/> is only used in Unix platforms.</remarks>
         public string GroupName
         {
-            get => _header._gName;
+            get => _header._gName ?? string.Empty;
             set
             {
                 ArgumentNullException.ThrowIfNull(value);
@@ -114,7 +114,7 @@ namespace System.Formats.Tar
         /// <exception cref="ArgumentNullException">Cannot set a null user name.</exception>
         public string UserName
         {
-            get => _header._uName;
+            get => _header._uName ?? string.Empty;
             set
             {
                 ArgumentNullException.ThrowIfNull(value);

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -116,7 +116,7 @@ namespace System.Formats.Tar
         /// <exception cref="InvalidOperationException">Cannot set the link name if the entry type is not <see cref="TarEntryType.HardLink"/> or <see cref="TarEntryType.SymbolicLink"/>.</exception>
         public string LinkName
         {
-            get => _header._linkName;
+            get => _header._linkName ?? string.Empty;
             set
             {
                 if (_header._typeFlag is not TarEntryType.HardLink and not TarEntryType.SymbolicLink)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -41,15 +41,8 @@ namespace System.Formats.Tar
                 TarHelpers.ThrowIfEntryTypeNotSupported(entryType, format);
             }
 
-            _header = default;
-            _header._format = format;
-
             // Default values for fields shared by all supported formats
-            _header._name = entryName;
-            _header._mode = TarHelpers.GetDefaultMode(entryType);
-            _header._mTime = DateTimeOffset.UtcNow;
-            _header._typeFlag = entryType;
-            _header._linkName = string.Empty;
+            _header = new TarHeader(format, entryName, TarHelpers.GetDefaultMode(entryType), DateTimeOffset.UtcNow, entryType);
         }
 
         // Constructor called when converting an entry to the selected format.
@@ -60,38 +53,13 @@ namespace System.Formats.Tar
                 throw new InvalidOperationException(SR.TarCannotConvertPaxGlobalExtendedAttributesEntry);
             }
 
-            TarEntryType compatibleEntryType;
-            if (other.Format is TarEntryFormat.V7 && other.EntryType is TarEntryType.V7RegularFile && format is TarEntryFormat.Ustar or TarEntryFormat.Pax or TarEntryFormat.Gnu)
-            {
-                compatibleEntryType = TarEntryType.RegularFile;
-            }
-            else if (other.Format is TarEntryFormat.Ustar or TarEntryFormat.Pax or TarEntryFormat.Gnu && other.EntryType is TarEntryType.RegularFile && format is TarEntryFormat.V7)
-            {
-                compatibleEntryType = TarEntryType.V7RegularFile;
-            }
-            else
-            {
-                compatibleEntryType = other.EntryType;
-            }
+            TarEntryType compatibleEntryType = TarHelpers.GetCorrectTypeFlagForFormat(format, other.EntryType);
 
             TarHelpers.ThrowIfEntryTypeNotSupported(compatibleEntryType, format);
 
             _readerOfOrigin = other._readerOfOrigin;
 
-            _header = default;
-            _header._format = format;
-
-            _header._name = other._header._name;
-            _header._mode = other._header._mode;
-            _header._uid = other._header._uid;
-            _header._gid = other._header._gid;
-            _header._size = other._header._size;
-            _header._mTime = other._header._mTime;
-            _header._checksum = 0;
-            _header._typeFlag = compatibleEntryType;
-            _header._linkName = other._header._linkName;
-
-            _header._dataStream = other._header._dataStream;
+            _header = new TarHeader(format, compatibleEntryType, other._header);
         }
 
         /// <summary>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 namespace System.Formats.Tar
 {
     // Reads the header attributes from a tar archive entry.
-    internal partial struct TarHeader
+    internal partial class TarHeader
     {
         private const string UstarPrefixFormat = "{0}/{1}"; // "prefix/name"
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -17,9 +17,9 @@ namespace System.Formats.Tar
     {
         private const string UstarPrefixFormat = "{0}/{1}"; // "prefix/name"
 
-        // Attempts to read all the fields of the next header.
+        // Attempts to retrieve the next header from the specified tar archive stream.
         // Throws if end of stream is reached or if any data type conversion fails.
-        // Returns true if all the attributes were read successfully, false otherwise.
+        // Returns a valid TarHeader object if the attributes were read successfully, null otherwise.
         internal static TarHeader? TryGetNextHeader(Stream archiveStream, bool copyData, TarEntryFormat initialFormat)
         {
             // The four supported formats have a header that fits in the default record size

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -13,63 +13,64 @@ using System.Threading.Tasks;
 namespace System.Formats.Tar
 {
     // Reads the header attributes from a tar archive entry.
-    internal partial class TarHeader
+    internal sealed partial class TarHeader
     {
         private const string UstarPrefixFormat = "{0}/{1}"; // "prefix/name"
 
         // Attempts to read all the fields of the next header.
         // Throws if end of stream is reached or if any data type conversion fails.
         // Returns true if all the attributes were read successfully, false otherwise.
-        internal bool TryGetNextHeader(Stream archiveStream, bool copyData)
+        internal static TarHeader? TryGetNextHeader(Stream archiveStream, bool copyData, TarEntryFormat initialFormat)
         {
             // The four supported formats have a header that fits in the default record size
             Span<byte> buffer = stackalloc byte[TarHelpers.RecordSize];
 
             archiveStream.ReadExactly(buffer);
 
+            TarHeader header = new(initialFormat);
+
             // Confirms if v7 or pax, or tentatively selects ustar
-            if (!TryReadCommonAttributes(buffer))
+            if (!header.TryReadCommonAttributes(buffer))
             {
-                return false;
+                return null;
             }
 
             // Confirms if gnu, or tentatively selects ustar
-            ReadMagicAttribute(buffer);
+            header.ReadMagicAttribute(buffer);
 
-            if (_format != TarEntryFormat.V7)
+            if (header._format != TarEntryFormat.V7)
             {
                 // Confirms if gnu
-                ReadVersionAttribute(buffer);
+                header.ReadVersionAttribute(buffer);
 
                 // Fields that ustar, pax and gnu share identically
-                ReadPosixAndGnuSharedAttributes(buffer);
+                header.ReadPosixAndGnuSharedAttributes(buffer);
 
-                Debug.Assert(_format is TarEntryFormat.Ustar or TarEntryFormat.Pax or TarEntryFormat.Gnu);
-                if (_format == TarEntryFormat.Ustar)
+                Debug.Assert(header._format is TarEntryFormat.Ustar or TarEntryFormat.Pax or TarEntryFormat.Gnu);
+                if (header._format == TarEntryFormat.Ustar)
                 {
-                    ReadUstarAttributes(buffer);
+                    header.ReadUstarAttributes(buffer);
                 }
-                else if (_format == TarEntryFormat.Gnu)
+                else if (header._format == TarEntryFormat.Gnu)
                 {
-                    ReadGnuAttributes(buffer);
+                    header.ReadGnuAttributes(buffer);
                 }
                 // In PAX, there is nothing to read in this section (empty space)
             }
 
-            ProcessDataBlock(archiveStream, copyData);
+            header.ProcessDataBlock(archiveStream, copyData);
 
-            return true;
+            return header;
         }
 
         // Asynchronously attempts read all the fields of the next header.
         // Throws if end of stream is reached or if any data type conversion fails.
         // Returns true if all the attributes were read successfully, false otherwise.
-        internal static async ValueTask<(bool, TarHeader)> TryGetNextHeaderAsync(Stream archiveStream, bool copyData, TarEntryFormat initialFormat, CancellationToken cancellationToken)
+        internal static async ValueTask<TarHeader?> TryGetNextHeaderAsync(Stream archiveStream, bool copyData, TarEntryFormat initialFormat, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            TarHeader header = default;
-            header._format = initialFormat;
+            TarHeader header = new(initialFormat);
 
             // The four supported formats have a header that fits in the default record size
             byte[] rented = ArrayPool<byte>.Shared.Rent(minimumLength: TarHelpers.RecordSize);
@@ -81,7 +82,7 @@ namespace System.Formats.Tar
             // Confirms if v7 or pax, or tentatively selects ustar
             if (!header.TryReadCommonAttributes(buffer.Span))
             {
-                return (false, default);
+                return null;
             }
 
             // Confirms if gnu, or tentatively selects ustar
@@ -181,7 +182,7 @@ namespace System.Formats.Tar
 
             ArrayPool<byte>.Shared.Return(rented);
 
-            return (true, header);
+            return header;
         }
 
         // Reads the elements from the passed dictionary, which comes from the previous extended attributes entry,

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace System.Formats.Tar
 {
     // Writes header attributes of a tar archive entry.
-    internal partial class TarHeader
+    internal sealed partial class TarHeader
     {
         private static ReadOnlySpan<byte> PaxMagicBytes => "ustar\0"u8;
         private static ReadOnlySpan<byte> PaxVersionBytes => "00"u8;
@@ -30,7 +30,7 @@ namespace System.Formats.Tar
         internal void WriteAsV7(Stream archiveStream, Span<byte> buffer)
         {
             long actualLength = GetTotalDataBytesToWrite();
-            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarEntryFormat.V7);
+            TarEntryType actualEntryType = TarHelpers.GetCorrectTypeFlagForFormat(TarEntryFormat.V7, _typeFlag);
 
             int checksum = WriteName(buffer, out _);
             checksum += WriteCommonFields(buffer, actualLength, actualEntryType);
@@ -50,7 +50,7 @@ namespace System.Formats.Tar
             cancellationToken.ThrowIfCancellationRequested();
 
             long actualLength = GetTotalDataBytesToWrite();
-            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarEntryFormat.V7);
+            TarEntryType actualEntryType = TarHelpers.GetCorrectTypeFlagForFormat(TarEntryFormat.V7, _typeFlag);
 
             int tmpChecksum = WriteName(buffer.Span, out _);
             tmpChecksum += WriteCommonFields(buffer.Span, actualLength, actualEntryType);
@@ -70,7 +70,7 @@ namespace System.Formats.Tar
         internal void WriteAsUstar(Stream archiveStream, Span<byte> buffer)
         {
             long actualLength = GetTotalDataBytesToWrite();
-            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarEntryFormat.Ustar);
+            TarEntryType actualEntryType = TarHelpers.GetCorrectTypeFlagForFormat(TarEntryFormat.Ustar, _typeFlag);
 
             int checksum = WritePosixName(buffer);
             checksum += WriteCommonFields(buffer, actualLength, actualEntryType);
@@ -92,7 +92,7 @@ namespace System.Formats.Tar
             cancellationToken.ThrowIfCancellationRequested();
 
             long actualLength = GetTotalDataBytesToWrite();
-            TarEntryType actualEntryType = GetCorrectTypeFlagForFormat(TarEntryFormat.Ustar);
+            TarEntryType actualEntryType = TarHelpers.GetCorrectTypeFlagForFormat(TarEntryFormat.Ustar, _typeFlag);
 
             int tmpChecksum = WritePosixName(buffer.Span);
             tmpChecksum += WriteCommonFields(buffer.Span, actualLength, actualEntryType);
@@ -142,7 +142,7 @@ namespace System.Formats.Tar
             Debug.Assert(_typeFlag is not TarEntryType.GlobalExtendedAttributes);
 
             // First, we write the preceding extended attributes header
-            TarHeader extendedAttributesHeader = default;
+            TarHeader extendedAttributesHeader = new(TarEntryFormat.Pax);
             // Fill the current header's dict
             CollectExtendedAttributesFromStandardFieldsIfNeeded();
             // And pass the attributes to the preceding extended attributes header for writing
@@ -161,7 +161,7 @@ namespace System.Formats.Tar
             cancellationToken.ThrowIfCancellationRequested();
 
             // First, we write the preceding extended attributes header
-            TarHeader extendedAttributesHeader = default;
+            TarHeader extendedAttributesHeader = new(TarEntryFormat.Pax);
             // Fill the current header's dict
             CollectExtendedAttributesFromStandardFieldsIfNeeded();
             // And pass them to the extended attributes header for writing
@@ -257,7 +257,7 @@ namespace System.Formats.Tar
             Debug.Assert((entryType is TarEntryType.LongPath && longTextLength > FieldLengths.Name) ||
                          (entryType is TarEntryType.LongLink && longTextLength > FieldLengths.LinkName));
 
-            TarHeader longMetadataHeader = default;
+            TarHeader longMetadataHeader = new(TarEntryFormat.Gnu);
 
             longMetadataHeader._name = GnuLongMetadataName; // Same name for both longpath or longlink
             longMetadataHeader._mode = TarHelpers.GetDefaultMode(entryType);
@@ -306,7 +306,7 @@ namespace System.Formats.Tar
             actualLength = GetTotalDataBytesToWrite();
 
             int tmpChecksum = WriteName(buffer, out _);
-            tmpChecksum += WriteCommonFields(buffer, actualLength, GetCorrectTypeFlagForFormat(TarEntryFormat.Gnu));
+            tmpChecksum += WriteCommonFields(buffer, actualLength, TarHelpers.GetCorrectTypeFlagForFormat(TarEntryFormat.Gnu, _typeFlag));
             tmpChecksum += WriteGnuMagicAndVersion(buffer);
             tmpChecksum += WritePosixAndGnuSharedFields(buffer);
             tmpChecksum += WriteGnuFields(buffer);
@@ -391,7 +391,7 @@ namespace System.Formats.Tar
             actualLength = GetTotalDataBytesToWrite();
 
             int tmpChecksum = WritePosixName(buffer);
-            tmpChecksum += WriteCommonFields(buffer, actualLength, GetCorrectTypeFlagForFormat(TarEntryFormat.Pax));
+            tmpChecksum += WriteCommonFields(buffer, actualLength, TarHelpers.GetCorrectTypeFlagForFormat(TarEntryFormat.Pax, _typeFlag));
             tmpChecksum += WritePosixMagicAndVersion(buffer);
             tmpChecksum += WritePosixAndGnuSharedFields(buffer);
             checksum = WriteChecksum(tmpChecksum, buffer);
@@ -457,26 +457,6 @@ namespace System.Formats.Tar
             }
 
             return checksum;
-        }
-
-        // When writing an entry that came from an archive of a different format, if its entry type happens to
-        // be an incompatible regular file entry type, convert it to the compatible one.
-        // No change for all other entry types.
-        private TarEntryType GetCorrectTypeFlagForFormat(TarEntryFormat format)
-        {
-            if (format is TarEntryFormat.V7)
-            {
-                if (_typeFlag is TarEntryType.RegularFile)
-                {
-                    return TarEntryType.V7RegularFile;
-                }
-            }
-            else if (_typeFlag is TarEntryType.V7RegularFile)
-            {
-                return TarEntryType.RegularFile;
-            }
-
-            return _typeFlag;
         }
 
         // Calculates how many data bytes should be written, depending on the position pointer of the stream.

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -180,7 +180,7 @@ namespace System.Formats.Tar
         internal void WriteAsGnu(Stream archiveStream, Span<byte> buffer)
         {
             // First, we determine if we need a preceding LongLink, and write it if needed
-            if (_linkName.Length > FieldLengths.LinkName)
+            if (_linkName?.Length > FieldLengths.LinkName)
             {
                 TarHeader longLinkHeader = GetGnuLongMetadataHeader(TarEntryType.LongLink, _linkName);
                 longLinkHeader.WriteAsGnuInternal(archiveStream, buffer);
@@ -206,7 +206,7 @@ namespace System.Formats.Tar
             cancellationToken.ThrowIfCancellationRequested();
 
             // First, we determine if we need a preceding LongLink, and write it if needed
-            if (_linkName.Length > FieldLengths.LinkName)
+            if (_linkName?.Length > FieldLengths.LinkName)
             {
                 TarHeader longLinkHeader = GetGnuLongMetadataHeader(TarEntryType.LongLink, _linkName);
                 await longLinkHeader.WriteAsGnuInternalAsync(archiveStream, buffer, cancellationToken).ConfigureAwait(false);
@@ -595,8 +595,14 @@ namespace System.Formats.Tar
             {
                 _extendedAttributes.Add(PaxEaMTime, TarHelpers.GetTimestampStringFromDateTimeOffset(_mTime));
             }
-            TryAddStringField(_extendedAttributes, PaxEaGName, _gName, FieldLengths.GName);
-            TryAddStringField(_extendedAttributes, PaxEaUName, _uName, FieldLengths.UName);
+            if (!string.IsNullOrEmpty(_gName))
+            {
+                TryAddStringField(_extendedAttributes, PaxEaGName, _gName, FieldLengths.GName);
+            }
+            if (!string.IsNullOrEmpty(_uName))
+            {
+                TryAddStringField(_extendedAttributes, PaxEaUName, _uName, FieldLengths.UName);
+            }
 
             if (!string.IsNullOrEmpty(_linkName))
             {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace System.Formats.Tar
 {
     // Writes header attributes of a tar archive entry.
-    internal partial struct TarHeader
+    internal partial class TarHeader
     {
         private static ReadOnlySpan<byte> PaxMagicBytes => "ustar\0"u8;
         private static ReadOnlySpan<byte> PaxVersionBytes => "00"u8;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -13,7 +13,7 @@ namespace System.Formats.Tar
     // - POSIX IEEE 1003.1-2001 ("POSIX.1") Pax Interchange Tar Format (pax).
     // - GNU Tar Format (gnu).
     // Documentation: https://www.freebsd.org/cgi/man.cgi?query=tar&sektion=5
-    internal partial struct TarHeader
+    internal partial class TarHeader
     {
         // POSIX fields (shared by Ustar and PAX)
         private const string UstarMagic = "ustar\0";

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -88,13 +88,8 @@ namespace System.Formats.Tar
         // fields have data, we store it to avoid data loss, but we don't yet expose it publicly.
         internal byte[]? _gnuUnusedBytes;
 
-        internal TarHeader(TarEntryFormat format)
-            : this(format, string.Empty, 0, default, 0)
-        {
-        }
-
         // Constructor called when creating an entry with default common fields.
-        internal TarHeader(TarEntryFormat format, string name, int mode, DateTimeOffset mTime, TarEntryType typeFlag)
+        internal TarHeader(TarEntryFormat format, string name = "", int mode = 0, DateTimeOffset mTime = default, TarEntryType typeFlag = TarEntryType.RegularFile)
         {
             _format = format;
             _name = name;
@@ -108,19 +103,13 @@ namespace System.Formats.Tar
         // Constructor called when creating an entry using the common fields from another entry.
         // The *TarEntry constructor calling this should take care of setting any format-specific fields.
         internal TarHeader(TarEntryFormat format, TarEntryType typeFlag, TarHeader other)
+            : this(format, other._name, other._mode, other._mTime, typeFlag)
         {
-            _format = format;
-            _name = other._name;
-            _mode = other._mode;
             _uid = other._uid;
             _gid = other._gid;
             _size = other._size;
-            _mTime = other._mTime;
             _checksum = other._checksum;
-            _typeFlag = typeFlag;
             _linkName = other._linkName;
-            _magic = GetMagicForFormat(format);
-            _version = GetVersionForFormat(format);
             _dataStream = other._dataStream;
         }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -60,20 +60,20 @@ namespace System.Formats.Tar
         internal DateTimeOffset _mTime;
         internal int _checksum;
         internal TarEntryType _typeFlag;
-        internal string _linkName;
+        internal string? _linkName;
 
         // POSIX and GNU shared attributes
 
         internal string _magic;
         internal string _version;
-        internal string _gName;
-        internal string _uName;
+        internal string? _gName;
+        internal string? _uName;
         internal int _devMajor;
         internal int _devMinor;
 
         // POSIX attributes
 
-        internal string _prefix;
+        internal string? _prefix;
 
         // PAX attributes
 
@@ -101,15 +101,12 @@ namespace System.Formats.Tar
             _mode = mode;
             _mTime = mTime;
             _typeFlag = typeFlag;
-            _linkName = string.Empty;
             _magic = GetMagicForFormat(format);
             _version = GetVersionForFormat(format);
-            _gName = string.Empty;
-            _uName = string.Empty;
-            _prefix = string.Empty;
         }
 
         // Constructor called when creating an entry using the common fields from another entry.
+        // The *TarEntry constructor calling this should take care of setting any format-specific fields.
         internal TarHeader(TarEntryFormat format, TarEntryType typeFlag, TarHeader other)
         {
             _format = format;
@@ -124,9 +121,6 @@ namespace System.Formats.Tar
             _linkName = other._linkName;
             _magic = GetMagicForFormat(format);
             _version = GetVersionForFormat(format);
-            _gName = string.Empty;
-            _uName = string.Empty;
-            _prefix = string.Empty;
             _dataStream = other._dataStream;
         }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -208,6 +208,26 @@ namespace System.Formats.Tar
             return false;
         }
 
+        // When writing an entry that came from an archive of a different format, if its entry type happens to
+        // be an incompatible regular file entry type, convert it to the compatible one.
+        // No change for all other entry types.
+        internal static TarEntryType GetCorrectTypeFlagForFormat(TarEntryFormat format, TarEntryType entryType)
+        {
+            if (format is TarEntryFormat.V7)
+            {
+                if (entryType is TarEntryType.RegularFile)
+                {
+                    return TarEntryType.V7RegularFile;
+                }
+            }
+            else if (entryType is TarEntryType.V7RegularFile)
+            {
+                return TarEntryType.RegularFile;
+            }
+
+            return entryType;
+        }
+
         // Receives a byte array that represents an ASCII string containing a number in octal base.
         // Converts the array to an octal base number, then transforms it to ten base and returns it.
         internal static int GetTenBaseNumberFromOctalAsciiChars(Span<byte> buffer)


### PR DESCRIPTION
The internal `TarHeader` struct is used as a member of the public `TarEntry` class. It describes all the fields of a tar header and hosts all the functionality that reads and writes the header into the archive stream buffer.

The fact that it is a struct caused some issues when adding the async functionality. Some examples:

- It is not possible to pass it as an async method argument because the original instance does not get modified.
- The same problem exists when calling one of the async methods from within an instance of a struct: the original instance's fields do not get modified.
- This forced me to write some of the async methods differently to their sync version, preventing me from reducing code duplication.
- Nullability handling is not as good when dealing with a struct, there's no enforced need to specify an initial value for, say, a non-nullable string member.

Having it defined as a struct does not help with perf since it is a large type. So changing it to a class shouldn't affect performance much. The main advantage is that I will be able to submit another PR removing all the code duplication (didn't put it all here to avoid creating a huge PR).

Additional changes:

- I moved to `TarHelpers` the method that decides if a regular file entry type should be converted to the appropriate target format, and reused it in another location that had the same need.
- Added constructors for the now `TarHeader` class. Initialized the mandatory fields, and converted the non-mandatory string fields to nullable.