### PR TITLE
NativeAOT: Run some optimization phases twice

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2987,10 +2987,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
             opts.compLongAddress = true;
         }
 
-        if (JitConfig.JitOptRepeat().contains(info.compMethodName, info.compClassName, &info.compMethodInfo->args))
-        {
-            opts.optRepeat = true;
-        }
+        opts.optRepeat = true;
 
         // If JitEarlyExpandMDArrays is non-zero, then early MD expansion is enabled.
         // If JitEarlyExpandMDArrays is zero, then conditionally enable it for functions specfied by
@@ -4898,7 +4895,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         bool doCse           = true;
         bool doAssertionProp = true;
         bool doRangeAnalysis = true;
-        int  iterations      = 1;
+        int  iterations      = 2;
 
 #if defined(OPT_CONFIG)
         doSsa           = (JitConfig.JitDoSsa() != 0);


### PR DESCRIPTION
In JIT we have a debug-only mode where we can run some optimization phases multiple times. It feels to me that we can enable it for NativeAOT even in Release. And I have a feeling that it should bring some nice diffs (probably needs jit-utils for proper diffs) - let's see what CI thinks about it.

E.g in https://github.com/dotnet/runtime/pull/70907 I've got nice diffs by simply running optRedundantBranches twice.

PS: not for net 7.0