### PR TITLE
Fix finding attribute data for syntax for assembly/module symbols

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeAnalyzer.cs
@@ -262,8 +262,8 @@ namespace Microsoft.Interop.Analyzers
                 AttributeSyntax syntax = (AttributeSyntax)context.Node;
                 ISymbol attributedSymbol = context.ContainingSymbol!;
 
-                AttributeData attr = GetAttributeData(syntax, attributedSymbol);
-                if (attr.AttributeClass?.ToDisplayString() == TypeNames.CustomMarshallerAttribute
+                AttributeData? attr = syntax.FindAttributeData(attributedSymbol);
+                if (attr?.AttributeClass?.ToDisplayString() == TypeNames.CustomMarshallerAttribute
                     && attr.AttributeConstructor is not null)
                 {
                     DiagnosticReporter managedTypeReporter = DiagnosticReporter.CreateForLocation(syntax.FindArgumentWithNameOrArity("managedType", 0).FindTypeExpressionOrNullLocation(), context.ReportDiagnostic);
@@ -312,20 +312,6 @@ namespace Microsoft.Interop.Analyzers
 #pragma warning restore CA1822 // Mark members as static
             {
                 // TODO: Implement for the V2 shapes
-            }
-
-            private static AttributeData GetAttributeData(AttributeSyntax syntax, ISymbol symbol)
-            {
-                if (syntax.FirstAncestorOrSelf<AttributeListSyntax>().Target?.Identifier.IsKind(SyntaxKind.ReturnKeyword) == true)
-                {
-                    return ((IMethodSymbol)symbol).GetReturnTypeAttributes().First(attributeSyntaxLocationMatches);
-                }
-                return symbol.GetAttributes().First(attributeSyntaxLocationMatches);
-
-                bool attributeSyntaxLocationMatches(AttributeData attrData)
-                {
-                    return attrData.ApplicationSyntaxReference!.SyntaxTree == syntax.SyntaxTree && attrData.ApplicationSyntaxReference.Span == syntax.Span;
-                }
             }
         }
     }

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/NativeMarshallingAttributeAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/NativeMarshallingAttributeAnalyzer.cs
@@ -86,8 +86,8 @@ namespace Microsoft.Interop.Analyzers
                 AttributeSyntax syntax = (AttributeSyntax)context.Node;
                 ISymbol attributedSymbol = context.ContainingSymbol!;
 
-                AttributeData attr = GetAttributeData(syntax, attributedSymbol);
-                if (attr.AttributeClass?.ToDisplayString() == TypeNames.NativeMarshallingAttribute
+                AttributeData? attr = syntax.FindAttributeData(attributedSymbol);
+                if (attr?.AttributeClass?.ToDisplayString() == TypeNames.NativeMarshallingAttribute
                     && attr.AttributeConstructor is not null)
                 {
                     INamedTypeSymbol? entryType = (INamedTypeSymbol?)attr.ConstructorArguments[0].Value;
@@ -160,20 +160,6 @@ namespace Microsoft.Interop.Analyzers
                         MarshallerEntryPointTypeMustHaveCustomMarshallerAttributeWithMatchingManagedTypeRule,
                         entryType.ToDisplayString(),
                         managedType.ToDisplayString());
-                }
-            }
-
-            private static AttributeData GetAttributeData(AttributeSyntax syntax, ISymbol symbol)
-            {
-                if (syntax.FirstAncestorOrSelf<AttributeListSyntax>().Target?.Identifier.IsKind(SyntaxKind.ReturnKeyword) == true)
-                {
-                    return ((IMethodSymbol)symbol).GetReturnTypeAttributes().First(attributeSyntaxLocationMatches);
-                }
-                return symbol.GetAttributes().First(attributeSyntaxLocationMatches);
-
-                bool attributeSyntaxLocationMatches(AttributeData attrData)
-                {
-                    return attrData.ApplicationSyntaxReference!.SyntaxTree == syntax.SyntaxTree && attrData.ApplicationSyntaxReference.Span == syntax.Span;
                 }
             }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/NativeMarshallingAttributeAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/NativeMarshallingAttributeAnalyzerTests.cs
@@ -256,5 +256,19 @@ namespace LibraryImportGenerator.UnitTests
             await VerifyCS.VerifyAnalyzerAsync(source,
                 VerifyCS.Diagnostic(GenericEntryPointMarshallerTypeMustBeClosedOrMatchArityRule).WithLocation(0).WithArguments("MarshallerType<U, V, W>", "ManagedType<T>"));
         }
+
+        [Fact]
+        public async Task UnrelatedAssemblyOrModuleTargetDiagnostic_DoesNotCauseException()
+        {
+            string source = """
+                using System.Reflection;
+                using System.Runtime.CompilerServices;
+
+                [assembly:AssemblyMetadata("MyKey", "MyValue")]
+                [module:SkipLocalsInit]
+                """;
+
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
     }
 }


### PR DESCRIPTION
Correctly handle attributes with assembly or module targets, and use 'null' fallback for unknown scenarios.

Unblocks dotnet/sdk and dotnet/aspnetcore intake of dotnet/runtime.