### PR TITLE
[NativeAOT] Some cleanup of assembly helpers in hijack area.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/ICodeManager.h
+++ b/src/coreclr/nativeaot/Runtime/ICodeManager.h
@@ -79,7 +79,11 @@ inline uint64_t ReturnKindToTransitionFrameFlags(GCRefKind returnKind)
     if (returnKind == GCRK_Scalar)
         return 0;
 
+#if defined(TARGET_UNIX)
     return PTFF_SAVE_RAX | PTFF_SAVE_RDX | ((uint64_t)returnKind << 16);
+#else
+    return PTFF_SAVE_RAX | ((uint64_t)returnKind << 16);
+#endif
 }
 
 inline GCRefKind TransitionFrameFlagsToReturnKind(uint64_t transFrameFlags)

--- a/src/coreclr/nativeaot/Runtime/ICodeManager.h
+++ b/src/coreclr/nativeaot/Runtime/ICodeManager.h
@@ -53,10 +53,9 @@ C_ASSERT(PTFF_X1_IS_BYREF == ((uint64_t)GCRK_Scalar_Byref << 32));
 
 inline uint64_t ReturnKindToTransitionFrameFlags(GCRefKind returnKind)
 {
-    if (returnKind == GCRK_Scalar)
-        return 0;
-
-    return PTFF_SAVE_X0 | PTFF_SAVE_X1 | ((uint64_t)returnKind << 32);
+    // just need to report gc ref bits here.
+    // appropriate PTFF_SAVE_ bits will be added by the frame building routine.
+    return ((uint64_t)returnKind << 32);
 }
 
 inline GCRefKind TransitionFrameFlagsToReturnKind(uint64_t transFrameFlags)
@@ -76,14 +75,9 @@ C_ASSERT(PTFF_RDX_IS_BYREF == ((uint64_t)GCRK_Scalar_Byref << 16));
 
 inline uint64_t ReturnKindToTransitionFrameFlags(GCRefKind returnKind)
 {
-    if (returnKind == GCRK_Scalar)
-        return 0;
-
-#if defined(TARGET_UNIX)
-    return PTFF_SAVE_RAX | PTFF_SAVE_RDX | ((uint64_t)returnKind << 16);
-#else
-    return PTFF_SAVE_RAX | ((uint64_t)returnKind << 16);
-#endif
+    // just need to report gc ref bits here.
+    // appropriate PTFF_SAVE_ bits will be added by the frame building routine.
+    return ((uint64_t)returnKind << 16);
 }
 
 inline GCRefKind TransitionFrameFlagsToReturnKind(uint64_t transFrameFlags)

--- a/src/coreclr/nativeaot/Runtime/amd64/AsmMacros.inc
+++ b/src/coreclr/nativeaot/Runtime/amd64/AsmMacros.inc
@@ -396,7 +396,6 @@ EXTERN RhpGcAlloc                               : PROC
 EXTERN RhpValidateExInfoPop                     : PROC
 EXTERN RhDebugBreak                             : PROC
 EXTERN RhpWaitForGC2                            : PROC
-EXTERN RhpReversePInvokeAttachOrTrapThread2     : PROC
 EXTERN RhExceptionHandling_FailedAllocation     : PROC
 EXTERN RhThrowHwEx                              : PROC
 EXTERN RhThrowEx                                : PROC

--- a/src/coreclr/nativeaot/Runtime/amd64/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/GcProbe.S
@@ -111,15 +111,17 @@
 NESTED_ENTRY RhpGcProbeHijack, _TEXT, NoHandler
         END_PROLOGUE
         FixupHijackedCallstack
+
+        test        dword ptr [C_VAR(RhpTrapThreads)], TrapThreadsFlags_TrapThreads
+        jnz         LOCAL_LABEL(DoRhpGcProbe)
+        ret
+
+LOCAL_LABEL(DoRhpGcProbe):
         or          ecx, DEFAULT_FRAME_SAVE_FLAGS  + PTFF_SAVE_RAX + PTFF_SAVE_RDX
         jmp         C_FUNC(RhpGcProbe)
 NESTED_END RhpGcProbeHijack, _TEXT
 
 NESTED_ENTRY RhpGcProbe, _TEXT, NoHandler
-        test        dword ptr [C_VAR(RhpTrapThreads)], TrapThreadsFlags_TrapThreads
-        jnz         LOCAL_LABEL(RhpGcProbe_Trap)
-        ret
-LOCAL_LABEL(RhpGcProbe_Trap):
         PUSH_PROBE_FRAME r11, rax, rcx
         END_PROLOGUE
 

--- a/src/coreclr/nativeaot/Runtime/amd64/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/GcProbe.S
@@ -113,15 +113,15 @@ NESTED_ENTRY RhpGcProbeHijack, _TEXT, NoHandler
         FixupHijackedCallstack
 
         test        dword ptr [C_VAR(RhpTrapThreads)], TrapThreadsFlags_TrapThreads
-        jnz         LOCAL_LABEL(DoRhpGcProbe)
+        jnz         LOCAL_LABEL(WaitForGC)
         ret
 
-LOCAL_LABEL(DoRhpGcProbe):
+LOCAL_LABEL(WaitForGC):
         or          ecx, DEFAULT_FRAME_SAVE_FLAGS  + PTFF_SAVE_RAX + PTFF_SAVE_RDX
-        jmp         C_FUNC(RhpGcProbe)
+        jmp         C_FUNC(RhpWaitForGC)
 NESTED_END RhpGcProbeHijack, _TEXT
 
-NESTED_ENTRY RhpGcProbe, _TEXT, NoHandler
+NESTED_ENTRY RhpWaitForGC, _TEXT, NoHandler
         PUSH_PROBE_FRAME r11, rax, rcx
         END_PROLOGUE
 
@@ -140,7 +140,7 @@ LOCAL_LABEL(Abort):
         pop         rdx         // return address as exception RIP
         jmp         C_FUNC(RhpThrowHwEx) // Throw the ThreadAbortException as a special kind of hardware exception
 
-NESTED_END RhpGcProbe, _TEXT
+NESTED_END RhpWaitForGC, _TEXT
 
 
 LEAF_ENTRY RhpGcPoll, _TEXT

--- a/src/coreclr/nativeaot/Runtime/amd64/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/GcProbe.S
@@ -68,24 +68,6 @@
 .endm
 
 //
-// Macro to clear the hijack state. This is safe to do because the suspension code will not Unhijack this
-// thread if it finds it at an IP that isn`t managed code.
-//
-// Register state on entry:
-//  R11: thread pointer
-//
-// Register state on exit:
-//  R9: trashed
-//
-.macro ClearHijackState
-        xor         r9, r9
-        mov         [r11 + OFFSETOF__Thread__m_ppvHijackedReturnAddressLocation], r9
-        mov         [r11 + OFFSETOF__Thread__m_pvHijackedReturnAddress], r9
-        mov         [r11 + OFFSETOF__Thread__m_uHijackedReturnValueFlags], r9
-.endm
-
-
-//
 // The prolog for all GC suspension hijacks (normal and stress). Fixes up the hijacked return address, and
 // clears the hijack state.
 //
@@ -117,53 +99,13 @@
 
         mov         rcx, [r11 + OFFSETOF__Thread__m_uHijackedReturnValueFlags]
 
-        ClearHijackState
-.endm
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// RhpWaitForGCNoAbort -- rare path for WaitForGCCompletion
-//
-//
-// INPUT: RDI: transition frame
-//
-// TRASHES: RCX, RDI, R8, R9, R10, R11
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-NESTED_ENTRY RhpWaitForGCNoAbort, _TEXT, NoHandler
-        END_PROLOGUE
-
-        mov         rdx, [rdi + OFFSETOF__PInvokeTransitionFrame__m_pThread]
-
-        test        dword ptr [rdx + OFFSETOF__Thread__m_ThreadStateFlags], TSF_DoNotTriggerGc
-        jnz         Done
-
-        // passing transition frame pointer in rdi
-        call        C_FUNC(RhpWaitForGC2)
-
-Done:
-        ret
-
-NESTED_END RhpWaitForGCNoAbort, _TEXT
-
-//
-// Set the Thread state and wait for a GC to complete.
-//
-// Register state on entry:
-//  RBX: thread pointer
-//
-// Register state on exit:
-//  RBX: thread pointer
-//  All other registers trashed
-//
-
-.macro WaitForGCCompletion
-        test        dword ptr [rbx + OFFSETOF__Thread__m_ThreadStateFlags], TSF_SuppressGcStress + TSF_DoNotTriggerGc
-        jnz         LOCAL_LABEL(NoWait)
-
-        mov         rdi, [rbx + OFFSETOF__Thread__m_pDeferredTransitionFrame]
-        call        C_FUNC(RhpWaitForGCNoAbort)
-LOCAL_LABEL(NoWait):
+        //
+        // Clear hijack state
+        //
+        xor         r9, r9
+        mov         [r11 + OFFSETOF__Thread__m_ppvHijackedReturnAddressLocation], r9
+        mov         [r11 + OFFSETOF__Thread__m_pvHijackedReturnAddress], r9
+        mov         [r11 + OFFSETOF__Thread__m_uHijackedReturnValueFlags], r9
 
 .endm
 
@@ -190,7 +132,8 @@ LOCAL_LABEL(RhpGcProbe_Trap):
         END_PROLOGUE
 
         mov         rbx, r11
-        WaitForGCCompletion
+        mov         rdi, [rbx + OFFSETOF__Thread__m_pDeferredTransitionFrame]
+        call        C_FUNC(RhpWaitForGC2)
 
         mov         rax, [rbx + OFFSETOF__Thread__m_pDeferredTransitionFrame]
         test        dword ptr [rax + OFFSETOF__PInvokeTransitionFrame__m_Flags], PTFF_THREAD_ABORT

--- a/src/coreclr/nativeaot/Runtime/amd64/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/GcProbe.S
@@ -80,7 +80,7 @@
 //  RAX, RDX preserved, other volatile regs trashed
 //
 .macro FixupHijackedCallstack
-        // preserve RAX, RDX as they may contain retuvalues
+        // preserve RAX, RDX as they may contain return values
         push rax
         push rdx
 
@@ -97,6 +97,7 @@
         mov         rcx, [r11 + OFFSETOF__Thread__m_pvHijackedReturnAddress]
         push        rcx
 
+        // Fetch the return address flags
         mov         rcx, [r11 + OFFSETOF__Thread__m_uHijackedReturnValueFlags]
 
         //
@@ -155,7 +156,6 @@ LEAF_ENTRY RhpGcPoll, _TEXT
         ret
 LOCAL_LABEL(RhpGcPoll_RarePath):
         jmp C_FUNC(RhpGcPollRare)
-
 LEAF_END RhpGcPoll, _TEXT
 
 NESTED_ENTRY RhpGcPollRare, _TEXT, NoHandler

--- a/src/coreclr/nativeaot/Runtime/amd64/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/GcProbe.S
@@ -91,32 +91,23 @@
         pop rdx
         pop rax
 
-        //
         // Fix the stack by pushing the original return address
-        //
         mov         rcx, [r11 + OFFSETOF__Thread__m_pvHijackedReturnAddress]
         push        rcx
 
         // Fetch the return address flags
         mov         rcx, [r11 + OFFSETOF__Thread__m_uHijackedReturnValueFlags]
 
-        //
         // Clear hijack state
-        //
         xor         r9, r9
         mov         [r11 + OFFSETOF__Thread__m_ppvHijackedReturnAddressLocation], r9
         mov         [r11 + OFFSETOF__Thread__m_pvHijackedReturnAddress], r9
         mov         [r11 + OFFSETOF__Thread__m_uHijackedReturnValueFlags], r9
-
 .endm
 
 //
-//
-//
 // GC Probe Hijack target
 //
-//
-
 NESTED_ENTRY RhpGcProbeHijack, _TEXT, NoHandler
         END_PROLOGUE
         FixupHijackedCallstack

--- a/src/coreclr/nativeaot/Runtime/amd64/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/GcProbe.asm
@@ -3,9 +3,6 @@
 
 include AsmMacros.inc
 
-PROBE_SAVE_FLAGS_EVERYTHING     equ DEFAULT_FRAME_SAVE_FLAGS + PTFF_SAVE_ALL_SCRATCH
-PROBE_SAVE_FLAGS_RAX_IS_GCREF   equ DEFAULT_FRAME_SAVE_FLAGS + PTFF_SAVE_RAX + PTFF_RAX_IS_GCREF
-
 ;;
 ;; See PUSH_COOP_PINVOKE_FRAME, this macro is very similar, but also saves RAX and accepts the register
 ;; bitmask in RCX
@@ -83,37 +80,27 @@ endm
 ;;  RAX: preserved, other volatile regs trashed
 ;;
 FixupHijackedCallstack macro
-
         ;; rdx <- GetThread(), TRASHES rcx
         INLINE_GETTHREAD rdx, rcx
 
-        ;;
         ;; Fix the stack by pushing the original return address
-        ;;
         mov         rcx, [rdx + OFFSETOF__Thread__m_pvHijackedReturnAddress]
         push        rcx
 
         ;; Fetch the return address flags
         mov         rcx, [rdx + OFFSETOF__Thread__m_uHijackedReturnValueFlags]
 
-        ;;
         ;; Clear hijack state
-        ;;
         xor         r9, r9
         mov         [rdx + OFFSETOF__Thread__m_ppvHijackedReturnAddressLocation], r9
         mov         [rdx + OFFSETOF__Thread__m_pvHijackedReturnAddress], r9
         mov         [rdx + OFFSETOF__Thread__m_uHijackedReturnValueFlags], r9
-
 endm
 
 EXTERN RhpPInvokeExceptionGuard : PROC
 
 ;;
-;;
-;;
 ;; GC Probe Hijack target
-;;
-
 ;;
 NESTED_ENTRY RhpGcProbeHijack, _TEXT, RhpPInvokeExceptionGuard
         END_PROLOGUE
@@ -170,9 +157,7 @@ NESTED_END RhpGcPollRare, _TEXT
 ifdef FEATURE_GC_STRESS
 
 ;;
-;;
 ;; GC Stress Hijack targets
-;;
 ;;
 LEAF_ENTRY RhpGcStressHijack, _TEXT
         FixupHijackedCallstack

--- a/src/coreclr/nativeaot/Runtime/amd64/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/GcProbe.asm
@@ -4,11 +4,11 @@
 include AsmMacros.inc
 
 ;;
-;; See PUSH_COOP_PINVOKE_FRAME, this macro is very similar, but also saves RAX and accepts the register
-;; bitmask in RCX
+;; See PUSH_COOP_PINVOKE_FRAME, this macro is very similar, but also saves RAX and accepts
+;; the register bitmask
 ;;
 ;; On entry:
-;;  - BITMASK: bitmask describing pushes, may be volatile register or constant value
+;;  - BITMASK: bitmask describing pushes, a volatile register
 ;;  - RAX: managed function return value, may be an object or byref
 ;;  - preserved regs: need to stay preserved, may contain objects or byrefs
 ;;
@@ -31,7 +31,7 @@ PUSH_PROBE_FRAME macro threadReg, trashReg, BITMASK
     push_vol_reg    BITMASK                     ; save the register bitmask passed in by caller
     push_vol_reg    threadReg                   ; Thread * (unused by stackwalker)
     push_nonvol_reg rbp                         ; save caller's RBP
-    mov             trashReg, [rsp + 12*8]  ; Find the return address
+    mov             trashReg, [rsp + 12*8]      ; Find the return address
     push_vol_reg    trashReg                    ; save m_RIP
     lea             trashReg, [rsp + 0]         ; trashReg == address of frame
 
@@ -41,7 +41,7 @@ PUSH_PROBE_FRAME macro threadReg, trashReg, BITMASK
     ;; save xmm0 in case it's being used as a return value
     movdqa          [rsp + 20h], xmm0
 
-    ; link the frame into the Thread
+    ;; link the frame into the Thread
     mov             [threadReg + OFFSETOF__Thread__m_pDeferredTransitionFrame], trashReg
 endm
 

--- a/src/coreclr/nativeaot/Runtime/amd64/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/GcProbe.asm
@@ -111,12 +111,12 @@ NESTED_ENTRY RhpGcProbeHijack, _TEXT, RhpPInvokeExceptionGuard
         ret
 @@:
         or          ecx, DEFAULT_FRAME_SAVE_FLAGS + PTFF_SAVE_RAX
-        jmp         RhpGcProbe
+        jmp         RhpWaitForGC
 NESTED_END RhpGcProbeHijack, _TEXT
 
 EXTERN RhpThrowHwEx : PROC
 
-NESTED_ENTRY RhpGcProbe, _TEXT
+NESTED_ENTRY RhpWaitForGC, _TEXT
         PUSH_PROBE_FRAME rdx, rax, rcx
         END_PROLOGUE
 
@@ -135,7 +135,7 @@ Abort:
         pop         rdx         ;; return address as exception RIP
         jmp         RhpThrowHwEx ;; Throw the ThreadAbortException as a special kind of hardware exception
 
-NESTED_END RhpGcProbe, _TEXT
+NESTED_END RhpWaitForGC, _TEXT
 
 LEAF_ENTRY RhpGcPoll, _TEXT
         cmp         [RhpTrapThreads], TrapThreadsFlags_None

--- a/src/coreclr/nativeaot/Runtime/amd64/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/GcProbe.asm
@@ -105,6 +105,11 @@ EXTERN RhpPInvokeExceptionGuard : PROC
 NESTED_ENTRY RhpGcProbeHijack, _TEXT, RhpPInvokeExceptionGuard
         END_PROLOGUE
         FixupHijackedCallstack
+
+        test        [RhpTrapThreads], TrapThreadsFlags_TrapThreads
+        jnz         @f
+        ret
+@@:
         or          ecx, DEFAULT_FRAME_SAVE_FLAGS + PTFF_SAVE_RAX
         jmp         RhpGcProbe
 NESTED_END RhpGcProbeHijack, _TEXT
@@ -112,10 +117,6 @@ NESTED_END RhpGcProbeHijack, _TEXT
 EXTERN RhpThrowHwEx : PROC
 
 NESTED_ENTRY RhpGcProbe, _TEXT
-        test        [RhpTrapThreads], TrapThreadsFlags_TrapThreads
-        jnz         @f
-        ret
-@@:
         PUSH_PROBE_FRAME rdx, rax, rcx
         END_PROLOGUE
 

--- a/src/coreclr/nativeaot/Runtime/amd64/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/PInvoke.asm
@@ -5,38 +5,6 @@ include asmmacros.inc
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; RhpWaitForGCNoAbort -- rare path for WaitForGCCompletion
-;;
-;;
-;; INPUT: RCX: transition frame
-;;
-;; TRASHES: RCX, RDX, R8, R9, R10, R11
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-NESTED_ENTRY RhpWaitForGCNoAbort, _TEXT
-        push_vol_reg    rax                 ; don't trash the integer return value
-        alloc_stack     30h
-        movdqa          [rsp + 20h], xmm0   ; don't trash the FP return value
-        END_PROLOGUE
-
-        mov         rdx, [rcx + OFFSETOF__PInvokeTransitionFrame__m_pThread]
-
-        test        dword ptr [rdx + OFFSETOF__Thread__m_ThreadStateFlags], TSF_DoNotTriggerGc
-        jnz         Done
-
-        ; passing transition frame pointer in rcx
-        call        RhpWaitForGC2
-
-Done:
-        movdqa      xmm0, [rsp + 20h]
-        add         rsp, 30h
-        pop         rax
-        ret
-
-NESTED_END RhpWaitForGCNoAbort, _TEXT
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
 ;; RhpPInvoke
 ;;
 ;; IN:  RCX: address of pinvoke frame

--- a/src/coreclr/nativeaot/Runtime/amd64/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/PInvoke.asm
@@ -76,55 +76,6 @@ NESTED_END RhpWaitForGC, _TEXT
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; RhpReversePInvokeAttachOrTrapThread
-;;
-;;
-;; INCOMING:  RAX -- address of reverse pinvoke frame
-;;
-;; PRESERVES: RCX, RDX, R8, R9 -- need to preserve these because the caller assumes they aren't trashed
-;;
-;; TRASHES:   RAX, R10, R11
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-NESTED_ENTRY RhpReversePInvokeAttachOrTrapThread, _TEXT
-        alloc_stack     88h     ; alloc scratch area and frame
-
-        ; save the integer arg regs
-        save_reg_postrsp        rcx, (20h + 0*8)
-        save_reg_postrsp        rdx, (20h + 1*8)
-        save_reg_postrsp        r8,  (20h + 2*8)
-        save_reg_postrsp        r9,  (20h + 3*8)
-
-        ; save the FP arg regs
-        save_xmm128_postrsp     xmm0, (20h + 4*8 + 0*10h)
-        save_xmm128_postrsp     xmm1, (20h + 4*8 + 1*10h)
-        save_xmm128_postrsp     xmm2, (20h + 4*8 + 2*10h)
-        save_xmm128_postrsp     xmm3, (20h + 4*8 + 3*10h)
-
-        END_PROLOGUE
-
-        mov         rcx, rax        ; rcx <- reverse pinvoke frame
-        call        RhpReversePInvokeAttachOrTrapThread2
-
-        movdqa      xmm0, [rsp + (20h + 4*8 + 0*10h)]
-        movdqa      xmm1, [rsp + (20h + 4*8 + 1*10h)]
-        movdqa      xmm2, [rsp + (20h + 4*8 + 2*10h)]
-        movdqa      xmm3, [rsp + (20h + 4*8 + 3*10h)]
-
-        mov         rcx, [rsp + (20h + 0*8)]
-        mov         rdx, [rsp + (20h + 1*8)]
-        mov         r8,  [rsp + (20h + 2*8)]
-        mov         r9,  [rsp + (20h + 3*8)]
-
-        ;; epilog
-        add         rsp, 88h
-        ret
-
-NESTED_END RhpReversePInvokeAttachOrTrapThread, _TEXT
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
 ;; RhpPInvoke
 ;;
 ;; IN:  RCX: address of pinvoke frame

--- a/src/coreclr/nativeaot/Runtime/arm/AsmMacros.h
+++ b/src/coreclr/nativeaot/Runtime/arm/AsmMacros.h
@@ -263,7 +263,6 @@ $Name
         EXTERN RhpGcAlloc
         EXTERN RhDebugBreak
         EXTERN RhpWaitForGC2
-        EXTERN RhpReversePInvokeAttachOrTrapThread2
         EXTERN RhExceptionHandling_FailedAllocation
 
 

--- a/src/coreclr/nativeaot/Runtime/arm/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/arm/GcProbe.asm
@@ -204,7 +204,7 @@ __PPF_ThreadReg SETS "r2"
         bx          lr
 0
         mov         r12, #(DEFAULT_FRAME_SAVE_FLAGS + PTFF_SAVE_R0)
-        b           RhpGcProbe
+        b           RhpWaitForGC
     NESTED_END RhpGcProbeHijackWrapper
 
 #ifdef FEATURE_GC_STRESS
@@ -245,7 +245,7 @@ __PPF_ThreadReg SETS "r2"
 
     EXTERN RhpThrowHwEx
 
-    NESTED_ENTRY RhpGcProbe
+    NESTED_ENTRY RhpWaitForGC
         PROLOG_PROBE_FRAME r2, r3, r12
 
         ldr         r0, [r2, #OFFSETOF__Thread__m_pDeferredTransitionFrame] 
@@ -263,7 +263,7 @@ __PPF_ThreadReg SETS "r2"
         EPILOG_NOP mov         r1, lr ;; return address as exception PC
         EPILOG_BRANCH RhpThrowHwEx
 
-    NESTED_END RhpGcProbe
+    NESTED_END RhpWaitForGC
 
     LEAF_ENTRY RhpGcPoll
         ldr         r0, =RhpTrapThreads

--- a/src/coreclr/nativeaot/Runtime/arm/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/arm/GcProbe.asm
@@ -136,25 +136,6 @@ __PPF_ThreadReg SETS "r2"
 
 
 ;;
-;; Macro to clear the hijack state. This is safe to do because the suspension code will not Unhijack this
-;; thread if it finds it at an IP that isn't managed code.
-;;
-;; Register state on entry:
-;;  r2: thread pointer
-;;
-;; Register state on exit:
-;;  r12: trashed
-;;
-    MACRO
-        ClearHijackState
-
-        mov         r12, #0
-        str         r12, [r2, #OFFSETOF__Thread__m_ppvHijackedReturnAddressLocation]
-        str         r12, [r2, #OFFSETOF__Thread__m_pvHijackedReturnAddress]
-    MEND
-
-
-;;
 ;; The prolog for all GC suspension hijacks (normal and stress). Fixes up the hijacked return address, and
 ;; clears the hijack state.
 ;;
@@ -177,32 +158,11 @@ __PPF_ThreadReg SETS "r2"
         ;;
         ldr         lr, [r2, #OFFSETOF__Thread__m_pvHijackedReturnAddress]
 
-        ClearHijackState
-    MEND
+        ;; Clear hijack state
+        mov         r12, #0
+        str         r12, [r2, #OFFSETOF__Thread__m_ppvHijackedReturnAddressLocation]
+        str         r12, [r2, #OFFSETOF__Thread__m_pvHijackedReturnAddress]
 
-;;
-;; Set the Thread state and wait for a GC to complete.
-;;
-;; Register state on entry:
-;;  r4: thread pointer
-;;
-;; Register state on exit:
-;;  r4: thread pointer
-;;  All other registers trashed
-;;
-
-    EXTERN RhpWaitForGCNoAbort
-
-    MACRO
-        WaitForGCCompletion
-
-        ldr         r2, [r4, #OFFSETOF__Thread__m_ThreadStateFlags]
-        tst         r2, #TSF_SuppressGcStress__OR__TSF_DoNotTriggerGC
-        bne         %ft0
-
-        ldr         r2, [r4, #OFFSETOF__Thread__m_pDeferredTransitionFrame]
-        bl          RhpWaitForGCNoAbort
-0
     MEND
 
 
@@ -326,8 +286,8 @@ __PPF_ThreadReg SETS "r2"
     NESTED_ENTRY RhpGcProbeRare
         PROLOG_PROBE_FRAME r2, r3, r12
 
-        mov         r4, r2
-        WaitForGCCompletion
+        ldr         r0, [r2, #OFFSETOF__Thread__m_pDeferredTransitionFrame] 
+        bl          RhpWaitForGC2
 
         ldr         r2, [sp, #OFFSETOF__PInvokeTransitionFrame__m_Flags]
         tst         r2, #PTFF_THREAD_ABORT
@@ -357,8 +317,8 @@ __PPF_ThreadReg SETS "r2"
         ; Unhijack this thread, if necessary.
         INLINE_THREAD_UNHIJACK  r2, r0, r1       ;; trashes r0, r1
 
-        mov         r4, r2
-        WaitForGCCompletion
+        ldr         r0, [r2, #OFFSETOF__Thread__m_pDeferredTransitionFrame]
+        bl          RhpWaitForGC2
 
         EPILOG_PROBE_FRAME
     NESTED_END RhpGcPollRare
@@ -410,181 +370,7 @@ DREG_SZ equ     (SIZEOF__PAL_LIMITED_CONTEXT - (OFFSETOF__PAL_LIMITED_CONTEXT__L
     NESTED_END RhpHijackForGcStress
 #endif ;; FEATURE_GC_STRESS
 
-
-;;
-;; The following functions are _jumped_ to when we need to transfer control from one method to another for EH
-;; dispatch. These are needed to properly coordinate with the GC hijacking logic. We are essentially replacing
-;; the return from the throwing method with a jump to the handler in the caller, but we need to be aware of
-;; any return address hijack that may be in place for GC suspension. These routines use a quick test of the
-;; return address against a specific GC hijack routine, and then fixup the stack pointer to what it would be
-;; after a real return from the throwing method. Then, if we are not hijacked we can simply jump to the
-;; handler in the caller.
-;;
-;; If we are hijacked, then we jump to a routine that will unhijack appropriatley and wait for the GC to
-;; complete. There are also variants for GC stress.
-;;
-;; Note that at this point we are eiher hijacked or we are not, and this will not change until we return to
-;; managed code. It is an invariant of the system that a thread will only attempt to hijack or unhijack
-;; another thread while the target thread is suspended in managed code, and this is _not_ managed code.
-;;
-;; Register state on entry:
-;;  r0: pointer to this function (i.e., trash)
-;;  r1: reference to the exception object.
-;;  r2: handler address we want to jump to.
-;;  Non-volatile registers are all already correct for return to the caller.
-;;  LR still contains the return address.
-;;
-;; Register state on exit:
-;;  All registers except r0 and lr unchanged
-;;
-    MACRO
-        RTU_EH_JUMP_HELPER $funcName, $hijackFuncName, $isStress, $stressFuncName
-
-        LEAF_ENTRY $funcName
-        ; Currently the EH epilog won't pop the return address back into LR,
-        ; so we have to have a funny load from [sp-4] here to retrieve it.
-
-            ldr         r0, =$hijackFuncName
-            cmp         r0, lr
-            beq         RhpGCProbeForEHJump
-
-            IF $isStress
-            ldr         r0, =$stressFuncName
-            cmp         r0, lr
-            beq         RhpGCStressProbeForEHJump
-            ENDIF
-
-            ;; We are not hijacked, so we can return to the handler.
-            ;; We return to keep the call/return prediction balanced.
-            mov         lr, r2  ; Update the return address
-            bx          lr
-        LEAF_END $funcName
-    MEND
-
-;; We need an instance of the helper for each possible hijack function. The binder has enough
-;; information to determine which one we need to use for any function.
-    RTU_EH_JUMP_HELPER RhpEHJumpScalar,         RhpGcProbeHijackScalar, {false}, 0
-    RTU_EH_JUMP_HELPER RhpEHJumpObject,         RhpGcProbeHijackObject, {false}, 0
-    RTU_EH_JUMP_HELPER RhpEHJumpByref,          RhpGcProbeHijackByref,  {false}, 0
 #ifdef FEATURE_GC_STRESS
-    RTU_EH_JUMP_HELPER RhpEHJumpScalarGCStress, RhpGcProbeHijackScalar, {true},  RhpGcStressHijackScalar
-    RTU_EH_JUMP_HELPER RhpEHJumpObjectGCStress, RhpGcProbeHijackObject, {true},  RhpGcStressHijackObject
-    RTU_EH_JUMP_HELPER RhpEHJumpByrefGCStress,  RhpGcProbeHijackByref,  {true},  RhpGcStressHijackByref
-#endif
-
-;;
-;; Macro to setup our frame and adjust the location of the EH object reference for EH jump probe funcs.
-;;
-;; Register state on entry:
-;;  r0: scratch
-;;  r1: reference to the exception object.
-;;  r2: handler address we want to jump to.
-;;  Non-volatile registers are all already correct for return to the caller.
-;;  The stack is as if we are just about to returned from the call
-;;
-;; Register state on exit:
-;;  r0: reference to the exception object
-;;  r2: thread pointer
-;;
-    MACRO
-        EHJumpProbeProlog
-
-        PROLOG_PUSH         {r1,r2}     ; save the handler address so we can jump to it later (save r1 just for alignment)
-        PROLOG_NOP          mov r0, r1  ; move the ex object reference into r0 so we can report it
-        ALLOC_PROBE_FRAME
-
-        ;; r2 <- GetThread(), TRASHES r1
-        INLINE_GETTHREAD r2, r1
-
-        ;; Recover the original return address and update the frame
-        ldr         lr, [r2, #OFFSETOF__Thread__m_pvHijackedReturnAddress]
-        str         lr, [sp, #OFFSETOF__PInvokeTransitionFrame__m_RIP]
-
-        ;; ClearHijackState expects thread in r2 (trashes r12).
-        ClearHijackState
-
-        ; TRASHES r1
-        INIT_PROBE_FRAME r2, r1, #PROBE_SAVE_FLAGS_R0_IS_GCREF, (PROBE_FRAME_SIZE + 8)
-        str         sp, [r2, #OFFSETOF__Thread__m_pDeferredTransitionFrame]
-    MEND
-
-;;
-;; Macro to re-adjust the location of the EH object reference, cleanup the frame, and make the
-;; final jump to the handler for EH jump probe funcs.
-;;
-;; Register state on entry:
-;;  r0: reference to the exception object
-;;  r1-r3: scratch
-;;
-;; Register state on exit:
-;;  sp: correct for return to the caller
-;;  r1: reference to the exception object
-;;
-    MACRO
-        EHJumpProbeEpilog
-
-        FREE_PROBE_FRAME        ; This restores exception object back into r0
-        EPILOG_NOP mov r1, r0   ; Move the Exception object back into r1 where the catch handler expects it
-        EPILOG_POP {r0,pc}      ; Recover the handler address and jump to it
-    MEND
-
-;;
-;; We are hijacked for a normal GC (not GC stress), so we need to unhijack and wait for the GC to complete.
-;;
-;; Register state on entry:
-;;  r0: reference to the exception object.
-;;  r2: thread
-;;  Non-volatile registers are all already correct for return to the caller.
-;;  The stack is as if we have tail called to this function (lr points to return address).
-;;
-;; Register state on exit:
-;;  r7: previous frame pointer
-;;  r0: reference to the exception object
-;;
-    NESTED_ENTRY RhpGCProbeForEHJump
-        EHJumpProbeProlog
-
-#ifdef _DEBUG
-        ;;
-        ;; If we get here, then we have been hijacked for a real GC, and our SyncState must
-        ;; reflect that we've been requested to synchronize.
-
-        ldr         r1, =RhpTrapThreads
-        ldr         r1, [r1]
-        tst         r1, #TrapThreadsFlags_TrapThreads
-        bne         %0
-
-        bl          RhDebugBreak
-0
-#endif ;; _DEBUG
-
-        mov         r4, r2
-        WaitForGCCompletion
-
-        EHJumpProbeEpilog
-    NESTED_END RhpGCProbeForEHJump
-
-#ifdef FEATURE_GC_STRESS
-;;
-;; We are hijacked for GC Stress (not a normal GC) so we need to invoke the GC stress helper.
-;;
-;; Register state on entry:
-;;  r1: reference to the exception object.
-;;  r2: thread
-;;  Non-volatile registers are all already correct for return to the caller.
-;;  The stack is as if we have tail called to this function (lr points to return address).
-;;
-;; Register state on exit:
-;;  r7: previous frame pointer
-;;  r0: reference to the exception object
-;;
-    NESTED_ENTRY RhpGCStressProbeForEHJump
-        EHJumpProbeProlog
-
-        bl          $REDHAWKGCINTERFACE__STRESSGC
-
-        EHJumpProbeEpilog
-    NESTED_END RhpGCStressProbeForEHJump
 
 ;;
 ;; INVARIANT: Don't trash the argument registers, the binder codegen depends on this.

--- a/src/coreclr/nativeaot/Runtime/arm/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/arm/PInvoke.asm
@@ -35,37 +35,4 @@ Done
 
         NESTED_END RhpWaitForGCNoAbort
 
-        EXTERN RhpThrowHwEx
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; RhpWaitForGC
-;;
-;;
-;; INPUT: r2: transition frame
-;;
-;; OUTPUT:
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-        NESTED_ENTRY RhpWaitForGC
-        PROLOG_PUSH  {r0,lr}
-
-        ldr         r0, =RhpTrapThreads
-        ldr         r0, [r0]
-        tst         r0, #TrapThreadsFlags_TrapThreads
-        beq         NoWait
-        bl          RhpWaitForGCNoAbort
-NoWait
-        tst         r0, #TrapThreadsFlags_AbortInProgress
-        beq         NoAbort
-        ldr         r0, [r2, #OFFSETOF__PInvokeTransitionFrame__m_Flags]
-        tst         r0, #PTFF_THREAD_ABORT
-        beq         NoAbort
-        EPILOG_POP  {r0,r1}         ; hijack target address as exception PC
-        EPILOG_NOP  mov r0, #STATUS_REDHAWK_THREAD_ABORT
-        EPILOG_BRANCH RhpThrowHwEx
-NoAbort
-        EPILOG_POP  {r0,pc}
-        NESTED_END RhpWaitForGC
-
         INLINE_GETTHREAD_CONSTANT_POOL

--- a/src/coreclr/nativeaot/Runtime/arm/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/arm/PInvoke.asm
@@ -5,34 +5,4 @@
 
         TEXTAREA
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; RhpWaitForGCNoAbort
-;;
-;;
-;; INPUT: r2: transition frame
-;;
-;; OUTPUT:
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-        NESTED_ENTRY RhpWaitForGCNoAbort
-
-        PROLOG_PUSH {r0-r6,lr}  ; Even number of registers to maintain 8-byte stack alignment
-        PROLOG_VPUSH {d0-d3}    ; Save float return value registers as well
-
-        ldr         r5, [r2, #OFFSETOF__PInvokeTransitionFrame__m_pThread]
-
-        ldr         r0, [r5, #OFFSETOF__Thread__m_ThreadStateFlags]
-        tst         r0, #TSF_DoNotTriggerGc
-        bne         Done
-
-        mov         r0, r2      ; passing transition frame in r0
-        bl          RhpWaitForGC2
-
-Done
-        EPILOG_VPOP {d0-d3}
-        EPILOG_POP  {r0-r6,pc}
-
-        NESTED_END RhpWaitForGCNoAbort
-
         INLINE_GETTHREAD_CONSTANT_POOL

--- a/src/coreclr/nativeaot/Runtime/arm/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/arm/PInvoke.asm
@@ -69,30 +69,3 @@ NoAbort
         NESTED_END RhpWaitForGC
 
         INLINE_GETTHREAD_CONSTANT_POOL
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; RhpReversePInvokeAttachOrTrapThread -- rare path for RhpPInvoke
-;;
-;;
-;; INPUT: r4: address of reverse pinvoke frame
-;;
-;; TRASHES: none
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-        NESTED_ENTRY RhpReversePInvokeAttachOrTrapThread
-
-        PROLOG_PUSH {r0-r4,lr}     ; Need to save argument registers r0-r3 and lr, r4 is just for alignment
-        PROLOG_VPUSH {d0-d7}       ; Save float argument registers as well since they're volatile
-
-        mov         r0, r4         ; passing reverse pinvoke frame pointer in r0
-        bl          RhpReversePInvokeAttachOrTrapThread2
-
-        EPILOG_VPOP {d0-d7}
-        EPILOG_POP  {r0-r4,pc}
-
-        NESTED_END RhpReversePInvokeTrapThread
-
-
-        end

--- a/src/coreclr/nativeaot/Runtime/arm64/AsmMacros.h
+++ b/src/coreclr/nativeaot/Runtime/arm64/AsmMacros.h
@@ -97,7 +97,6 @@ OFFSETOF__Thread__m_alloc_context__alloc_limit      equ OFFSETOF__Thread__m_rgbA
     EXTERN RhExceptionHandling_FailedAllocation
     EXTERN RhDebugBreak
     EXTERN RhpWaitForGC2
-    EXTERN RhpReversePInvokeAttachOrTrapThread2
     EXTERN RhThrowHwEx
     EXTERN RhThrowEx
     EXTERN RhRethrow

--- a/src/coreclr/nativeaot/Runtime/arm64/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/GcProbe.asm
@@ -68,8 +68,11 @@ PROBE_FRAME_SIZE    field 0
         str         $trashReg, [$threadReg, #OFFSETOF__Thread__m_pDeferredTransitionFrame]
     MEND
 
-    ;; Undo the effects of an ALLOC_PROBE_FRAME. This may only be called within an epilog. Note that all
-    ;; registers are restored (apart for sp and pc), even volatiles.
+;;
+;; Remove the frame from a previous call to PUSH_PROBE_FRAME from the top of the stack and restore preserved
+;; registers and return value to their values from before the probe was called (while also updating any
+;; object refs or byrefs).
+;;
     MACRO
         POP_PROBE_FRAME
 
@@ -209,7 +212,7 @@ DoRhpGcProbe
     LEAF_END RhpGcStressHijack
 ;;
 ;; Worker for our GC stress probes.  Do not call directly!!
-;; Instead, go through RhpGcStressHijack{Scalar|Object|Byref}.
+;; Instead, go through RhpGcStressHijack.
 ;; This worker performs the GC Stress work and returns to the original return address.
 ;;
 ;; Register state on entry:

--- a/src/coreclr/nativeaot/Runtime/arm64/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/GcProbe.asm
@@ -160,7 +160,7 @@ PROBE_FRAME_SIZE    field 0
         ret
 
 DoRhpGcProbe
-        orr         x12, x12, #DEFAULT_FRAME_SAVE_FLAGS
+        orr         x12, x12, #(DEFAULT_FRAME_SAVE_FLAGS + PTFF_SAVE_X0 + PTFF_SAVE_X1)
         b           RhpGcProbe
     NESTED_END RhpGcProbeHijackWrapper
 
@@ -207,7 +207,7 @@ DoRhpGcProbe
 ;;
     LEAF_ENTRY RhpGcStressHijack
         FixupHijackedCallstack
-        orr         x12, x12, #DEFAULT_FRAME_SAVE_FLAGS
+        orr         x12, x12, #(DEFAULT_FRAME_SAVE_FLAGS + PTFF_SAVE_X0 + PTFF_SAVE_X1)
         b           RhpGcStressProbe
     LEAF_END RhpGcStressHijack
 ;;

--- a/src/coreclr/nativeaot/Runtime/arm64/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/GcProbe.asm
@@ -156,17 +156,17 @@ PROBE_FRAME_SIZE    field 0
 
         ldr         x3, =RhpTrapThreads
         ldr         w3, [x3]
-        tbnz        x3, #TrapThreadsFlags_TrapThreads_Bit, DoRhpGcProbe
+        tbnz        x3, #TrapThreadsFlags_TrapThreads_Bit, WaitForGC
         ret
 
-DoRhpGcProbe
+WaitForGC
         orr         x12, x12, #(DEFAULT_FRAME_SAVE_FLAGS + PTFF_SAVE_X0 + PTFF_SAVE_X1)
-        b           RhpGcProbe
+        b           RhpWaitForGC
     NESTED_END RhpGcProbeHijackWrapper
 
     EXTERN RhpThrowHwEx
 
-    NESTED_ENTRY RhpGcProbe
+    NESTED_ENTRY RhpWaitForGC
         PUSH_PROBE_FRAME x2, x3, x12
 
         ldr         x0, [x2, #OFFSETOF__Thread__m_pDeferredTransitionFrame]
@@ -182,7 +182,7 @@ DoRhpGcProbe
         EPILOG_NOP mov w0, #STATUS_REDHAWK_THREAD_ABORT
         EPILOG_NOP mov x1, lr ;; return address as exception PC
         EPILOG_NOP b RhpThrowHwEx
-    NESTED_END RhpGcProbe
+    NESTED_END RhpWaitForGC
 
     LEAF_ENTRY RhpGcPoll
         ldr         x0, =RhpTrapThreads

--- a/src/coreclr/nativeaot/Runtime/arm64/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/GcProbe.asm
@@ -239,7 +239,7 @@ __PPF_ThreadReg SETS "x2"
 ;;
 ;;
 ;;
-;; GC Probe Hijack targets
+;; GC Probe Hijack target
 ;;
 ;;
     EXTERN RhpPInvokeExceptionGuard
@@ -253,41 +253,6 @@ __PPF_ThreadReg SETS "x2"
         orr         x12, x12, #DEFAULT_FRAME_SAVE_FLAGS
         b           RhpGcProbe
     NESTED_END RhpGcProbeHijackWrapper
-
-#ifdef FEATURE_GC_STRESS
-;;
-;;
-;; GC Stress Hijack targets
-;;
-;;
-    LEAF_ENTRY RhpGcStressHijack
-        FixupHijackedCallstack
-        orr         x12, x12, #DEFAULT_FRAME_SAVE_FLAGS
-        b           RhpGcStressProbe
-    LEAF_END RhpGcStressHijack
-;;
-;; Worker for our GC stress probes.  Do not call directly!!
-;; Instead, go through RhpGcStressHijack{Scalar|Object|Byref}.
-;; This worker performs the GC Stress work and returns to the original return address.
-;;
-;; Register state on entry:
-;;  x0: hijacked function return value
-;;  x1: hijacked function return value
-;;  x2: thread pointer
-;;  w12: register bitmask
-;;
-;; Register state on exit:
-;;  Scratch registers, except for x0, have been trashed
-;;  All other registers restored as they were when the hijack was first reached.
-;;
-    NESTED_ENTRY RhpGcStressProbe
-        PROLOG_PROBE_FRAME x2, x3, x12,
-
-        bl          $REDHAWKGCINTERFACE__STRESSGC
-
-        EPILOG_PROBE_FRAME
-    NESTED_END RhpGcStressProbe
-#endif ;; FEATURE_GC_STRESS
 
     LEAF_ENTRY RhpGcProbe
         ldr         x3, =RhpTrapThreads
@@ -330,7 +295,41 @@ __PPF_ThreadReg SETS "x2"
         ret
     NESTED_END RhpGcPollRare
 
+
 #ifdef FEATURE_GC_STRESS
+;;
+;;
+;; GC Stress Hijack target
+;;
+;;
+    LEAF_ENTRY RhpGcStressHijack
+        FixupHijackedCallstack
+        orr         x12, x12, #DEFAULT_FRAME_SAVE_FLAGS
+        b           RhpGcStressProbe
+    LEAF_END RhpGcStressHijack
+;;
+;; Worker for our GC stress probes.  Do not call directly!!
+;; Instead, go through RhpGcStressHijack{Scalar|Object|Byref}.
+;; This worker performs the GC Stress work and returns to the original return address.
+;;
+;; Register state on entry:
+;;  x0: hijacked function return value
+;;  x1: hijacked function return value
+;;  x2: thread pointer
+;;  w12: register bitmask
+;;
+;; Register state on exit:
+;;  Scratch registers, except for x0, have been trashed
+;;  All other registers restored as they were when the hijack was first reached.
+;;
+    NESTED_ENTRY RhpGcStressProbe
+        PROLOG_PROBE_FRAME x2, x3, x12,
+
+        bl          $REDHAWKGCINTERFACE__STRESSGC
+
+        EPILOG_PROBE_FRAME
+    NESTED_END RhpGcStressProbe
+
     NESTED_ENTRY RhpHijackForGcStress
         ;; This function should be called from right before epilog
 

--- a/src/coreclr/nativeaot/Runtime/arm64/PInvoke.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/PInvoke.S
@@ -88,58 +88,6 @@ NoAbort:
 
     NESTED_END RhpWaitForGC, _TEXT
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// RhpReversePInvokeAttachOrTrapThread -- rare path for RhpPInvoke
-//
-//
-// INPUT: x9: address of reverse pinvoke frame
-//
-// PRESERVES: x0-x8 -- need to preserve these because the caller assumes they are not trashed
-//
-// TRASHES: none
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    NESTED_ENTRY RhpReversePInvokeAttachOrTrapThread, _TEXT, NoHandler
-
-        // FP and LR registers
-        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -0xA0            // Push down stack pointer and store FP and LR
-
-        // Need to save argument registers x0-x7 and the return buffer register x8 (twice for 16B alignment)
-        stp         x0, x1, [sp, #0x10]
-        stp         x2, x3, [sp, #0x20]
-        stp         x4, x5, [sp, #0x30]
-        stp         x6, x7, [sp, #0x40]
-        stp         x8, x8, [sp, #0x50]
-
-        // Save float argument registers as well since they are volatile
-        stp         d0, d1, [sp, #0x60]
-        stp         d2, d3, [sp, #0x70]
-        stp         d4, d5, [sp, #0x80]
-        stp         d6, d7, [sp, #0x90]
-
-        mov         x0, x9         // passing reverse pinvoke frame pointer in x0
-        bl          RhpReversePInvokeAttachOrTrapThread2
-
-        // Restore floating point registers
-        ldp         d0, d1, [sp, #0x60]
-        ldp         d2, d3, [sp, #0x70]
-        ldp         d4, d5, [sp, #0x80]
-        ldp         d6, d7, [sp, #0x90]
-
-        // Restore the argument registers
-        ldp         x0, x1, [sp, #0x10]
-        ldp         x2, x3, [sp, #0x20]
-        ldp         x4, x5, [sp, #0x30]
-        ldp         x6, x7, [sp, #0x40]
-        ldr         x8, [sp, #0x50]
-
-        // Restore FP and LR registers, and free the allocated stack block
-        EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 0xA0
-        EPILOG_RETURN
-
-    NESTED_END RhpReversePInvokeAttachOrTrapThread, _TEXT
-
 //
 // RhpPInvoke
 //

--- a/src/coreclr/nativeaot/Runtime/arm64/PInvoke.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/PInvoke.S
@@ -18,42 +18,6 @@ TSF_Attached_Bit                = 0
 TSF_SuppressGcStress_Bit        = 3
 TSF_DoNotTriggerGc_Bit          = 4
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// RhpWaitForGCNoAbort
-//
-//
-// INPUT: x9: transition frame
-//
-// TRASHES: None
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    NESTED_ENTRY RhpWaitForGCNoAbort, _TEXT, NoHandler
-
-        // FP and LR registers
-        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -0x40            // Push down stack pointer and store FP and LR
-
-        // Save the integer return registers, as well as the floating return registers
-        stp         x0, x1, [sp, #0x10]
-        stp         d0, d1, [sp, #0x20]
-        stp         d2, d3, [sp, #0x30]
-
-        ldr         x0, [x9, #OFFSETOF__PInvokeTransitionFrame__m_pThread]
-        ldr         w0, [x0, #OFFSETOF__Thread__m_ThreadStateFlags]
-        tbnz        x0, #TSF_DoNotTriggerGc_Bit, Done
-
-        mov         x0, x9      // passing transition frame in x0
-        bl          RhpWaitForGC2
-
-Done:
-        ldp         x0, x1, [sp, #0x10]
-        ldp         d0, d1, [sp, #0x20]
-        ldp         d2, d3, [sp, #0x30]
-        EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 0x40
-        EPILOG_RETURN
-
-    NESTED_END RhpWaitForGCNoAbort
-
 //
 // RhpPInvoke
 //

--- a/src/coreclr/nativeaot/Runtime/arm64/PInvoke.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/PInvoke.S
@@ -54,40 +54,6 @@ Done:
 
     NESTED_END RhpWaitForGCNoAbort
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// RhpWaitForGC
-//
-//
-// INPUT: x9: transition frame
-//
-// TRASHES: x0, x1, x10
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    NESTED_ENTRY RhpWaitForGC, _TEXT, NoHandler
-
-        PROLOG_SAVE_REG_PAIR_INDEXED    fp, lr, -0x10
-
-        PREPARE_EXTERNAL_VAR_INDIRECT_W RhpTrapThreads, 10
-
-        tbz         x10, #TrapThreadsFlags_TrapThreads_Bit, NoWait
-        bl          RhpWaitForGCNoAbort
-NoWait:
-        tbz         x10, #TrapThreadsFlags_AbortInProgress_Bit, NoAbort
-        ldr         x10, [x9, #OFFSETOF__PInvokeTransitionFrame__m_Flags]
-        tbz         x10, #PTFF_THREAD_ABORT_BIT, NoAbort
-
-        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 0x10
-        mov w0, #STATUS_REDHAWK_THREAD_ABORT
-        mov x1, lr          // hijack target address as exception PC
-        b RhpThrowHwEx
-
-NoAbort:
-        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 0x10
-        EPILOG_RETURN
-
-    NESTED_END RhpWaitForGC, _TEXT
-
 //
 // RhpPInvoke
 //

--- a/src/coreclr/nativeaot/Runtime/arm64/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/PInvoke.asm
@@ -41,42 +41,6 @@ Done
 
     NESTED_END RhpWaitForGCNoAbort
 
-    EXTERN RhpThrowHwEx
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; RhpWaitForGC
-;;
-;;
-;; INPUT: x9: transition frame
-;;
-;; TRASHES: x0, x1, x10
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-    NESTED_ENTRY RhpWaitForGC
-
-        PROLOG_SAVE_REG_PAIR    fp, lr, #-0x10!
-
-        ldr         x10, =RhpTrapThreads
-        ldr         w10, [x10]
-        tbz         x10, #TrapThreadsFlags_TrapThreads_Bit, NoWait
-        bl          RhpWaitForGCNoAbort
-NoWait
-        tbz         x10, #TrapThreadsFlags_AbortInProgress_Bit, NoAbort
-        ldr         x10, [x9, #OFFSETOF__PInvokeTransitionFrame__m_Flags]
-        tbz         x10, #PTFF_THREAD_ABORT_BIT, NoAbort
-
-        EPILOG_RESTORE_REG_PAIR fp, lr, #0x10!
-        EPILOG_NOP  mov w0, #STATUS_REDHAWK_THREAD_ABORT
-        EPILOG_NOP  mov x1, lr          ; hijack target address as exception PC
-        EPILOG_NOP  b RhpThrowHwEx
-
-NoAbort
-        EPILOG_RESTORE_REG_PAIR fp, lr, #0x10!
-        EPILOG_RETURN
-
-    NESTED_END RhpWaitForGC
-
     INLINE_GETTHREAD_CONSTANT_POOL
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/coreclr/nativeaot/Runtime/arm64/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/PInvoke.asm
@@ -81,59 +81,6 @@ NoAbort
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; RhpReversePInvokeAttachOrTrapThread -- rare path for RhpPInvoke
-;;
-;;
-;; INPUT: x9: address of reverse pinvoke frame
-;;
-;; PRESERVES: x0-x8 -- need to preserve these because the caller assumes they aren't trashed
-;;
-;; TRASHES: none
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-    NESTED_ENTRY RhpReversePInvokeAttachOrTrapThread
-
-        ;; FP and LR registers
-        PROLOG_SAVE_REG_PAIR   fp, lr, #-0xA0!            ;; Push down stack pointer and store FP and LR
-
-        ;; Need to save argument registers x0-x7 and the return buffer register x8 (twice for 16B alignment)
-        stp         x0, x1, [sp, #0x10]
-        stp         x2, x3, [sp, #0x20]
-        stp         x4, x5, [sp, #0x30]
-        stp         x6, x7, [sp, #0x40]
-        stp         x8, x8, [sp, #0x50]
-
-        ;; Save float argument registers as well since they're volatile
-        stp         d0, d1, [sp, #0x60]
-        stp         d2, d3, [sp, #0x70]
-        stp         d4, d5, [sp, #0x80]
-        stp         d6, d7, [sp, #0x90]
-
-        mov         x0, x9         ; passing reverse pinvoke frame pointer in x0
-        bl          RhpReversePInvokeAttachOrTrapThread2
-
-        ;; Restore floating point registers
-        ldp         d0, d1, [sp, #0x60]
-        ldp         d2, d3, [sp, #0x70]
-        ldp         d4, d5, [sp, #0x80]
-        ldp         d6, d7, [sp, #0x90]
-
-        ;; Restore the argument registers
-        ldp         x0, x1, [sp, #0x10]
-        ldp         x2, x3, [sp, #0x20]
-        ldp         x4, x5, [sp, #0x30]
-        ldp         x6, x7, [sp, #0x40]
-        ldr         x8, [sp, #0x50]
-
-        ;; Restore FP and LR registers, and free the allocated stack block
-        EPILOG_RESTORE_REG_PAIR   fp, lr, #0xA0!
-        EPILOG_RETURN
-
-    NESTED_END RhpReversePInvokeAttachOrTrapThread
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
 ;; RhpPInvoke
 ;;
 ;; IN: x0: address of pinvoke frame

--- a/src/coreclr/nativeaot/Runtime/arm64/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/PInvoke.asm
@@ -7,44 +7,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; RhpWaitForGCNoAbort
-;;
-;;
-;; INPUT: x9: transition frame
-;;
-;; TRASHES: None
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-    NESTED_ENTRY RhpWaitForGCNoAbort
-
-        ;; FP and LR registers
-        PROLOG_SAVE_REG_PAIR   fp, lr, #-0x40!            ;; Push down stack pointer and store FP and LR
-
-        ;; Save the integer return registers, as well as the floating return registers
-        stp         x0, x1, [sp, #0x10]
-        stp         d0, d1, [sp, #0x20]
-        stp         d2, d3, [sp, #0x30]
-
-        ldr         x0, [x9, #OFFSETOF__PInvokeTransitionFrame__m_pThread]
-        ldr         w0, [x0, #OFFSETOF__Thread__m_ThreadStateFlags]
-        tbnz        x0, #TSF_DoNotTriggerGc_Bit, Done
-
-        mov         x0, x9      ; passing transition frame in x0
-        bl          RhpWaitForGC2
-
-Done
-        ldp         x0, x1, [sp, #0x10]
-        ldp         d0, d1, [sp, #0x20]
-        ldp         d2, d3, [sp, #0x30]
-        EPILOG_RESTORE_REG_PAIR   fp, lr, #0x40!
-        EPILOG_RETURN
-
-    NESTED_END RhpWaitForGCNoAbort
-
-    INLINE_GETTHREAD_CONSTANT_POOL
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
 ;; RhpPInvoke
 ;;
 ;; IN: x0: address of pinvoke frame

--- a/src/coreclr/nativeaot/Runtime/i386/AsmMacros.inc
+++ b/src/coreclr/nativeaot/Runtime/i386/AsmMacros.inc
@@ -180,7 +180,6 @@ G_EPHEMERAL_LOW                             equ _g_ephemeral_low
 G_EPHEMERAL_HIGH                            equ _g_ephemeral_high
 G_CARD_TABLE                                equ _g_card_table
 RhpWaitForGC2                               equ @RhpWaitForGC2@4
-RhpReversePInvokeAttachOrTrapThread2        equ @RhpReversePInvokeAttachOrTrapThread2@4
 RhpTrapThreads                              equ _RhpTrapThreads
 
 ifdef FEATURE_GC_STRESS
@@ -194,7 +193,6 @@ endif ;; FEATURE_GC_STRESS
 EXTERN RhpGcAlloc                               : PROC
 EXTERN RhDebugBreak                             : PROC
 EXTERN RhpWaitForGC2                            : PROC
-EXTERN RhpReversePInvokeAttachOrTrapThread2     : PROC
 EXTERN RhExceptionHandling_FailedAllocation     : PROC
 EXTERN RhThrowHwEx                              : PROC
 EXTERN RhThrowEx                                : PROC

--- a/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
@@ -13,20 +13,6 @@ include AsmMacros.inc
 DEFAULT_PROBE_SAVE_FLAGS        equ PTFF_SAVE_ALL_PRESERVED + PTFF_SAVE_RSP
 PROBE_SAVE_FLAGS_EVERYTHING     equ DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_ALL_SCRATCH
 PROBE_SAVE_FLAGS_RAX_IS_GCREF   equ DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX + PTFF_RAX_IS_GCREF
-;;
-;; Macro to clear the hijack state. This is safe to do because the suspension code will not Unhijack this
-;; thread if it finds it at an IP that isn't managed code.
-;;
-;; Register state on entry:
-;;  EDX: thread pointer
-;;
-;; Register state on exit:
-;;  No changes
-;;
-ClearHijackState macro
-        mov         dword ptr [edx + OFFSETOF__Thread__m_ppvHijackedReturnAddressLocation], 0
-        mov         dword ptr [edx + OFFSETOF__Thread__m_pvHijackedReturnAddress], 0
-endm
 
 ;;
 ;; The prolog for all GC suspension hijackes (normal and stress). Sets up an EBP frame,
@@ -58,7 +44,12 @@ HijackFixupProlog macro
         mov         ecx, [edx + OFFSETOF__Thread__m_pvHijackedReturnAddress]
         mov         [ebp + 4], ecx
 
-        ClearHijackState
+        ;;
+        ;; Clear hijack state
+        ;;
+        mov         dword ptr [edx + OFFSETOF__Thread__m_ppvHijackedReturnAddressLocation], 0
+        mov         dword ptr [edx + OFFSETOF__Thread__m_pvHijackedReturnAddress], 0
+
 endm
 
 ;;
@@ -145,33 +136,6 @@ PopProbeFrame macro
         pop         eax
 endm
 
-;;
-;; Set the Thread state and wait for a GC to complete.
-;;
-;; Register state on entry:
-;;  ESP: pointer to a PInvokeTransitionFrame on the stack
-;;  EBX: thread pointer
-;;  EBP: EBP frame
-;;
-;; Register state on exit:
-;;  ESP: pointer to a PInvokeTransitionFrame on the stack
-;;  EBX: thread pointer
-;;  EBP: EBP frame
-;;  All other registers trashed
-;;
-
-EXTERN _RhpWaitForGCNoAbort : PROC
-
-WaitForGCCompletion macro
-        test        dword ptr [ebx + OFFSETOF__Thread__m_ThreadStateFlags], TSF_SuppressGcStress + TSF_DoNotTriggerGc
-        jnz         @F
-
-        mov         ecx, esp
-        call        _RhpWaitForGCNoAbort
-@@:
-
-endm
-
 RhpThrowHwEx equ @RhpThrowHwEx@0
 extern RhpThrowHwEx : proc
 
@@ -198,7 +162,8 @@ RhpGcProbe  proc
 SynchronousRendezVous:
         PushProbeFrame ecx      ; bitmask in ECX
 
-        WaitForGCCompletion
+        mov         ecx, esp
+        call        RhpWaitForGC2
 
         mov         edx, [esp + OFFSETOF__PInvokeTransitionFrame__m_Flags]
         ;;
@@ -356,201 +321,6 @@ FASTCALL_FUNC RhpHijackForGcStress, 0
         pop         ebp
         ret
 FASTCALL_ENDFUNC
-endif ;; FEATURE_GC_STRESS
-
-;;
-;; The following functions are _jumped_ to when we need to transfer control from one method to another for EH
-;; dispatch. These are needed to properly coordinate with the GC hijacking logic. We are essentially replacing
-;; the return from the throwing method with a jump to the handler in the caller, but we need to be aware of
-;; any return address hijack that may be in place for GC suspension. These routines use a quick test of the
-;; return address against a specific GC hijack routine, and then fixup the stack pointer to what it would be
-;; after a real return from the throwing method. Then, if we are not hijacked we can simply jump to the
-;; handler in the caller.
-;;
-;; If we are hijacked, then we jump to a routine that will unhijack appropriatley and wait for the GC to
-;; complete. There are also variants for GC stress.
-;;
-;; Note that at this point we are eiher hijacked or we are not, and this will not change until we return to
-;; managed code. It is an invariant of the system that a thread will only attempt to hijack or unhijack
-;; another thread while the target thread is suspended in managed code, and this is _not_ managed code.
-;;
-;; Register state on entry:
-;;  EAX: handler address we want to jump to.
-;;  ECX: reference to the exception object.
-;;  EDX: what ESP should be after the return address and arg space are removed.
-;;  EBX, ESI, EDI, and EBP are all already correct for return to the caller.
-;;  The stack still contains the return address and the arguments to the call.
-;;
-;; Register state on exit:
-;;  ESP: what it would be after a complete return to the caller.
-;;
-RTU_EH_JUMP_HELPER macro funcName, hijackFuncName, isStress, stressFuncName
-FASTCALL_FUNC funcName, 0
-        cmp         [esp], hijackFuncName
-        je          RhpGCProbeForEHJump
-
-IF isStress EQ 1
-        cmp         [esp], stressFuncName
-        je          RhpGCStressProbeForEHJump
-ENDIF
-
-        ;; We are not hijacked, so we can return to the handler.
-        ;; We return to keep the call/return prediction balanced.
-        mov         esp, edx        ; The stack is now as if we have returned from the call.
-        push eax                    ; Push the handler as the return address.
-        ret
-
-FASTCALL_ENDFUNC
-endm
-
-
-;; We need an instance of the helper for each possible hijack function. The binder has enough
-;; information to determine which one we need to use for any function.
-RTU_EH_JUMP_HELPER RhpEHJumpScalar,         @RhpGcProbeHijackScalar@0,  0, 0
-RTU_EH_JUMP_HELPER RhpEHJumpObject,         @RhpGcProbeHijackObject@0,  0, 0
-RTU_EH_JUMP_HELPER RhpEHJumpByref,          @RhpGcProbeHijackByref@0,   0, 0
-ifdef FEATURE_GC_STRESS
-RTU_EH_JUMP_HELPER RhpEHJumpScalarGCStress, @RhpGcProbeHijackScalar@0,  1, @RhpGcStressHijackScalar@0
-RTU_EH_JUMP_HELPER RhpEHJumpObjectGCStress, @RhpGcProbeHijackObject@0,  1, @RhpGcStressHijackObject@0
-RTU_EH_JUMP_HELPER RhpEHJumpByrefGCStress,  @RhpGcProbeHijackByref@0,   1, @RhpGcStressHijackByref@0
-endif
-
-;;
-;; Macro to setup our EBP frame and adjust the location of the EH object reference for EH jump probe funcs.
-;;
-;; Register state on entry:
-;;  EAX: handler address we want to jump to.
-;;  ECX: reference to the exception object.
-;;  EDX: scratch
-;;  EBX, ESI, EDI, and EBP are all already correct for return to the caller.
-;;  The stack is as if we have returned from the call
-;;
-;; Register state on exit:
-;;  ESP: ebp frame
-;;  EBP: ebp frame setup with space reserved for the repaired return address
-;;  EAX: reference to the exception object
-;;  ECX: scratch
-;;
-EHJumpProbeProlog macro
-        push        eax         ; save a slot for the repaired return address
-        push        ebp         ; setup an ebp frame to keep the stack nicely crawlable
-        mov         ebp, esp
-        push        eax         ; save the handler address so we can jump to it later
-        mov         eax, ecx    ; move the ex object reference into eax so we can report it
-endm
-
-;;
-;; Macro to re-adjust the location of the EH object reference, cleanup the EBP frame, and make the
-;; final jump to the handler for EH jump probe funcs.
-;;
-;; Register state on entry:
-;;  EAX: reference to the exception object
-;;  ESP: ebp frame
-;;  EBP: ebp frame setup with the correct return (handler) address
-;;  ECX: scratch
-;;  EDX: scratch
-;;
-;; Register state on exit:
-;;  ESP: correct for return to the caller
-;;  EBP: previous ebp frame
-;;  ECX: reference to the exception object
-;;  EDX: trashed
-;;
-EHJumpProbeEpilog macro
-        mov         ecx, eax    ; Put the EX obj ref back into ecx for the handler.
-        pop         eax         ; Recover the handler address.
-        pop         ebp         ; Pop the ebp frame we setup.
-        pop         edx         ; Pop the original return address, which we do not need.
-        push eax                ; Push the handler as the return address.
-        ret
-endm
-
-;;
-;; We are hijacked for a normal GC (not GC stress), so we need to unhijcak and wait for the GC to complete.
-;;
-;; Register state on entry:
-;;  EAX: handler address we want to jump to.
-;;  ECX: reference to the exception object.
-;;  EDX: what ESP should be after the return address and arg space are removed.
-;;  EBX, ESI, EDI, and EBP are all already correct for return to the caller.
-;;  The stack is as if we have returned from the call
-;;
-;; Register state on exit:
-;;  ESP: correct for return to the caller
-;;  EBP: previous ebp frame
-;;  ECX: reference to the exception object
-;;
-RhpGCProbeForEHJump proc
-        mov         esp, edx        ; The stack is now as if we have returned from the call.
-        EHJumpProbeProlog
-
-        ;; edx <- GetThread(), TRASHES ecx
-        INLINE_GETTHREAD edx, ecx
-
-        ;; Fix the stack by pushing the original return address
-        mov         ecx, [edx + OFFSETOF__Thread__m_pvHijackedReturnAddress]
-        mov         [ebp + 4], ecx
-
-        ClearHijackState
-
-ifdef _DEBUG
-        ;;
-        ;; If we get here, then we have been hijacked for a real GC, and our SyncState must
-        ;; reflect that we've been requested to synchronize.
-
-        test        [RhpTrapThreads], TrapThreadsFlags_TrapThreads
-        jnz         @F
-
-        call        RhDebugBreak
-@@:
-endif ;; _DEBUG
-
-
-        PushProbeFrame  PROBE_SAVE_FLAGS_RAX_IS_GCREF
-        WaitForGCCompletion
-        PopProbeFrame
-
-        EHJumpProbeEpilog
-
-RhpGCProbeForEHJump endp
-
-ifdef FEATURE_GC_STRESS
-;;
-;; We are hijacked for GC Stress (not a normal GC) so we need to invoke the GC stress helper.
-;;
-;; Register state on entry:
-;;  EAX: handler address we want to jump to.
-;;  ECX: reference to the exception object.
-;;  EDX: what ESP should be after the return address and arg space are removed.
-;;  EBX, ESI, EDI, and EBP are all already correct for return to the caller.
-;;  The stack is as if we have returned from the call
-;;
-;; Register state on exit:
-;;  ESP: correct for return to the caller
-;;  EBP: previous ebp frame
-;;  ECX: reference to the exception object
-;;
-RhpGCStressProbeForEHJump proc
-        mov         esp, edx        ; The stack is now as if we have returned from the call.
-        EHJumpProbeProlog
-
-        ;; edx <- GetThread(), TRASHES ecx
-        INLINE_GETTHREAD edx, ecx
-
-        ;; Fix the stack by pushing the original return address
-        mov         ecx, [edx + OFFSETOF__Thread__m_pvHijackedReturnAddress]
-        mov         [ebp + 4], ecx
-
-        ClearHijackState
-
-        PushProbeFrame  PROBE_SAVE_FLAGS_RAX_IS_GCREF
-        StressGC
-        PopProbeFrame
-
-        EHJumpProbeEpilog
-
-RhpGCStressProbeForEHJump endp
-
 endif ;; FEATURE_GC_STRESS
 
         end

--- a/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
@@ -154,12 +154,6 @@ extern RhpThrowHwEx : proc
 ;;  All registers restored as they were when the hijack was first reached.
 ;;
 RhpGcProbe  proc
-        test        [RhpTrapThreads], TrapThreadsFlags_TrapThreads
-        jnz         SynchronousRendezVous
-
-        HijackFixupEpilog
-
-SynchronousRendezVous:
         PushProbeFrame ecx      ; bitmask in ECX
 
         mov         ecx, esp
@@ -236,51 +230,23 @@ RhpGcStressProbe  endp
 
 endif ;; FEATURE_GC_STRESS
 
-FASTCALL_FUNC RhpGcProbeHijackScalar, 0
-
+FASTCALL_FUNC RhpGcProbeHijack, 0
         HijackFixupProlog
-        mov         ecx, DEFAULT_PROBE_SAVE_FLAGS
-        jmp         RhpGcProbe
+        test        [RhpTrapThreads], TrapThreadsFlags_TrapThreads
+        jnz         DoRhpGcProbe
+        HijackFixupEpilog
 
-FASTCALL_ENDFUNC
-
-FASTCALL_FUNC RhpGcProbeHijackObject, 0
-
-        HijackFixupProlog
-        mov         ecx, DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX + PTFF_RAX_IS_GCREF
-        jmp         RhpGcProbe
-
-FASTCALL_ENDFUNC
-
-FASTCALL_FUNC RhpGcProbeHijackByref, 0
-
-        HijackFixupProlog
-        mov         ecx, DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX + PTFF_RAX_IS_BYREF
+DoRhpGcProbe:
+        mov         ecx, DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX
         jmp         RhpGcProbe
 
 FASTCALL_ENDFUNC
 
 ifdef FEATURE_GC_STRESS
-FASTCALL_FUNC RhpGcStressHijackScalar, 0
+FASTCALL_FUNC RhpGcStressHijack, 0
 
         HijackFixupProlog
-        mov         ecx, DEFAULT_PROBE_SAVE_FLAGS
-        jmp         RhpGcStressProbe
-
-FASTCALL_ENDFUNC
-
-FASTCALL_FUNC RhpGcStressHijackObject, 0
-
-        HijackFixupProlog
-        mov         ecx, DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX + PTFF_RAX_IS_GCREF
-        jmp         RhpGcStressProbe
-
-FASTCALL_ENDFUNC
-
-FASTCALL_FUNC RhpGcStressHijackByref, 0
-
-        HijackFixupProlog
-        mov         ecx, DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX + PTFF_RAX_IS_BYREF
+        mov         ecx, DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX
         jmp         RhpGcStressProbe
 
 FASTCALL_ENDFUNC

--- a/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
@@ -153,7 +153,7 @@ extern RhpThrowHwEx : proc
 ;; Register state on exit:
 ;;  All registers restored as they were when the hijack was first reached.
 ;;
-RhpGcProbe  proc
+RhpWaitForGC  proc
         PushProbeFrame ecx      ; bitmask in ECX
 
         mov         ecx, esp
@@ -177,7 +177,7 @@ Abort:
         pop         edx         ;; return address as exception RIP
         jmp         RhpThrowHwEx
 
-RhpGcProbe  endp
+RhpWaitForGC  endp
 
 ifdef FEATURE_GC_STRESS
 ;;
@@ -233,12 +233,12 @@ endif ;; FEATURE_GC_STRESS
 FASTCALL_FUNC RhpGcProbeHijack, 0
         HijackFixupProlog
         test        [RhpTrapThreads], TrapThreadsFlags_TrapThreads
-        jnz         DoRhpGcProbe
+        jnz         WaitForGC
         HijackFixupEpilog
 
-DoRhpGcProbe:
+WaitForGC:
         mov         ecx, DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX
-        jmp         RhpGcProbe
+        jmp         RhpWaitForGC
 
 FASTCALL_ENDFUNC
 

--- a/src/coreclr/nativeaot/Runtime/i386/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/PInvoke.asm
@@ -44,45 +44,4 @@ Done:
         ret
 _RhpWaitForGCNoAbort endp
 
-RhpThrowHwEx equ @RhpThrowHwEx@0
-EXTERN RhpThrowHwEx : PROC
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; RhpWaitForGC
-;;
-;;
-;; INPUT: ECX: transition frame
-;;
-;; OUTPUT:
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-_RhpWaitForGC proc public
-        push        ebp
-        mov         ebp, esp
-        push        ebx
-
-        mov         ebx, ecx
-        test        [RhpTrapThreads], TrapThreadsFlags_TrapThreads
-        jz          NoWait
-
-        call        _RhpWaitForGCNoAbort
-NoWait:
-        test        [RhpTrapThreads], TrapThreadsFlags_AbortInProgress
-        jz          Done
-        test        dword ptr [ebx + OFFSETOF__PInvokeTransitionFrame__m_Flags], PTFF_THREAD_ABORT
-        jz          Done
-
-        mov         ecx, STATUS_REDHAWK_THREAD_ABORT
-        pop         ebx
-        pop         ebp
-        pop         edx                 ; return address as exception RIP
-        jmp         RhpThrowHwEx        ; Throw the ThreadAbortException as a special kind of hardware exception
-Done:
-        pop         ebx
-        pop         ebp
-        ret
-_RhpWaitForGC endp
-
-
         end

--- a/src/coreclr/nativeaot/Runtime/i386/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/PInvoke.asm
@@ -9,39 +9,4 @@
 
 include AsmMacros.inc
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; RhpWaitForGCNoAbort
-;;
-;;
-;; INPUT: ECX: transition frame
-;;
-;; OUTPUT:
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-_RhpWaitForGCNoAbort proc public
-        push        ebp
-        mov         ebp, esp
-        push        eax
-        push        edx
-        push        ebx
-        push        esi
-
-        mov         esi, [ecx + OFFSETOF__PInvokeTransitionFrame__m_pThread]
-
-        test        dword ptr [esi + OFFSETOF__Thread__m_ThreadStateFlags], TSF_DoNotTriggerGc
-        jnz         Done
-
-        ; passing transition frame pointer in ecx
-        call        RhpWaitForGC2
-
-Done:
-        pop         esi
-        pop         ebx
-        pop         edx
-        pop         eax
-        pop         ebp
-        ret
-_RhpWaitForGCNoAbort endp
-
         end

--- a/src/coreclr/nativeaot/Runtime/portable.cpp
+++ b/src/coreclr/nativeaot/Runtime/portable.cpp
@@ -406,15 +406,7 @@ void * ReturnFromCallDescrThunk;
 // Return address hijacking
 //
 #if !defined (HOST_ARM64)
-COOP_PINVOKE_HELPER(void, RhpGcStressHijackScalar, ())
-{
-    ASSERT_UNCONDITIONALLY("NYI");
-}
-COOP_PINVOKE_HELPER(void, RhpGcStressHijackObject, ())
-{
-    ASSERT_UNCONDITIONALLY("NYI");
-}
-COOP_PINVOKE_HELPER(void, RhpGcStressHijackByref, ())
+COOP_PINVOKE_HELPER(void, RhpGcStressHijack, ())
 {
     ASSERT_UNCONDITIONALLY("NYI");
 }

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -1340,6 +1340,12 @@ COOP_PINVOKE_HELPER(uint64_t, RhCurrentOSThreadId, ())
     return PalGetCurrentThreadIdForLogging();
 }
 
+// Standard calling convention variant and actual implementation for RhpReversePInvokeAttachOrTrapThread
+EXTERN_C NOINLINE void FASTCALL RhpReversePInvokeAttachOrTrapThread2(ReversePInvokeFrame* pFrame)
+{
+    ASSERT(pFrame->m_savedThread == ThreadStore::RawGetCurrentThread());
+    pFrame->m_savedThread->ReversePInvokeAttachOrTrapThread(pFrame);
+}
 
 //
 // PInvoke
@@ -1352,7 +1358,7 @@ COOP_PINVOKE_HELPER(void, RhpReversePInvoke, (ReversePInvokeFrame * pFrame))
     if (pCurThread->InlineTryFastReversePInvoke(pFrame))
         return;
 
-    pCurThread->ReversePInvokeAttachOrTrapThread(pFrame);
+    RhpReversePInvokeAttachOrTrapThread2(pFrame);
 }
 
 COOP_PINVOKE_HELPER(void, RhpReversePInvokeReturn, (ReversePInvokeFrame * pFrame))

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -571,7 +571,7 @@ void Thread::Hijack()
     }
 
 #if defined(TARGET_ARM64) && defined(TARGET_UNIX)
-    // TODO: RhpGcProbe and related asm helpers NYI for ARM64/UNIX.
+    // TODO: RhpGcProbeHijack and related asm helpers NYI for ARM64/UNIX.
     //       disabling hijacking for now.
     return;
 #endif

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -1395,12 +1395,6 @@ COOP_PINVOKE_HELPER(uint64_t, RhCurrentOSThreadId, ())
     return PalGetCurrentThreadIdForLogging();
 }
 
-// Standard calling convention variant and actual implementation for RhpReversePInvokeAttachOrTrapThread
-EXTERN_C NOINLINE void FASTCALL RhpReversePInvokeAttachOrTrapThread2(ReversePInvokeFrame * pFrame)
-{
-    ASSERT(pFrame->m_savedThread == ThreadStore::RawGetCurrentThread());
-    pFrame->m_savedThread->ReversePInvokeAttachOrTrapThread(pFrame);
-}
 
 //
 // PInvoke
@@ -1413,7 +1407,7 @@ COOP_PINVOKE_HELPER(void, RhpReversePInvoke, (ReversePInvokeFrame * pFrame))
     if (pCurThread->InlineTryFastReversePInvoke(pFrame))
         return;
 
-    RhpReversePInvokeAttachOrTrapThread2(pFrame);
+    pCurThread->ReversePInvokeAttachOrTrapThread(pFrame);
 }
 
 COOP_PINVOKE_HELPER(void, RhpReversePInvokeReturn, (ReversePInvokeFrame * pFrame))

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -550,11 +550,11 @@ EXTERN_C void FASTCALL RhpGcStressHijack();
 // static
 bool Thread::IsHijackTarget(void* address)
 {
-        if (&RhpGcProbeHijack == address)
-            return true;
+    if (&RhpGcProbeHijack == address)
+        return true;
 #ifdef FEATURE_GC_STRESS
-        if (&RhpGcStressHijack == address)
-            return true;
+    if (&RhpGcStressHijack == address)
+        return true;
 #endif // FEATURE_GC_STRESS
     return false;
 }

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -70,21 +70,14 @@ struct ThreadBuffer
 {
     uint8_t                 m_rgbAllocContextBuffer[SIZEOF_ALLOC_CONTEXT];
     uint32_t volatile       m_ThreadStateFlags;                     // see Thread::ThreadStateFlags enum
-#if DACCESS_COMPILE
-    volatile
     PInvokeTransitionFrame* m_pTransitionFrame;
-#else
-    PInvokeTransitionFrame* m_pTransitionFrame;
-#endif
     PInvokeTransitionFrame* m_pDeferredTransitionFrame;             // see Thread::EnablePreemptiveMode
     PInvokeTransitionFrame* m_pCachedTransitionFrame;
     PTR_Thread              m_pNext;                                // used by ThreadStore's SList<Thread>
     HANDLE                  m_hPalThread;                           // WARNING: this may legitimately be INVALID_HANDLE_VALUE
     void **                 m_ppvHijackedReturnAddressLocation;
     void *                  m_pvHijackedReturnAddress;
-#ifdef HOST_64BIT
-    uintptr_t               m_uHijackedReturnValueFlags;             // used on ARM64 and UNIX only; however, ARM64 and AMD64 share field offsets
-#endif // HOST_64BIT
+    uintptr_t               m_uHijackedReturnValueFlags;            
     PTR_ExInfo              m_pExInfoStackHead;
     Object*                 m_threadAbortException;                 // ThreadAbortException instance -set only during thread abort
     PTR_PTR_VOID            m_pThreadLocalModuleStatics;
@@ -145,7 +138,12 @@ private:
 
     static void HijackCallback(NATIVE_CONTEXT* pThreadContext, void* pThreadToHijack);
 
+    //
+    // Hijack funcs are not called, they are "returned to". And when done, they return to the actual caller.
+    // Thus they cannot have any parameters or return anything.
+    //
     typedef void HijackFunc();
+
     void HijackReturnAddress(PAL_LIMITED_CONTEXT* pSuspendCtx, HijackFunc* pfnHijackFunction);
     void HijackReturnAddress(NATIVE_CONTEXT* pSuspendCtx, HijackFunc* pfnHijackFunction);
     void HijackReturnAddressWorker(StackFrameIterator* frameIterator, HijackFunc* pfnHijackFunction);

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -142,10 +142,13 @@ private:
     void ClearState(ThreadStateFlags flags);
     bool IsStateSet(ThreadStateFlags flags);
 
+
     static void HijackCallback(NATIVE_CONTEXT* pThreadContext, void* pThreadToHijack);
-    void HijackReturnAddress(PAL_LIMITED_CONTEXT* pSuspendCtx, void * pvHijackTargets[]);
-    void HijackReturnAddress(NATIVE_CONTEXT* pSuspendCtx, void* pvHijackTargets[]);
-    void HijackReturnAddressWorker(StackFrameIterator* frameIterator, void* pvHijackTargets[]);
+
+    typedef void HijackFunc();
+    void HijackReturnAddress(PAL_LIMITED_CONTEXT* pSuspendCtx, HijackFunc* pfnHijackFunction);
+    void HijackReturnAddress(NATIVE_CONTEXT* pSuspendCtx, HijackFunc* pfnHijackFunction);
+    void HijackReturnAddressWorker(StackFrameIterator* frameIterator, HijackFunc* pfnHijackFunction);
     bool InlineSuspend(NATIVE_CONTEXT* interruptedContext);
 
 #ifdef FEATURE_SUSPEND_REDIRECTION

--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
@@ -320,7 +320,7 @@ C_FUNC(\Name):
 DEFAULT_FRAME_SAVE_FLAGS = PTFF_SAVE_ALL_PRESERVED + PTFF_SAVE_RSP
 
 .macro PUSH_COOP_PINVOKE_FRAME trashReg
-    push_nonvol_reg rbp                         // push RBP frame  // TODO: do we need this? not on windows.
+    push_nonvol_reg rbp                         // push RBP frame
     mov             rbp, rsp
     lea             \trashReg, [rsp + 0x10]
     push_register   \trashReg                   // save caller's RSP


### PR DESCRIPTION
Mostly removing stuff to simplify porting to unix-arm64

- Deleting some dead code
- Merged macros with too few uses into callers, where it made the code more clear or similar across platforms.
- Making win-x64 to use the same shape of hijack helpers as other working implementations 
(re:https://github.com/dotnet/runtime/pull/71187#discussion_r923556443)
- Making `RhpGcProbeHijack` to be similar between win-x64, unix-x64, win-arm64. 
Especially the win-arm64 implementation that had many differences.
- Added/tweaked a few comments

There should be no new functionality or any behavior changes here. Just deleting/refactoring code.
