### PR TITLE
Emit warning instead of an error in package compatibility check

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -204,7 +204,7 @@
 <![CDATA[<Project InitialTargets="$(_NETStandardCompatErrorFileTarget)">
   <Target Name="$(_NETStandardCompatErrorFileTarget)"
           Condition="'%24(SuppressTfmSupportBuildWarnings)' == ''">
-    <Error Text="$(PackageId) doesn't support %24(TargetFramework). Consider updating your TargetFramework to %(NETStandardCompatError.Supported) or later." />
+    <Warning Text="$(PackageId) $(PackageVersion) doesn't support %24(TargetFramework) and has not been tested with it. Consider upgrading your TargetFramework to %(NETStandardCompatError.Supported) or later. You may also set &lt;SuppressTfmSupportBuildWarnings&gt;true&lt;/SuppressTfmSupportBuildWarnings&gt; in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk." />
   </Target>
 </Project>]]>
       </_NETStandardCompatErrorFileContent>


### PR DESCRIPTION
Based on the conversation happening in https://github.com/open-telemetry/opentelemetry-dotnet/issues/3448, we want to emit a warning instead of an error on unsupported target frameworks. We still explicitly indicate that this is an unsupported scenario but don't actively block consumers anymore and also print how to suppress the warning.

cc @andrewlock 