### PR TITLE
Ensure metadata originating from converters is surfaced while JsonTypeInfo is mutable.

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -352,7 +352,7 @@
     <value>The JSON property name for '{0}.{1}' cannot be null.</value>
   </data>
   <data name="SerializationDataExtensionPropertyInvalid" xml:space="preserve">
-    <value>The data extension property '{0}.{1}' is invalid. It must implement 'IDictionary&lt;string, JsonElement&gt;' or 'IDictionary&lt;string, object&gt;', or be 'JsonObject'.</value>
+    <value>The extension data property '{0}.{1}' is invalid. It must implement 'IDictionary&lt;string, JsonElement&gt;' or 'IDictionary&lt;string, object&gt;', or be 'JsonObject'.</value>
   </data>
   <data name="SerializationDuplicateTypeAttribute" xml:space="preserve">
     <value>The type '{0}' cannot have more than one member that has the attribute '{1}'.</value>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
@@ -3,14 +3,15 @@
 
 using System.Diagnostics;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class JsonObjectConverter : JsonConverter<JsonObject>
     {
-        internal override object CreateObject(JsonSerializerOptions options)
+        internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
-            return new JsonObject(options.GetNodeOptions());
+            jsonTypeInfo.CreateObjectForExtensionDataProperty = () => new JsonObject(options.GetNodeOptions());
         }
 
         internal override void ReadElementAndSetProperty(
@@ -27,7 +28,7 @@ namespace System.Text.Json.Serialization.Converters
             JsonObject jObject = (JsonObject)obj;
 
             Debug.Assert(value == null || value is JsonNode);
-            JsonNode? jNodeValue = (JsonNode?)value;
+            JsonNode? jNodeValue = value;
 
             jObject[propertyName] = jNodeValue;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -82,7 +82,7 @@ namespace System.Text.Json.Serialization.Converters
                         {
                             Debug.Assert(jsonPropertyInfo == state.Current.JsonTypeInfo.ExtensionDataProperty);
                             state.Current.JsonPropertyNameAsString = dataExtKey;
-                            JsonSerializer.CreateDataExtensionProperty(obj, jsonPropertyInfo, options);
+                            JsonSerializer.CreateExtensionDataProperty(obj, jsonPropertyInfo, options);
                         }
 
                         ReadPropertyValue(obj, ref state, ref tempReader, jsonPropertyInfo, useExtensionProperty);
@@ -190,7 +190,7 @@ namespace System.Text.Json.Serialization.Converters
                         {
                             Debug.Assert(jsonPropertyInfo == state.Current.JsonTypeInfo.ExtensionDataProperty);
 
-                            JsonSerializer.CreateDataExtensionProperty(obj, jsonPropertyInfo, options);
+                            JsonSerializer.CreateExtensionDataProperty(obj, jsonPropertyInfo, options);
                             object extDictionary = jsonPropertyInfo.GetValueAsObject(obj)!;
 
                             if (extDictionary is IDictionary<string, JsonElement> dict)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -49,14 +49,6 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// Used to support JsonObject as an extension property in a loosely-typed, trimmable manner.
         /// </summary>
-        internal virtual object CreateObject(JsonSerializerOptions options)
-        {
-            throw new InvalidOperationException(SR.NodeJsonObjectCustomConverterNotAllowedOnExtensionProperty);
-        }
-
-        /// <summary>
-        /// Used to support JsonObject as an extension property in a loosely-typed, trimmable manner.
-        /// </summary>
         internal virtual void ReadElementAndSetProperty(
             object obj,
             string propertyName,
@@ -64,7 +56,9 @@ namespace System.Text.Json.Serialization
             JsonSerializerOptions options,
             ref ReadStack state)
         {
-            throw new InvalidOperationException(SR.NodeJsonObjectCustomConverterNotAllowedOnExtensionProperty);
+            Debug.Fail("Should not be reachable.");
+
+            throw new InvalidOperationException();
         }
 
         internal abstract JsonParameterInfo CreateJsonParameterInfo();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -56,7 +56,7 @@ namespace System.Text.Json
                     if (createExtensionProperty)
                     {
                         Debug.Assert(obj != null, "obj is null");
-                        CreateDataExtensionProperty(obj, dataExtProperty, options);
+                        CreateExtensionDataProperty(obj, dataExtProperty, options);
                     }
 
                     jsonPropertyInfo = dataExtProperty;
@@ -98,7 +98,7 @@ namespace System.Text.Json
             return unescapedPropertyName;
         }
 
-        internal static void CreateDataExtensionProperty(
+        internal static void CreateExtensionDataProperty(
             object obj,
             JsonPropertyInfo jsonPropertyInfo,
             JsonSerializerOptions options)
@@ -130,18 +130,15 @@ namespace System.Text.Json
                     // Avoid a reference to the JsonNode type for trimming
                     if (jsonPropertyInfo.PropertyType.FullName == JsonTypeInfo.JsonObjectTypeName)
                     {
-                        extensionData = jsonPropertyInfo.EffectiveConverter.CreateObject(options);
+                        ThrowHelper.ThrowInvalidOperationException_NodeJsonObjectCustomConverterNotAllowedOnExtensionProperty();
                     }
                     else
                     {
                         ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(jsonPropertyInfo.PropertyType);
                     }
                 }
-                else
-                {
-                    extensionData = createObjectForExtensionDataProp();
-                }
 
+                extensionData = createObjectForExtensionDataProp();
                 jsonPropertyInfo.SetExtensionDictionaryAsObject(obj, extensionData);
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -60,7 +60,7 @@ namespace System.Text.Json.Serialization.Metadata
         private protected abstract void SetCreateObject(Delegate? createObject);
         private protected Func<object>? _createObject;
 
-        internal Func<object>? CreateObjectForExtensionDataProperty { get; private protected set; }
+        internal Func<object>? CreateObjectForExtensionDataProperty { get; set; }
 
         /// <summary>
         /// Gets or sets a callback to be invoked before serialization occurs.
@@ -523,7 +523,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
-        internal virtual void Configure()
+        internal void Configure()
         {
             Debug.Assert(Monitor.IsEntered(_configureLock), "Configure called directly, use EnsureConfigured which locks this method");
 
@@ -538,8 +538,6 @@ namespace System.Text.Json.Serialization.Metadata
             JsonConverter converter = Converter;
             Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == Converter.ConverterStrategy,
                 $"ConverterStrategy from PropertyInfoForTypeInfo.ConverterStrategy ({PropertyInfoForTypeInfo.ConverterStrategy}) does not match converter's ({Converter.ConverterStrategy})");
-
-            converter.ConfigureJsonTypeInfo(this, Options);
 
             if (Kind == JsonTypeInfoKind.Object)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -35,16 +35,10 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             CreateObjectForExtensionDataProperty = createObject;
-        }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "The ctor is marked as RequiresUnreferencedCode")]
-        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-            Justification = "The ctor is marked RequiresDynamicCode.")]
-        internal override void Configure()
-        {
-            base.Configure();
-            Converter.ConfigureJsonTypeInfoUsingReflection(this, Options);
+            // Plug in any converter configuration -- should be run last.
+            converter.ConfigureJsonTypeInfo(this, options);
+            converter.ConfigureJsonTypeInfoUsingReflection(this, options);
         }
 
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
@@ -22,12 +22,15 @@ namespace System.Text.Json.Serialization.Metadata
         {
             PopulatePolymorphismMetadata();
             MapInterfaceTypesToCallbacks();
+
+            // Plug in any converter configuration -- should be run last.
+            converter.ConfigureJsonTypeInfo(this, options);
         }
 
         /// <summary>
         /// Creates serialization metadata for an object.
         /// </summary>
-        public SourceGenJsonTypeInfo(JsonSerializerOptions options, JsonObjectInfoValues<T> objectInfo) : this(GetConverter(objectInfo), options)
+        public SourceGenJsonTypeInfo(JsonSerializerOptions options, JsonObjectInfoValues<T> objectInfo) : base(GetConverter(objectInfo), options)
         {
             if (objectInfo.ObjectWithParameterizedConstructorCreator != null)
             {
@@ -43,6 +46,11 @@ namespace System.Text.Json.Serialization.Metadata
             PropInitFunc = objectInfo.PropertyMetadataInitializer;
             SerializeHandler = objectInfo.SerializeHandler;
             NumberHandling = objectInfo.NumberHandling;
+            PopulatePolymorphismMetadata();
+            MapInterfaceTypesToCallbacks();
+
+            // Plug in any converter configuration -- should be run last.
+            Converter.ConfigureJsonTypeInfo(this, options);
         }
 
         /// <summary>
@@ -54,7 +62,7 @@ namespace System.Text.Json.Serialization.Metadata
             Func<JsonConverter<T>> converterCreator,
             object? createObjectWithArgs = null,
             object? addFunc = null)
-            : this(new JsonMetadataServicesConverter<T>(converterCreator()), options)
+            : base(new JsonMetadataServicesConverter<T>(converterCreator()), options)
         {
             if (collectionInfo is null)
             {
@@ -69,6 +77,11 @@ namespace System.Text.Json.Serialization.Metadata
             CreateObjectWithArgs = createObjectWithArgs;
             AddMethodDelegate = addFunc;
             CreateObject = collectionInfo.ObjectCreator;
+            PopulatePolymorphismMetadata();
+            MapInterfaceTypesToCallbacks();
+
+            // Plug in any converter configuration -- should be run last.
+            Converter.ConfigureJsonTypeInfo(this, options);
         }
 
         private static JsonConverter GetConverter(JsonObjectInfoValues<T> objectInfo)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -411,6 +411,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowInvalidOperationException_NodeJsonObjectCustomConverterNotAllowedOnExtensionProperty()
+        {
+            throw new InvalidOperationException(SR.NodeJsonObjectCustomConverterNotAllowedOnExtensionProperty);
+        }
+
+        [DoesNotReturn]
         public static void ThrowNotSupportedException(ref ReadStack state, in Utf8JsonReader reader, NotSupportedException ex)
         {
             string message = ex.Message;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -940,6 +941,24 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("foo", deserialized.B);
             Assert.Equal("bar", deserialized.C);
             Assert.True(deserialized.E);
+        }
+
+
+        [Theory]
+        [InlineData(typeof(ICollection<string>))]
+        [InlineData(typeof(IList))]
+        [InlineData(typeof(IList<bool>))]
+        [InlineData(typeof(IDictionary))]
+        [InlineData(typeof(IDictionary<string, bool>))]
+        [InlineData(typeof(ISet<Guid>))]
+        public static void AbstractCollectionMetadata_SurfacesCreateObjectWhereApplicable(Type type)
+        {
+            var options = new JsonSerializerOptions();
+            var resolver = new DefaultJsonTypeInfoResolver();
+
+            JsonTypeInfo metadata = resolver.GetTypeInfo(type, options);
+            Assert.NotNull(metadata.CreateObject);
+            Assert.IsAssignableFrom(type, metadata.CreateObject());
         }
 
         private class ClassWithLargeParameterizedConstructor


### PR DESCRIPTION
Discovered while investigating #60560.

Some of our internal converter implementations override the `JsonConverter.ConfigureJsonTypeInfo` method when needing to modify contract metadata. Currently, this configuration step is run _after_ the metadata instance gets locked, so none of these changes are visible to contract resolver authors. This PR changes this so that the method in question is invoked at metadata construction time, and only when said metadata originates from `DefaultJsonTypeInfoResolver` or `JsonSerializerContext`.

Contributes to #63686.