### PR TITLE
Update DebuggerDisplay for metadata types & JsonSerializerOptions

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConfigurationList.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConfigurationList.cs
@@ -3,8 +3,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
 
 namespace System.Text.Json.Serialization
 {
@@ -20,7 +18,7 @@ namespace System.Text.Json.Serialization
             _list = source is null ? new List<TItem>() : new List<TItem>(source);
         }
 
-        protected abstract bool IsLockedInstance { get; }
+        protected abstract bool IsImmutable { get; }
         protected abstract void VerifyMutable();
         protected virtual void OnAddingElement(TItem item) { }
 
@@ -45,7 +43,7 @@ namespace System.Text.Json.Serialization
 
         public int Count => _list.Count;
 
-        public bool IsReadOnly => IsLockedInstance;
+        public bool IsReadOnly => IsImmutable;
 
         public void Add(TItem item)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
@@ -21,7 +21,7 @@ namespace System.Text.Json
 
             options ??= JsonSerializerOptions.Default;
 
-            if (!options.IsLockedInstance || !DefaultJsonTypeInfoResolver.IsDefaultInstanceRooted)
+            if (!options.IsImmutable || !DefaultJsonTypeInfoResolver.IsDefaultInstanceRooted)
             {
                 options.InitializeForReflectionSerializer();
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -24,13 +24,13 @@ namespace System.Text.Json.Serialization
         /// </remarks>
         public JsonSerializerOptions Options
         {
-            get => _options ??= new JsonSerializerOptions { TypeInfoResolver = this, IsLockedInstance = true };
+            get => _options ??= new JsonSerializerOptions { TypeInfoResolver = this, IsImmutable = true };
 
             internal set
             {
-                Debug.Assert(!value.IsLockedInstance);
+                Debug.Assert(!value.IsImmutable);
                 value.TypeInfoResolver = this;
-                value.IsLockedInstance = true;
+                value.IsImmutable = true;
                 _options = value;
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -57,7 +57,7 @@ namespace System.Text.Json
         {
             JsonTypeInfo? typeInfo = null;
 
-            if (IsLockedInstance)
+            if (IsImmutable)
             {
                 typeInfo = GetCachingContext()?.GetOrAddJsonTypeInfo(type);
                 if (ensureConfigured)
@@ -115,7 +115,7 @@ namespace System.Text.Json
 
         private CachingContext? GetCachingContext()
         {
-            Debug.Assert(IsLockedInstance);
+            Debug.Assert(IsImmutable);
 
             return _cachingContext ??= TrackedCachingContexts.GetOrCreate(this);
         }
@@ -166,7 +166,7 @@ namespace System.Text.Json
 
             public static CachingContext GetOrCreate(JsonSerializerOptions options)
             {
-                Debug.Assert(options.IsLockedInstance, "Cannot create caching contexts for mutable JsonSerializerOptions instances");
+                Debug.Assert(options.IsImmutable, "Cannot create caching contexts for mutable JsonSerializerOptions instances");
                 Debug.Assert(options._typeInfoResolver != null);
 
                 ConcurrentDictionary<JsonSerializerOptions, WeakReference<CachingContext>> cache = s_cache;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
@@ -120,7 +120,7 @@ namespace System.Text.Json.Serialization.Metadata
                 _resolver = resolver;
             }
 
-            protected override bool IsLockedInstance => !_resolver._mutable;
+            protected override bool IsImmutable => !_resolver._mutable;
             protected override void VerifyMutable()
             {
                 if (!_resolver._mutable)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPolymorphismOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPolymorphismOptions.cs
@@ -87,7 +87,7 @@ namespace System.Text.Json.Serialization.Metadata
                 _parent = parent;
             }
 
-            protected override bool IsLockedInstance => _parent.DeclaringTypeInfo?.IsConfigured == true;
+            protected override bool IsImmutable => _parent.DeclaringTypeInfo?.IsConfigured == true;
             protected override void VerifyMutable() => _parent.DeclaringTypeInfo?.VerifyMutable();
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -824,6 +824,6 @@ namespace System.Text.Json.Serialization.Metadata
         internal abstract object? DefaultValue { get; }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string DebuggerDisplay => $"MemberInfo={AttributeProvider as MemberInfo}";
+        private string DebuggerDisplay => $"DeclaringType = {DeclaringType}, PropertyType = {PropertyType}, Name = {Name}";
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -824,6 +824,6 @@ namespace System.Text.Json.Serialization.Metadata
         internal abstract object? DefaultValue { get; }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string DebuggerDisplay => $"DeclaringType = {DeclaringType}, PropertyType = {PropertyType}, Name = {Name}";
+        private string DebuggerDisplay => $"PropertyType = {PropertyType}, Name = {Name}, DeclaringType = {DeclaringType}";
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -527,7 +527,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             Debug.Assert(Monitor.IsEntered(_configureLock), "Configure called directly, use EnsureConfigured which locks this method");
 
-            if (!Options.IsLockedInstance)
+            if (!Options.IsImmutable)
             {
                 Options.InitializeForMetadataGeneration();
             }
@@ -1053,7 +1053,7 @@ namespace System.Text.Json.Serialization.Metadata
                 _jsonTypeInfo = jsonTypeInfo;
             }
 
-            protected override bool IsLockedInstance => _jsonTypeInfo.IsConfigured || _jsonTypeInfo.Kind != JsonTypeInfoKind.Object;
+            protected override bool IsImmutable => _jsonTypeInfo.IsConfigured || _jsonTypeInfo.Kind != JsonTypeInfoKind.Object;
             protected override void VerifyMutable()
             {
                 _jsonTypeInfo.VerifyMutable();
@@ -1071,6 +1071,6 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string DebuggerDisplay => $"Type:{Type.Name}, TypeInfoKind:{Kind}";
+        private string DebuggerDisplay => $"Type = {Type.Name}, Kind = {Kind}";
     }
 }


### PR DESCRIPTION
Also renames internal uses of `IsLockedInstance` to `IsImmutable` following feedback from https://github.com/dotnet/runtime/issues/54482#issuecomment-865000031