### PR TITLE
Remove code duplication in TarHeader class

### DIFF
--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -232,7 +232,7 @@
     <value>A POSIX format was expected (Ustar or PAX), but could not be reliably determined for entry '{0}'.</value>
   </data>
   <data name="TarSizeFieldNegative" xml:space="preserve">
-    <value>The size field is negative in the tar entry '{0}'.</value>
+    <value>The size field is negative in a tar entry.</value>
   </data>
   <data name="TarSizeFieldTooLargeForEntryType" xml:space="preserve">
     <value>The value of the size field for the current entry of type '{0}' is beyond the expected length.</value>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
@@ -54,13 +54,13 @@ namespace System.Formats.Tar
 
                 if (other is PaxTarEntry paxOther)
                 {
-                    changedATime = TarHelpers.TryGetDateTimeOffsetFromTimestampString(paxOther._header._extendedAttributes, TarHeader.PaxEaATime, out DateTimeOffset aTime);
+                    changedATime = TarHelpers.TryGetDateTimeOffsetFromTimestampString(paxOther._header.ExtendedAttributes, TarHeader.PaxEaATime, out DateTimeOffset aTime);
                     if (changedATime)
                     {
                         _header._aTime = aTime;
                     }
 
-                    changedCTime = TarHelpers.TryGetDateTimeOffsetFromTimestampString(paxOther._header._extendedAttributes, TarHeader.PaxEaCTime, out DateTimeOffset cTime);
+                    changedCTime = TarHelpers.TryGetDateTimeOffsetFromTimestampString(paxOther._header.ExtendedAttributes, TarHeader.PaxEaCTime, out DateTimeOffset cTime);
                     if (changedCTime)
                     {
                         _header._cTime = cTime;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxGlobalExtendedAttributesTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxGlobalExtendedAttributesTarEntry.cs
@@ -29,20 +29,13 @@ namespace System.Formats.Tar
             : base(TarEntryType.GlobalExtendedAttributes, TarHeader.GlobalHeadFormatPrefix, TarEntryFormat.Pax, isGea: true)
         {
             ArgumentNullException.ThrowIfNull(globalExtendedAttributes);
-            _header._extendedAttributes = new Dictionary<string, string>(globalExtendedAttributes);
+            _header.InitializeExtendedAttributesWithExisting(globalExtendedAttributes);
         }
 
         /// <summary>
         /// Returns the global extended attributes stored in this entry.
         /// </summary>
-        public IReadOnlyDictionary<string, string> GlobalExtendedAttributes
-        {
-            get
-            {
-                _header._extendedAttributes ??= new Dictionary<string, string>();
-                return _readOnlyGlobalExtendedAttributes ??= _header._extendedAttributes.AsReadOnly();
-            }
-        }
+        public IReadOnlyDictionary<string, string> GlobalExtendedAttributes => _readOnlyGlobalExtendedAttributes ??= _header.ExtendedAttributes.AsReadOnly();
 
         // Determines if the current instance's entry type supports setting a data stream.
         internal override bool IsDataStreamSetterSupported() => false;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -529,7 +529,7 @@ namespace System.Formats.Tar
 
             // Rely on FileStream's ctor for further checking destinationFileName parameter
             FileStream fs = new FileStream(destinationFileName, CreateFileStreamOptions(isAsync: true));
-            await using (fs)
+            await using (fs.ConfigureAwait(false))
             {
                 if (DataStream != null)
                 {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -526,7 +526,7 @@ namespace System.Formats.Tar
             if (buffer != null)
             {
                 archiveStream.ReadExactly(buffer);
-                _extendedAttributes = ReadExtendedAttributesFromBuffer(buffer, _name);
+                ReadExtendedAttributesFromBuffer(buffer, _name);
             }
         }
 
@@ -539,7 +539,7 @@ namespace System.Formats.Tar
             if (buffer != null)
             {
                 await archiveStream.ReadExactlyAsync(buffer, cancellationToken).ConfigureAwait(false);
-                _extendedAttributes = ReadExtendedAttributesFromBuffer(buffer, _name);
+                ReadExtendedAttributesFromBuffer(buffer, _name);
             }
         }
 
@@ -567,9 +567,9 @@ namespace System.Formats.Tar
         }
 
         // Returns a dictionary containing the extended attributes collected from the provided byte buffer.
-        private static Dictionary<string, string> ReadExtendedAttributesFromBuffer(ReadOnlySpan<byte> buffer, string name)
+        private void ReadExtendedAttributesFromBuffer(ReadOnlySpan<byte> buffer, string name)
         {
-            Dictionary<string, string> extendedAttributes = new();
+            _extendedAttributes = new Dictionary<string, string>();
 
             string dataAsString = TarHelpers.GetTrimmedUtf8String(buffer);
 
@@ -577,14 +577,12 @@ namespace System.Formats.Tar
 
             while (TryGetNextExtendedAttribute(reader, out string? key, out string? value))
             {
-                if (extendedAttributes.ContainsKey(key))
+                if (_extendedAttributes.ContainsKey(key))
                 {
                     throw new FormatException(string.Format(SR.TarDuplicateExtendedAttribute, name));
                 }
-                extendedAttributes.Add(key, value);
+                _extendedAttributes.Add(key, value);
             }
-
-            return extendedAttributes;
         }
 
         // Reads the long path found in the data section of a GNU entry of type 'K' or 'L'

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -405,7 +405,7 @@ namespace System.Formats.Tar
             _size = TarHelpers.GetTenBaseNumberFromOctalAsciiChars(buffer.Slice(FieldLocations.Size, FieldLengths.Size));
             if (_size < 0)
             {
-                throw new FormatException(string.Format(SR.TarSizeFieldNegative, _name));
+                throw new FormatException(string.Format(SR.TarSizeFieldNegative));
             }
 
             // Continue with the rest of the fields that require no special checks

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -46,7 +46,6 @@ namespace System.Formats.Tar
             // The four supported formats have a header that fits in the default record size
             byte[] rented = ArrayPool<byte>.Shared.Rent(minimumLength: TarHelpers.RecordSize);
             Memory<byte> buffer = rented.AsMemory(0, TarHelpers.RecordSize); // minimumLength means the array could've been larger
-            buffer.Span.Clear(); // Rented arrays aren't clean
 
             await archiveStream.ReadExactlyAsync(buffer, cancellationToken).ConfigureAwait(false);
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -102,11 +102,11 @@ namespace System.Formats.Tar
             long actualLength = GetTotalDataBytesToWrite();
             TarEntryType actualEntryType = TarHelpers.GetCorrectTypeFlagForFormat(TarEntryFormat.Ustar, _typeFlag);
 
-            int checksum = WritePosixName(buffer);
-            checksum += WriteCommonFields(buffer, actualLength, actualEntryType);
-            checksum += WritePosixMagicAndVersion(buffer);
-            checksum += WritePosixAndGnuSharedFields(buffer);
-            _checksum = WriteChecksum(checksum, buffer);
+            int tmpChecksum = WritePosixName(buffer);
+            tmpChecksum += WriteCommonFields(buffer, actualLength, actualEntryType);
+            tmpChecksum += WritePosixMagicAndVersion(buffer);
+            tmpChecksum += WritePosixAndGnuSharedFields(buffer);
+            _checksum = WriteChecksum(tmpChecksum, buffer);
 
             return actualLength;
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 
 namespace System.Formats.Tar
@@ -77,7 +78,8 @@ namespace System.Formats.Tar
 
         // PAX attributes
 
-        internal Dictionary<string, string>? _extendedAttributes;
+        private Dictionary<string, string>? _ea;
+        internal Dictionary<string, string> ExtendedAttributes => _ea ??= new Dictionary<string, string>();
 
         // GNU attributes
 
@@ -111,6 +113,12 @@ namespace System.Formats.Tar
             _checksum = other._checksum;
             _linkName = other._linkName;
             _dataStream = other._dataStream;
+        }
+
+        internal void InitializeExtendedAttributesWithExisting(IEnumerable<KeyValuePair<string, string>> existing)
+        {
+            Debug.Assert(_ea == null);
+            _ea = new Dictionary<string, string>(existing);
         }
 
         private static string GetMagicForFormat(TarEntryFormat format) => format switch

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
@@ -430,10 +430,8 @@ namespace System.Formats.Tar
                 throw new FormatException(string.Format(SR.TarUnexpectedMetadataEntry, actualHeader._typeFlag, TarEntryType.ExtendedAttributes));
             }
 
-            Debug.Assert(extendedAttributesHeader._extendedAttributes != null);
-
             // Replace all the attributes representing standard fields with the extended ones, if any
-            actualHeader.ReplaceNormalAttributesWithExtended(extendedAttributesHeader._extendedAttributes);
+            actualHeader.ReplaceNormalAttributesWithExtended(extendedAttributesHeader.ExtendedAttributes);
 
             return true;
         }
@@ -466,10 +464,8 @@ namespace System.Formats.Tar
                 throw new FormatException(string.Format(SR.TarUnexpectedMetadataEntry, TarEntryType.ExtendedAttributes, TarEntryType.ExtendedAttributes));
             }
 
-            Debug.Assert(extendedAttributesHeader._extendedAttributes != null);
-
             // Replace all the attributes representing standard fields with the extended ones, if any
-            actualHeader.ReplaceNormalAttributesWithExtended(extendedAttributesHeader._extendedAttributes);
+            actualHeader.ReplaceNormalAttributesWithExtended(extendedAttributesHeader.ExtendedAttributes);
 
             return actualHeader;
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -363,7 +363,7 @@ namespace System.Formats.Tar
                     break;
 
                 case TarEntryFormat.Gnu:
-                    entry._header._checksum = await entry._header.WriteAsGnuAsync(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
+                    await entry._header.WriteAsGnuAsync(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
                     break;
 
                 case TarEntryFormat.Unknown:

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -353,12 +353,12 @@ namespace System.Formats.Tar
                 case TarEntryFormat.Pax:
                     if (entry._header._typeFlag is TarEntryType.GlobalExtendedAttributes)
                     {
-                        entry._header._checksum = await entry._header.WriteAsPaxGlobalExtendedAttributesAsync(_archiveStream, buffer, _nextGlobalExtendedAttributesEntryNumber, cancellationToken).ConfigureAwait(false);
+                        await entry._header.WriteAsPaxGlobalExtendedAttributesAsync(_archiveStream, buffer, _nextGlobalExtendedAttributesEntryNumber, cancellationToken).ConfigureAwait(false);
                         _nextGlobalExtendedAttributesEntryNumber++;
                     }
                     else
                     {
-                        entry._header._checksum = await entry._header.WriteAsPaxAsync(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
+                        await entry._header.WriteAsPaxAsync(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
                     }
                     break;
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -343,7 +343,7 @@ namespace System.Formats.Tar
             switch (entry.Format)
             {
                 case TarEntryFormat.V7:
-                    entry._header._checksum = await entry._header.WriteAsV7Async(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
+                    await entry._header.WriteAsV7Async(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
                     break;
 
                 case TarEntryFormat.Ustar:

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -347,7 +347,7 @@ namespace System.Formats.Tar
                     break;
 
                 case TarEntryFormat.Ustar:
-                    entry._header._checksum = await entry._header.WriteAsUstarAsync(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
+                    await entry._header.WriteAsUstarAsync(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
                     break;
 
                 case TarEntryFormat.Pax:

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -192,45 +192,7 @@ namespace System.Formats.Tar
         {
             ObjectDisposedException.ThrowIf(_isDisposed, this);
             ArgumentNullException.ThrowIfNull(entry);
-
-            byte[] rented = ArrayPool<byte>.Shared.Rent(minimumLength: TarHelpers.RecordSize);
-            Span<byte> buffer = rented.AsSpan(0, TarHelpers.RecordSize); // minimumLength means the array could've been larger
-            buffer.Clear(); // Rented arrays aren't clean
-            try
-            {
-                switch (entry.Format)
-                {
-                    case TarEntryFormat.V7:
-                        entry._header.WriteAsV7(_archiveStream, buffer);
-                        break;
-                    case TarEntryFormat.Ustar:
-                        entry._header.WriteAsUstar(_archiveStream, buffer);
-                        break;
-                    case TarEntryFormat.Pax:
-                        if (entry._header._typeFlag is TarEntryType.GlobalExtendedAttributes)
-                        {
-                            entry._header.WriteAsPaxGlobalExtendedAttributes(_archiveStream, buffer, _nextGlobalExtendedAttributesEntryNumber);
-                            _nextGlobalExtendedAttributesEntryNumber++;
-                        }
-                        else
-                        {
-                            entry._header.WriteAsPax(_archiveStream, buffer);
-                        }
-                        break;
-                    case TarEntryFormat.Gnu:
-                        entry._header.WriteAsGnu(_archiveStream, buffer);
-                        break;
-                    default:
-                        Debug.Assert(entry.Format == TarEntryFormat.Unknown, "Missing format handler");
-                        throw new FormatException(string.Format(SR.TarInvalidFormat, Format));
-                }
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(rented);
-            }
-
-            _wroteEntries = true;
+            WriteEntryInternal(entry);
         }
 
         /// <summary>
@@ -331,6 +293,48 @@ namespace System.Formats.Tar
             }
         }
 
+        // Portion of the WriteEntry(entry) method that rents a buffer and writes to the archive.
+        private void WriteEntryInternal(TarEntry entry)
+        {
+            byte[] rented = ArrayPool<byte>.Shared.Rent(minimumLength: TarHelpers.RecordSize);
+            Span<byte> buffer = rented.AsSpan(0, TarHelpers.RecordSize); // minimumLength means the array could've been larger
+            buffer.Clear(); // Rented arrays aren't clean
+            try
+            {
+                switch (entry.Format)
+                {
+                    case TarEntryFormat.V7:
+                        entry._header.WriteAsV7(_archiveStream, buffer);
+                        break;
+                    case TarEntryFormat.Ustar:
+                        entry._header.WriteAsUstar(_archiveStream, buffer);
+                        break;
+                    case TarEntryFormat.Pax:
+                        if (entry._header._typeFlag is TarEntryType.GlobalExtendedAttributes)
+                        {
+                            entry._header.WriteAsPaxGlobalExtendedAttributes(_archiveStream, buffer, _nextGlobalExtendedAttributesEntryNumber++);
+                        }
+                        else
+                        {
+                            entry._header.WriteAsPax(_archiveStream, buffer);
+                        }
+                        break;
+                    case TarEntryFormat.Gnu:
+                        entry._header.WriteAsGnu(_archiveStream, buffer);
+                        break;
+                    default:
+                        Debug.Assert(entry.Format == TarEntryFormat.Unknown, "Missing format handler");
+                        throw new FormatException(string.Format(SR.TarInvalidFormat, Format));
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+
+            _wroteEntries = true;
+        }
+
         // Portion of the WriteEntryAsync(TarEntry, CancellationToken) method containing awaits.
         private async Task WriteEntryAsyncInternal(TarEntry entry, CancellationToken cancellationToken)
         {
@@ -340,36 +344,17 @@ namespace System.Formats.Tar
             Memory<byte> buffer = rented.AsMemory(0, TarHelpers.RecordSize); // minimumLength means the array could've been larger
             buffer.Span.Clear(); // Rented arrays aren't clean
 
-            switch (entry.Format)
+            Task task = entry.Format switch
             {
-                case TarEntryFormat.V7:
-                    await entry._header.WriteAsV7Async(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
-                    break;
+                TarEntryFormat.V7 => entry._header.WriteAsV7Async(_archiveStream, buffer, cancellationToken),
+                TarEntryFormat.Ustar => entry._header.WriteAsUstarAsync(_archiveStream, buffer, cancellationToken),
+                TarEntryFormat.Pax when entry._header._typeFlag is TarEntryType.GlobalExtendedAttributes => entry._header.WriteAsPaxGlobalExtendedAttributesAsync(_archiveStream, buffer, _nextGlobalExtendedAttributesEntryNumber++, cancellationToken),
+                TarEntryFormat.Pax => entry._header.WriteAsPaxAsync(_archiveStream, buffer, cancellationToken),
+                TarEntryFormat.Gnu => entry._header.WriteAsGnuAsync(_archiveStream, buffer, cancellationToken),
+                _ => throw new FormatException(string.Format(SR.TarInvalidFormat, Format)),
+            };
+            await task.ConfigureAwait(false);
 
-                case TarEntryFormat.Ustar:
-                    await entry._header.WriteAsUstarAsync(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
-                    break;
-
-                case TarEntryFormat.Pax:
-                    if (entry._header._typeFlag is TarEntryType.GlobalExtendedAttributes)
-                    {
-                        await entry._header.WriteAsPaxGlobalExtendedAttributesAsync(_archiveStream, buffer, _nextGlobalExtendedAttributesEntryNumber, cancellationToken).ConfigureAwait(false);
-                        _nextGlobalExtendedAttributesEntryNumber++;
-                    }
-                    else
-                    {
-                        await entry._header.WriteAsPaxAsync(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
-                    }
-                    break;
-
-                case TarEntryFormat.Gnu:
-                    await entry._header.WriteAsGnuAsync(_archiveStream, buffer, cancellationToken).ConfigureAwait(false);
-                    break;
-
-                case TarEntryFormat.Unknown:
-                default:
-                    throw new FormatException(string.Format(SR.TarInvalidFormat, Format));
-            }
             _wroteEntries = true;
 
             ArrayPool<byte>.Shared.Return(rented);


### PR DESCRIPTION
Now that the `TarHeader` struct has been converted to a class in https://github.com/dotnet/runtime/pull/72472, it is possible to reduce code duplication that had to exist due to the way structs are handled in async code (they get passed by value).