### PR TITLE
Add missing nullability annotation in CodeDom

### DIFF
--- a/src/libraries/Common/src/System/CodeDom/CodeTypeReference.cs
+++ b/src/libraries/Common/src/System/CodeDom/CodeTypeReference.cs
@@ -70,7 +70,7 @@ namespace System.Runtime.Serialization
             Options = codeTypeReferenceOption;
         }
 
-        public CodeTypeReference(string typeName, CodeTypeReferenceOptions codeTypeReferenceOption)
+        public CodeTypeReference(string? typeName, CodeTypeReferenceOptions codeTypeReferenceOption)
         {
             Initialize(typeName, codeTypeReferenceOption);
         }

--- a/src/libraries/System.CodeDom/tests/System/CodeDom/CodeTypeReferenceTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/CodeTypeReferenceTests.cs
@@ -115,14 +115,15 @@ namespace System.CodeDom.Tests
         }
 
         [Theory]
-        [InlineData("System.Int32", (CodeTypeReferenceOptions)(-1))]
-        [InlineData("System.Object", (CodeTypeReferenceOptions)0)]
-        [InlineData("System.Void", CodeTypeReferenceOptions.GenericTypeParameter)]
-        [InlineData("System.String", CodeTypeReferenceOptions.GenericTypeParameter + 1)]
-        public void Ctor_String_CodeReferenceTypeOptions(string type, CodeTypeReferenceOptions options)
+        [InlineData("System.Int32", (CodeTypeReferenceOptions)(-1), "System.Int32")]
+        [InlineData("System.Object", (CodeTypeReferenceOptions)0, "System.Object")]
+        [InlineData("System.Void", CodeTypeReferenceOptions.GenericTypeParameter, "System.Void")]
+        [InlineData(null, (CodeTypeReferenceOptions)0, "System.Void")]
+        [InlineData("System.String", CodeTypeReferenceOptions.GenericTypeParameter + 1, "System.String")]
+        public void Ctor_String_CodeReferenceTypeOptions(string type, CodeTypeReferenceOptions options, string expectedBaseType)
         {
             var typeReference = new CodeTypeReference(type, options);
-            Assert.Equal(type, typeReference.BaseType);
+            Assert.Equal(expectedBaseType, typeReference.BaseType);
             Assert.Equal(options, typeReference.Options);
         }
 


### PR DESCRIPTION
The `CodeTypeReference` constructors allow a `null` type name to be provided, but one constructor was missed during annotation.