### PR TITLE
Update /// comments for new InteropServices APIs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Architecture.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Architecture.cs
@@ -40,7 +40,7 @@ namespace System.Runtime.InteropServices
         /// A 32-bit ARMv6 processor architecture.
         /// </summary>
         /// <remarks>
-        /// This value indicates the following configuration, ARMv6 base instructions, VFPv2 floating point support and registers, hard-float ABI, and no compact instruction set.
+        /// This value indicates ARMv6 base instructions, VFPv2 floating point support and registers, hard-float ABI, and no compact instruction set.
         /// </remarks>
         Armv6,
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Architecture.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Architecture.cs
@@ -3,16 +3,49 @@
 
 namespace System.Runtime.InteropServices
 {
+    /// <summary>
+    /// Indicates the processor architecture.
+    /// </summary>
     public enum Architecture
     {
+        /// <summary>
+        /// An Intel-based 32-bit processor architecture.
+        /// </summary>
         X86,
+        /// <summary>
+        /// An Intel-based 64-bit processor architecture.
+        /// </summary>
         X64,
+        /// <summary>
+        /// A 32-bit ARM processor architecture.
+        /// </summary>
         Arm,
+        /// <summary>
+        /// A 64-bit ARM processor architecture.
+        /// </summary>
         Arm64,
+        /// <summary>
+        /// The WebAssembly platform.
+        /// </summary>
         Wasm,
+        /// <summary>
+        /// A S390x platform architecture.
+        /// </summary>
         S390x,
+        /// <summary>
+        /// A LoongArch64 processor architecture.
+        /// </summary>
         LoongArch64,
+        /// <summary>
+        /// A 32-bit ARMv6 processor architecture.
+        /// </summary>
+        /// <remarks>
+        /// This value indicates the following configuration, ARMv6 base instructions, VFPv2 floating point support and registers, hard-float ABI, and no compact instruction set.
+        /// </remarks>
         Armv6,
+        /// <summary>
+        /// A PowerPC 64-bit (little-endian) processor architecture.
+        /// </summary>
         Ppc64le,
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Architecture.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Architecture.cs
@@ -19,6 +19,9 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// A 32-bit ARM processor architecture.
         /// </summary>
+        /// <remarks>
+        /// This value indicates ARMv7 base instructions, VFPv3 floating point support and registers, and Thumb2 compact instruction set.
+        /// </remarks>
         Arm,
         /// <summary>
         /// A 64-bit ARM processor architecture.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
@@ -92,7 +92,7 @@ namespace System.Runtime.InteropServices.Marshalling
             => new ReadOnlySpan<TUnmanagedElement>(unmanagedValue, numElements);
 
         /// <summary>
-        /// Frees memory for the unmanaged array
+        /// Frees memory for the unmanaged array.
         /// </summary>
         /// <param name="unmanaged">Unmanaged array</param>
         public static void Free(TUnmanagedElement* unmanaged)
@@ -182,7 +182,7 @@ namespace System.Runtime.InteropServices.Marshalling
             }
 
             /// <summary>
-            /// Gets a pinnable reference to the managed span to a pointer to pass directly to unmanaged code.
+            /// Gets a pinnable reference to the managed array.
             /// </summary>
             /// <param name="array">The managed array.</param>
             /// <returns>The reference that can be pinned and directly passed to unmanaged code.</returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
@@ -26,7 +26,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Allocate memory for the unmanaged representation of the collection.
         /// </summary>
         /// <param name="managed">A managed array</param>
-        /// <param name="numElements">A unmanaged element count</param>
+        /// <param name="numElements">The unmanaged element count</param>
         /// <returns>An unmanaged pointer to the allocated memory</returns>
         public static TUnmanagedElement* AllocateContainerForUnmanagedElements(T[]? managed, out int numElements)
         {
@@ -44,10 +44,10 @@ namespace System.Runtime.InteropServices.Marshalling
         }
 
         /// <summary>
-        /// Retrieve a source for the managed elements in the collection.
+        /// Retrieves a source for the managed elements in the collection.
         /// </summary>
         /// <param name="managed">A managed array</param>
-        /// <returns>A <see cref="ReadOnlyMemory{T}"/> containing the managed elements to marshal</returns>
+        /// <returns>A <see cref="ReadOnlySpan{T}"/> containing the managed elements to marshal</returns>
         public static ReadOnlySpan<T> GetManagedValuesSource(T[]? managed)
             => managed;
 
@@ -87,7 +87,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="unmanagedValue">An unmanaged collection</param>
         /// <param name="numElements">The unmanaged element count</param>
-        /// <returns>A <see cref="ReadOnlyMemory{TUnmanagedElement}"/> containing the unmanaged elements to marshal</returns>
+        /// <returns>A <see cref="ReadOnlySpan{TUnmanagedElement}"/> containing the unmanaged elements to marshal</returns>
         public static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements)
             => new ReadOnlySpan<TUnmanagedElement>(unmanagedValue, numElements);
 
@@ -104,7 +104,7 @@ namespace System.Runtime.InteropServices.Marshalling
         public ref struct ManagedToUnmanagedIn
         {
             /// <summary>
-            /// Requested caller allocated buffer size.
+            /// Requested caller-allocated buffer size.
             /// </summary>
             /// <remarks>
             /// Represents a potential optimization for the marshaller.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
@@ -22,6 +22,12 @@ namespace System.Runtime.InteropServices.Marshalling
     public static unsafe class ArrayMarshaller<T, TUnmanagedElement>
         where TUnmanagedElement : unmanaged
     {
+        /// <summary>
+        /// Allocate memory for the unmanaged representation of the collection.
+        /// </summary>
+        /// <param name="managed">A managed array</param>
+        /// <param name="numElements">A unmanaged element count</param>
+        /// <returns>An unmanaged pointer to the allocated memory</returns>
         public static TUnmanagedElement* AllocateContainerForUnmanagedElements(T[]? managed, out int numElements)
         {
             if (managed is null)
@@ -37,12 +43,29 @@ namespace System.Runtime.InteropServices.Marshalling
             return (TUnmanagedElement*)Marshal.AllocCoTaskMem(spaceToAllocate);
         }
 
+        /// <summary>
+        /// Retrieve a source for the managed elements in the collection.
+        /// </summary>
+        /// <param name="managed">A managed array</param>
+        /// <returns>A <see cref="ReadOnlyMemory{T}"/> containing the managed elements to marshal</returns>
         public static ReadOnlySpan<T> GetManagedValuesSource(T[]? managed)
             => managed;
 
+        /// <summary>
+        /// Retrieve a destination for the unmanaged elements in the collection.
+        /// </summary>
+        /// <param name="unmanaged">An unmanaged allocation</param>
+        /// <param name="numElements">The unmanaged element count</param>
+        /// <returns>A <see cref="Span{TUnmanagedElement}"/> of unmanaged elements</returns>
         public static Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements)
             => new Span<TUnmanagedElement>(unmanaged, numElements);
 
+        /// <summary>
+        /// Allocate memory for the managed representation of the collection.
+        /// </summary>
+        /// <param name="unmanaged">The unmanaged collection</param>
+        /// <param name="numElements">The unmanaged element count</param>
+        /// <returns>A managed array</returns>
         public static T[]? AllocateContainerForManagedElements(TUnmanagedElement* unmanaged, int numElements)
         {
             if (unmanaged is null)
@@ -51,17 +74,41 @@ namespace System.Runtime.InteropServices.Marshalling
             return new T[numElements];
         }
 
+        /// <summary>
+        /// Retrieve a destination for the managed elements in the collection.
+        /// </summary>
+        /// <param name="managed">A managed array</param>
+        /// <returns>A <see cref="Span{T}"/> of managed elements</returns>
         public static Span<T> GetManagedValuesDestination(T[]? managed)
             => managed;
 
+        /// <summary>
+        /// Retrieve a source for the unmanaged elements in the collection.
+        /// </summary>
+        /// <param name="unmanagedValue">An unmanaged collection</param>
+        /// <param name="numElements">The unmanaged element count</param>
+        /// <returns>A <see cref="ReadOnlyMemory{TUnmanagedElement}"/> containing the unmanaged elements to marshal</returns>
         public static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements)
             => new ReadOnlySpan<TUnmanagedElement>(unmanagedValue, numElements);
 
+        /// <summary>
+        /// Free memory for the unmanaged collection
+        /// </summary>
+        /// <param name="unmanaged">Unmanaged collection</param>
         public static void Free(TUnmanagedElement* unmanaged)
             => Marshal.FreeCoTaskMem((IntPtr)unmanaged);
 
+        /// <summary>
+        /// Marshaller for marshalling a collection from managed to unmanaged.
+        /// </summary>
         public ref struct ManagedToUnmanagedIn
         {
+            /// <summary>
+            /// Requested caller allocated buffer size.
+            /// </summary>
+            /// <remarks>
+            /// Represents a potential optimization for the marshaller.
+            /// </remarks>
             // We'll keep the buffer size at a maximum of 200 bytes to avoid overflowing the stack.
             public static int BufferSize { get; } = 0x200 / sizeof(TUnmanagedElement);
 
@@ -134,6 +181,11 @@ namespace System.Runtime.InteropServices.Marshalling
                 NativeMemory.Free(_allocatedMemory);
             }
 
+            /// <summary>
+            /// Pin the managed span to a pointer to pass directly to unmanaged code.
+            /// </summary>
+            /// <param name="array">The managed array.</param>
+            /// <returns>A reference that can be pinned and directly passed to unmanaged code.</returns>
             public static ref T GetPinnableReference(T[]? array)
             {
                 if (array is null)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
@@ -23,11 +23,11 @@ namespace System.Runtime.InteropServices.Marshalling
         where TUnmanagedElement : unmanaged
     {
         /// <summary>
-        /// Allocate memory for the unmanaged representation of the collection.
+        /// Allocates memory for the unmanaged representation of the array.
         /// </summary>
-        /// <param name="managed">A managed array</param>
+        /// <param name="managed">The managed array</param>
         /// <param name="numElements">The unmanaged element count</param>
-        /// <returns>An unmanaged pointer to the allocated memory</returns>
+        /// <returns>The unmanaged pointer to the allocated memory</returns>
         public static TUnmanagedElement* AllocateContainerForUnmanagedElements(T[]? managed, out int numElements)
         {
             if (managed is null)
@@ -44,28 +44,28 @@ namespace System.Runtime.InteropServices.Marshalling
         }
 
         /// <summary>
-        /// Retrieves a source for the managed elements in the collection.
+        /// Gets a source for the managed elements in the array.
         /// </summary>
-        /// <param name="managed">A managed array</param>
-        /// <returns>A <see cref="ReadOnlySpan{T}"/> containing the managed elements to marshal</returns>
+        /// <param name="managed">The managed array</param>
+        /// <returns>The <see cref="ReadOnlySpan{T}"/> containing the managed elements to marshal</returns>
         public static ReadOnlySpan<T> GetManagedValuesSource(T[]? managed)
             => managed;
 
         /// <summary>
-        /// Retrieve a destination for the unmanaged elements in the collection.
+        /// Gets a destination for the unmanaged elements in the array.
         /// </summary>
-        /// <param name="unmanaged">An unmanaged allocation</param>
+        /// <param name="unmanaged">The unmanaged allocation</param>
         /// <param name="numElements">The unmanaged element count</param>
-        /// <returns>A <see cref="Span{TUnmanagedElement}"/> of unmanaged elements</returns>
+        /// <returns>The <see cref="Span{TUnmanagedElement}"/> of unmanaged elements</returns>
         public static Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements)
             => new Span<TUnmanagedElement>(unmanaged, numElements);
 
         /// <summary>
-        /// Allocate memory for the managed representation of the collection.
+        /// Allocates memory for the managed representation of the array.
         /// </summary>
-        /// <param name="unmanaged">The unmanaged collection</param>
+        /// <param name="unmanaged">The unmanaged array</param>
         /// <param name="numElements">The unmanaged element count</param>
-        /// <returns>A managed array</returns>
+        /// <returns>The managed array</returns>
         public static T[]? AllocateContainerForManagedElements(TUnmanagedElement* unmanaged, int numElements)
         {
             if (unmanaged is null)
@@ -75,31 +75,31 @@ namespace System.Runtime.InteropServices.Marshalling
         }
 
         /// <summary>
-        /// Retrieve a destination for the managed elements in the collection.
+        /// Gets a destination for the managed elements in the array.
         /// </summary>
-        /// <param name="managed">A managed array</param>
-        /// <returns>A <see cref="Span{T}"/> of managed elements</returns>
+        /// <param name="managed">The managed array</param>
+        /// <returns>The <see cref="Span{T}"/> of managed elements</returns>
         public static Span<T> GetManagedValuesDestination(T[]? managed)
             => managed;
 
         /// <summary>
-        /// Retrieve a source for the unmanaged elements in the collection.
+        /// Gets a source for the unmanaged elements in the array.
         /// </summary>
-        /// <param name="unmanagedValue">An unmanaged collection</param>
+        /// <param name="unmanagedValue">The unmanaged array</param>
         /// <param name="numElements">The unmanaged element count</param>
-        /// <returns>A <see cref="ReadOnlySpan{TUnmanagedElement}"/> containing the unmanaged elements to marshal</returns>
+        /// <returns>The <see cref="ReadOnlySpan{TUnmanagedElement}"/> containing the unmanaged elements to marshal</returns>
         public static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements)
             => new ReadOnlySpan<TUnmanagedElement>(unmanagedValue, numElements);
 
         /// <summary>
-        /// Free memory for the unmanaged collection
+        /// Frees memory for the unmanaged array
         /// </summary>
-        /// <param name="unmanaged">Unmanaged collection</param>
+        /// <param name="unmanaged">Unmanaged array</param>
         public static void Free(TUnmanagedElement* unmanaged)
             => Marshal.FreeCoTaskMem((IntPtr)unmanaged);
 
         /// <summary>
-        /// Marshaller for marshalling a collection from managed to unmanaged.
+        /// Marshaller for marshalling a array from managed to unmanaged.
         /// </summary>
         public ref struct ManagedToUnmanagedIn
         {
@@ -182,10 +182,10 @@ namespace System.Runtime.InteropServices.Marshalling
             }
 
             /// <summary>
-            /// Pin the managed span to a pointer to pass directly to unmanaged code.
+            /// Gets a pinnable reference to the managed span to a pointer to pass directly to unmanaged code.
             /// </summary>
             /// <param name="array">The managed array.</param>
-            /// <returns>A reference that can be pinned and directly passed to unmanaged code.</returns>
+            /// <returns>The reference that can be pinned and directly passed to unmanaged code.</returns>
             public static ref T GetPinnableReference(T[]? array)
             {
                 if (array is null)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
@@ -24,11 +24,11 @@ namespace System.Runtime.InteropServices.Marshalling
         where TUnmanagedElement : unmanaged
     {
         /// <summary>
-        /// Allocate memory for the unmanaged representation of the collection.
+        /// Allocates memory for the unmanaged representation of the array.
         /// </summary>
-        /// <param name="managed">A managed array to marshal</param>
-        /// <param name="numElements">A unmanaged element count</param>
-        /// <returns>An unmanaged pointer to the allocated memory</returns>
+        /// <param name="managed">The managed array to marshal</param>
+        /// <param name="numElements">The unmanaged element count</param>
+        /// <returns>The unmanaged pointer to the allocated memory</returns>
         public static TUnmanagedElement* AllocateContainerForUnmanagedElements(T*[]? managed, out int numElements)
         {
             if (managed is null)
@@ -45,28 +45,28 @@ namespace System.Runtime.InteropServices.Marshalling
         }
 
         /// <summary>
-        /// Retrieve a source for the managed elements in the collection.
+        /// Gets a source for the managed elements in the array.
         /// </summary>
-        /// <param name="managed">A managed array</param>
-        /// <returns>A <see cref="ReadOnlySpan{IntPtr}"/> containing the managed elements to marshal</returns>
+        /// <param name="managed">The managed array</param>
+        /// <returns>The <see cref="ReadOnlySpan{IntPtr}"/> containing the managed elements to marshal</returns>
         public static ReadOnlySpan<IntPtr> GetManagedValuesSource(T*[]? managed)
             => Unsafe.As<IntPtr[]>(managed);
 
         /// <summary>
-        /// Retrieve a destination for the unmanaged elements in the collection.
+        /// Gets a destination for the unmanaged elements in the array.
         /// </summary>
-        /// <param name="unmanaged">An unmanaged allocation</param>
+        /// <param name="unmanaged">The unmanaged allocation</param>
         /// <param name="numElements">The unmanaged element count</param>
-        /// <returns>A <see cref="Span{TUnmanagedElement}"/> of unmanaged elements</returns>
+        /// <returns>The <see cref="Span{TUnmanagedElement}"/> of unmanaged elements</returns>
         public static Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements)
             => new Span<TUnmanagedElement>(unmanaged, numElements);
 
         /// <summary>
-        /// Allocate memory for the managed representation of the collection.
+        /// Allocates memory for the managed representation of the array.
         /// </summary>
-        /// <param name="unmanaged">The unmanaged collection</param>
+        /// <param name="unmanaged">The unmanaged array</param>
         /// <param name="numElements">The unmanaged element count</param>
-        /// <returns>A managed array</returns>
+        /// <returns>The managed array</returns>
         public static T*[]? AllocateContainerForManagedElements(TUnmanagedElement* unmanaged, int numElements)
         {
             if (unmanaged is null)
@@ -76,31 +76,31 @@ namespace System.Runtime.InteropServices.Marshalling
         }
 
         /// <summary>
-        /// Retrieve a destination for the managed elements in the collection.
+        /// Gets a destination for the managed elements in the array.
         /// </summary>
-        /// <param name="managed">A managed array</param>
-        /// <returns>A <see cref="Span{T}"/> of managed elements</returns>
+        /// <param name="managed">The managed array</param>
+        /// <returns>The <see cref="Span{T}"/> of managed elements</returns>
         public static Span<IntPtr> GetManagedValuesDestination(T*[]? managed)
             => Unsafe.As<IntPtr[]>(managed);
 
         /// <summary>
-        /// Retrieve a source for the unmanaged elements in the collection.
+        /// Gets a source for the unmanaged elements in the array.
         /// </summary>
-        /// <param name="unmanagedValue">An unmanaged collection</param>
+        /// <param name="unmanagedValue">The unmanaged array</param>
         /// <param name="numElements">The unmanaged element count</param>
-        /// <returns>A <see cref="ReadOnlySpan{TUnmanagedElement}"/> containing the unmanaged elements to marshal</returns>
+        /// <returns>The <see cref="ReadOnlySpan{TUnmanagedElement}"/> containing the unmanaged elements to marshal</returns>
         public static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements)
             => new ReadOnlySpan<TUnmanagedElement>(unmanagedValue, numElements);
 
         /// <summary>
-        /// Free memory for the unmanaged collection
+        /// Frees memory for the unmanaged array
         /// </summary>
-        /// <param name="unmanaged">Unmanaged collection</param>
+        /// <param name="unmanaged">Unmanaged array</param>
         public static void Free(TUnmanagedElement* unmanaged)
             => Marshal.FreeCoTaskMem((IntPtr)unmanaged);
 
         /// <summary>
-        /// Marshaller for marshalling a collection from managed to unmanaged.
+        /// Marshaller for marshalling a array from managed to unmanaged.
         /// </summary>
         public ref struct ManagedToUnmanagedIn
         {
@@ -183,10 +183,10 @@ namespace System.Runtime.InteropServices.Marshalling
             }
 
             /// <summary>
-            /// Pin the managed span to a pointer to pass directly to unmanaged code.
+            /// Gets a pinnable reference to the managed span to a pointer to pass directly to unmanaged code.
             /// </summary>
             /// <param name="array">The managed array.</param>
-            /// <returns>A reference that can be pinned and directly passed to unmanaged code.</returns>
+            /// <returns>The reference that can be pinned and directly passed to unmanaged code.</returns>
             public static ref byte GetPinnableReference(T*[]? array)
             {
                 if (array is null)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
@@ -48,7 +48,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Retrieve a source for the managed elements in the collection.
         /// </summary>
         /// <param name="managed">A managed array</param>
-        /// <returns>A <see cref="ReadOnlyMemory{IntPtr}"/> containing the managed elements to marshal</returns>
+        /// <returns>A <see cref="ReadOnlySpan{IntPtr}"/> containing the managed elements to marshal</returns>
         public static ReadOnlySpan<IntPtr> GetManagedValuesSource(T*[]? managed)
             => Unsafe.As<IntPtr[]>(managed);
 
@@ -88,7 +88,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="unmanagedValue">An unmanaged collection</param>
         /// <param name="numElements">The unmanaged element count</param>
-        /// <returns>A <see cref="ReadOnlyMemory{TUnmanagedElement}"/> containing the unmanaged elements to marshal</returns>
+        /// <returns>A <see cref="ReadOnlySpan{TUnmanagedElement}"/> containing the unmanaged elements to marshal</returns>
         public static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements)
             => new ReadOnlySpan<TUnmanagedElement>(unmanagedValue, numElements);
 
@@ -105,7 +105,7 @@ namespace System.Runtime.InteropServices.Marshalling
         public ref struct ManagedToUnmanagedIn
         {
             /// <summary>
-            /// Requested caller allocated buffer size.
+            /// Requested caller-allocated buffer size.
             /// </summary>
             /// <remarks>
             /// Represents a potential optimization for the marshaller.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
@@ -93,7 +93,7 @@ namespace System.Runtime.InteropServices.Marshalling
             => new ReadOnlySpan<TUnmanagedElement>(unmanagedValue, numElements);
 
         /// <summary>
-        /// Frees memory for the unmanaged array
+        /// Frees memory for the unmanaged array.
         /// </summary>
         /// <param name="unmanaged">Unmanaged array</param>
         public static void Free(TUnmanagedElement* unmanaged)
@@ -183,7 +183,7 @@ namespace System.Runtime.InteropServices.Marshalling
             }
 
             /// <summary>
-            /// Gets a pinnable reference to the managed span to a pointer to pass directly to unmanaged code.
+            /// Gets a pinnable reference to the managed array.
             /// </summary>
             /// <param name="array">The managed array.</param>
             /// <returns>The reference that can be pinned and directly passed to unmanaged code.</returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/SpanMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/SpanMarshaller.cs
@@ -181,7 +181,7 @@ namespace System.Runtime.InteropServices.Marshalling
             }
 
             /// <summary>
-            /// Pin the managed span to a pointer to pass directly to unmanaged code.
+            /// Gets a pinnable reference to the managed span.
             /// </summary>
             /// <param name="managed">The managed span.</param>
             /// <returns>A reference that can be pinned and directly passed to unmanaged code.</returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/SpanMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/SpanMarshaller.cs
@@ -180,6 +180,11 @@ namespace System.Runtime.InteropServices.Marshalling
                 NativeMemory.Free(_allocatedMemory);
             }
 
+            /// <summary>
+            /// Pin the managed span to a pointer to pass directly to unmanaged code.
+            /// </summary>
+            /// <param name="managed">The managed span.</param>
+            /// <returns>A reference that can be pinned and directly passed to unmanaged code.</returns>
             public static ref T GetPinnableReference(Span<T> managed)
             {
                 return ref MemoryMarshal.GetReference(managed);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StringMarshalling.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StringMarshalling.cs
@@ -20,8 +20,19 @@ namespace System.Runtime.InteropServices
 #endif
     enum StringMarshalling
     {
+        /// <summary>
+        /// Indicates the user is suppling a specific marshaller in <see cref="LibraryImportAttribute.StringMarshallingCustomType"/>.
+        /// </summary>
         Custom = 0,
-        Utf8,   // UTF-8
-        Utf16,  // UTF-16, machine-endian
+        /// <summary>
+        /// Use the platform provided UTF-8 marshaller.
+        /// <see cref="Marshalling.Utf8StringMarshaller"/>
+        /// </summary>
+        Utf8,
+        /// <summary>
+        /// Use the platform provided UTF-16 marshaller.
+        /// <see cref="Marshalling.Utf16StringMarshaller"/>
+        /// </summary>
+        Utf16,
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StringMarshalling.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StringMarshalling.cs
@@ -25,11 +25,11 @@ namespace System.Runtime.InteropServices
         /// </summary>
         Custom = 0,
         /// <summary>
-        /// Use the platform provided UTF-8 marshaller.
+        /// Use the platform-provided UTF-8 marshaller.
         /// </summary>
         Utf8,
         /// <summary>
-        /// Use the platform provided UTF-16 marshaller.
+        /// Use the platform-provided UTF-16 marshaller.
         /// </summary>
         Utf16,
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StringMarshalling.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StringMarshalling.cs
@@ -26,12 +26,10 @@ namespace System.Runtime.InteropServices
         Custom = 0,
         /// <summary>
         /// Use the platform provided UTF-8 marshaller.
-        /// <see cref="Marshalling.Utf8StringMarshaller"/>
         /// </summary>
         Utf8,
         /// <summary>
         /// Use the platform provided UTF-16 marshaller.
-        /// <see cref="Marshalling.Utf16StringMarshaller"/>
         /// </summary>
         Utf16,
     }


### PR DESCRIPTION
Add `///` documentation for new interop APIs.

Contributes to https://github.com/dotnet/runtime/issues/72400

@directhex Please take a look at the doc I've added for the `Architecture` enum values, specifically `Armv6`.

/cc @carlossanlop