### PR TITLE
Fix flaky PhysicalFileProviderTests

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.cs
@@ -377,6 +377,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS, "System.IO.FileSystem.Watcher is not supported on Browser/iOS/tvOS")]
+        [SkipOnCoreClr("JitStress slows this down too much", RuntimeTestModes.JitStress | RuntimeTestModes.JitStressRegs)]
         public async Task TokenCallbackInvokedOnFileChange()
         {
             using (var root = new TempDirectory(GetTestFilePath()))
@@ -402,7 +403,7 @@ namespace Microsoft.Extensions.FileProviders
                             }, state: null);
 
                             fileSystemWatcher.CallOnChanged(new FileSystemEventArgs(WatcherChangeTypes.Changed, root.Path, fileName));
-                            await Task.Delay(WaitTimeForTokenToFire);
+                            await Task.Delay(WaitTimeForTokenCallback);
 
                             Assert.True(callbackInvoked, "Callback should have been invoked");
                         }
@@ -803,7 +804,7 @@ namespace Microsoft.Extensions.FileProviders
 
                             // Callback expected.
                             fileSystemWatcher.CallOnChanged(new FileSystemEventArgs(WatcherChangeTypes.Changed, root.Path, fileName));
-                            await Task.Delay(WaitTimeForTokenToFire);
+                            await Task.Delay(WaitTimeForTokenCallback);
 
                             // Callback not expected.
                             fileSystemWatcher.CallOnChanged(new FileSystemEventArgs(WatcherChangeTypes.Changed, root.Path, fileName));
@@ -886,7 +887,7 @@ namespace Microsoft.Extensions.FileProviders
                             }, null);
 
                             fileSystemWatcher.CallOnChanged(new FileSystemEventArgs(WatcherChangeTypes.Changed, root.Path, fileName));
-                            await Task.Delay(WaitTimeForTokenToFire);
+                            await Task.Delay(WaitTimeForTokenCallback);
 
                             Assert.True(token.HasChanged);
                         }


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/52631

Occasionally the call back was not firing before the end of the timeout. While it's possible there's an actual bug, this was mostly on JitStress or x86, suggesting it's possibly just slow. And I noticed that it's using a 500ms timeout, despite defining a 10sec timeout for callbacks.

Changed to use the callback timeout where callback is being expected.
Also disabled this test for JitStress as belt and braces. (Belt and suspenders in the US?)