### PR TITLE
Avoid empty segments from PipeReader.ReadAsync

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -59,7 +59,18 @@ namespace System.IO.Pipelines
             AvailableMemory = arrayPoolBuffer;
         }
 
-        public void ResetMemory(bool preserveIndex = false)
+        // Resets memory and internal state, should be called when removing the segment from the linked list
+        public void Reset()
+        {
+            ResetMemory();
+
+            Next = null;
+            RunningIndex = 0;
+            _next = null;
+        }
+
+        // Resets memory only, should be called when keeping the BufferSegment in the linked list and only swapping out the memory
+        public void ResetMemory()
         {
             IMemoryOwner<byte>? memoryOwner = _memoryOwner;
             if (memoryOwner != null)
@@ -74,11 +85,8 @@ namespace System.IO.Pipelines
                 _array = null;
             }
 
-            Next = null;
-            // RunningIndex is used to determine the total length of the linked segments and contains the length of all the previous segments (not including this one)
-            RunningIndex = preserveIndex ? RunningIndex : 0;
+
             Memory = default;
-            _next = null;
             _end = 0;
             AvailableMemory = default;
         }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -59,7 +59,7 @@ namespace System.IO.Pipelines
             AvailableMemory = arrayPoolBuffer;
         }
 
-        public void ResetMemory()
+        public void ResetMemory(bool preserveIndex = false)
         {
             IMemoryOwner<byte>? memoryOwner = _memoryOwner;
             if (memoryOwner != null)
@@ -75,7 +75,8 @@ namespace System.IO.Pipelines
             }
 
             Next = null;
-            RunningIndex = 0;
+            // RunningIndex is used to determine the total length of the linked segments and contains the length of all the previous segments (not including this one)
+            RunningIndex = preserveIndex ? RunningIndex : 0;
             Memory = default;
             _next = null;
             _end = 0;

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -202,8 +202,8 @@ namespace System.IO.Pipelines
                             // If we got here that means Advance was called with 0 bytes or GetMemory was called again without any writes occurring
                             // And, the newly requested memory size is greater than our unused segments internal memory buffer
                             // So we should reuse the BufferSegment and replace the memory it's holding, this way ReadAsync will not receive a buffer with one segment being empty
-                            _writingHead.ResetMemory(preserveIndex: true);
-                            SetupSegment(_writingHead, sizeHint);
+                            _writingHead.ResetMemory();
+                            RentMemory(_writingHead, sizeHint);
                         }
                         else
                         {
@@ -221,12 +221,12 @@ namespace System.IO.Pipelines
         {
             BufferSegment newSegment = CreateSegmentUnsynchronized();
 
-            SetupSegment(newSegment, sizeHint);
+            RentMemory(newSegment, sizeHint);
 
             return newSegment;
         }
 
-        private void SetupSegment(BufferSegment segment, int sizeHint)
+        private void RentMemory(BufferSegment segment, int sizeHint)
         {
             // Segment should be new or reset, otherwise a memory leak could occur
             Debug.Assert(segment.MemoryOwner is null);
@@ -572,7 +572,7 @@ namespace System.IO.Pipelines
                 while (returnStart != null && returnStart != returnEnd)
                 {
                     BufferSegment? next = returnStart.NextSegment;
-                    returnStart.ResetMemory();
+                    returnStart.Reset();
                     ReturnSegmentUnsynchronized(returnStart);
                     returnStart = next;
                 }
@@ -885,7 +885,7 @@ namespace System.IO.Pipelines
                     BufferSegment returnSegment = segment;
                     segment = segment.NextSegment;
 
-                    returnSegment.ResetMemory();
+                    returnSegment.Reset();
                 }
 
                 _writingHead = null;

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -197,10 +197,21 @@ namespace System.IO.Pipelines
                             _writingHeadBytesBuffered = 0;
                         }
 
-                        BufferSegment newSegment = AllocateSegment(sizeHint);
+                        if (_writingHead.Length == 0)
+                        {
+                            // If we got here that means Advance was called with 0 bytes or GetMemory was called again without any writes occurring
+                            // And, the newly requested memory size is greater than our unused segments internal memory buffer
+                            // So we should reuse the BufferSegment and replace the memory it's holding, this way ReadAsync will not receive a buffer with one segment being empty
+                            _writingHead.ResetMemory();
+                            SetupSegment(_writingHead, sizeHint);
+                        }
+                        else
+                        {
+                            BufferSegment newSegment = AllocateSegment(sizeHint);
 
-                        _writingHead.SetNext(newSegment);
-                        _writingHead = newSegment;
+                            _writingHead.SetNext(newSegment);
+                            _writingHead = newSegment;
+                        }
                     }
                 }
             }
@@ -208,8 +219,18 @@ namespace System.IO.Pipelines
 
         private BufferSegment AllocateSegment(int sizeHint)
         {
-            Debug.Assert(sizeHint >= 0);
             BufferSegment newSegment = CreateSegmentUnsynchronized();
+
+            SetupSegment(newSegment, sizeHint);
+
+            return newSegment;
+        }
+
+        private void SetupSegment(BufferSegment segment, int sizeHint)
+        {
+            // Segment should be new or reset, otherwise a memory leak could occur
+            Debug.Assert(segment.MemoryOwner is null);
+            Debug.Assert(sizeHint >= 0);
 
             MemoryPool<byte>? pool = null;
             int maxSize = -1;
@@ -223,18 +244,16 @@ namespace System.IO.Pipelines
             if (sizeHint <= maxSize)
             {
                 // Use the specified pool as it fits. Specified pool is not null as maxSize == -1 if _pool is null.
-                newSegment.SetOwnedMemory(pool!.Rent(GetSegmentSize(sizeHint, maxSize)));
+                segment.SetOwnedMemory(pool!.Rent(GetSegmentSize(sizeHint, maxSize)));
             }
             else
             {
                 // Use the array pool
                 int sizeToRequest = GetSegmentSize(sizeHint);
-                newSegment.SetOwnedMemory(ArrayPool<byte>.Shared.Rent(sizeToRequest));
+                segment.SetOwnedMemory(ArrayPool<byte>.Shared.Rent(sizeToRequest));
             }
 
-            _writingHeadMemory = newSegment.AvailableMemory;
-
-            return newSegment;
+            _writingHeadMemory = segment.AvailableMemory;
         }
 
         private int GetSegmentSize(int sizeHint, int maxBufferSize = int.MaxValue)

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -202,7 +202,7 @@ namespace System.IO.Pipelines
                             // If we got here that means Advance was called with 0 bytes or GetMemory was called again without any writes occurring
                             // And, the newly requested memory size is greater than our unused segments internal memory buffer
                             // So we should reuse the BufferSegment and replace the memory it's holding, this way ReadAsync will not receive a buffer with one segment being empty
-                            _writingHead.ResetMemory();
+                            _writingHead.ResetMemory(preserveIndex: true);
                             SetupSegment(_writingHead, sizeHint);
                         }
                         else

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
@@ -151,7 +151,6 @@ namespace System.IO.Pipelines
             while (returnStart != returnEnd)
             {
                 BufferSegment next = returnStart.NextSegment!;
-                returnStart.ResetMemory();
                 ReturnSegmentUnsynchronized(returnStart);
                 returnStart = next;
             }
@@ -192,7 +191,7 @@ namespace System.IO.Pipelines
                 BufferSegment returnSegment = segment;
                 segment = segment.NextSegment;
 
-                returnSegment.ResetMemory();
+                returnSegment.Reset();
             }
 
             return !LeaveOpen;
@@ -623,6 +622,8 @@ namespace System.IO.Pipelines
         {
             Debug.Assert(segment != _readHead, "Returning _readHead segment that's in use!");
             Debug.Assert(segment != _readTail, "Returning _readTail segment that's in use!");
+
+            segment.Reset();
 
             if (_bufferSegmentPool.Count < MaxSegmentPoolSize)
             {

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -193,6 +193,7 @@ namespace System.IO.Pipelines
 
         private void ReturnSegmentUnsynchronized(BufferSegment segment)
         {
+            segment.Reset();
             if (_bufferSegmentPool.Count < MaxSegmentPoolSize)
             {
                 _bufferSegmentPool.Push(segment);
@@ -323,7 +324,6 @@ namespace System.IO.Pipelines
                             await InnerStream.WriteAsync(returnSegment.Memory, localToken).ConfigureAwait(false);
                         }
 
-                        returnSegment.ResetMemory();
                         ReturnSegmentUnsynchronized(returnSegment);
 
                         // Update the head segment after we return the current segment
@@ -400,7 +400,6 @@ namespace System.IO.Pipelines
 #endif
                 }
 
-                returnSegment.ResetMemory();
                 ReturnSegmentUnsynchronized(returnSegment);
 
                 // Update the head segment after we return the current segment

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -163,6 +163,42 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        public async Task WriteNothingThenWriteToNewSegment()
+        {
+            // Regression test: write nothing to force a segment to be created, then do a large write that's larger than the currently empty segment to force another new segment
+            // Verify that no 0 length segments are returned from the Reader.
+            PipeWriter buffer = Pipe.Writer;
+            Memory<byte> memory = buffer.GetMemory();
+            buffer.Advance(0); // doing nothing, the hard way
+            await buffer.FlushAsync();
+
+            memory = buffer.GetMemory(memory.Length + 1);
+            buffer.Advance(memory.Length);
+            await buffer.FlushAsync();
+
+            var res = await Pipe.Reader.ReadAsync();
+            Assert.True(res.Buffer.IsSingleSegment);
+            Assert.Equal(memory.Length, res.Buffer.Length);
+        }
+
+        [Fact]
+        public async Task WriteNothingThenWriteSomeBytes()
+        {
+            PipeWriter buffer = Pipe.Writer;
+            _ = buffer.GetMemory();
+            buffer.Advance(0); // doing nothing, the hard way
+            await buffer.FlushAsync();
+
+            var memory = buffer.GetMemory();
+            buffer.Advance(memory.Length);
+            await buffer.FlushAsync();
+
+            var res = await Pipe.Reader.ReadAsync();
+            Assert.True(res.Buffer.IsSingleSegment);
+            Assert.Equal(memory.Length, res.Buffer.Length);
+        }
+
+        [Fact]
         public void EmptyWriteDoesNotThrow()
         {
             Pipe.Writer.Write(new byte[0]);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/30786

Reuses a `BufferSegment` if it is unused and a larger memory buffer is requested.

There was already a memory pool test for this type of scenario, so I haven't added a new one.