### PR TITLE
Add pod names into the area-owners.json file to support querying by pod

### DIFF
--- a/docs/area-owners.json
+++ b/docs/area-owners.json
@@ -141,6 +141,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "eerhardt",
         "ericstj",
@@ -181,6 +182,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "eerhardt",
         "ericstj",
@@ -192,6 +194,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "eerhardt",
         "ericstj",
@@ -203,6 +206,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "eerhardt",
         "ericstj",
@@ -214,6 +218,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "adam-david",
       "owners": [
         "adamsitnik",
         "eerhardt",
@@ -226,6 +231,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "eerhardt",
         "ericstj",
@@ -237,6 +243,7 @@
     },
     {
       "lead": "karelz",
+      "pod": "networking",
       "owners": [
         "antonfirsov",
         "CarnaViire",
@@ -252,6 +259,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "eerhardt",
         "ericstj",
@@ -263,6 +271,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "eerhardt",
         "ericstj",
@@ -274,6 +283,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "eerhardt",
         "ericstj",
@@ -373,6 +383,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "akhil-carlos-viktor",
       "owners": [
         "bartonjs",
         "carlossanlop",
@@ -407,6 +418,7 @@
     },
     {
       "lead": "danmoseley",
+      "pod": "eric-jeff",
       "owners": [
         "danmoseley",
         "ericstj",
@@ -432,6 +444,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "akhil-carlos-viktor",
       "owners": [
         "carlossanlop",
         "ericstj",
@@ -511,6 +524,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "drew-michael-tanner",
       "owners": [
         "dakersnar",
         "ericstj",
@@ -523,6 +537,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "buyaa-jose-steve",
       "owners": [
         "buyaa-n",
         "ericstj",
@@ -534,6 +549,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "eirik-krzysztof-layomi",
       "owners": [
         "eiriktsarpalis",
         "ericstj",
@@ -546,6 +562,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "eerhardt",
         "ericstj",
@@ -557,6 +574,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "eerhardt",
         "ericstj",
@@ -576,6 +594,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "eerhardt",
         "ericstj",
@@ -587,6 +606,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "buyaa-jose-steve",
       "owners": [
         "buyaa-n",
         "ericstj",
@@ -598,6 +618,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "adam-david",
       "owners": [
         "adamsitnik",
         "ericstj",
@@ -671,6 +692,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "akhil-carlos-viktor",
       "owners": [
         "carlossanlop",
         "ericstj",
@@ -689,6 +711,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "akhil-carlos-viktor",
       "owners": [
         "carlossanlop",
         "ericstj",
@@ -700,6 +723,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "adam-david",
       "owners": [
         "adamsitnik",
         "ericstj",
@@ -719,6 +743,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "akhil-carlos-viktor",
       "owners": [
         "carlossanlop",
         "ericstj",
@@ -730,6 +755,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "buyaa-jose-steve",
       "owners": [
         "buyaa-n",
         "ericstj",
@@ -741,6 +767,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "akhil-carlos-viktor",
       "owners": [
         "carlossanlop",
         "ericstj",
@@ -760,6 +787,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "jeremy-levi",
       "owners": [
         "bartonjs",
         "ericstj",
@@ -770,6 +798,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "jeremy-levi",
       "owners": [
         "bartonjs",
         "eiriktsarpalis",
@@ -781,6 +810,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "eric-maryam-tarek",
       "owners": [
         "ericstj",
         "jeffhandley",
@@ -791,6 +821,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "adam-david",
       "owners": [
         "adamsitnik",
         "ericstj",
@@ -801,6 +832,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "adam-david",
       "owners": [
         "adamsitnik",
         "ericstj",
@@ -820,6 +852,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "eirik-krzysztof-layomi",
       "owners": [
         "eiriktsarpalis",
         "ericstj",
@@ -839,6 +872,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "adam-david",
       "owners": [
         "adamsitnik",
         "ericstj",
@@ -850,6 +884,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "akhil-carlos-viktor",
       "owners": [
         "carlossanlop",
         "ericstj",
@@ -861,6 +896,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "adam-david",
       "owners": [
         "adamsitnik",
         "ericstj",
@@ -872,6 +908,7 @@
     },
     {
       "lead": "karelz",
+      "pod": "networking",
       "owners": [
         "antonfirsov",
         "CarnaViire",
@@ -887,6 +924,7 @@
     },
     {
       "lead": "karelz",
+      "pod": "networking",
       "owners": [
         "antonfirsov",
         "CarnaViire",
@@ -902,6 +940,7 @@
     },
     {
       "lead": "karelz",
+      "pod": "networking",
       "owners": [
         "antonfirsov",
         "CarnaViire",
@@ -917,6 +956,7 @@
     },
     {
       "lead": "karelz",
+      "pod": "networking",
       "owners": [
         "antonfirsov",
         "CarnaViire",
@@ -932,6 +972,7 @@
     },
     {
       "lead": "karelz",
+      "pod": "networking",
       "owners": [
         "antonfirsov",
         "CarnaViire",
@@ -947,6 +988,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "drew-michael-tanner",
       "owners": [
         "dakersnar",
         "ericstj",
@@ -958,6 +1000,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "drew-michael-tanner",
       "owners": [
         "dakersnar",
         "ericstj",
@@ -969,6 +1012,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "buyaa-jose-steve",
       "owners": [
         "buyaa-n",
         "ericstj",
@@ -987,6 +1031,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "buyaa-jose-steve",
       "owners": [
         "buyaa-n",
         "ericstj",
@@ -998,6 +1043,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "buyaa-jose-steve",
       "owners": [
         "buyaa-n",
         "ericstj",
@@ -1009,6 +1055,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "buyaa-jose-steve",
       "owners": [
         "buyaa-n",
         "ericstj",
@@ -1021,6 +1068,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "drew-michael-tanner",
       "owners": [
         "dakersnar",
         "ericstj",
@@ -1040,6 +1088,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "buyaa-jose-steve",
       "owners": [
         "buyaa-n",
         "ericstj",
@@ -1066,6 +1115,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "drew-michael-tanner",
       "owners": [
         "dakersnar",
         "jeffhandley",
@@ -1076,6 +1126,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "jeremy-levi",
       "owners": [
         "bartonjs",
         "ericstj",
@@ -1103,6 +1154,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "akhil-carlos-viktor",
       "owners": [
         "carlossanlop",
         "ericstj",
@@ -1121,6 +1173,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "jeremy-levi",
       "owners": [
         "bartonjs",
         "ericstj",
@@ -1132,6 +1185,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "jeremy-levi",
       "owners": [
         "bartonjs",
         "ericstj",
@@ -1143,6 +1197,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "eirik-krzysztof-layomi",
       "owners": [
         "eiriktsarpalis",
         "ericstj",
@@ -1155,6 +1210,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "buyaa-jose-steve",
       "owners": [
         "buyaa-n",
         "ericstj",
@@ -1173,6 +1229,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "buyaa-jose-steve",
       "owners": [
         "buyaa-n",
         "ericstj",
@@ -1193,6 +1250,7 @@
     },
     {
       "lead": "ericstj",
+      "pod": "buyaa-jose-steve",
       "owners": [
         "buyaa-n",
         "ericstj",
@@ -1212,6 +1270,7 @@
     },
     {
       "lead": "jeffhandley",
+      "pod": "eirik-krzysztof-layomi",
       "owners": [
         "eiriktsarpalis",
         "ericstj",

--- a/docs/area-owners.json
+++ b/docs/area-owners.json
@@ -908,6 +908,7 @@
       "lead": "ericstj",
       "pod": "eric-maryam-tarek",
       "owners": [
+        "eerhardt",
         "ericstj",
         "jeffhandley",
         "maryamariyan",

--- a/docs/area-owners.json
+++ b/docs/area-owners.json
@@ -9,6 +9,67 @@
       "label": "arch-wasm"
     }
   ],
+  "operatingSystems": [
+    {
+      "lead": "",
+      "owners": [
+        ""
+      ],
+      "label": "os-alpine"
+    },
+    {
+      "lead": "steveisok",
+      "owners": [
+        "akoeplinger"
+      ],
+      "label": "os-android"
+    },
+    {
+      "lead": "",
+      "owners": [
+        ""
+      ],
+      "label": "os-freebsd"
+    },
+    {
+      "lead": "",
+      "owners": [
+        ""
+      ],
+      "label": "os-mac-os-x"
+    },
+    {
+      "lead": "steveisok",
+      "owners": [
+        ""
+      ],
+      "label": "os-maccatalyst"
+    },
+    {
+      "lead": "steveisok",
+      "owners": [
+        "vargaz"
+      ],
+      "label": "os-ios"
+    },
+    {
+      "lead": "alpencolt",
+      "owners": [
+        "clamp03",
+        "gbalykov",
+        "hjleee",
+        "wscho77"
+      ],
+      "label": "os-tizen"
+    },
+    {
+      "lead": "steveisok",
+      "owners": [
+        "vargaz"
+      ],
+      "label": "os-tvos"
+    }
+  ],
   "areas": [
     {
       "lead": "agocke",
@@ -38,7 +99,8 @@
       "owners": [
         "danmoseley",
         "jeffschwMSFT",
-        "marek-safar"
+        "marek-safar",
+        "dotnet/dnr-codeflow"
       ],
       "label": "area-Codeflow"
     },
@@ -62,7 +124,8 @@
         "kunalspathak",
         "markples",
         "SingleAccretion",
-        "TIHan"
+        "TIHan",
+        "dotnet/jit-contrib"
       ],
       "label": "area-CodeGen-coreclr"
     },
@@ -112,7 +175,8 @@
         "jkotas",
         "mangod9",
         "MichalStrehovsky",
-        "trylek"
+        "trylek",
+        "dotnet/crossgen-contrib"
       ],
       "label": "area-CrossGen/NGEN-coreclr"
     },
@@ -127,7 +191,8 @@
         "jkotas",
         "mangod9",
         "MichalStrehovsky",
-        "trylek"
+        "trylek",
+        "dotnet/crossgen-contrib"
       ],
       "label": "area-crossgen2-coreclr"
     },
@@ -147,7 +212,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-dependencymodel"
       ],
       "label": "area-DependencyModel"
     },
@@ -188,7 +254,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-extensions-caching"
       ],
       "label": "area-Extensions-Caching"
     },
@@ -200,7 +267,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-extensions-configuration"
       ],
       "label": "area-Extensions-Configuration"
     },
@@ -212,7 +280,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-extensions-dependencyinjection"
       ],
       "label": "area-Extensions-DependencyInjection"
     },
@@ -225,7 +294,8 @@
         "ericstj",
         "jeffhandley",
         "Jozkee",
-        "maryamariyan"
+        "maryamariyan",
+        "dotnet/area-extensions-filesystem"
       ],
       "label": "area-Extensions-FileSystem"
     },
@@ -237,7 +307,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-extensions-hosting"
       ],
       "label": "area-Extensions-Hosting"
     },
@@ -253,7 +324,8 @@
         "ManickaP",
         "MihaZupan",
         "rzikm",
-        "wfurt"
+        "wfurt",
+        "dotnet/ncl"
       ],
       "label": "area-Extensions-HttpClientFactory"
     },
@@ -265,7 +337,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-extensions-logging"
       ],
       "label": "area-Extensions-Logging"
     },
@@ -277,7 +350,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-extensions-options"
       ],
       "label": "area-Extensions-Options"
     },
@@ -289,7 +363,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-extensions-primitives"
       ],
       "label": "area-Extensions-Primitives"
     },
@@ -337,7 +412,8 @@
         "kunalspathak",
         "markples",
         "SingleAccretion",
-        "TIHan"
+        "TIHan",
+        "dotnet/jit-contrib"
       ],
       "label": "area-ILTools-coreclr"
     },
@@ -354,7 +430,8 @@
         "kunalspathak",
         "markples",
         "SingleAccretion",
-        "TIHan"
+        "TIHan",
+        "dotnet/jit-contrib"
       ],
       "label": "area-ILVerification"
     },
@@ -390,7 +467,8 @@
         "ericstj",
         "jeffhandley",
         "smasher164",
-        "ViktorHofer"
+        "ViktorHofer",
+        "dotnet/area-infrastructure-libraries"
       ],
       "label": "area-Infrastructure-libraries"
     },
@@ -422,7 +500,8 @@
       "owners": [
         "danmoseley",
         "ericstj",
-        "jeffhandley"
+        "jeffhandley",
+        "dotnet/area-meta"
       ],
       "label": "area-Meta"
     },
@@ -450,7 +529,8 @@
         "ericstj",
         "jeffhandley",
         "smasher164",
-        "ViktorHofer"
+        "ViktorHofer",
+        "dotnet/area-microsoft-win32"
       ],
       "label": "area-Microsoft.Win32"
     },
@@ -531,7 +611,8 @@
         "GrabYourPitchforks",
         "jeffhandley",
         "michaelgsharp",
-        "tannergooding"
+        "tannergooding",
+        "dotnet/area-system-buffers"
       ],
       "label": "area-System.Buffers"
     },
@@ -543,7 +624,8 @@
         "ericstj",
         "jeffhandley",
         "joperezr",
-        "steveharter"
+        "steveharter",
+        "dotnet/area-system-codedom"
       ],
       "label": "area-System.CodeDom"
     },
@@ -556,7 +638,8 @@
         "GrabYourPitchforks",
         "jeffhandley",
         "krwq",
-        "layomia"
+        "layomia",
+        "dotnet/area-system-collections"
       ],
       "label": "area-System.Collections"
     },
@@ -568,7 +651,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-system-componentmodel"
       ],
       "label": "area-System.ComponentModel"
     },
@@ -580,7 +664,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-system-componentmodel-composition"
       ],
       "label": "area-System.ComponentModel.Composition"
     },
@@ -600,7 +685,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-system-composition"
       ],
       "label": "area-System.Composition"
     },
@@ -612,7 +698,8 @@
         "ericstj",
         "jeffhandley",
         "joperezr",
-        "steveharter"
+        "steveharter",
+        "dotnet/area-system-configuration"
       ],
       "label": "area-System.Configuration"
     },
@@ -623,7 +710,8 @@
         "adamsitnik",
         "ericstj",
         "jeffhandley",
-        "Jozkee"
+        "Jozkee",
+        "dotnet/area-system-console"
       ],
       "label": "area-System.Console"
     },
@@ -698,7 +786,8 @@
         "ericstj",
         "jeffhandley",
         "smasher164",
-        "ViktorHofer"
+        "ViktorHofer",
+        "dotnet/area-system-diagnostics-eventlog"
       ],
       "label": "area-System.Diagnostics.EventLog"
     },
@@ -717,7 +806,8 @@
         "ericstj",
         "jeffhandley",
         "smasher164",
-        "ViktorHofer"
+        "ViktorHofer",
+        "dotnet/area-system-diagnostics-performancecounter"
       ],
       "label": "area-System.Diagnostics.PerformanceCounter"
     },
@@ -728,7 +818,8 @@
         "adamsitnik",
         "ericstj",
         "jeffhandley",
-        "Jozkee"
+        "Jozkee",
+        "dotnet/area-system-diagnostics-process"
       ],
       "label": "area-System.Diagnostics.Process"
     },
@@ -749,7 +840,8 @@
         "ericstj",
         "jeffhandley",
         "smasher164",
-        "ViktorHofer"
+        "ViktorHofer",
+        "dotnet/area-system-diagnostics-tracesource"
       ],
       "label": "area-System.Diagnostics.TraceSource"
     },
@@ -761,7 +853,8 @@
         "ericstj",
         "jeffhandley",
         "joperezr",
-        "steveharter"
+        "steveharter",
+        "dotnet/area-system-directoryservices"
       ],
       "label": "area-System.DirectoryServices"
     },
@@ -773,7 +866,8 @@
         "ericstj",
         "jeffhandley",
         "smasher164",
-        "ViktorHofer"
+        "ViktorHofer",
+        "dotnet/area-system-drawing"
       ],
       "label": "area-System.Drawing"
     },
@@ -792,7 +886,8 @@
         "bartonjs",
         "ericstj",
         "GrabYourPitchforks",
-        "jeffhandley"
+        "jeffhandley",
+        "dotnet/area-system-formats-asn1"
       ],
       "label": "area-System.Formats.Asn1"
     },
@@ -804,7 +899,8 @@
         "eiriktsarpalis",
         "ericstj",
         "GrabYourPitchforks",
-        "jeffhandley"
+        "jeffhandley",
+        "dotnet/area-system-formats-cbor"
       ],
       "label": "area-System.Formats.Cbor"
     },
@@ -815,7 +911,8 @@
         "ericstj",
         "jeffhandley",
         "maryamariyan",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-system-globalization"
       ],
       "label": "area-System.Globalization"
     },
@@ -826,7 +923,8 @@
         "adamsitnik",
         "ericstj",
         "jeffhandley",
-        "Jozkee"
+        "Jozkee",
+        "dotnet/area-system-io"
       ],
       "label": "area-System.IO"
     },
@@ -837,7 +935,8 @@
         "adamsitnik",
         "ericstj",
         "jeffhandley",
-        "Jozkee"
+        "Jozkee",
+        "dotnet/area-system-io-compression"
       ],
       "label": "area-System.IO.Compression"
     },
@@ -858,7 +957,8 @@
         "ericstj",
         "jeffhandley",
         "krwq",
-        "layomia"
+        "layomia",
+        "dotnet/area-system-linq"
       ],
       "label": "area-System.Linq"
     },
@@ -878,7 +978,8 @@
         "ericstj",
         "jeffhandley",
         "Jozkee",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-system-linq-parallel"
       ],
       "label": "area-System.Linq.Parallel"
     },
@@ -890,7 +991,8 @@
         "ericstj",
         "jeffhandley",
         "smasher164",
-        "ViktorHofer"
+        "ViktorHofer",
+        "dotnet/area-system-management"
       ],
       "label": "area-System.Management"
     },
@@ -902,7 +1004,8 @@
         "ericstj",
         "GrabYourPitchforks",
         "jeffhandley",
-        "Jozkee"
+        "Jozkee",
+        "dotnet/area-system-memory"
       ],
       "label": "area-System.Memory"
     },
@@ -918,7 +1021,8 @@
         "ManickaP",
         "MihaZupan",
         "rzikm",
-        "wfurt"
+        "wfurt",
+        "dotnet/ncl"
       ],
       "label": "area-System.Net"
     },
@@ -934,7 +1038,8 @@
         "ManickaP",
         "MihaZupan",
         "rzikm",
-        "wfurt"
+        "wfurt",
+        "dotnet/ncl"
       ],
       "label": "area-System.Net.Http"
     },
@@ -950,7 +1055,8 @@
         "ManickaP",
         "MihaZupan",
         "rzikm",
-        "wfurt"
+        "wfurt",
+        "dotnet/ncl"
       ],
       "label": "area-System.Net.Quic"
     },
@@ -966,7 +1072,8 @@
         "ManickaP",
         "MihaZupan",
         "rzikm",
-        "wfurt"
+        "wfurt",
+        "dotnet/ncl"
       ],
       "label": "area-System.Net.Security"
     },
@@ -982,7 +1089,8 @@
         "ManickaP",
         "MihaZupan",
         "rzikm",
-        "wfurt"
+        "wfurt",
+        "dotnet/ncl"
       ],
       "label": "area-System.Net.Sockets"
     },
@@ -994,7 +1102,8 @@
         "ericstj",
         "jeffhandley",
         "michaelgsharp",
-        "tannergooding"
+        "tannergooding",
+        "dotnet/area-system-numerics"
       ],
       "label": "area-System.Numerics"
     },
@@ -1006,7 +1115,8 @@
         "ericstj",
         "jeffhandley",
         "michaelgsharp",
-        "tannergooding"
+        "tannergooding",
+        "dotnet/area-system-numerics-tensors"
       ],
       "label": "area-System.Numerics.Tensors"
     },
@@ -1018,7 +1128,8 @@
         "ericstj",
         "jeffhandley",
         "joperezr",
-        "steveharter"
+        "steveharter",
+        "dotnet/area-system-reflection"
       ],
       "label": "area-System.Reflection"
     },
@@ -1037,7 +1148,8 @@
         "ericstj",
         "jeffhandley",
         "joperezr",
-        "steveharter"
+        "steveharter",
+        "dotnet/area-system-reflection-emit"
       ],
       "label": "area-System.Reflection.Emit"
     },
@@ -1049,7 +1161,8 @@
         "ericstj",
         "jeffhandley",
         "joperezr",
-        "steveharter"
+        "steveharter",
+        "dotnet/area-system-reflection-metadata"
       ],
       "label": "area-System.Reflection.Metadata"
     },
@@ -1062,7 +1175,8 @@
         "jeffhandley",
         "joperezr",
         "steveharter",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-system-resources"
       ],
       "label": "area-System.Resources"
     },
@@ -1074,7 +1188,8 @@
         "ericstj",
         "jeffhandley",
         "michaelgsharp",
-        "tannergooding"
+        "tannergooding",
+        "dotnet/area-system-runtime"
       ],
       "label": "area-System.Runtime"
     },
@@ -1094,7 +1209,8 @@
         "ericstj",
         "jeffhandley",
         "joperezr",
-        "steveharter"
+        "steveharter",
+        "dotnet/area-system-runtime-compilerservices"
       ],
       "label": "area-System.Runtime.CompilerServices"
     },
@@ -1120,7 +1236,8 @@
         "dakersnar",
         "jeffhandley",
         "michaelgsharp",
-        "tannergooding"
+        "tannergooding",
+        "dotnet/area-system-runtime-intrinsics"
       ],
       "label": "area-System.Runtime.Intrinsics"
     },
@@ -1132,7 +1249,8 @@
         "ericstj",
         "GrabYourPitchforks",
         "jeffhandley",
-        "krwq"
+        "krwq",
+        "dotnet/area-system-security"
       ],
       "label": "area-System.Security"
     },
@@ -1160,7 +1278,8 @@
         "ericstj",
         "jeffhandley",
         "smasher164",
-        "ViktorHofer"
+        "ViktorHofer",
+        "dotnet/area-system-serviceprocess"
       ],
       "label": "area-System.ServiceProcess"
     },
@@ -1179,7 +1298,8 @@
         "ericstj",
         "GrabYourPitchforks",
         "jeffhandley",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-system-text-encoding"
       ],
       "label": "area-System.Text.Encoding"
     },
@@ -1191,7 +1311,8 @@
         "ericstj",
         "GrabYourPitchforks",
         "jeffhandley",
-        "tarekgh"
+        "tarekgh",
+        "dotnet/area-system-text-encodings-web"
       ],
       "label": "area-System.Text.Encodings.Web"
     },
@@ -1204,7 +1325,8 @@
         "jeffhandley",
         "krwq",
         "layomia",
-        "steveharter"
+        "steveharter",
+        "dotnet/area-system-text-json"
       ],
       "label": "area-System.Text.Json"
     },
@@ -1216,7 +1338,8 @@
         "ericstj",
         "jeffhandley",
         "joperezr",
-        "steveharter"
+        "steveharter",
+        "dotnet/area-system-text-regularexpressions"
       ],
       "label": "area-System.Text.RegularExpressions"
     },
@@ -1236,7 +1359,8 @@
         "jeffhandley",
         "joperezr",
         "stephentoub",
-        "steveharter"
+        "steveharter",
+        "dotnet/area-system-threading-channels"
       ],
       "label": "area-System.Threading.Channels"
     },
@@ -1257,7 +1381,8 @@
         "jeffhandley",
         "joperezr",
         "stephentoub",
-        "steveharter"
+        "steveharter",
+        "dotnet/area-system-threading-tasks"
       ],
       "label": "area-System.Threading.Tasks"
     },
@@ -1276,7 +1401,8 @@
         "ericstj",
         "jeffhandley",
         "krwq",
-        "layomia"
+        "layomia",
+        "dotnet/area-system-xml"
       ],
       "label": "area-System.Xml"
     },
@@ -1339,67 +1465,6 @@
         "lambdageek"
       ],
       "label": "area-VM-meta-mono"
-    }
-  ],
-  "operatingSystems": [
-    {
-      "lead": "",
-      "owners": [
-        ""
-      ],
-      "label": "os-alpine"
-    },
-    {
-      "lead": "steveisok",
-      "owners": [
-        "akoeplinger"
-      ],
-      "label": "os-android"
-    },
-    {
-      "lead": "",
-      "owners": [
-        ""
-      ],
-      "label": "os-freebsd"
-    },
-    {
-      "lead": "",
-      "owners": [
-        ""
-      ],
-      "label": "os-mac-os-x"
-    },
-    {
-      "lead": "steveisok",
-      "owners": [
-        ""
-      ],
-      "label": "os-maccatalyst"
-    },
-    {
-      "lead": "steveisok",
-      "owners": [
-        "vargaz"
-      ],
-      "label": "os-ios"
-    },
-    {
-      "lead": "alpencolt",
-      "owners": [
-        "clamp03",
-        "gbalykov",
-        "hjleee",
-        "wscho77"
-      ],
-      "label": "os-tizen"
-    },
-    {
-      "lead": "steveisok",
-      "owners": [
-        "vargaz"
-      ],
-      "label": "os-tvos"
     }
   ]
 }


### PR DESCRIPTION
This pairs with terrajobst/issuesof.net#13 and add the ability to query issuesof.net using `area-pod:{podName}`.

By adding the pod name into this file, issuesof.net will index the pod names on areas that have them, and it uses the mapping of area label to pod name to enable querying and grouping by `area-pod`.

We start by just having the (first names, sorted alphabetically, joined by dashes) pod names. But area pods can give themselves nicknames if they want by updating their pod name in this file. This is illustrated by giving the name "networking" to @karelz's team's areas.

Per offline feedback, I also updated the [script](https://github.com/terrajobst/issuesof.net/pull/14) that generates this file so that the team names will be retained in the list of owners. That allows for `area-owner:dotnet/{teamname}` to work as well.