### PR TITLE
Update recursive resource load message

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SR.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SR.cs
@@ -65,7 +65,7 @@ namespace System
 #if SYSTEM_PRIVATE_CORELIB
                     // Note: our infrastructure for reporting this exception will again cause resource lookup.
                     // This is the most direct way of dealing with that problem.
-                    string message = $@"Encountered infinite recursion while looking up resource '{key}' in {System.CoreLib.Name} .Verify the installation of .NET is complete and does not need repairing, and that the state of the process has not become corrupted.";
+                    string message = $@"Encountered infinite recursion while looking up resource '{key}' in {System.CoreLib.Name}. Verify the installation of .NET is complete and does not need repairing, and that the state of the process has not become corrupted.";
                     Environment.FailFast(message);
 #endif
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/SR.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SR.cs
@@ -65,9 +65,7 @@ namespace System
 #if SYSTEM_PRIVATE_CORELIB
                     // Note: our infrastructure for reporting this exception will again cause resource lookup.
                     // This is the most direct way of dealing with that problem.
-                    string message = $@"Encountered infinite recursion while looking up resource '{key}' in {System.CoreLib.Name}.
-                                        Verify the installation of .NET is complete and does not need repairing, and that the state of the process has not become corrupted.
-                                         It is also possible that this was caused by a bug in relevant extensibility points such as assembly resolve events or CultureInfo names.";
+                    string message = $@"Encountered infinite recursion while looking up resource '{key}' in {System.CoreLib.Name} .Verify the installation of .NET is complete and does not need repairing, and that the state of the process has not become corrupted.";
                     Environment.FailFast(message);
 #endif
                 }
@@ -92,7 +90,7 @@ namespace System
                 string? s = ResourceManager.GetString(key, null);
                 _currentlyLoading.RemoveAt(_currentlyLoading.Count - 1); // Pop
 
-                Debug.Assert(s != null, $"Managed resource string lookup failed.  Was your resource name misspelled?  Did you rebuild mscorlib after adding a resource to resources.txt?  Debug this w/ cordbg and bug whoever owns the code that called SR.GetResourceString.  Resource name was: \"{key}\"");
+                Debug.Assert(s != null, $"Looking up resource '{key}' failed. Was your resource name misspelled? Did you rebuild {System.CoreLib.Name} after adding a resource?");
                 return s ?? key;
             }
             catch

--- a/src/libraries/System.Private.CoreLib/src/System/SR.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SR.cs
@@ -65,7 +65,9 @@ namespace System
 #if SYSTEM_PRIVATE_CORELIB
                     // Note: our infrastructure for reporting this exception will again cause resource lookup.
                     // This is the most direct way of dealing with that problem.
-                    string message = $"Infinite recursion during resource lookup within {System.CoreLib.Name}.  This may be a bug in {System.CoreLib.Name}, or potentially in certain extensibility points such as assembly resolve events or CultureInfo names.  Resource name: {key}";
+                    string message = $@"Encountered infinite recursion while looking up resource '{key}' in {System.CoreLib.Name}.
+                                        Verify the installation of .NET is complete and does not need repairing, and that the state of the process has not become corrupted.
+                                         It is also possible that this was caused by a bug in relevant extensibility points such as assembly resolve events or CultureInfo names.";
                     Environment.FailFast(message);
 #endif
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/SR.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SR.cs
@@ -90,7 +90,7 @@ namespace System
                 string? s = ResourceManager.GetString(key, null);
                 _currentlyLoading.RemoveAt(_currentlyLoading.Count - 1); // Pop
 
-                Debug.Assert(s != null, $"Looking up resource '{key}' failed. Was your resource name misspelled? Did you rebuild {System.CoreLib.Name} after adding a resource?");
+                Debug.Assert(s != null, $"Looking up resource '{key}' failed. Was your resource name misspelled? Did you rebuild after adding a resource?");
                 return s ?? key;
             }
             catch


### PR DESCRIPTION
Relates to
https://github.com/dotnet/runtime/issues/72381 
https://github.com/dotnet/runtime/issues/53833 
https://github.com/dotnet/runtime/issues/53504 
https://github.com/dotnet/runtime/issues/1716

Our experience is that this is typically caused by a corrupted/incomplete install, or possibly a corrupted process state, or some other bug in certain user code. It's unlikely that there is a bug in .NET, especially in GA bits, but the existing message leads with that.

Changing the message to send users in the right direction.

BTW I'm not sure of the "CultureInfo names" reference here - @tarekgh is there a way we can put that more clearly?