### PR TITLE
Re-enable test that passes locally

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -913,9 +913,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/v2.1/DDB/B168384/LdfldaHack/*">
             <Issue>https://github.com/dotnet/runtime/issues/615</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_60035/Runtime_60035/*">
-            <Issue>https://github.com/dotnet/runtime/issues/64419</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
             <Issue>Not compatible with crossgen2</Issue>
         </ExcludeList>


### PR DESCRIPTION
Re-enable the test that was disabled against https://github.com/dotnet/runtime/issues/64419. It looks like one of the many layout fixes this release already fixed this test locally.

Fixes #64419
