### PR TITLE
Fix hang caused by calling Environment.FailFast on multiple threads

### DIFF
--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -340,6 +340,7 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
     }
     else if (pPreviousThread != nullptr)
     {
+        GCX_PREEMP(); // Avoid blocking other threads that may be trying to suspend the runtime
         while (s_pCrashingThread != FatalErrorLoggingFinished)
         {
             ClrSleepEx(50, /*bAlertable*/ FALSE);


### PR DESCRIPTION
Fixes #72565