### PR TITLE
Clean up #nullable in source

### DIFF
--- a/src/libraries/Common/src/Extensions/ParameterDefaultValue/ParameterDefaultValue.cs
+++ b/src/libraries/Common/src/Extensions/ParameterDefaultValue/ParameterDefaultValue.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;

--- a/src/libraries/Common/src/Extensions/ParameterDefaultValue/ParameterDefaultValue.netcoreapp.cs
+++ b/src/libraries/Common/src/Extensions/ParameterDefaultValue/ParameterDefaultValue.netcoreapp.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;

--- a/src/libraries/Common/src/Extensions/ParameterDefaultValue/ParameterDefaultValue.netstandard.cs
+++ b/src/libraries/Common/src/Extensions/ParameterDefaultValue/ParameterDefaultValue.netstandard.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;

--- a/src/libraries/Common/src/Extensions/ProviderAliasUtilities/ProviderAliasUtilities.cs
+++ b/src/libraries/Common/src/Extensions/ProviderAliasUtilities/ProviderAliasUtilities.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/libraries/Common/src/Extensions/TypeNameHelper/TypeNameHelper.cs
+++ b/src/libraries/Common/src/Extensions/TypeNameHelper/TypeNameHelper.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Text;
 using System.Collections.Generic;

--- a/src/libraries/Common/src/Interop/OSX/System.Native/Interop.AutoreleasePool.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Native/Interop.AutoreleasePool.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SignVerify.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SignVerify.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Diagnostics;

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegQueryValueEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegQueryValueEx.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 #if REGISTRY_ASSEMBLY
 using Microsoft.Win32.SafeHandles;
 #else

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextProperty_NO_NULLABLE.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextProperty_NO_NULLABLE.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         internal static partial bool CertGetCertificateContextProperty(
             SafeCertContextHandle pCertContext,
             CertContextPropId dwPropId,
-            byte[] pvData,
+            byte[]? pvData,
             ref int pcbData);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateFileMapping.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateFileMapping.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Runtime.InteropServices;

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetComputerName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetComputerName.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeCertContextHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeCertContextHandle.cs
@@ -9,13 +9,12 @@ using static Interop.Crypt32;
 
 namespace Microsoft.Win32.SafeHandles
 {
-#nullable disable
     /// <summary>
     /// SafeHandle for the CERT_CONTEXT structure defined by crypt32.
     /// </summary>
     internal class SafeCertContextHandle : SafeCrypt32Handle<SafeCertContextHandle>
     {
-        private SafeCertContextHandle _parent;
+        private SafeCertContextHandle? _parent;
 
         public SafeCertContextHandle() { }
 

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeHandleCache.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeHandleCache.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;

--- a/src/libraries/Common/src/System/CodeDom/CodeObject.cs
+++ b/src/libraries/Common/src/System/CodeDom/CodeObject.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections;
 using System.Collections.Specialized;
 

--- a/src/libraries/Common/src/System/CodeDom/CodeTypeReference.cs
+++ b/src/libraries/Common/src/System/CodeDom/CodeTypeReference.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 
-#nullable enable
-
 #if CODEDOM
 namespace System.CodeDom
 #else

--- a/src/libraries/Common/src/System/Drawing/ColorConverterCommon.cs
+++ b/src/libraries/Common/src/System/Drawing/ColorConverterCommon.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System.Diagnostics;
 using System.Globalization;
 

--- a/src/libraries/Common/src/System/Drawing/ColorTable.cs
+++ b/src/libraries/Common/src/System/Drawing/ColorTable.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;

--- a/src/libraries/Common/src/System/LocalAppContextSwitches.Common.cs
+++ b/src/libraries/Common/src/System/LocalAppContextSwitches.Common.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System.Runtime.CompilerServices;
 
 namespace System

--- a/src/libraries/Common/src/System/Runtime/InteropServices/HandleRefMarshaller.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/HandleRefMarshaller.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Runtime.InteropServices.Marshalling

--- a/src/libraries/Common/src/System/SR.cs
+++ b/src/libraries/Common/src/System/SR.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System.Resources;
 
 namespace System

--- a/src/libraries/Common/src/System/Security/IdentityHelper.cs
+++ b/src/libraries/Common/src/System/Security/IdentityHelper.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;

--- a/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
+++ b/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/libraries/Common/tests/System/IO/ByteLoggingStream.cs
+++ b/src/libraries/Common/tests/System/IO/ByteLoggingStream.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/libraries/Common/tests/System/IO/ConnectedStreams.cs
+++ b/src/libraries/Common/tests/System/IO/ConnectedStreams.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;

--- a/src/libraries/Common/tests/System/IO/DelayStream.cs
+++ b/src/libraries/Common/tests/System/IO/DelayStream.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/libraries/Common/tests/TestUtilities/RandomTestCaseOrderer.cs
+++ b/src/libraries/Common/tests/TestUtilities/RandomTestCaseOrderer.cs
@@ -9,8 +9,6 @@ using System.Threading;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-#nullable enable
-
 namespace TestUtilities;
 
 // Based on https://github.com/xunit/xunit/blob/v2/src/xunit.execution/Sdk/DefaultTestCaseOrderer.cs

--- a/src/libraries/Common/tests/TestUtilities/RandomTestCollectionOrderer.cs
+++ b/src/libraries/Common/tests/TestUtilities/RandomTestCollectionOrderer.cs
@@ -7,8 +7,6 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-#nullable enable
-
 namespace TestUtilities;
 
 public class RandomTestCollectionOrderer : ITestCollectionOrderer

--- a/src/libraries/Common/tests/TestUtilities/System/ThreadCultureChange.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/ThreadCultureChange.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using System.Globalization;
 
 namespace System.Tests

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -95,8 +95,9 @@
     <!-- Enable documentation file generation by the compiler for all libraries except for vbproj. -->
     <GenerateDocumentationFile Condition="'$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' != '.vbproj'">true</GenerateDocumentationFile>
     <CLSCompliant Condition="'$(CLSCompliant)' == '' and '$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true'">true</CLSCompliant>
-    <!-- Nullability is enabled by default except for test projects. -->
-    <Nullable Condition="'$(Nullable)' == ''">enable</Nullable>
+    <!-- Nullability is enabled by default except for test projects, which instead default to annotations. -->
+    <Nullable Condition="'$(Nullable)' == '' and '$(IsTestProject)' != 'true'">enable</Nullable>
+    <Nullable Condition="'$(Nullable)' == '' and '$(IsTestProject)' == 'true'">annotations</Nullable>
   </PropertyGroup>
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <EditorConfigFiles Remove="$(RepositoryEngineeringDir)CodeAnalysis.src.globalconfig" />

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <EnableDefaultItems>true</EnableDefaultItems>
     <CLSCompliant>false</CLSCompliant>
     <IsTrimmable>false</IsTrimmable>

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -9,8 +9,6 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.Extensions.Hosting
 {
     internal sealed class HostFactoryResolver

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -958,9 +958,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 client.Service,
                 request.Properties[nameof(SingletonService)]);
 #else
-#nullable enable
             request.Options.TryGetValue(new HttpRequestOptionsKey<SingletonService>(nameof(SingletonService)), out SingletonService? optService);
-#nullable disable
+
             Assert.Same(
                 services.GetRequiredService<SingletonService>(),
                 optService);
@@ -1006,9 +1005,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     client.Service,
                     request.Properties[nameof(SingletonService)]);
 #else
-#nullable enable
                 request.Options.TryGetValue(new HttpRequestOptionsKey<SingletonService>(nameof(SingletonService)), out SingletonService? optService);
-#nullable disable
 
                 Assert.Same(
                     services.GetRequiredService<SingletonService>(),
@@ -1080,9 +1077,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     client.Service,
                     request.Properties[nameof(ScopedService)]);
 #else
-#nullable enable
                 request.Options.TryGetValue(new HttpRequestOptionsKey<ScopedService>(nameof(ScopedService)), out ScopedService? optService);
-#nullable disable
+
                 Assert.NotSame(
                     scope.ServiceProvider.GetRequiredService<ScopedService>(),
                     optService);
@@ -1127,9 +1123,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 client.Service,
                 request.Properties[nameof(TransientService)]);
 #else
-#nullable enable
             request.Options.TryGetValue(new HttpRequestOptionsKey<TransientService>(nameof(TransientService)), out TransientService? optService);
-#nullable disable
+
             Assert.NotSame(
                 services.GetRequiredService<TransientService>(),
                 optService);
@@ -1171,9 +1166,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     client.Service,
                     request.Properties[nameof(TransientService)]);
 #else
-#nullable enable
-            request.Options.TryGetValue(new HttpRequestOptionsKey<TransientService>(nameof(TransientService)), out TransientService? optService);
-#nullable disable
+                request.Options.TryGetValue(new HttpRequestOptionsKey<TransientService>(nameof(TransientService)), out TransientService? optService);
+
                 Assert.NotSame(
                     services.GetRequiredService<TransientService>(),
                     optService);

--- a/src/libraries/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
@@ -3,6 +3,7 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent);net48</TargetFrameworks>
     <Nullable>disable</Nullable> <!-- Disable nullable attributes as some tests depend on them not being present. -->
+    <NoWarn>$(NoWarn);nullable</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\ComponentModel\DataAnnotations\AssociatedMetadataTypeTypeDescriptionProviderTests.cs" />

--- a/src/libraries/System.ComponentModel.Composition.Registration/src/System.ComponentModel.Composition.Registration.csproj
+++ b/src/libraries/System.ComponentModel.Composition.Registration/src/System.ComponentModel.Composition.Registration.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.1</TargetFrameworks>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <IsTrimmable>false</IsTrimmable>
     <IsPackable>true</IsPackable>
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>

--- a/src/libraries/System.ComponentModel.Composition.Registration/tests/System.ComponentModel.Composition.Registration.Tests.csproj
+++ b/src/libraries/System.ComponentModel.Composition.Registration/tests/System.ComponentModel.Composition.Registration.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <Nullable>disable</Nullable> <!-- Disable nullable attributes as some tests depend on them not being present. -->
+    <NoWarn>$(NoWarn);nullable</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InternalCalls.cs" />

--- a/src/libraries/System.Composition.AttributedModel/src/System.Composition.AttributedModel.csproj
+++ b/src/libraries/System.Composition.AttributedModel/src/System.Composition.AttributedModel.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides common attributes used by System.Composition types.

--- a/src/libraries/System.Composition.Convention/src/System.Composition.Convention.csproj
+++ b/src/libraries/System.Composition.Convention/src/System.Composition.Convention.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <IsTrimmable>false</IsTrimmable>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsPackable>true</IsPackable>

--- a/src/libraries/System.Composition.Hosting/src/System.Composition.Hosting.csproj
+++ b/src/libraries/System.Composition.Hosting/src/System.Composition.Hosting.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <IsTrimmable>false</IsTrimmable>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsPackable>true</IsPackable>

--- a/src/libraries/System.Composition.Runtime/src/System.Composition.Runtime.csproj
+++ b/src/libraries/System.Composition.Runtime/src/System.Composition.Runtime.csproj
@@ -3,6 +3,7 @@
     <RootNamespace>System.Composition</RootNamespace>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsPackable>true</IsPackable>
     <PackageDescription>Contains runtime components of the Managed Extensibility Framework.

--- a/src/libraries/System.Composition.TypedParts/src/System.Composition.TypedParts.csproj
+++ b/src/libraries/System.Composition.TypedParts/src/System.Composition.TypedParts.csproj
@@ -3,6 +3,7 @@
     <RootNamespace>System.Composition</RootNamespace>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <IsTrimmable>false</IsTrimmable>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsPackable>true</IsPackable>

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <!-- opt-out of trimming until it works https://github.com/dotnet/runtime/issues/49062 -->
     <IsTrimmable>false</IsTrimmable>
     <NoWarn>$(NoWarn);CA1847</NoWarn>

--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DbConnectionTests.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DbConnectionTests.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading;

--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DbDataReaderMock.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DbDataReaderMock.cs
@@ -24,8 +24,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable enable
-
 using System.Collections;
 using System.Linq;
 using System.Data.Common;

--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DbDataReaderTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DbDataReaderTest.cs
@@ -21,8 +21,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#nullable enable
-
 using System.Linq;
 using System.IO;
 using System.Threading;

--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DbExceptionTests.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DbExceptionTests.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Xunit;
 
 namespace System.Data.Common.Tests

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicDependencyAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicDependencyAttribute.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/RequiresUnreferencedCodeAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/RequiresUnreferencedCodeAttribute.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>Specifies the syntax used in a string.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/UnconditionalSuppressMessageAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/UnconditionalSuppressMessageAttribute.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/LibraryImportAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/LibraryImportAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace System.Runtime.InteropServices
 {
     /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/CustomMarshallerAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/CustomMarshallerAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-#nullable enable
 
 namespace System.Runtime.InteropServices.Marshalling
 {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/Http/HttpRequestMessageTest.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/Http/HttpRequestMessageTest.cs
@@ -18,9 +18,7 @@ namespace System.Runtime.InteropServices.JavaScript.Http.Tests
     {
         private readonly Version _expectedRequestMessageVersion = HttpVersion.Version11;
         private HttpRequestOptionsKey<bool> EnableStreamingResponse = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse");
-#nullable enable
         private HttpRequestOptionsKey<IDictionary<string, object?>> FetchOptions = new HttpRequestOptionsKey<IDictionary<string, object?>>("WebAssemblyFetchOptions");
-#nullable disable
 
         [Fact]
         public void Ctor_Default_CorrectDefaults()
@@ -166,7 +164,6 @@ namespace System.Runtime.InteropServices.JavaScript.Http.Tests
             Assert.NotNull(rm.Options);
         }
 
-#nullable enable
         [Theory]
         [InlineData("https://example.com")]
         [InlineData("blob:https://example.com")]
@@ -208,9 +205,7 @@ namespace System.Runtime.InteropServices.JavaScript.Http.Tests
                 }
             }
         }
-#nullable disable
 
-#nullable enable
         [Theory]
         [InlineData("https://example.com")]
         [InlineData("blob:https://example.com")]
@@ -239,7 +234,7 @@ namespace System.Runtime.InteropServices.JavaScript.Http.Tests
             rm.Options.TryGetValue(FetchOptions, out IDictionary<string, object?>? fetchOptionsValue);
             Assert.Null(fetchOptionsValue);
         }
-#nullable disable
+
         [Theory]
         [InlineData("https://example.com")]
         [InlineData("blob:https://example.com")]
@@ -465,10 +460,8 @@ namespace System.Runtime.InteropServices.JavaScript.Http.Tests
                 throw new NotImplementedException();
             }
 
-#nullable enable
             protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
             {
-#nullable disable
                 throw new NotImplementedException();
             }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlEncodedRawTextWriter.cs
@@ -4,9 +4,9 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify HtmlRawTextWriterGenerator.ttinclude
 
-#nullable disable
 using System.IO;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Xml
 {
@@ -19,7 +19,7 @@ namespace System.Xml
         private bool _endsWithAmpersand;
         private byte[] _uriEscapingBuffer;
 
-        private string _mediaType;
+        private string? _mediaType;
         private bool _doNotEscapeUriAttributes;
 
         private const int StackIncrement = 10;
@@ -45,7 +45,7 @@ namespace System.Xml
         }
 
         /// Html rules allow public ID without system ID and always output "html"
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             Debug.Assert(name != null && name.Length > 0);
 
@@ -92,7 +92,7 @@ namespace System.Xml
         }
 
         // For the HTML element, it should call this method with ns and prefix as String.Empty
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
@@ -283,7 +283,7 @@ namespace System.Xml
         //          output amp;
         //     }
         //
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
@@ -351,7 +351,7 @@ namespace System.Xml
         }
 
         // HTML PI's use ">" to terminate rather than "?>".
-        public override void WriteProcessingInstruction(string target, string text)
+        public override void WriteProcessingInstruction(string target, string? text)
         {
             Debug.Assert(target != null && target.Length != 0 && text != null);
 
@@ -373,7 +373,7 @@ namespace System.Xml
         }
 
         // Serialize either attribute or element text using HTML rules.
-        public override unsafe void WriteString(string text)
+        public override unsafe void WriteString(string? text)
         {
             Debug.Assert(text != null);
 
@@ -433,6 +433,8 @@ namespace System.Xml
         // Private methods
         //
 
+        [MemberNotNull(nameof(_elementScope))]
+        [MemberNotNull(nameof(_uriEscapingBuffer))]
         private void Init(XmlWriterSettings settings)
         {
             Debug.Assert((int)ElementProperties.URI_PARENT == (int)AttributeProperties.URI);
@@ -456,7 +458,7 @@ namespace System.Xml
             base.RawText(" content=\"");
             base.RawText(_mediaType);
             base.RawText("; charset=");
-            base.RawText(base._encoding.WebName);
+            base.RawText(base._encoding!.WebName);
             base.RawText("\">");
         }
 
@@ -801,7 +803,7 @@ namespace System.Xml
         /// <summary>
         /// Serialize the document type declaration.
         /// </summary>
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             base.WriteDocType(name, pubid, sysid, subset);
 
@@ -809,7 +811,7 @@ namespace System.Xml
             _endBlockPos = base._bufPos;
         }
 
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
@@ -872,7 +874,7 @@ namespace System.Xml
             }
         }
 
-        internal override void WriteEndElement(string prefix, string localName, string ns)
+        internal override void WriteEndElement(string? prefix, string localName, string? ns)
         {
             bool isBlockWs;
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
@@ -904,7 +906,7 @@ namespace System.Xml
             }
         }
 
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             if (_newLineOnAttributes)
             {
@@ -926,6 +928,7 @@ namespace System.Xml
         //
         // Private methods
         //
+        [MemberNotNull(nameof(_indentChars))]
         private void Init(XmlWriterSettings settings)
         {
             _indentLevel = 0;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlRawTextWriterGenerator.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlRawTextWriterGenerator.ttinclude
@@ -5,9 +5,9 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify HtmlRawTextWriterGenerator.ttinclude
 
-#nullable disable
 using System.IO;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Xml
 {
@@ -20,7 +20,7 @@ namespace System.Xml
         private bool _endsWithAmpersand;
         private byte[] _uriEscapingBuffer;
 
-        private string _mediaType;
+        private string? _mediaType;
         private bool _doNotEscapeUriAttributes;
 
         private const int StackIncrement = 10;
@@ -48,7 +48,7 @@ namespace System.Xml
         }
 
         /// Html rules allow public ID without system ID and always output "html"
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             Debug.Assert(name != null && name.Length > 0);<#
 /* Code block is to squash extra line. */
@@ -95,7 +95,7 @@ namespace System.Xml
         }
 
         // For the HTML element, it should call this method with ns and prefix as String.Empty
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
@@ -286,7 +286,7 @@ namespace System.Xml
         //          output amp;
         //     }
         //
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
@@ -354,7 +354,7 @@ namespace System.Xml
         }
 
         // HTML PI's use ">" to terminate rather than "?>".
-        public override void WriteProcessingInstruction(string target, string text)
+        public override void WriteProcessingInstruction(string target, string? text)
         {
             Debug.Assert(target != null && target.Length != 0 && text != null);<#
 
@@ -376,7 +376,7 @@ namespace System.Xml
         }
 
         // Serialize either attribute or element text using HTML rules.
-        public override unsafe void WriteString(string text)
+        public override unsafe void WriteString(string? text)
         {
             Debug.Assert(text != null);<#
 
@@ -435,7 +435,9 @@ namespace System.Xml
         //
         // Private methods
         //
-
+        
+        [MemberNotNull(nameof(_elementScope))]
+        [MemberNotNull(nameof(_uriEscapingBuffer))]
         private void Init(XmlWriterSettings settings)
         {
             Debug.Assert((int)ElementProperties.URI_PARENT == (int)AttributeProperties.URI);
@@ -462,7 +464,7 @@ namespace System.Xml
             base.RawText(" content=\"");
             base.RawText(_mediaType);
             base.RawText("; charset=");
-            base.RawText(base._encoding.WebName);
+            base.RawText(base._encoding!.WebName);
             base.RawText("\">");
         }
 
@@ -813,7 +815,7 @@ namespace System.Xml
         /// <summary>
         /// Serialize the document type declaration.
         /// </summary>
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             base.WriteDocType(name, pubid, sysid, subset);
 
@@ -821,7 +823,7 @@ namespace System.Xml
             _endBlockPos = base._bufPos;
         }
 
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);<#
 
@@ -884,7 +886,7 @@ namespace System.Xml
             }
         }
 
-        internal override void WriteEndElement(string prefix, string localName, string ns)
+        internal override void WriteEndElement(string? prefix, string localName, string? ns)
         {
             bool isBlockWs;
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
@@ -916,7 +918,7 @@ namespace System.Xml
             }
         }
 
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             if (_newLineOnAttributes)
             {
@@ -938,6 +940,7 @@ namespace System.Xml
         //
         // Private methods
         //
+        [MemberNotNull(nameof(_indentChars))]
         private void Init(XmlWriterSettings settings)
         {
             _indentLevel = 0;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlUtf8RawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlUtf8RawTextWriter.cs
@@ -4,9 +4,9 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify HtmlRawTextWriterGenerator.ttinclude
 
-#nullable disable
 using System.IO;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Xml
 {
@@ -19,7 +19,7 @@ namespace System.Xml
         private bool _endsWithAmpersand;
         private byte[] _uriEscapingBuffer;
 
-        private string _mediaType;
+        private string? _mediaType;
         private bool _doNotEscapeUriAttributes;
 
         private const int StackIncrement = 10;
@@ -40,7 +40,7 @@ namespace System.Xml
         }
 
         /// Html rules allow public ID without system ID and always output "html"
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             Debug.Assert(name != null && name.Length > 0);
 
@@ -85,7 +85,7 @@ namespace System.Xml
         }
 
         // For the HTML element, it should call this method with ns and prefix as String.Empty
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
@@ -270,7 +270,7 @@ namespace System.Xml
         //          output amp;
         //     }
         //
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
@@ -334,7 +334,7 @@ namespace System.Xml
         }
 
         // HTML PI's use ">" to terminate rather than "?>".
-        public override void WriteProcessingInstruction(string target, string text)
+        public override void WriteProcessingInstruction(string target, string? text)
         {
             Debug.Assert(target != null && target.Length != 0 && text != null);
 
@@ -354,7 +354,7 @@ namespace System.Xml
         }
 
         // Serialize either attribute or element text using HTML rules.
-        public override unsafe void WriteString(string text)
+        public override unsafe void WriteString(string? text)
         {
             Debug.Assert(text != null);
 
@@ -410,6 +410,8 @@ namespace System.Xml
         // Private methods
         //
 
+        [MemberNotNull(nameof(_elementScope))]
+        [MemberNotNull(nameof(_uriEscapingBuffer))]
         private void Init(XmlWriterSettings settings)
         {
             Debug.Assert((int)ElementProperties.URI_PARENT == (int)AttributeProperties.URI);
@@ -773,7 +775,7 @@ namespace System.Xml
         /// <summary>
         /// Serialize the document type declaration.
         /// </summary>
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             base.WriteDocType(name, pubid, sysid, subset);
 
@@ -781,7 +783,7 @@ namespace System.Xml
             _endBlockPos = base._bufPos;
         }
 
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
@@ -842,7 +844,7 @@ namespace System.Xml
             }
         }
 
-        internal override void WriteEndElement(string prefix, string localName, string ns)
+        internal override void WriteEndElement(string? prefix, string localName, string? ns)
         {
             bool isBlockWs;
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
@@ -874,7 +876,7 @@ namespace System.Xml
             }
         }
 
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             if (_newLineOnAttributes)
             {
@@ -896,6 +898,7 @@ namespace System.Xml
         //
         // Private methods
         //
+        [MemberNotNull(nameof(_indentChars))]
         private void Init(XmlWriterSettings settings)
         {
             _indentLevel = 0;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/TextEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/TextEncodedRawTextWriter.cs
@@ -4,7 +4,6 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify TextRawTextWriterGenerator.ttinclude
 
-#nullable disable
 using System;
 using System.IO;
 using System.Text;
@@ -43,20 +42,20 @@ namespace System.Xml
         }
 
         // Ignore DTD
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
         }
 
         // Ignore Elements
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
         }
 
-        internal override void WriteEndElement(string prefix, string localName, string ns)
+        internal override void WriteEndElement(string? prefix, string localName, string? ns)
         {
         }
 
-        internal override void WriteFullEndElement(string prefix, string localName, string ns)
+        internal override void WriteFullEndElement(string prefix, string localName, string? ns)
         {
         }
 
@@ -65,7 +64,7 @@ namespace System.Xml
         }
 
         // Ignore attributes
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             base._inAttributeValue = true;
         }
@@ -89,18 +88,18 @@ namespace System.Xml
         }
 
         // Output content of CDATA sections as plain text without escaping
-        public override void WriteCData(string text)
+        public override void WriteCData(string? text)
         {
-            base.WriteRaw(text);
+            base.WriteRaw(text!);
         }
 
         // Ignore comments
-        public override void WriteComment(string text)
+        public override void WriteComment(string? text)
         {
         }
 
         // Ignore processing instructions
-        public override void WriteProcessingInstruction(string name, string text)
+        public override void WriteProcessingInstruction(string name, string? text)
         {
         }
 
@@ -116,20 +115,20 @@ namespace System.Xml
         }
 
         // Output text content without any escaping; ignore attribute values
-        public override void WriteWhitespace(string ws)
+        public override void WriteWhitespace(string? ws)
         {
             if (!base._inAttributeValue)
             {
-                base.WriteRaw(ws);
+                base.WriteRaw(ws!);
             }
         }
 
         // Output text content without any escaping; ignore attribute values
-        public override void WriteString(string textBlock)
+        public override void WriteString(string? textBlock)
         {
             if (!base._inAttributeValue)
             {
-                base.WriteRaw(textBlock);
+                base.WriteRaw(textBlock!);
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/TextRawTextWriterGenerator.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/TextRawTextWriterGenerator.ttinclude
@@ -5,7 +5,6 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify TextRawTextWriterGenerator.ttinclude
 
-#nullable disable
 using System;
 using System.IO;
 using System.Text;
@@ -46,12 +45,12 @@ namespace System.Xml
         }
 
         // Ignore DTD
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
         }
 
         // Ignore Elements
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string ns)
         {
         }
 
@@ -68,7 +67,7 @@ namespace System.Xml
         }
 
         // Ignore attributes
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             base._inAttributeValue = true;
         }
@@ -92,18 +91,18 @@ namespace System.Xml
         }
 
         // Output content of CDATA sections as plain text without escaping
-        public override void WriteCData(string text)
+        public override void WriteCData(string? text)
         {
-            base.WriteRaw(text);
+            base.WriteRaw(text!);
         }
 
         // Ignore comments
-        public override void WriteComment(string text)
+        public override void WriteComment(string? text)
         {
         }
 
         // Ignore processing instructions
-        public override void WriteProcessingInstruction(string name, string text)
+        public override void WriteProcessingInstruction(string name, string? text)
         {
         }
 
@@ -119,20 +118,20 @@ namespace System.Xml
         }
 
         // Output text content without any escaping; ignore attribute values
-        public override void WriteWhitespace(string ws)
+        public override void WriteWhitespace(string? ws)
         {
             if (!base._inAttributeValue)
             {
-                base.WriteRaw(ws);
+                base.WriteRaw(ws!);
             }
         }
 
         // Output text content without any escaping; ignore attribute values
-        public override void WriteString(string textBlock)
+        public override void WriteString(string? textBlock)
         {
             if (!base._inAttributeValue)
             {
-                base.WriteRaw(textBlock);
+                base.WriteRaw(textBlock!);
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/TextUtf8RawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/TextUtf8RawTextWriter.cs
@@ -4,7 +4,6 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify TextRawTextWriterGenerator.ttinclude
 
-#nullable disable
 using System;
 using System.IO;
 using System.Text;
@@ -38,12 +37,12 @@ namespace System.Xml
         }
 
         // Ignore DTD
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
         }
 
         // Ignore Elements
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
         }
 
@@ -60,7 +59,7 @@ namespace System.Xml
         }
 
         // Ignore attributes
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             base._inAttributeValue = true;
         }
@@ -84,18 +83,18 @@ namespace System.Xml
         }
 
         // Output content of CDATA sections as plain text without escaping
-        public override void WriteCData(string text)
+        public override void WriteCData(string? text)
         {
-            base.WriteRaw(text);
+            base.WriteRaw(text!);
         }
 
         // Ignore comments
-        public override void WriteComment(string text)
+        public override void WriteComment(string? text)
         {
         }
 
         // Ignore processing instructions
-        public override void WriteProcessingInstruction(string name, string text)
+        public override void WriteProcessingInstruction(string name, string? text)
         {
         }
 
@@ -111,20 +110,20 @@ namespace System.Xml
         }
 
         // Output text content without any escaping; ignore attribute values
-        public override void WriteWhitespace(string ws)
+        public override void WriteWhitespace(string? ws)
         {
             if (!base._inAttributeValue)
             {
-                base.WriteRaw(ws);
+                base.WriteRaw(ws!);
             }
         }
 
         // Output text content without any escaping; ignore attribute values
-        public override void WriteString(string textBlock)
+        public override void WriteString(string? textBlock)
         {
             if (!base._inAttributeValue)
             {
-                base.WriteRaw(textBlock);
+                base.WriteRaw(textBlock!);
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -4,11 +4,11 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify XmlRawTextWriterGenerator.ttinclude
 
-#nullable disable
 using System.IO;
 using System.Text;
 using System.Diagnostics;
 using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Xml
 {
@@ -24,13 +24,13 @@ namespace System.Xml
         private readonly bool _useAsync;
 
         // main buffer
-        protected byte[] _bufBytes;
+        protected byte[]? _bufBytes;
 
         // output stream
-        protected Stream _stream;
+        protected Stream? _stream;
 
         // encoding of the stream or text writer
-        protected Encoding _encoding;
+        protected Encoding? _encoding;
 
         // buffer positions
         protected int _bufPos = 1;     // buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
@@ -46,21 +46,21 @@ namespace System.Xml
         protected bool _hadDoubleBracket;
         protected bool _inAttributeValue;
         protected int _bufBytesUsed;
-        protected char[] _bufChars;
+        protected char[] _bufChars = null!;
 
         // encoder for encoding chars in specified encoding when writing to stream
-        protected Encoder _encoder;
+        protected Encoder? _encoder;
 
         // output text writer
-        protected TextWriter _writer;
+        protected TextWriter? _writer;
 
         // escaping of characters invalid in the output encoding
         protected bool _trackTextContent;
         protected bool _inTextContent;
         private int _lastMarkPos;
-        private int[] _textContentMarks;   // even indices contain text content start positions
+        private int[]? _textContentMarks;   // even indices contain text content start positions
                                            // odd indices contain markup start positions
-        private readonly CharEntityEncoderFallback _charEntityFallback;
+        private readonly CharEntityEncoderFallback? _charEntityFallback;
 
         // writer settings
         protected NewLineHandling _newLineHandling;
@@ -191,7 +191,7 @@ namespace System.Xml
             {
                 XmlWriterSettings settings = new XmlWriterSettings();
 
-                settings.Encoding = _encoding;
+                settings.Encoding = _encoding!;
                 settings.OmitXmlDeclaration = _omitXmlDeclaration;
                 settings.NewLineHandling = _newLineHandling;
                 settings.NewLineChars = _newLineChars;
@@ -248,7 +248,7 @@ namespace System.Xml
         }
 
         // Serialize the document type declaration.
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             Debug.Assert(name != null && name.Length > 0);
 
@@ -289,7 +289,7 @@ namespace System.Xml
         }
 
         // Serialize the beginning of an element start tag: "<prefix:localName"
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
@@ -373,7 +373,7 @@ namespace System.Xml
         }
 
         // Serialize an attribute tag using double quotes around the attribute value: 'prefix:localName="'
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
@@ -458,7 +458,7 @@ namespace System.Xml
 
         // Serialize a CData section.  If the "]]>" pattern is found within
         // the text, replace it with "]]><![CDATA[>".
-        public override void WriteCData(string text)
+        public override void WriteCData(string? text)
         {
             Debug.Assert(text != null);
 
@@ -495,7 +495,7 @@ namespace System.Xml
         }
 
         // Serialize a comment.
-        public override void WriteComment(string text)
+        public override void WriteComment(string? text)
         {
             Debug.Assert(text != null);
 
@@ -514,7 +514,7 @@ namespace System.Xml
         }
 
         // Serialize a processing instruction.
-        public override void WriteProcessingInstruction(string name, string text)
+        public override void WriteProcessingInstruction(string name, string? text)
         {
             Debug.Assert(name != null && name.Length > 0);
             Debug.Assert(text != null);
@@ -583,7 +583,7 @@ namespace System.Xml
 
         // Serialize a whitespace node.
 
-        public override unsafe void WriteWhitespace(string ws)
+        public override unsafe void WriteWhitespace(string? ws)
         {
             Debug.Assert(ws != null);
 
@@ -605,7 +605,7 @@ namespace System.Xml
 
         // Serialize either attribute or element text using XML rules.
 
-        public override unsafe void WriteString(string text)
+        public override unsafe void WriteString(string? text)
         {
             Debug.Assert(text != null);
 
@@ -789,21 +789,21 @@ namespace System.Xml
                     {
                         if (_trackTextContent)
                         {
-                            _charEntityFallback.Reset(_textContentMarks, _lastMarkPos);
+                            _charEntityFallback!.Reset(_textContentMarks!, _lastMarkPos);
                             // reset text content tracking
 
                             if ((_lastMarkPos & 1) != 0)
                             {
                                 // If the previous buffer ended inside a text content we need to preserve that info
                                 //   which means the next index to which we write has to be even
-                                _textContentMarks[1] = 1;
+                                _textContentMarks![1] = 1;
                                 _lastMarkPos = 1;
                             }
                             else
                             {
                                 _lastMarkPos = 0;
                             }
-                            Debug.Assert(_textContentMarks[0] == 1);
+                            Debug.Assert(_textContentMarks![0] == 1);
                         }
                         EncodeChars(1, _bufPos, true);
                     }
@@ -812,7 +812,7 @@ namespace System.Xml
                         if (_bufPos - 1 > 0)
                         {
                             // Write text to TextWriter
-                            _writer.Write(_bufChars, 1, _bufPos - 1);
+                            _writer!.Write(_bufChars, 1, _bufPos - 1);
                         }
                     }
                 }
@@ -849,18 +849,18 @@ namespace System.Xml
                 {
                     _charEntityFallback.StartOffset = startOffset;
                 }
-                _encoder.Convert(_bufChars, startOffset, endOffset - startOffset, _bufBytes, _bufBytesUsed, _bufBytes.Length - _bufBytesUsed, false, out chEnc, out bEnc, out _);
+                _encoder!.Convert(_bufChars, startOffset, endOffset - startOffset, _bufBytes!, _bufBytesUsed, _bufBytes!.Length - _bufBytesUsed, false, out chEnc, out bEnc, out _);
                 startOffset += chEnc;
                 _bufBytesUsed += bEnc;
                 if (_bufBytesUsed >= (_bufBytes.Length - 16))
                 {
-                    _stream.Write(_bufBytes, 0, _bufBytesUsed);
+                    _stream!.Write(_bufBytes, 0, _bufBytesUsed);
                     _bufBytesUsed = 0;
                 }
             }
             if (writeAllToStream && _bufBytesUsed > 0)
             {
-                _stream.Write(_bufBytes, 0, _bufBytesUsed);
+                _stream!.Write(_bufBytes!, 0, _bufBytesUsed);
                 _bufBytesUsed = 0;
             }
         }
@@ -872,7 +872,7 @@ namespace System.Xml
             {
                 int bEnc;
                 // decode no chars, just flush
-                _encoder.Convert(_bufChars, 1, 0, _bufBytes, 0, _bufBytes.Length, true, out _, out bEnc, out _);
+                _encoder!.Convert(_bufChars, 1, 0, _bufBytes!, 0, _bufBytes!.Length, true, out _, out bEnc, out _);
                 if (bEnc != 0)
                 {
                     _stream.Write(_bufBytes, 0, bEnc);
@@ -1681,7 +1681,7 @@ namespace System.Xml
             Debug.Assert(_inTextContent != value);
             Debug.Assert(_inTextContent || ((_lastMarkPos & 1) == 0));
             _inTextContent = value;
-            if (_lastMarkPos + 1 == _textContentMarks.Length)
+            if (_lastMarkPos + 1 == _textContentMarks!.Length)
             {
                 GrowTextContentMarks();
             }
@@ -1690,7 +1690,7 @@ namespace System.Xml
 
         private void GrowTextContentMarks()
         {
-            Debug.Assert(_lastMarkPos + 1 == _textContentMarks.Length);
+            Debug.Assert(_lastMarkPos + 1 == _textContentMarks!.Length);
             int[] newTextContentMarks = new int[_textContentMarks.Length * 2];
             Array.Copy(_textContentMarks, newTextContentMarks, _textContentMarks.Length);
             _textContentMarks = newTextContentMarks;
@@ -1943,7 +1943,7 @@ namespace System.Xml
             }
         }
 
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             // Add indentation
             if (!_mixedContent && base._textPos != base._bufPos)
@@ -1953,7 +1953,7 @@ namespace System.Xml
             base.WriteDocType(name, pubid, sysid, subset);
         }
 
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
@@ -2026,7 +2026,7 @@ namespace System.Xml
         }
 
         // Same as base class, plus possible indentation.
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             // Add indentation
             if (_newLineOnAttributes)
@@ -2037,13 +2037,13 @@ namespace System.Xml
             base.WriteStartAttribute(prefix, localName, ns);
         }
 
-        public override void WriteCData(string text)
+        public override void WriteCData(string? text)
         {
             _mixedContent = true;
             base.WriteCData(text);
         }
 
-        public override void WriteComment(string text)
+        public override void WriteComment(string? text)
         {
             if (!_mixedContent && base._textPos != base._bufPos)
             {
@@ -2053,7 +2053,7 @@ namespace System.Xml
             base.WriteComment(text);
         }
 
-        public override void WriteProcessingInstruction(string target, string text)
+        public override void WriteProcessingInstruction(string target, string? text)
         {
             if (!_mixedContent && base._textPos != base._bufPos)
             {
@@ -2081,13 +2081,13 @@ namespace System.Xml
             base.WriteSurrogateCharEntity(lowChar, highChar);
         }
 
-        public override void WriteWhitespace(string ws)
+        public override void WriteWhitespace(string? ws)
         {
             _mixedContent = true;
             base.WriteWhitespace(ws);
         }
 
-        public override void WriteString(string text)
+        public override void WriteString(string? text)
         {
             _mixedContent = true;
             base.WriteString(text);
@@ -2120,6 +2120,8 @@ namespace System.Xml
         //
         // Private methods
         //
+        [MemberNotNull(nameof(_indentChars))]
+        [MemberNotNull(nameof(_mixedContentStack))]
         private void Init(XmlWriterSettings settings)
         {
             _indentLevel = 0;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
@@ -4,7 +4,6 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify XmlRawTextWriterGeneratorAsync.ttinclude
 
-#nullable disable
 using System;
 using System.IO;
 using System.Xml;
@@ -101,7 +100,7 @@ namespace System.Xml
                         }
                         finally
                         {
-                            _stream = null;
+                            _stream = null!;
                         }
                     }
                 }
@@ -122,7 +121,7 @@ namespace System.Xml
                         }
                         finally
                         {
-                            _writer = null;
+                            _writer = null!;
                         }
                     }
                 }
@@ -130,7 +129,7 @@ namespace System.Xml
         }
 
         // Serialize the document type declaration.
-        public override async Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset)
+        public override async Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
         {
             CheckAsyncCall();
             Debug.Assert(name != null && name.Length > 0);
@@ -172,7 +171,7 @@ namespace System.Xml
         }
 
         // Serialize the beginning of an element start tag: "<prefix:localName"
-        public override Task WriteStartElementAsync(string prefix, string localName, string ns)
+        public override Task WriteStartElementAsync(string? prefix, string localName, string? ns)
         {
             CheckAsyncCall();
             Debug.Assert(localName != null && localName.Length > 0);
@@ -257,7 +256,7 @@ namespace System.Xml
         }
 
         // Serialize an attribute tag using double quotes around the attribute value: 'prefix:localName="'
-        protected internal override Task WriteStartAttributeAsync(string prefix, string localName, string ns)
+        protected internal override Task WriteStartAttributeAsync(string? prefix, string localName, string? ns)
         {
             CheckAsyncCall();
             Debug.Assert(localName != null && localName.Length > 0);
@@ -352,7 +351,7 @@ namespace System.Xml
 
         // Serialize a CData section.  If the "]]>" pattern is found within
         // the text, replace it with "]]><![CDATA[>".
-        public override async Task WriteCDataAsync(string text)
+        public override async Task WriteCDataAsync(string? text)
         {
             CheckAsyncCall();
             Debug.Assert(text != null);
@@ -390,7 +389,7 @@ namespace System.Xml
         }
 
         // Serialize a comment.
-        public override async Task WriteCommentAsync(string text)
+        public override async Task WriteCommentAsync(string? text)
         {
             CheckAsyncCall();
             Debug.Assert(text != null);
@@ -410,7 +409,7 @@ namespace System.Xml
         }
 
         // Serialize a processing instruction.
-        public override async Task WriteProcessingInstructionAsync(string name, string text)
+        public override async Task WriteProcessingInstructionAsync(string name, string? text)
         {
             CheckAsyncCall();
             Debug.Assert(name != null && name.Length > 0);
@@ -482,7 +481,7 @@ namespace System.Xml
 
         // Serialize a whitespace node.
 
-        public override Task WriteWhitespaceAsync(string ws)
+        public override Task WriteWhitespaceAsync(string? ws)
         {
             CheckAsyncCall();
             Debug.Assert(ws != null);
@@ -501,7 +500,7 @@ namespace System.Xml
 
         // Serialize either attribute or element text using XML rules.
 
-        public override Task WriteStringAsync(string text)
+        public override Task WriteStringAsync(string? text)
         {
             CheckAsyncCall();
             Debug.Assert(text != null);
@@ -622,21 +621,21 @@ namespace System.Xml
                     {
                         if (_trackTextContent)
                         {
-                            _charEntityFallback.Reset(_textContentMarks, _lastMarkPos);
+                            _charEntityFallback!.Reset(_textContentMarks!, _lastMarkPos);
                             // reset text content tracking
 
                             if ((_lastMarkPos & 1) != 0)
                             {
                                 // If the previous buffer ended inside a text content we need to preserve that info
                                 //   which means the next index to which we write has to be even
-                                _textContentMarks[1] = 1;
+                                _textContentMarks![1] = 1;
                                 _lastMarkPos = 1;
                             }
                             else
                             {
                                 _lastMarkPos = 0;
                             }
-                            Debug.Assert(_textContentMarks[0] == 1);
+                            Debug.Assert(_textContentMarks![0] == 1);
                         }
                         await EncodeCharsAsync(1, _bufPos, true).ConfigureAwait(false);
                     }
@@ -645,7 +644,7 @@ namespace System.Xml
                         if (_bufPos - 1 > 0)
                         {
                             // Write text to TextWriter
-                            await _writer.WriteAsync(_bufChars.AsMemory(1, _bufPos - 1)).ConfigureAwait(false);
+                            await _writer!.WriteAsync(_bufChars.AsMemory(1, _bufPos - 1)).ConfigureAwait(false);
                         }
                     }
                 }
@@ -682,18 +681,18 @@ namespace System.Xml
                 {
                     _charEntityFallback.StartOffset = startOffset;
                 }
-                _encoder.Convert(_bufChars, startOffset, endOffset - startOffset, _bufBytes, _bufBytesUsed, _bufBytes.Length - _bufBytesUsed, false, out chEnc, out bEnc, out _);
+                _encoder!.Convert(_bufChars, startOffset, endOffset - startOffset, _bufBytes!, _bufBytesUsed, _bufBytes!.Length - _bufBytesUsed, false, out chEnc, out bEnc, out _);
                 startOffset += chEnc;
                 _bufBytesUsed += bEnc;
                 if (_bufBytesUsed >= (_bufBytes.Length - 16))
                 {
-                    await _stream.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
+                    await _stream!.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
                     _bufBytesUsed = 0;
                 }
             }
             if (writeAllToStream && _bufBytesUsed > 0)
             {
-                await _stream.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
+                await _stream!.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
                 _bufBytesUsed = 0;
             }
         }
@@ -705,7 +704,7 @@ namespace System.Xml
             {
                 int bEnc;
                 // decode no chars, just flush
-                _encoder.Convert(_bufChars, 1, 0, _bufBytes, 0, _bufBytes.Length, true, out _, out bEnc, out _);
+                _encoder!.Convert(_bufChars, 1, 0, _bufBytes!, 0, _bufBytes!.Length, true, out _, out bEnc, out _);
                 if (bEnc != 0)
                 {
                     return _stream.WriteAsync(_bufBytes, 0, bEnc);
@@ -1250,7 +1249,7 @@ namespace System.Xml
                 Task.CompletedTask;
         }
 
-        protected Task RawTextAsync(string text1, string text2 = null, string text3 = null, string text4 = null)
+        protected Task RawTextAsync(string text1, string? text2 = null, string? text3 = null, string? text4 = null)
         {
             Debug.Assert(text1 != null);
             Debug.Assert(text2 != null || (text3 == null && text4 == null));
@@ -1308,7 +1307,7 @@ namespace System.Xml
 
         private async Task _RawTextAsync(
             string text1, int curIndex1, int leftCount1,
-            string text2 = null, string text3 = null, string text4 = null)
+            string? text2 = null, string? text3 = null, string? text4 = null)
         {
             Debug.Assert(text1 != null);
             Debug.Assert(text2 != null || (text3 == null && text4 == null));
@@ -1901,7 +1900,7 @@ namespace System.Xml
     // Same as base text writer class except that elements, attributes, comments, and pi's are indented.
     internal partial class XmlEncodedRawTextWriterIndent : XmlEncodedRawTextWriter
     {
-        public override async Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset)
+        public override async Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
         {
             CheckAsyncCall();
             // Add indentation
@@ -1912,7 +1911,7 @@ namespace System.Xml
             await base.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(false);
         }
 
-        public override async Task WriteStartElementAsync(string prefix, string localName, string ns)
+        public override async Task WriteStartElementAsync(string? prefix, string localName, string? ns)
         {
             CheckAsyncCall();
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
@@ -1965,7 +1964,7 @@ namespace System.Xml
         }
 
         // Same as base class, plus possible indentation.
-        protected internal override async Task WriteStartAttributeAsync(string prefix, string localName, string ns)
+        protected internal override async Task WriteStartAttributeAsync(string? prefix, string localName, string? ns)
         {
             CheckAsyncCall();
             // Add indentation
@@ -1977,14 +1976,14 @@ namespace System.Xml
             await base.WriteStartAttributeAsync(prefix, localName, ns).ConfigureAwait(false);
         }
 
-        public override Task WriteCDataAsync(string text)
+        public override Task WriteCDataAsync(string? text)
         {
             CheckAsyncCall();
             _mixedContent = true;
             return base.WriteCDataAsync(text);
         }
 
-        public override async Task WriteCommentAsync(string text)
+        public override async Task WriteCommentAsync(string? text)
         {
             CheckAsyncCall();
             if (!_mixedContent && base._textPos != base._bufPos)
@@ -1995,7 +1994,7 @@ namespace System.Xml
             await base.WriteCommentAsync(text).ConfigureAwait(false);
         }
 
-        public override async Task WriteProcessingInstructionAsync(string target, string text)
+        public override async Task WriteProcessingInstructionAsync(string target, string? text)
         {
             CheckAsyncCall();
             if (!_mixedContent && base._textPos != base._bufPos)
@@ -2027,14 +2026,14 @@ namespace System.Xml
             return base.WriteSurrogateCharEntityAsync(lowChar, highChar);
         }
 
-        public override Task WriteWhitespaceAsync(string ws)
+        public override Task WriteWhitespaceAsync(string? ws)
         {
             CheckAsyncCall();
             _mixedContent = true;
             return base.WriteWhitespaceAsync(ws);
         }
 
-        public override Task WriteStringAsync(string text)
+        public override Task WriteStringAsync(string? text)
         {
             CheckAsyncCall();
             _mixedContent = true;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.ttinclude
@@ -5,7 +5,6 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify XmlRawTextWriterGenerator.ttinclude
 
-#nullable disable
 using System;
 using System.IO;
 using System.Xml;
@@ -277,7 +276,7 @@ namespace System.Xml
         }
 
         // Serialize the document type declaration.
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             Debug.Assert(name != null && name.Length > 0);<#
 
@@ -1997,7 +1996,7 @@ namespace System.Xml
             }
         }
 
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             // Add indentation
             if (!_mixedContent && base._textPos != base._bufPos)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
@@ -5,7 +5,6 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify XmlRawTextWriterGeneratorAsync.ttinclude
 
-#nullable disable
 using System;
 using System.IO;
 using System.Xml;
@@ -133,7 +132,7 @@ namespace System.Xml
         }
 
         // Serialize the document type declaration.
-        public override async Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset)
+        public override async Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
         {
             CheckAsyncCall();
             Debug.Assert(name != null && name.Length > 0);<#
@@ -1844,7 +1843,7 @@ namespace System.Xml
     // Same as base text writer class except that elements, attributes, comments, and pi's are indented.
     internal partial class <#= ClassNameIndent #> : <#= ClassName #>
     {
-        public override async Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset)
+        public override async Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
         {
             CheckAsyncCall();
             // Add indentation

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriter.cs
@@ -4,13 +4,13 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify XmlRawTextWriterGenerator.ttinclude
 
-#nullable disable
 using System;
 using System.IO;
 using System.Xml;
 using System.Text;
 using System.Diagnostics;
 using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Xml
 {
@@ -26,13 +26,13 @@ namespace System.Xml
         private readonly bool _useAsync;
 
         // main buffer
-        protected byte[] _bufBytes;
+        protected byte[] _bufBytes = null!;
 
         // output stream
-        protected Stream _stream;
+        protected Stream _stream = null!;
 
         // encoding of the stream or text writer
-        protected Encoding _encoding;
+        protected Encoding _encoding = null!;
 
         // buffer positions
         protected int _bufPos = 1;     // buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
@@ -194,7 +194,7 @@ namespace System.Xml
         }
 
         // Serialize the document type declaration.
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             Debug.Assert(name != null && name.Length > 0);
 
@@ -233,7 +233,7 @@ namespace System.Xml
         }
 
         // Serialize the beginning of an element start tag: "<prefix:localName"
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
@@ -311,7 +311,7 @@ namespace System.Xml
         }
 
         // Serialize an attribute tag using double quotes around the attribute value: 'prefix:localName="'
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
@@ -388,7 +388,7 @@ namespace System.Xml
 
         // Serialize a CData section.  If the "]]>" pattern is found within
         // the text, replace it with "]]><![CDATA[>".
-        public override void WriteCData(string text)
+        public override void WriteCData(string? text)
         {
             Debug.Assert(text != null);
 
@@ -423,7 +423,7 @@ namespace System.Xml
         }
 
         // Serialize a comment.
-        public override void WriteComment(string text)
+        public override void WriteComment(string? text)
         {
             Debug.Assert(text != null);
 
@@ -440,7 +440,7 @@ namespace System.Xml
         }
 
         // Serialize a processing instruction.
-        public override void WriteProcessingInstruction(string name, string text)
+        public override void WriteProcessingInstruction(string name, string? text)
         {
             Debug.Assert(name != null && name.Length > 0);
             Debug.Assert(text != null);
@@ -503,7 +503,7 @@ namespace System.Xml
 
         // Serialize a whitespace node.
 
-        public override unsafe void WriteWhitespace(string ws)
+        public override unsafe void WriteWhitespace(string? ws)
         {
             Debug.Assert(ws != null);
 
@@ -523,7 +523,7 @@ namespace System.Xml
 
         // Serialize either attribute or element text using XML rules.
 
-        public override unsafe void WriteString(string text)
+        public override unsafe void WriteString(string? text)
         {
             Debug.Assert(text != null);
 
@@ -636,7 +636,7 @@ namespace System.Xml
                         }
                         finally
                         {
-                            _stream = null;
+                            _stream = null!;
                         }
                     }
                 }
@@ -1800,7 +1800,7 @@ namespace System.Xml
             }
         }
 
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             // Add indentation
             if (!_mixedContent && base._textPos != base._bufPos)
@@ -1810,7 +1810,7 @@ namespace System.Xml
             base.WriteDocType(name, pubid, sysid, subset);
         }
 
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
@@ -1883,7 +1883,7 @@ namespace System.Xml
         }
 
         // Same as base class, plus possible indentation.
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             // Add indentation
             if (_newLineOnAttributes)
@@ -1894,13 +1894,13 @@ namespace System.Xml
             base.WriteStartAttribute(prefix, localName, ns);
         }
 
-        public override void WriteCData(string text)
+        public override void WriteCData(string? text)
         {
             _mixedContent = true;
             base.WriteCData(text);
         }
 
-        public override void WriteComment(string text)
+        public override void WriteComment(string? text)
         {
             if (!_mixedContent && base._textPos != base._bufPos)
             {
@@ -1910,7 +1910,7 @@ namespace System.Xml
             base.WriteComment(text);
         }
 
-        public override void WriteProcessingInstruction(string target, string text)
+        public override void WriteProcessingInstruction(string target, string? text)
         {
             if (!_mixedContent && base._textPos != base._bufPos)
             {
@@ -1938,13 +1938,13 @@ namespace System.Xml
             base.WriteSurrogateCharEntity(lowChar, highChar);
         }
 
-        public override void WriteWhitespace(string ws)
+        public override void WriteWhitespace(string? ws)
         {
             _mixedContent = true;
             base.WriteWhitespace(ws);
         }
 
-        public override void WriteString(string text)
+        public override void WriteString(string? text)
         {
             _mixedContent = true;
             base.WriteString(text);
@@ -1977,6 +1977,8 @@ namespace System.Xml
         //
         // Private methods
         //
+        [MemberNotNull(nameof(_indentChars))]
+        [MemberNotNull(nameof(_mixedContentStack))]
         private void Init(XmlWriterSettings settings)
         {
             _indentLevel = 0;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
@@ -4,7 +4,6 @@
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify XmlRawTextWriterGeneratorAsync.ttinclude
 
-#nullable disable
 using System;
 using System.IO;
 using System.Xml;
@@ -100,7 +99,7 @@ namespace System.Xml
                         }
                         finally
                         {
-                            _stream = null;
+                            _stream = null!;
                         }
                     }
                 }
@@ -108,7 +107,7 @@ namespace System.Xml
         }
 
         // Serialize the document type declaration.
-        public override async Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset)
+        public override async Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
         {
             CheckAsyncCall();
             Debug.Assert(name != null && name.Length > 0);
@@ -148,7 +147,7 @@ namespace System.Xml
         }
 
         // Serialize the beginning of an element start tag: "<prefix:localName"
-        public override Task WriteStartElementAsync(string prefix, string localName, string ns)
+        public override Task WriteStartElementAsync(string? prefix, string localName, string? ns)
         {
             CheckAsyncCall();
             Debug.Assert(localName != null && localName.Length > 0);
@@ -227,7 +226,7 @@ namespace System.Xml
         }
 
         // Serialize an attribute tag using double quotes around the attribute value: 'prefix:localName="'
-        protected internal override Task WriteStartAttributeAsync(string prefix, string localName, string ns)
+        protected internal override Task WriteStartAttributeAsync(string? prefix, string localName, string? ns)
         {
             CheckAsyncCall();
             Debug.Assert(localName != null && localName.Length > 0);
@@ -312,7 +311,7 @@ namespace System.Xml
 
         // Serialize a CData section.  If the "]]>" pattern is found within
         // the text, replace it with "]]><![CDATA[>".
-        public override async Task WriteCDataAsync(string text)
+        public override async Task WriteCDataAsync(string? text)
         {
             CheckAsyncCall();
             Debug.Assert(text != null);
@@ -348,7 +347,7 @@ namespace System.Xml
         }
 
         // Serialize a comment.
-        public override async Task WriteCommentAsync(string text)
+        public override async Task WriteCommentAsync(string? text)
         {
             CheckAsyncCall();
             Debug.Assert(text != null);
@@ -366,7 +365,7 @@ namespace System.Xml
         }
 
         // Serialize a processing instruction.
-        public override async Task WriteProcessingInstructionAsync(string name, string text)
+        public override async Task WriteProcessingInstructionAsync(string name, string? text)
         {
             CheckAsyncCall();
             Debug.Assert(name != null && name.Length > 0);
@@ -432,7 +431,7 @@ namespace System.Xml
 
         // Serialize a whitespace node.
 
-        public override Task WriteWhitespaceAsync(string ws)
+        public override Task WriteWhitespaceAsync(string? ws)
         {
             CheckAsyncCall();
             Debug.Assert(ws != null);
@@ -449,7 +448,7 @@ namespace System.Xml
 
         // Serialize either attribute or element text using XML rules.
 
-        public override Task WriteStringAsync(string text)
+        public override Task WriteStringAsync(string? text)
         {
             CheckAsyncCall();
             Debug.Assert(text != null);
@@ -1118,7 +1117,7 @@ namespace System.Xml
                 Task.CompletedTask;
         }
 
-        protected Task RawTextAsync(string text1, string text2 = null, string text3 = null, string text4 = null)
+        protected Task RawTextAsync(string text1, string? text2 = null, string? text3 = null, string? text4 = null)
         {
             Debug.Assert(text1 != null);
             Debug.Assert(text2 != null || (text3 == null && text4 == null));
@@ -1176,7 +1175,7 @@ namespace System.Xml
 
         private async Task _RawTextAsync(
             string text1, int curIndex1, int leftCount1,
-            string text2 = null, string text3 = null, string text4 = null)
+            string? text2 = null, string? text3 = null, string? text4 = null)
         {
             Debug.Assert(text1 != null);
             Debug.Assert(text2 != null || (text3 == null && text4 == null));
@@ -1766,7 +1765,7 @@ namespace System.Xml
     // Same as base text writer class except that elements, attributes, comments, and pi's are indented.
     internal partial class XmlUtf8RawTextWriterIndent : XmlUtf8RawTextWriter
     {
-        public override async Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset)
+        public override async Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
         {
             CheckAsyncCall();
             // Add indentation
@@ -1777,7 +1776,7 @@ namespace System.Xml
             await base.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(false);
         }
 
-        public override async Task WriteStartElementAsync(string prefix, string localName, string ns)
+        public override async Task WriteStartElementAsync(string? prefix, string localName, string? ns)
         {
             CheckAsyncCall();
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
@@ -1830,7 +1829,7 @@ namespace System.Xml
         }
 
         // Same as base class, plus possible indentation.
-        protected internal override async Task WriteStartAttributeAsync(string prefix, string localName, string ns)
+        protected internal override async Task WriteStartAttributeAsync(string? prefix, string localName, string? ns)
         {
             CheckAsyncCall();
             // Add indentation
@@ -1842,14 +1841,14 @@ namespace System.Xml
             await base.WriteStartAttributeAsync(prefix, localName, ns).ConfigureAwait(false);
         }
 
-        public override Task WriteCDataAsync(string text)
+        public override Task WriteCDataAsync(string? text)
         {
             CheckAsyncCall();
             _mixedContent = true;
             return base.WriteCDataAsync(text);
         }
 
-        public override async Task WriteCommentAsync(string text)
+        public override async Task WriteCommentAsync(string? text)
         {
             CheckAsyncCall();
             if (!_mixedContent && base._textPos != base._bufPos)
@@ -1860,7 +1859,7 @@ namespace System.Xml
             await base.WriteCommentAsync(text).ConfigureAwait(false);
         }
 
-        public override async Task WriteProcessingInstructionAsync(string target, string text)
+        public override async Task WriteProcessingInstructionAsync(string target, string? text)
         {
             CheckAsyncCall();
             if (!_mixedContent && base._textPos != base._bufPos)
@@ -1892,14 +1891,14 @@ namespace System.Xml
             return base.WriteSurrogateCharEntityAsync(lowChar, highChar);
         }
 
-        public override Task WriteWhitespaceAsync(string ws)
+        public override Task WriteWhitespaceAsync(string? ws)
         {
             CheckAsyncCall();
             _mixedContent = true;
             return base.WriteWhitespaceAsync(ws);
         }
 
-        public override Task WriteStringAsync(string text)
+        public override Task WriteStringAsync(string? text)
         {
             CheckAsyncCall();
             _mixedContent = true;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterSettings.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterSettings.cs
@@ -660,11 +660,11 @@ namespace System.Xml
             // NewLineHandling newLineHandling;
             NewLineHandling = (NewLineHandling)reader.ReadSByte(0, (sbyte)NewLineHandling.None);
             // string newLineChars;
-            NewLineChars = reader.ReadStringQ();
+            NewLineChars = reader.ReadStringQ()!;
             // TriState indent;
             IndentInternal = (TriState)reader.ReadSByte((sbyte)TriState.Unknown, (sbyte)TriState.True);
             // string indentChars;
-            IndentChars = reader.ReadStringQ();
+            IndentChars = reader.ReadStringQ()!;
             // bool newLineOnAttributes;
             NewLineOnAttributes = reader.ReadBoolean();
             // bool closeOutput;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/DocumentXmlWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/DocumentXmlWriter.cs
@@ -173,7 +173,7 @@ namespace System.Xml
             _write = _write.ParentNode;
         }
 
-        internal override void WriteEndElement(string prefix, string localName, string ns)
+        internal override void WriteEndElement(string? prefix, string localName, string? ns)
         {
             WriteEndElement();
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/ValidateNames.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/ValidateNames.cs
@@ -426,7 +426,7 @@ namespace System.Xml
         /// specified by the Flags.
         /// NOTE: Namespaces should be passed using a prefix, ns pair.  "localName" is always string.Empty.
         /// </summary>
-        internal static void ValidateNameThrow(string prefix, string localName, string ns, XPathNodeType nodeKind, Flags flags)
+        internal static void ValidateNameThrow(string? prefix, string localName, string? ns, XPathNodeType nodeKind, Flags flags)
         {
             // throwOnError = true
             ValidateNameInternal(prefix, localName, ns, nodeKind, flags, true);
@@ -437,7 +437,7 @@ namespace System.Xml
         /// specified by the Flags.
         /// NOTE: Namespaces should be passed using a prefix, ns pair.  "localName" is always string.Empty.
         /// </summary>
-        internal static bool ValidateName(string prefix, string localName, string ns, XPathNodeType nodeKind, Flags flags)
+        internal static bool ValidateName(string? prefix, string localName, string? ns, XPathNodeType nodeKind, Flags flags)
         {
             // throwOnError = false
             return ValidateNameInternal(prefix, localName, ns, nodeKind, flags, false);
@@ -448,7 +448,7 @@ namespace System.Xml
         /// that are specified by the Flags.
         /// NOTE: Namespaces should be passed using a prefix, ns pair.  "localName" is always string.Empty.
         /// </summary>
-        private static bool ValidateNameInternal(string prefix, string localName, string ns, XPathNodeType nodeKind, Flags flags, bool throwOnError)
+        private static bool ValidateNameInternal(string? prefix, string localName, string? ns, XPathNodeType nodeKind, Flags flags, bool throwOnError)
         {
             Debug.Assert(prefix != null && localName != null && ns != null);
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlIlVisitor.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlIlVisitor.cs
@@ -3606,7 +3606,8 @@ namespace System.Xml.Xsl.IlGen
         {
             QilName ndName = ndInvoke.Name;
             XmlExtensionFunction extFunc;
-            Type clrTypeRetSrc, clrTypeRetDst;
+            Type? clrTypeRetSrc;
+            Type clrTypeRetDst;
 
             // Retrieve metadata from the extension function
             extFunc = new XmlExtensionFunction(ndName.LocalName, ndName.NamespaceUri, ndInvoke.ClrMethod);
@@ -3621,7 +3622,7 @@ namespace System.Xml.Xsl.IlGen
             }
 
             // If this is not a static method, then get the instance object
-            if (!extFunc.Method.IsStatic)
+            if (!extFunc.Method!.IsStatic)
             {
                 // Special-case the XsltLibrary object
                 if (ndName.NamespaceUri.Length == 0)
@@ -3712,7 +3713,7 @@ namespace System.Xml.Xsl.IlGen
             else if (clrTypeRetSrc != clrTypeRetDst)
             {
                 // (T) runtime.ChangeTypeXsltResult(idxType, (object) value);
-                _helper.TreatAs(clrTypeRetSrc, typeof(object));
+                _helper.TreatAs(clrTypeRetSrc!, typeof(object));
                 _helper.Call(XmlILMethods.ChangeTypeXsltResult);
                 _helper.TreatAs(typeof(object), clrTypeRetDst);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/QIL/QilTypeChecker.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/QIL/QilTypeChecker.cs
@@ -947,7 +947,7 @@ namespace System.Xml.Xsl.Qil
 
             XmlExtensionFunction extFunc = new XmlExtensionFunction(node.Name.LocalName, node.Name.NamespaceUri, node.ClrMethod);
             QilList actualArgs = node.Arguments;
-            Check(actualArgs.Count == extFunc.Method.GetParameters().Length, actualArgs, "InvokeEarlyBound argument count must match function's argument count");
+            Check(actualArgs.Count == extFunc.Method!.GetParameters().Length, actualArgs, "InvokeEarlyBound argument count must match function's argument count");
 
             for (int i = 0; i < actualArgs.Count; i++)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/QueryReaderSettings.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/QueryReaderSettings.cs
@@ -84,7 +84,7 @@ namespace System.Xml.Xsl
             }
         }
 
-        public XmlReader CreateReader(Stream stream, string baseUri)
+        public XmlReader CreateReader(Stream stream, string? baseUri)
         {
             XmlReader reader;
             if (_xmlReaderSettings != null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/ContentIterators.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/ContentIterators.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Xml;
 using System.Xml.XPath;
@@ -303,7 +302,7 @@ namespace System.Xml.Xsl.Runtime
     public struct ContentMergeIterator
     {
         private XmlNavigatorFilter _filter;
-        private XPathNavigator _navCurrent, _navNext;
+        private XPathNavigator? _navCurrent, _navNext;
         private XmlNavigatorStack _navStack;
         private IteratorState _state;
 
@@ -387,8 +386,8 @@ namespace System.Xml.Xsl.Runtime
                 case IteratorState.HaveCurrentNoNext:
                 case IteratorState.HaveCurrentHaveNext:
                     // If the current node has no more matching siblings,
-                    if (isContent ? !_filter.MoveToNextContent(_navCurrent) :
-                                    !_filter.MoveToFollowingSibling(_navCurrent))
+                    if (isContent ? !_filter.MoveToNextContent(_navCurrent!) :
+                                    !_filter.MoveToFollowingSibling(_navCurrent!))
                     {
                         if (_navStack.IsEmpty)
                         {
@@ -399,7 +398,7 @@ namespace System.Xml.Xsl.Runtime
                             }
 
                             // Make navNext the new current node and fetch a new navNext
-                            _navCurrent = XmlQueryRuntime.SyncToNavigator(_navCurrent, _navNext);
+                            _navCurrent = XmlQueryRuntime.SyncToNavigator(_navCurrent, _navNext!);
                             _state = IteratorState.HaveCurrentNeedNext;
                             return IteratorResult.NeedInputNode;
                         }
@@ -425,7 +424,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public XPathNavigator Current
         {
-            get { return _navCurrent; }
+            get { return _navCurrent!; }
         }
 
         /// <summary>
@@ -441,7 +440,7 @@ namespace System.Xml.Xsl.Runtime
             Debug.Assert(_state == IteratorState.HaveCurrentHaveNext);
 
             // Compare location of navCurrent with navNext
-            cmp = _navCurrent.ComparePosition(_navNext);
+            cmp = _navCurrent!.ComparePosition(_navNext);
 
             // If navCurrent is before navNext in document order,
             // If cmp = XmlNodeOrder.Unknown, then navCurrent is before navNext (since input is in doc order)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/DecimalFormatter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/DecimalFormatter.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
@@ -27,9 +26,9 @@ namespace System.Xml.Xsl.Runtime
     internal sealed class DecimalFormatter
     {
         private readonly NumberFormatInfo _posFormatInfo;
-        private readonly NumberFormatInfo _negFormatInfo;
-        private readonly string _posFormat;
-        private readonly string _negFormat;
+        private readonly NumberFormatInfo? _negFormatInfo;
+        private readonly string? _posFormat;
+        private readonly string? _negFormat;
         private readonly char _zeroDigit;
 
         // These characters have special meaning for CLR and must be escaped
@@ -191,7 +190,7 @@ namespace System.Xml.Xsl.Runtime
             {
                 throw XsltException.Create(SR.Xslt_InvalidFormat8);
             }
-            NumberFormatInfo formatInfo = sawPattern ? _negFormatInfo : _posFormatInfo;
+            NumberFormatInfo formatInfo = sawPattern ? _negFormatInfo! : _posFormatInfo;
 
             if (decimalIndex < 0)
             {
@@ -234,7 +233,7 @@ namespace System.Xml.Xsl.Runtime
         public string Format(double value)
         {
             NumberFormatInfo formatInfo;
-            string subPicture;
+            string? subPicture;
 
             if (value < 0 && _negFormatInfo != null)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/DocumentOrderComparer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/DocumentOrderComparer.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -18,7 +17,7 @@ namespace System.Xml.Xsl.Runtime
     /// </summary>
     internal sealed class DocumentOrderComparer : IComparer<XPathNavigator>
     {
-        private List<XPathNavigator> _roots;
+        private List<XPathNavigator>? _roots;
 
         /// <summary>
         /// Return:
@@ -26,9 +25,9 @@ namespace System.Xml.Xsl.Runtime
         ///      0 if navThis has the same position as navThat
         ///      1 if navThis is positioned after navThat
         /// </summary>
-        public int Compare(XPathNavigator navThis, XPathNavigator navThat)
+        public int Compare(XPathNavigator? navThis, XPathNavigator? navThat)
         {
-            switch (navThis.ComparePosition(navThat))
+            switch (navThis!.ComparePosition(navThat))
             {
                 case XmlNodeOrder.Before: return -1;
                 case XmlNodeOrder.Same: return 0;
@@ -38,8 +37,8 @@ namespace System.Xml.Xsl.Runtime
             // Use this.roots to impose stable ordering
             _roots ??= new List<XPathNavigator>();
 
-            Debug.Assert(GetDocumentIndex(navThis) != GetDocumentIndex(navThat));
-            return GetDocumentIndex(navThis) < GetDocumentIndex(navThat) ? -1 : 1;
+            Debug.Assert(GetDocumentIndex(navThis) != GetDocumentIndex(navThat!));
+            return GetDocumentIndex(navThis) < GetDocumentIndex(navThat!) ? -1 : 1;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/DodSequenceMerge.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/DodSequenceMerge.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Collections.Generic;
 using System.Xml.XPath;
@@ -17,8 +16,8 @@ namespace System.Xml.Xsl.Runtime
     [EditorBrowsable(EditorBrowsableState.Never)]
     public struct DodSequenceMerge
     {
-        private IList<XPathNavigator> _firstSequence;
-        private List<IEnumerator<XPathNavigator>> _sequencesToMerge;
+        private IList<XPathNavigator>? _firstSequence;
+        private List<IEnumerator<XPathNavigator>>? _sequencesToMerge;
         private int _nodeCount;
         private XmlQueryRuntime _runtime;
 
@@ -118,7 +117,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         private void InsertSequence(IEnumerator<XPathNavigator> sequence)
         {
-            for (int i = _sequencesToMerge.Count - 1; i >= 0; i--)
+            for (int i = _sequencesToMerge!.Count - 1; i >= 0; i--)
             {
                 int cmp = _runtime.ComparePosition(sequence.Current, _sequencesToMerge[i].Current);
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/EarlyBoundInfo.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/EarlyBoundInfo.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -25,7 +24,7 @@ namespace System.Xml.Xsl.Runtime
             // Get the default constructor
             _namespaceUri = namespaceUri;
             _ebType = ebType;
-            _constrInfo = ebType.GetConstructor(Type.EmptyTypes);
+            _constrInfo = ebType.GetConstructor(Type.EmptyTypes)!;
             Debug.Assert(_constrInfo != null, $"The early bound object type {ebType.FullName} must have a public default constructor");
         }
 
@@ -51,9 +50,9 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Override Equals method so that EarlyBoundInfo to implement value comparison.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals([NotNullWhen(true)] object? obj)
         {
-            EarlyBoundInfo info = obj as EarlyBoundInfo;
+            EarlyBoundInfo? info = obj as EarlyBoundInfo;
             if (info == null)
                 return false;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/NumberFormatter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/NumberFormatter.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Diagnostics;
 using System.Text;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/RtfNavigator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/RtfNavigator.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Threading;
 using System.IO;
@@ -288,7 +287,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public override bool MoveTo(XPathNavigator other)
         {
-            RtfTreeNavigator that = other as RtfTreeNavigator;
+            RtfTreeNavigator? that = other as RtfTreeNavigator;
             if (that != null)
             {
                 _events = that._events;
@@ -399,7 +398,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public override bool MoveTo(XPathNavigator other)
         {
-            RtfTextNavigator that = other as RtfTextNavigator;
+            RtfTextNavigator? that = other as RtfTextNavigator;
             if (that != null)
             {
                 _text = that._text;
@@ -418,7 +417,7 @@ namespace System.Xml.Xsl.Runtime
     /// </summary>
     internal sealed class NavigatorConstructor
     {
-        private object _cache;
+        private object? _cache;
 
         /// <summary>
         /// Create a document from the cache of events.  If a document has already been created previously, return it.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/SetIterators.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/SetIterators.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Xml;
 using System.Xml.XPath;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/SiblingIterators.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/SiblingIterators.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Xml;
 using System.Xml.XPath;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/TreeIterators.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/TreeIterators.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Xml.XPath;
@@ -15,7 +14,7 @@ namespace System.Xml.Xsl.Runtime
     public struct DescendantIterator
     {
         private XmlNavigatorFilter _filter;
-        private XPathNavigator _navCurrent, _navEnd;
+        private XPathNavigator? _navCurrent, _navEnd;
         private bool _hasFirst;
 
         /// <summary>
@@ -53,7 +52,7 @@ namespace System.Xml.Xsl.Runtime
                 _hasFirst = false;
                 return true;
             }
-            return (_filter.MoveToFollowing(_navCurrent, _navEnd));
+            return (_filter.MoveToFollowing(_navCurrent!, _navEnd));
         }
 
         /// <summary>
@@ -61,7 +60,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public XPathNavigator Current
         {
-            get { return _navCurrent; }
+            get { return _navCurrent!; }
         }
     }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/WhitespaceRuleLookup.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/WhitespaceRuleLookup.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Xml;
 using System.Collections;
@@ -9,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using MS.Internal.Xml;
 using System.Xml.Xsl.Qil;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Xml.Xsl.Runtime
 {
@@ -20,8 +20,8 @@ namespace System.Xml.Xsl.Runtime
     {
         private readonly Hashtable _qnames;
         private readonly ArrayList _wildcards;
-        private readonly InternalWhitespaceRule _ruleTemp;
-        private XmlNameTable _nameTable;
+        private readonly InternalWhitespaceRule? _ruleTemp;
+        private XmlNameTable? _nameTable;
 
         public WhitespaceRuleLookup()
         {
@@ -85,10 +85,10 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public bool ShouldStripSpace(string localName, string namespaceName)
         {
-            InternalWhitespaceRule qnameRule, wildcardRule;
+            InternalWhitespaceRule? qnameRule, wildcardRule;
             Debug.Assert(_nameTable != null && _ruleTemp != null);
-            Debug.Assert(localName != null && (object)_nameTable.Get(localName) == (object)localName);
-            Debug.Assert(namespaceName != null && (object)_nameTable.Get(namespaceName) == (object)namespaceName);
+            Debug.Assert(localName != null && (object?)_nameTable.Get(localName) == (object)localName);
+            Debug.Assert(namespaceName != null && (object?)_nameTable.Get(namespaceName) == (object)namespaceName);
 
             _ruleTemp.Init(localName, namespaceName, false, 0);
 
@@ -103,7 +103,7 @@ namespace System.Xml.Xsl.Runtime
                 if (qnameRule != null)
                 {
                     // If qname priority is greater than any subsequent wildcard's priority, then we're done
-                    if (qnameRule.Priority > wildcardRule.Priority)
+                    if (qnameRule.Priority > wildcardRule!.Priority)
                         return !qnameRule.PreserveSpace;
 
                     // Don't bother to consider wildcards with the same PreserveSpace flag
@@ -111,7 +111,7 @@ namespace System.Xml.Xsl.Runtime
                         continue;
                 }
 
-                if (wildcardRule.LocalName == null || (object)wildcardRule.LocalName == (object)localName)
+                if (wildcardRule!.LocalName == null || (object)wildcardRule.LocalName == (object)localName)
                 {
                     if (wildcardRule.NamespaceName == null || (object)wildcardRule.NamespaceName == (object)namespaceName)
                     {
@@ -133,12 +133,12 @@ namespace System.Xml.Xsl.Runtime
             {
             }
 
-            public InternalWhitespaceRule(string localName, string namespaceName, bool preserveSpace, int priority)
+            public InternalWhitespaceRule(string? localName, string? namespaceName, bool preserveSpace, int priority)
             {
                 Init(localName, namespaceName, preserveSpace, priority);
             }
 
-            public void Init(string localName, string namespaceName, bool preserveSpace, int priority)
+            public void Init(string? localName, string? namespaceName, bool preserveSpace, int priority)
             {
                 base.Init(localName, namespaceName, preserveSpace);
                 _priority = priority;
@@ -168,12 +168,12 @@ namespace System.Xml.Xsl.Runtime
                 return _hashCode;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals([NotNullWhen(true)] object? obj)
             {
                 Debug.Assert(obj is InternalWhitespaceRule);
-                InternalWhitespaceRule that = obj as InternalWhitespaceRule;
+                InternalWhitespaceRule? that = obj as InternalWhitespaceRule;
 
-                Debug.Assert(LocalName != null && that.LocalName != null);
+                Debug.Assert(LocalName != null && that!.LocalName != null);
                 Debug.Assert(NamespaceName != null && that.NamespaceName != null);
 
                 // string == operator compares object references first and if they are not the same compares contents

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/WhitespaceRuleReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/WhitespaceRuleReader.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Diagnostics;
 
 namespace System.Xml.Xsl.Runtime
@@ -13,15 +12,15 @@ namespace System.Xml.Xsl.Runtime
         private readonly WhitespaceRuleLookup _wsRules;
         private readonly BitStack _stkStrip;
         private bool _shouldStrip, _preserveAdjacent;
-        private string _val;
+        private string? _val;
 
-        public static XmlReader CreateReader(XmlReader baseReader, WhitespaceRuleLookup wsRules)
+        public static XmlReader CreateReader(XmlReader baseReader, WhitespaceRuleLookup? wsRules)
         {
             if (wsRules == null)
             {
                 return baseReader;    // There is no rules to process
             }
-            XmlReaderSettings readerSettings = baseReader.Settings;
+            XmlReaderSettings? readerSettings = baseReader.Settings;
             if (readerSettings != null)
             {
                 if (readerSettings.IgnoreWhitespace)
@@ -31,12 +30,12 @@ namespace System.Xml.Xsl.Runtime
             }
             else
             {
-                XmlTextReader txtReader = baseReader as XmlTextReader;
+                XmlTextReader? txtReader = baseReader as XmlTextReader;
                 if (txtReader != null && txtReader.WhitespaceHandling == WhitespaceHandling.None)
                 {
                     return baseReader;        // V1 XmlTextReader that strips all WS
                 }
-                XmlTextReaderImpl txtReaderImpl = baseReader as XmlTextReaderImpl;
+                XmlTextReaderImpl? txtReaderImpl = baseReader as XmlTextReaderImpl;
                 if (txtReaderImpl != null && txtReaderImpl.WhitespaceHandling == WhitespaceHandling.None)
                 {
                     return baseReader;        // XmlTextReaderImpl that strips all WS
@@ -72,7 +71,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public override bool Read()
         {
-            string ws = null;
+            string? ws = null;
 
             // Clear text value
             _val = null;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlAggregates.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlAggregates.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Xml;
 using System.Diagnostics;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlAttributeCache.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlAttributeCache.cs
@@ -7,7 +7,6 @@ using System.Xml;
 using System.Xml.XPath;
 using System.Xml.Schema;
 
-#nullable disable
 namespace System.Xml.Xsl.Runtime
 {
     /// <summary>
@@ -17,9 +16,9 @@ namespace System.Xml.Xsl.Runtime
     /// </summary>
     internal sealed class XmlAttributeCache : XmlRawWriter, IRemovableWriter
     {
-        private XmlRawWriter _wrapped;
-        private OnRemoveWriter _onRemove;        // Event handler that is called when cached attributes are flushed to wrapped writer
-        private AttrNameVal[] _arrAttrs;         // List of cached attribute names and value parts
+        private XmlRawWriter? _wrapped;
+        private OnRemoveWriter? _onRemove;        // Event handler that is called when cached attributes are flushed to wrapped writer
+        private AttrNameVal[]? _arrAttrs;         // List of cached attribute names and value parts
         private int _numEntries;                 // Number of attributes in the cache
         private int _idxLastName;                // The entry containing the name of the last attribute to be cached
         private int _hashCodeUnion;              // Set of hash bits that can quickly guarantee a name is not a duplicate
@@ -54,7 +53,7 @@ namespace System.Xml.Xsl.Runtime
         /// This writer will raise this event once cached attributes have been flushed in order to signal that the cache
         /// no longer needs to be part of the pipeline.
         /// </summary>
-        public OnRemoveWriter OnRemoveWriterEvent
+        public OnRemoveWriter? OnRemoveWriterEvent
         {
             get { return _onRemove; }
             set { _onRemove = value; }
@@ -63,10 +62,10 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// The wrapped writer will callback on this method if it wishes to remove itself from the pipeline.
         /// </summary>
-        private void SetWrappedWriter(XmlRawWriter writer)
+        private void SetWrappedWriter(XmlRawWriter? writer)
         {
             // If new writer might remove itself from pipeline, have it callback on this method when its ready to go
-            IRemovableWriter removable = writer as IRemovableWriter;
+            IRemovableWriter? removable = writer as IRemovableWriter;
             if (removable != null)
                 removable.OnRemoveWriterEvent = SetWrappedWriter;
 
@@ -81,7 +80,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Add an attribute to the cache.  If an attribute if the same name already exists, replace it.
         /// </summary>
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             int hashCode;
             int idx = 0;
@@ -98,7 +97,7 @@ namespace System.Xml.Xsl.Runtime
 
                 do
                 {
-                    if (_arrAttrs[idx].IsDuplicate(localName, ns, hashCode))
+                    if (_arrAttrs![idx].IsDuplicate(localName, ns, hashCode))
                         break;
 
                     // Next attribute name
@@ -115,9 +114,9 @@ namespace System.Xml.Xsl.Runtime
             // Insert new attribute; link attribute names together in a list
             EnsureAttributeCache();
             if (_numEntries != 0)
-                _arrAttrs[_idxLastName].NextNameIndex = _numEntries;
+                _arrAttrs![_idxLastName].NextNameIndex = _numEntries;
             _idxLastName = _numEntries++;
-            _arrAttrs[_idxLastName].Init(prefix, localName, ns, hashCode);
+            _arrAttrs![_idxLastName].Init(prefix, localName, ns, hashCode);
         }
 
         /// <summary>
@@ -133,14 +132,14 @@ namespace System.Xml.Xsl.Runtime
         internal override void WriteNamespaceDeclaration(string prefix, string ns)
         {
             FlushAttributes();
-            _wrapped.WriteNamespaceDeclaration(prefix, ns);
+            _wrapped!.WriteNamespaceDeclaration(prefix, ns);
         }
 
         /// <summary>
         /// Add a block of text to the cache.  This text block makes up some or all of the untyped string
         /// value of the current attribute.
         /// </summary>
-        public override void WriteString(string text)
+        public override void WriteString(string? text)
         {
             Debug.Assert(text != null);
             Debug.Assert(_arrAttrs != null && _numEntries != 0);
@@ -169,22 +168,22 @@ namespace System.Xml.Xsl.Runtime
             FlushAttributes();
 
             // Call StartElementContent on wrapped writer
-            _wrapped.StartElementContent();
+            _wrapped!.StartElementContent();
         }
 
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Fail("Should never be called on XmlAttributeCache.");
         }
-        internal override void WriteEndElement(string prefix, string localName, string ns)
+        internal override void WriteEndElement(string? prefix, string localName, string? ns)
         {
             Debug.Fail("Should never be called on XmlAttributeCache.");
         }
-        public override void WriteComment(string text)
+        public override void WriteComment(string? text)
         {
             Debug.Fail("Should never be called on XmlAttributeCache.");
         }
-        public override void WriteProcessingInstruction(string name, string text)
+        public override void WriteProcessingInstruction(string name, string? text)
         {
             Debug.Fail("Should never be called on XmlAttributeCache.");
         }
@@ -193,7 +192,7 @@ namespace System.Xml.Xsl.Runtime
             Debug.Fail("Should never be called on XmlAttributeCache.");
         }
 
-        public override void WriteValue(string value)
+        public override void WriteValue(string? value)
         {
             Debug.Fail("Should never be called on XmlAttributeCache.");
         }
@@ -203,7 +202,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public override void Close()
         {
-            _wrapped.Close();
+            _wrapped!.Close();
         }
 
         /// <summary>
@@ -211,7 +210,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public override void Flush()
         {
-            _wrapped.Flush();
+            _wrapped!.Flush();
         }
 
 
@@ -222,12 +221,12 @@ namespace System.Xml.Xsl.Runtime
         private void FlushAttributes()
         {
             int idx = 0, idxNext;
-            string localName;
+            string? localName;
 
             while (idx != _numEntries)
             {
                 // Get index of next attribute's name (0 if this is the last attribute)
-                idxNext = _arrAttrs[idx].NextNameIndex;
+                idxNext = _arrAttrs![idx].NextNameIndex;
                 if (idxNext == 0)
                     idxNext = _numEntries;
 
@@ -238,17 +237,17 @@ namespace System.Xml.Xsl.Runtime
                     string prefix = _arrAttrs[idx].Prefix;
                     string ns = _arrAttrs[idx].Namespace;
 
-                    _wrapped.WriteStartAttribute(prefix, localName, ns);
+                    _wrapped!.WriteStartAttribute(prefix, localName, ns);
 
                     // Output all of this attribute's text or typed values
                     while (++idx != idxNext)
                     {
-                        string text = _arrAttrs[idx].Text;
+                        string? text = _arrAttrs[idx].Text;
 
                         if (text != null)
                             _wrapped.WriteString(text);
                         else
-                            _wrapped.WriteValue(_arrAttrs[idx].Value);
+                            _wrapped.WriteValue(_arrAttrs[idx].Value!);
                     }
 
                     _wrapped.WriteEndAttribute();
@@ -261,24 +260,24 @@ namespace System.Xml.Xsl.Runtime
             }
 
             // Notify event listener that attributes have been flushed
-            _onRemove?.Invoke(_wrapped);
+            _onRemove?.Invoke(_wrapped!);
         }
 
         private struct AttrNameVal
         {
-            private string _localName;
+            private string? _localName;
             private string _prefix;
             private string _namespaceName;
-            private string _text;
-            private XmlAtomicValue _value;
+            private string? _text;
+            private XmlAtomicValue? _value;
             private int _hashCode;
             private int _nextNameIndex;
 
-            public string LocalName { get { return _localName; } }
+            public string? LocalName { get { return _localName; } }
             public string Prefix { get { return _prefix; } }
             public string Namespace { get { return _namespaceName; } }
-            public string Text { get { return _text; } }
-            public XmlAtomicValue Value { get { return _value; } }
+            public string? Text { get { return _text; } }
+            public XmlAtomicValue? Value { get { return _value; } }
             public int NextNameIndex { get { return _nextNameIndex; } set { _nextNameIndex = value; } }
 
             /// <summary>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Unix.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Unix.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Globalization;
 
 namespace System.Xml.Xsl.Runtime

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Windows.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Windows.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Globalization;
 
 namespace System.Xml.Xsl.Runtime

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.cs
@@ -1,13 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace System.Xml.Xsl.Runtime
 {
@@ -31,7 +31,7 @@ namespace System.Xml.Xsl.Runtime
         private const string kaGEmode = "ka-GE_modern";
 
         // Invariant: compops == (options & Options.mask)
-        private readonly CultureInfo _cultInfo;
+        private readonly CultureInfo? _cultInfo;
         private Options _options;
         private readonly CompareOptions _compops;
 
@@ -120,7 +120,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Construct a collation that uses the specified culture and compare options.
         /// </summary>
-        private XmlCollation(CultureInfo cultureInfo, Options options)
+        private XmlCollation(CultureInfo? cultureInfo, Options options)
         {
             _cultInfo = cultureInfo;
             _options = options;
@@ -144,13 +144,14 @@ namespace System.Xml.Xsl.Runtime
 
         internal static XmlCollation Create(string collationLiteral)
         {
-            return Create(collationLiteral, /*throw:*/true);
+            return Create(collationLiteral, throwOnError: true)!;
         }
+
         // This function is used in both parser and F&O library, so just strictly map valid literals to XmlCollation.
         // Set compare options one by one:
         //     0, false: no effect; 1, true: yes
         // Disregard unrecognized options.
-        internal static XmlCollation Create(string collationLiteral, bool throwOnError)
+        internal static XmlCollation? Create(string collationLiteral, bool throwOnError)
         {
             Debug.Assert(collationLiteral != null, "collation literal should not be null");
 
@@ -159,8 +160,8 @@ namespace System.Xml.Xsl.Runtime
                 return CodePointCollation;
             }
 
-            Uri collationUri;
-            CultureInfo cultInfo = null;
+            Uri? collationUri;
+            CultureInfo? cultInfo = null;
             Options options = default;
 
             if (throwOnError)
@@ -213,7 +214,7 @@ namespace System.Xml.Xsl.Runtime
             // Sort & Compare option
             // at least a '?' will be returned for Uri.Query if not empty
             string query = collationUri.Query;
-            string sort = null;
+            string? sort = null;
 
             if (query.Length != 0)
             {
@@ -341,14 +342,14 @@ namespace System.Xml.Xsl.Runtime
         //-----------------------------------------------
 
         // Redefine Equals and GetHashCode methods, they are needed for UniqueList<XmlCollation>
-        public override bool Equals(object obj)
+        public override bool Equals([NotNullWhen(true)] object? obj)
         {
             if (this == obj)
             {
                 return true;
             }
 
-            XmlCollation that = obj as XmlCollation;
+            XmlCollation? that = obj as XmlCollation;
             return that != null &&
                 _options == that._options &&
                 object.Equals(_cultInfo, that._cultInfo);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlExtensionFunction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlExtensionFunction.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Collections.Generic;
 using System.Xml;
@@ -20,7 +19,7 @@ namespace System.Xml.Xsl.Runtime
     internal sealed class XmlExtensionFunctionTable
     {
         private readonly Dictionary<XmlExtensionFunction, XmlExtensionFunction> _table;
-        private XmlExtensionFunction _funcCached;
+        private XmlExtensionFunction? _funcCached;
 
         public XmlExtensionFunctionTable()
         {
@@ -34,7 +33,7 @@ namespace System.Xml.Xsl.Runtime
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type objectType,
             BindingFlags flags)
         {
-            XmlExtensionFunction func;
+            XmlExtensionFunction? func;
 
             _funcCached ??= new XmlExtensionFunction();
 
@@ -59,19 +58,19 @@ namespace System.Xml.Xsl.Runtime
     /// </summary>
     internal sealed class XmlExtensionFunction
     {
-        private string _namespaceUri;                // Extension object identifier
-        private string _name;                        // Name of this method
+        private string? _namespaceUri;                // Extension object identifier
+        private string? _name;                        // Name of this method
         private int _numArgs;                        // Argument count
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
-        private Type _objectType;                    // Type of the object which will be searched for matching methods
+        private Type? _objectType;                    // Type of the object which will be searched for matching methods
         private BindingFlags _flags;                 // Modifiers that were used to search for a matching signature
         private int _hashCode;                       // Pre-computed hashcode
 
-        private MethodInfo _meth;                    // MethodInfo for extension function
-        private Type[] _argClrTypes;                 // Type array for extension function arguments
-        private Type _retClrType;                    // Type for extension function return value
-        private XmlQueryType[] _argXmlTypes;         // XmlQueryType array for extension function arguments
-        private XmlQueryType _retXmlType;            // XmlQueryType for extension function return value
+        private MethodInfo? _meth;                    // MethodInfo for extension function
+        private Type[]? _argClrTypes;                 // Type array for extension function arguments
+        private Type? _retClrType;                    // Type for extension function return value
+        private XmlQueryType[]? _argXmlTypes;         // XmlQueryType array for extension function arguments
+        private XmlQueryType? _retXmlType;            // XmlQueryType for extension function return value
 
         /// <summary>
         /// Constructor.
@@ -121,7 +120,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Once Bind has been successfully called, Method will be non-null.
         /// </summary>
-        public MethodInfo Method
+        public MethodInfo? Method
         {
             get { return _meth; }
         }
@@ -132,14 +131,14 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public Type GetClrArgumentType(int index)
         {
-            return _argClrTypes[index];
+            return _argClrTypes![index];
         }
 
         /// <summary>
         /// Once Bind has been successfully called, the Clr type of the return value can be accessed.
         /// Note that this may be different than Method.GetParameterInfo().ReturnType.
         /// </summary>
-        public Type ClrReturnType
+        public Type? ClrReturnType
         {
             get { return _retClrType; }
         }
@@ -149,13 +148,13 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public XmlQueryType GetXmlArgumentType(int index)
         {
-            return _argXmlTypes[index];
+            return _argXmlTypes![index];
         }
 
         /// <summary>
         /// Once Bind has been successfully called, the inferred Xml type of the return value can be accessed.
         /// </summary>
-        public XmlQueryType XmlReturnType
+        public XmlQueryType? XmlReturnType
         {
             get { return _retXmlType; }
         }
@@ -165,7 +164,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public bool CanBind()
         {
-            MethodInfo[] methods = _objectType.GetMethods(_flags);
+            MethodInfo[] methods = _objectType!.GetMethods(_flags);
             bool ignoreCase = (_flags & BindingFlags.IgnoreCase) != 0;
             StringComparison comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
@@ -188,8 +187,8 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public void Bind()
         {
-            MethodInfo[] methods = _objectType.GetMethods(_flags);
-            MethodInfo methMatch = null;
+            MethodInfo[] methods = _objectType!.GetMethods(_flags);
+            MethodInfo? methMatch = null;
             bool ignoreCase = (_flags & BindingFlags.IgnoreCase) != 0;
             StringComparison comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
@@ -256,7 +255,7 @@ namespace System.Xml.Xsl.Runtime
                 //    Xslt functions allow Rtf.
                 // 2. Script arguments should allow node-sets which are not statically known
                 //    to be Dod to be passed, so relax static typing in this case.
-                if (_namespaceUri.Length == 0)
+                if (_namespaceUri!.Length == 0)
                 {
                     if ((object)_argXmlTypes[i] == (object)XmlQueryTypeFactory.NodeNotRtf)
                         _argXmlTypes[i] = XmlQueryTypeFactory.Node;
@@ -277,10 +276,10 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Convert the incoming arguments to an array of CLR objects, and then invoke the external function on the "extObj" object instance.
         /// </summary>
-        public object Invoke(object extObj, object[] args)
+        public object? Invoke(object extObj, object?[] args)
         {
             Debug.Assert(_meth != null, "Must call Bind() before calling Invoke.");
-            Debug.Assert(args.Length == _argClrTypes.Length, "Mismatched number of actual and formal arguments.");
+            Debug.Assert(args.Length == _argClrTypes!.Length, "Mismatched number of actual and formal arguments.");
 
             try
             {
@@ -303,9 +302,9 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return true if this XmlExtensionFunction has the same values as another XmlExtensionFunction.
         /// </summary>
-        public override bool Equals(object other)
+        public override bool Equals([NotNullWhen(true)] object? other)
         {
-            XmlExtensionFunction that = other as XmlExtensionFunction;
+            XmlExtensionFunction? that = other as XmlExtensionFunction;
             Debug.Assert(that != null);
 
             // Compare name, argument count, object type, and binding flags

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlILIndex.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlILIndex.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -30,7 +29,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public void Add(string key, XPathNavigator navigator)
         {
-            XmlQueryNodeSequence seq;
+            XmlQueryNodeSequence? seq;
 
             if (!_table.TryGetValue(key, out seq))
             {
@@ -57,7 +56,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public XmlQueryNodeSequence Lookup(string key)
         {
-            XmlQueryNodeSequence seq;
+            XmlQueryNodeSequence? seq;
 
             if (!_table.TryGetValue(key, out seq))
                 seq = new XmlQueryNodeSequence();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlILStorageConverter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlILStorageConverter.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -85,7 +84,7 @@ namespace System.Xml.Xsl.Runtime
         public static IList<XPathItem> NavigatorsToItems(IList<XPathNavigator> listNavigators)
         {
             // Check to see if the navigator cache implements IList<XPathItem>
-            IList<XPathItem> listItems = listNavigators as IList<XPathItem>;
+            IList<XPathItem>? listItems = listNavigators as IList<XPathItem>;
             if (listItems != null)
                 return listItems;
 
@@ -96,7 +95,7 @@ namespace System.Xml.Xsl.Runtime
         public static IList<XPathNavigator> ItemsToNavigators(IList<XPathItem> listItems)
         {
             // Check to see if the navigator cache implements IList<XPathNavigator>
-            IList<XPathNavigator> listNavs = listItems as IList<XPathNavigator>;
+            IList<XPathNavigator>? listNavs = listItems as IList<XPathNavigator>;
             if (listNavs != null)
                 return listNavs;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlIterators.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlIterators.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Xml;
 using System.Xml.XPath;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlNavigatorFilter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlNavigatorFilter.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Xml;
 using System.Xml.XPath;
 using System.Diagnostics;
@@ -46,7 +45,7 @@ namespace System.Xml.Xsl.Runtime
         /// Reposition the navigator to the next following node (inc. descendants); skip over filtered nodes.
         /// If there are no matching nodes, then return false.
         /// </summary>
-        public abstract bool MoveToFollowing(XPathNavigator navigator, XPathNavigator navigatorEnd);
+        public abstract bool MoveToFollowing(XPathNavigator navigator, XPathNavigator? navigatorEnd);
 
         /// <summary>
         /// Return true if the navigator's current node matches the filter condition.
@@ -115,7 +114,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Reposition the navigator on the next following element with a matching name.
         /// </summary>
-        public override bool MoveToFollowing(XPathNavigator navigator, XPathNavigator navEnd)
+        public override bool MoveToFollowing(XPathNavigator navigator, XPathNavigator? navEnd)
         {
             return navigator.MoveToFollowing(_localName, _namespaceUri, navEnd);
         }
@@ -206,7 +205,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Reposition the navigator on the next following element with a matching kind.
         /// </summary>
-        public override bool MoveToFollowing(XPathNavigator navigator, XPathNavigator navEnd)
+        public override bool MoveToFollowing(XPathNavigator navigator, XPathNavigator? navEnd)
         {
             return navigator.MoveToFollowing(_nodeType, navEnd);
         }
@@ -278,7 +277,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Reposition the navigator on the next following non-attribute.
         /// </summary>
-        public override bool MoveToFollowing(XPathNavigator navigator, XPathNavigator navEnd)
+        public override bool MoveToFollowing(XPathNavigator navigator, XPathNavigator? navEnd)
         {
             return navigator.MoveToFollowing(XPathNodeType.All, navEnd);
         }
@@ -350,7 +349,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Reposition the navigator on the next following node.
         /// </summary>
-        public override bool MoveToFollowing(XPathNavigator navigator, XPathNavigator navEnd)
+        public override bool MoveToFollowing(XPathNavigator navigator, XPathNavigator? navEnd)
         {
             return navigator.MoveToFollowing(XPathNodeType.All, navEnd);
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlNavigatorStack.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlNavigatorStack.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Xml;
 using System.Xml.XPath;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryContext.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryContext.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -30,18 +29,18 @@ namespace System.Xml.Xsl.Runtime
     public sealed class XmlQueryContext
     {
         private readonly XmlQueryRuntime _runtime;
-        private readonly XPathNavigator _defaultDataSource;
+        private readonly XPathNavigator? _defaultDataSource;
         private readonly XmlResolver _dataSources;
         private readonly Hashtable _dataSourceCache;
-        private readonly XsltArgumentList _argList;
-        private XmlExtensionFunctionTable _extFuncsLate;
-        private readonly WhitespaceRuleLookup _wsRules;
+        private readonly XsltArgumentList? _argList;
+        private XmlExtensionFunctionTable? _extFuncsLate;
+        private readonly WhitespaceRuleLookup? _wsRules;
         private readonly QueryReaderSettings _readerSettings; // If we create reader out of stream we will use these settings
 
         /// <summary>
         /// This constructor is internal so that external users cannot construct it (and therefore we do not have to test it separately).
         /// </summary>
-        internal XmlQueryContext(XmlQueryRuntime runtime, object defaultDataSource, XmlResolver dataSources, XsltArgumentList argList, WhitespaceRuleLookup wsRules)
+        internal XmlQueryContext(XmlQueryRuntime runtime, object defaultDataSource, XmlResolver dataSources, XsltArgumentList? argList, WhitespaceRuleLookup? wsRules)
         {
             _runtime = runtime;
             _dataSources = dataSources;
@@ -60,13 +59,13 @@ namespace System.Xml.Xsl.Runtime
                 _readerSettings = new QueryReaderSettings(new NameTable());
             }
 
-            if (defaultDataSource is string)
+            if (defaultDataSource is string s)
             {
                 // Load the default document from a Uri
-                _defaultDataSource = GetDataSource(defaultDataSource as string, null);
+                _defaultDataSource = GetDataSource(s, null);
 
                 if (_defaultDataSource == null)
-                    throw new XslTransformException(SR.XmlIl_UnknownDocument, defaultDataSource as string);
+                    throw new XslTransformException(SR.XmlIl_UnknownDocument, s);
             }
             else if (defaultDataSource != null)
             {
@@ -91,7 +90,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Returns the name table used by the default data source, or null if there is no default data source.
         /// </summary>
-        public XmlNameTable DefaultNameTable
+        public XmlNameTable? DefaultNameTable
         {
             get { return _defaultDataSource?.NameTable; }
         }
@@ -116,11 +115,11 @@ namespace System.Xml.Xsl.Runtime
         /// If the resolver returns a stream or reader, create an instance of XPathDocument.  If the resolver returns an
         /// XPathNavigator, return the navigator.  Throw an exception if no data source was found.
         /// </summary>
-        public XPathNavigator GetDataSource(string uriRelative, string uriBase)
+        public XPathNavigator? GetDataSource(string uriRelative, string? uriBase)
         {
-            object input;
-            Uri uriResolvedBase, uriResolved;
-            XPathNavigator nav = null;
+            object? input;
+            Uri? uriResolvedBase, uriResolved;
+            XPathNavigator? nav = null;
 
             try
             {
@@ -133,13 +132,13 @@ namespace System.Xml.Xsl.Runtime
                 if (nav == null)
                 {
                     // Get the entity from the resolver and ensure it is cached as a document
-                    input = _dataSources.GetEntity(uriResolved, null, null);
+                    input = _dataSources.GetEntity(uriResolved!, null, null);
 
                     if (input != null)
                     {
                         // Construct a document from the entity and add the document to the cache
                         nav = ConstructDocument(input, uriRelative, uriResolved);
-                        _dataSourceCache.Add(uriResolved, nav);
+                        _dataSourceCache.Add(uriResolved!, nav);
                     }
                 }
             }
@@ -163,10 +162,10 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Ensure that "dataSource" is cached as an XPathDocument and return a navigator over the document.
         /// </summary>
-        private XPathNavigator ConstructDocument(object dataSource, string uriRelative, Uri uriResolved)
+        private XPathNavigator? ConstructDocument(object dataSource, string? uriRelative, Uri? uriResolved)
         {
             Debug.Assert(dataSource != null, "GetType() below assumes dataSource is not null");
-            Stream stream = dataSource as Stream;
+            Stream? stream = dataSource as Stream;
             if (stream != null)
             {
                 // Create document from stream
@@ -183,18 +182,18 @@ namespace System.Xml.Xsl.Runtime
                     reader.Close();
                 }
             }
-            else if (dataSource is XmlReader)
+            else if (dataSource is XmlReader reader)
             {
                 // Create document from reader
                 // Create WhitespaceRuleReader if whitespace should be stripped
-                return new XPathDocument(WhitespaceRuleReader.CreateReader(dataSource as XmlReader, _wsRules), XmlSpace.Preserve).CreateNavigator();
+                return new XPathDocument(WhitespaceRuleReader.CreateReader(reader, _wsRules), XmlSpace.Preserve).CreateNavigator();
             }
-            else if (dataSource is IXPathNavigable)
+            else if (dataSource is IXPathNavigable xPathNavigable)
             {
                 if (_wsRules != null)
                     throw new XslTransformException(SR.XmlIl_CantStripNav, string.Empty);
 
-                return (dataSource as IXPathNavigable).CreateNavigator();
+                return xPathNavigable.CreateNavigator();
             }
 
             Debug.Assert(uriRelative != null, "Relative URI should not be null");
@@ -210,7 +209,7 @@ namespace System.Xml.Xsl.Runtime
         /// Get a named parameter from the external argument list.  Return null if no argument list was provided, or if
         /// there is no parameter by that name.
         /// </summary>
-        public object GetParameter(string localName, string namespaceUri)
+        public object? GetParameter(string localName, string namespaceUri)
         {
             return _argList?.GetParam(localName, namespaceUri);
         }
@@ -225,7 +224,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = XsltArgumentList.ExtensionObjectSuppresion)]
-        public object GetLateBoundObject(string namespaceUri)
+        public object? GetLateBoundObject(string namespaceUri)
         {
             return _argList?.GetExtensionObject(namespaceUri);
         }
@@ -236,7 +235,7 @@ namespace System.Xml.Xsl.Runtime
         [RequiresUnreferencedCode(Scripts.ExtensionFunctionCannotBeStaticallyAnalyzed)]
         public bool LateBoundFunctionExists(string name, string namespaceUri)
         {
-            object instance;
+            object? instance;
 
             if (_argList == null)
                 return false;
@@ -255,11 +254,11 @@ namespace System.Xml.Xsl.Runtime
         [RequiresUnreferencedCode(Scripts.ExtensionFunctionCannotBeStaticallyAnalyzed)]
         public IList<XPathItem> InvokeXsltLateBoundFunction(string name, string namespaceUri, IList<XPathItem>[] args)
         {
-            object instance;
+            object? instance;
             object[] objActualArgs;
             XmlQueryType xmlTypeFormalArg;
             Type clrTypeFormalArg;
-            object objRet;
+            object? objRet;
 
             // Get external object instance from argument list (throw if either the list or the instance doesn't exist)
             instance = _argList?.GetExtensionObject(namespaceUri);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryOutput.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryOutput.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -36,21 +35,21 @@ namespace System.Xml.Xsl.Runtime
     public sealed class XmlQueryOutput : XmlWriter
     {
         // Never set these fields directly--instead use corresponding properties
-        private XmlRawWriter _xwrt;                  // Output to XmlRawWriter--get and set this using the Writer property
+        private XmlRawWriter? _xwrt;                  // Output to XmlRawWriter--get and set this using the Writer property
 
         // It is OK to set these properties directly
         private readonly XmlQueryRuntime _runtime;            // The XmlQueryRuntime instance that keeps global state
-        private XmlAttributeCache _attrCache;        // Cache used to detect duplicate attributes
+        private XmlAttributeCache? _attrCache;        // Cache used to detect duplicate attributes
         private int _depth;                          // Depth of the currently constructing tree
         private XmlState _xstate;                    // Current XML state
-        private readonly XmlSequenceWriter _seqwrt;           // Current XmlSequenceWriter
-        private XmlNamespaceManager _nsmgr;          // Output namespace manager
+        private readonly XmlSequenceWriter? _seqwrt;           // Current XmlSequenceWriter
+        private XmlNamespaceManager? _nsmgr;          // Output namespace manager
         private int _cntNmsp;                        // Number of pending namespaces
-        private Dictionary<string, string> _conflictPrefixes;         // Remembers prefixes that were auto-generated previously in case they can be reused
+        private Dictionary<string, string>? _conflictPrefixes;         // Remembers prefixes that were auto-generated previously in case they can be reused
         private int _prefixIndex;                    // Counter used to auto-generate non-conflicting attribute prefixes
-        private string _piTarget/*nmspPrefix*/;      // Cache pi target or namespace prefix
+        private string? _piTarget/*nmspPrefix*/;      // Cache pi target or namespace prefix
         private StringConcat _nodeText;              // Cache pi, comment, or namespace text
-        private Stack<string> _stkNames;             // Keep stack of name parts computed during StartElement
+        private Stack<string>? _stkNames;             // Keep stack of name parts computed during StartElement
         private XPathNodeType _rootType;             // NodeType of the root of the tree
 
         private readonly Dictionary<string, string> _usedPrefixes = new Dictionary<string, string>(); //The prefies that used in the current scope
@@ -82,7 +81,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Sequence writer to which output is directed by this class.
         /// </summary>
-        internal XmlSequenceWriter SequenceWriter
+        internal XmlSequenceWriter? SequenceWriter
         {
             get { return _seqwrt; }
         }
@@ -90,13 +89,13 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Raw writer to which output is directed by this class.
         /// </summary>
-        internal XmlRawWriter Writer
+        internal XmlRawWriter? Writer
         {
             get { return _xwrt; }
             set
             {
                 // If new writer might remove itself from pipeline, have it callback on this method when it's ready to go
-                IRemovableWriter removable = value as IRemovableWriter;
+                IRemovableWriter? removable = value as IRemovableWriter;
                 if (removable != null)
                     removable.OnRemoveWriterEvent = SetWrappedWriter;
 
@@ -150,7 +149,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Should never be called.
         /// </summary>
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             throw new NotSupportedException();
         }
@@ -158,7 +157,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Before calling XmlRawWriter.WriteStartElement(), perform various checks to ensure well-formedness.
         /// </summary>
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             Debug.Assert(prefix != null && localName != null && localName.Length != 0 && ns != null, "Invalid argument");
             Debug.Assert(ValidateNames.ValidateName(prefix, localName, ns, XPathNodeType.Element, ValidateNames.Flags.All), "Name validation failed");
@@ -175,7 +174,7 @@ namespace System.Xml.Xsl.Runtime
             // Cache attributes in order to detect duplicates
             _attrCache ??= new XmlAttributeCache();
 
-            _attrCache.Init(Writer);
+            _attrCache.Init(Writer!);
             Writer = _attrCache;
             _attrCache = null;
 
@@ -217,7 +216,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Before calling XmlRawWriter.WriteStartAttribute(), perform various checks to ensure well-formedness.
         /// </summary>
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             Debug.Assert(prefix != null && localName != null && ns != null, "Invalid argument");
 
@@ -264,7 +263,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Before writing a comment, perform various checks to ensure well-formedness.
         /// </summary>
-        public override void WriteComment(string text)
+        public override void WriteComment(string? text)
         {
             WriteStartComment();
             WriteCommentString(text);
@@ -274,7 +273,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Before writing a processing instruction, perform various checks to ensure well-formedness.
         /// </summary>
-        public override void WriteProcessingInstruction(string target, string text)
+        public override void WriteProcessingInstruction(string target, string? text)
         {
             WriteStartProcessingInstruction(target);
             WriteProcessingInstructionString(text);
@@ -308,7 +307,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Treat whitespace as regular text.
         /// </summary>
-        public override void WriteWhitespace(string ws)
+        public override void WriteWhitespace(string? ws)
         {
             throw new NotSupportedException();
         }
@@ -316,9 +315,9 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Before writing text, perform various checks to ensure well-formedness.
         /// </summary>
-        public override void WriteString(string text)
+        public override void WriteString(string? text)
         {
-            WriteString(text, false);
+            WriteString(text!, false);
         }
 
         /// <summary>
@@ -348,9 +347,9 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Write CData text as regular text.
         /// </summary>
-        public override void WriteCData(string text)
+        public override void WriteCData(string? text)
         {
-            WriteString(text, false);
+            WriteString(text!, false);
         }
 
         /// <summary>
@@ -418,7 +417,7 @@ namespace System.Xml.Xsl.Runtime
         public void StartTree(XPathNodeType rootType)
         {
             Debug.Assert(_xstate == XmlState.WithinSequence, $"StartTree cannot be called in the {_xstate} state.");
-            Writer = _seqwrt.StartTree(rootType, _nsmgr, _runtime.NameTable);
+            Writer = _seqwrt!.StartTree(rootType, _nsmgr, _runtime.NameTable);
             _rootType = rootType;
             _xstate = (rootType == XPathNodeType.Attribute || rootType == XPathNodeType.Namespace) ? XmlState.EnumAttrs : XmlState.WithinContent;
         }
@@ -429,7 +428,7 @@ namespace System.Xml.Xsl.Runtime
         public void EndTree()
         {
             Debug.Assert(_xstate == XmlState.EnumAttrs || _xstate == XmlState.WithinContent, $"EndTree cannot be called in the {_xstate} state.");
-            _seqwrt.EndTree();
+            _seqwrt!.EndTree();
             _xstate = XmlState.WithinSequence;
             Writer = null;
         }
@@ -446,7 +445,7 @@ namespace System.Xml.Xsl.Runtime
         {
             Debug.Assert(_xstate == XmlState.WithinContent, $"WriteStartElement cannot be called in the {_xstate} state.");
             _nsmgr?.PushScope();
-            Writer.WriteStartElement(prefix, localName, ns);
+            Writer!.WriteStartElement(prefix, localName, ns);
             //reset when enter element
             _usedPrefixes.Clear();
             _usedPrefixes[prefix] = ns;
@@ -473,7 +472,7 @@ namespace System.Xml.Xsl.Runtime
             if (_cntNmsp != 0)
                 WriteCachedNamespaces();
 
-            Writer.StartElementContent();
+            Writer!.StartElementContent();
             _xstate = XmlState.WithinContent;
         }
 
@@ -483,7 +482,7 @@ namespace System.Xml.Xsl.Runtime
         public void WriteEndElementUnchecked(string prefix, string localName, string ns)
         {
             Debug.Assert(_xstate == XmlState.EnumAttrs || _xstate == XmlState.WithinContent, $"WriteEndElement cannot be called in the {_xstate} state.");
-            Writer.WriteEndElement(prefix, localName, ns);
+            Writer!.WriteEndElement(prefix, localName, ns);
             _xstate = XmlState.WithinContent;
             _depth--;
             _nsmgr?.PopScope();
@@ -500,10 +499,10 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// XmlRawWriter.WriteStartAttribute() with prefix, local-name, ns, and schema type.
         /// </summary>
-        public void WriteStartAttributeUnchecked(string prefix, string localName, string ns)
+        public void WriteStartAttributeUnchecked(string? prefix, string localName, string? ns)
         {
             Debug.Assert(_xstate == XmlState.EnumAttrs, $"WriteStartAttribute cannot be called in the {_xstate} state.");
-            Writer.WriteStartAttribute(prefix, localName, ns);
+            Writer!.WriteStartAttribute(prefix, localName, ns);
             _xstate = XmlState.WithinAttr;
             _depth++;
         }
@@ -522,7 +521,7 @@ namespace System.Xml.Xsl.Runtime
         public void WriteEndAttributeUnchecked()
         {
             Debug.Assert(_xstate == XmlState.WithinAttr, $"WriteEndAttribute cannot be called in the {_xstate} state.");
-            Writer.WriteEndAttribute();
+            Writer!.WriteEndAttribute();
             _xstate = XmlState.EnumAttrs;
             _depth--;
         }
@@ -545,7 +544,7 @@ namespace System.Xml.Xsl.Runtime
             if (_depth == 0)
             {
                 // At top-level, so write namespace declaration directly to output
-                Writer.WriteNamespaceDeclaration(prefix, ns);
+                Writer!.WriteNamespaceDeclaration(prefix, ns);
                 return;
             }
 
@@ -571,7 +570,7 @@ namespace System.Xml.Xsl.Runtime
         public void WriteStringUnchecked(string text)
         {
             Debug.Assert(_xstate != XmlState.WithinSequence && _xstate != XmlState.EnumAttrs, $"WriteTextBlock cannot be called in the {_xstate} state.");
-            Writer.WriteString(text);
+            Writer!.WriteString(text);
         }
 
         /// <summary>
@@ -580,7 +579,7 @@ namespace System.Xml.Xsl.Runtime
         public void WriteRawUnchecked(string text)
         {
             Debug.Assert(_xstate != XmlState.WithinSequence && _xstate != XmlState.EnumAttrs, $"WriteTextBlockNoEntities cannot be called in the {_xstate} state.");
-            Writer.WriteRaw(text);
+            Writer!.WriteRaw(text);
         }
 
 
@@ -696,7 +695,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public void WriteNamespaceDeclaration(string prefix, string ns)
         {
-            string nsExisting;
+            string? nsExisting;
             Debug.Assert(prefix != null && ns != null);
 
             ConstructInEnumAttrs(XPathNodeType.Namespace);
@@ -775,7 +774,7 @@ namespace System.Xml.Xsl.Runtime
             _depth--;
 
             // Write cached namespace attribute
-            WriteNamespaceDeclaration(_piTarget/*nmspPrefix*/, _nodeText.GetResult());
+            WriteNamespaceDeclaration(_piTarget!/*nmspPrefix*/, _nodeText.GetResult());
 
             if (_depth == 0)
                 EndTree();
@@ -797,7 +796,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Cache the comment's text.
         /// </summary>
-        public void WriteCommentString(string text)
+        public void WriteCommentString(string? text)
         {
             Debug.Assert(_xstate == XmlState.WithinComment, $"WriteCommentString cannot be called in the {_xstate} state.");
             _nodeText.ConcatNoDelimiter(text);
@@ -810,7 +809,7 @@ namespace System.Xml.Xsl.Runtime
         {
             Debug.Assert(_xstate == XmlState.WithinComment, $"WriteEndComment cannot be called in the {_xstate} state.");
 
-            Writer.WriteComment(_nodeText.GetResult());
+            Writer!.WriteComment(_nodeText.GetResult());
 
             _xstate = XmlState.WithinContent;
             _depth--;
@@ -840,7 +839,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Cache the processing instruction's text.
         /// </summary>
-        public void WriteProcessingInstructionString(string text)
+        public void WriteProcessingInstructionString(string? text)
         {
             Debug.Assert(_xstate == XmlState.WithinPI, $"WriteProcessingInstructionString cannot be called in the {_xstate} state.");
             _nodeText.ConcatNoDelimiter(text);
@@ -853,7 +852,7 @@ namespace System.Xml.Xsl.Runtime
         {
             Debug.Assert(_xstate == XmlState.WithinPI, $"WriteEndProcessingInstruction cannot be called in the {_xstate} state.");
 
-            Writer.WriteProcessingInstruction(_piTarget, _nodeText.GetResult());
+            Writer!.WriteProcessingInstruction(_piTarget!, _nodeText.GetResult());
 
             _xstate = XmlState.WithinContent;
             _depth--;
@@ -875,7 +874,7 @@ namespace System.Xml.Xsl.Runtime
 
                 // If this is a top-level node, write a reference to it; else copy it by value
                 if (_xstate == XmlState.WithinSequence)
-                    _seqwrt.WriteItem(navigator);
+                    _seqwrt!.WriteItem(navigator);
                 else
                     CopyNode(navigator);
             }
@@ -883,7 +882,7 @@ namespace System.Xml.Xsl.Runtime
             {
                 // Call WriteItem for atomic values
                 Debug.Assert(_xstate == XmlState.WithinSequence, "Values can only be written at the top-level.");
-                _seqwrt.WriteItem(item);
+                _seqwrt!.WriteItem(item);
             }
         }
 
@@ -895,7 +894,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public void XsltCopyOf(XPathNavigator navigator)
         {
-            RtfNavigator navRtf = navigator as RtfNavigator;
+            RtfNavigator? navRtf = navigator as RtfNavigator;
 
             if (navRtf != null)
             {
@@ -968,7 +967,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         private void AddNamespace(string prefix, string ns)
         {
-            _nsmgr.AddNamespace(prefix, ns);
+            _nsmgr!.AddNamespace(prefix, ns);
             _cntNmsp++;
             _usedPrefixes[prefix] = ns;
         }
@@ -1144,7 +1143,7 @@ namespace System.Xml.Xsl.Runtime
                     if (callChk)
                     {
                         // Do not allow namespaces to be copied after attributes
-                        XmlAttributeCache attrCache = Writer as XmlAttributeCache;
+                        XmlAttributeCache? attrCache = Writer as XmlAttributeCache;
                         if (attrCache != null && attrCache.Count != 0)
                             throw new XslTransformException(SR.XmlIl_NmspAfterAttr, string.Empty);
 
@@ -1312,7 +1311,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         private void WriteCachedNamespaces()
         {
-            string prefix, ns;
+            string? prefix, ns;
 
             while (_cntNmsp != 0)
             {
@@ -1320,7 +1319,7 @@ namespace System.Xml.Xsl.Runtime
                 Debug.Assert(_nsmgr != null);
                 _cntNmsp--;
                 _nsmgr.GetNamespaceDeclaration(_cntNmsp, out prefix, out ns);
-                Writer.WriteNamespaceDeclaration(prefix, ns);
+                Writer!.WriteNamespaceDeclaration(prefix!, ns!);
             }
         }
 
@@ -1348,7 +1347,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         private string CheckAttributePrefix(string prefix, string ns)
         {
-            string nsExisting;
+            string? nsExisting;
             Debug.Assert(prefix.Length != 0 && ns.Length != 0);
 
             // Ensure that this attribute's prefix does not conflict with previously declared prefixes in this scope
@@ -1396,7 +1395,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         private string RemapPrefix(string prefix, string ns, bool isElemPrefix)
         {
-            string genPrefix;
+            string? genPrefix;
             Debug.Assert(prefix != null && ns != null && ns.Length != 0);
 
             _conflictPrefixes ??= new Dictionary<string, string>(16);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryRuntime.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryRuntime.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -30,31 +29,31 @@ namespace System.Xml.Xsl.Runtime
     {
         // Early-Bound Library Objects
         private readonly XmlQueryContext _ctxt;
-        private XsltLibrary _xsltLib;
-        private readonly EarlyBoundInfo[] _earlyInfo;
-        private readonly object[] _earlyObjects;
+        private XsltLibrary? _xsltLib;
+        private readonly EarlyBoundInfo[]? _earlyInfo;
+        private readonly object[]? _earlyObjects;
 
         // Global variables and parameters
-        private readonly string[] _globalNames;
-        private readonly object[] _globalValues;
+        private readonly string[]? _globalNames;
+        private readonly object[]? _globalValues;
 
         // Names, prefix mappings, and name filters
         private readonly XmlNameTable _nameTableQuery;
-        private readonly string[] _atomizedNames;             // Names after atomization
-        private readonly XmlNavigatorFilter[] _filters;       // Name filters (contain atomized names)
-        private readonly StringPair[][] _prefixMappingsList;  // Lists of prefix mappings (used to resolve computed names)
+        private readonly string[]? _atomizedNames;             // Names after atomization
+        private readonly XmlNavigatorFilter[]? _filters;       // Name filters (contain atomized names)
+        private readonly StringPair[][]? _prefixMappingsList;  // Lists of prefix mappings (used to resolve computed names)
 
         // Xml types
-        private readonly XmlQueryType[] _types;
+        private readonly XmlQueryType[]? _types;
 
         // Collations
-        private readonly XmlCollation[] _collations;
+        private readonly XmlCollation[]? _collations;
 
         // Document ordering
         private readonly DocumentOrderComparer _docOrderCmp;
 
         // Indexes
-        private ArrayList[] _indexes;
+        private ArrayList[]? _indexes;
 
         // Output construction
         private XmlQueryOutput _output;
@@ -68,12 +67,12 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// This constructor is internal so that external users cannot construct it (and therefore we do not have to test it separately).
         /// </summary>
-        internal XmlQueryRuntime(XmlQueryStaticData data, object defaultDataSource, XmlResolver dataSources, XsltArgumentList argList, XmlSequenceWriter seqWrt)
+        internal XmlQueryRuntime(XmlQueryStaticData data, object defaultDataSource, XmlResolver dataSources, XsltArgumentList? argList, XmlSequenceWriter seqWrt)
         {
             Debug.Assert(data != null);
-            string[] names = data.Names;
-            Int32Pair[] filters = data.Filters;
-            WhitespaceRuleLookup wsRules;
+            string[]? names = data.Names;
+            Int32Pair[]? filters = data.Filters;
+            WhitespaceRuleLookup? wsRules;
             int i;
 
             // Early-Bound Library Objects
@@ -95,7 +94,7 @@ namespace System.Xml.Xsl.Runtime
             {
                 // Atomize all names in "nameTableQuery".  Use names from the default data source's
                 // name table when possible.
-                XmlNameTable nameTableDefault = _ctxt.DefaultNameTable;
+                XmlNameTable? nameTableDefault = _ctxt.DefaultNameTable;
                 _atomizedNames = new string[names.Length];
 
                 if (nameTableDefault != _nameTableQuery && nameTableDefault != null)
@@ -104,7 +103,7 @@ namespace System.Xml.Xsl.Runtime
                     // name table used in this query
                     for (i = 0; i < names.Length; i++)
                     {
-                        string name = nameTableDefault.Get(names[i]);
+                        string? name = nameTableDefault.Get(names[i]);
                         _atomizedNames[i] = _nameTableQuery.Add(name ?? names[i]);
                     }
                 }
@@ -125,7 +124,7 @@ namespace System.Xml.Xsl.Runtime
                 _filters = new XmlNavigatorFilter[filters.Length];
 
                 for (i = 0; i < filters.Length; i++)
-                    _filters[i] = XmlNavNameFilter.Create(_atomizedNames[filters[i].Left], _atomizedNames[filters[i].Right]);
+                    _filters[i] = XmlNavNameFilter.Create(_atomizedNames![filters[i].Left], _atomizedNames[filters[i].Right]);
             }
 
             // Prefix maping lists
@@ -157,7 +156,7 @@ namespace System.Xml.Xsl.Runtime
         /// Return array containing the names of all the global variables and parameters used in this query, in this format:
         ///     {namespace}prefix:local-name
         /// </summary>
-        public string[] DebugGetGlobalNames()
+        public string[]? DebugGetGlobalNames()
         {
             return _globalNames;
         }
@@ -166,14 +165,14 @@ namespace System.Xml.Xsl.Runtime
         /// Get the value of a global value having the specified name.  Always return the global value as a list of XPathItem.
         /// Return null if there is no global value having the specified name.
         /// </summary>
-        public IList DebugGetGlobalValue(string name)
+        public IList? DebugGetGlobalValue(string name)
         {
-            for (int idx = 0; idx < _globalNames.Length; idx++)
+            for (int idx = 0; idx < _globalNames!.Length; idx++)
             {
                 if (_globalNames[idx] == name)
                 {
                     Debug.Assert(IsGlobalComputed(idx), "Cannot get the value of a global value until it has been computed.");
-                    Debug.Assert(_globalValues[idx] is IList<XPathItem>, "Only debugger should call this method, and all global values should have type item* in debugging scenarios.");
+                    Debug.Assert(_globalValues![idx] is IList<XPathItem>, "Only debugger should call this method, and all global values should have type item* in debugging scenarios.");
                     return (IList)_globalValues[idx];
                 }
             }
@@ -185,12 +184,12 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public void DebugSetGlobalValue(string name, object value)
         {
-            for (int idx = 0; idx < _globalNames.Length; idx++)
+            for (int idx = 0; idx < _globalNames!.Length; idx++)
             {
                 if (_globalNames[idx] == name)
                 {
                     Debug.Assert(IsGlobalComputed(idx), "Cannot get the value of a global value until it has been computed.");
-                    Debug.Assert(_globalValues[idx] is IList<XPathItem>, "Only debugger should call this method, and all global values should have type item* in debugging scenarios.");
+                    Debug.Assert(_globalValues![idx] is IList<XPathItem>, "Only debugger should call this method, and all global values should have type item* in debugging scenarios.");
 
                     // Always convert "value" to a list of XPathItem using the item* converter
                     _globalValues[idx] = (IList<XPathItem>)XmlAnyListConverter.ItemList.ChangeType(value, typeof(XPathItem[]), null);
@@ -202,11 +201,11 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Convert sequence to it's appropriate XSLT type and return to caller.
         /// </summary>
-        public object DebugGetXsltValue(IList seq)
+        public object? DebugGetXsltValue(IList? seq)
         {
             if (seq != null && seq.Count == 1)
             {
-                XPathItem item = seq[0] as XPathItem;
+                XPathItem? item = seq[0] as XPathItem;
                 if (item != null && !item.IsNode)
                 {
                     return item.TypedValue;
@@ -254,7 +253,7 @@ namespace System.Xml.Xsl.Runtime
             if (obj == null)
             {
                 // Early-bound object does not yet exist, so create it now
-                obj = _earlyInfo[index].CreateObject();
+                obj = _earlyInfo![index].CreateObject();
                 _earlyObjects[index] = obj;
             }
 
@@ -289,7 +288,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public bool IsGlobalComputed(int index)
         {
-            return _globalValues[index] != null;
+            return _globalValues![index] != null;
         }
 
         /// <summary>
@@ -299,7 +298,7 @@ namespace System.Xml.Xsl.Runtime
         public object GetGlobalValue(int index)
         {
             Debug.Assert(IsGlobalComputed(index), "Cannot get the value of a global value until it has been computed.");
-            return _globalValues[index];
+            return _globalValues![index];
         }
 
         /// <summary>
@@ -309,7 +308,7 @@ namespace System.Xml.Xsl.Runtime
         public void SetGlobalValue(int index, object value)
         {
             Debug.Assert(!IsGlobalComputed(index), "Global value should only be set once.");
-            _globalValues[index] = value;
+            _globalValues![index] = value;
         }
 
 
@@ -366,7 +365,8 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public XmlQualifiedName ParseTagName(string tagName, int indexPrefixMappings)
         {
-            string localName, ns;
+            string localName;
+            string? ns;
 
             // Parse the tagName as a prefix, localName pair and resolve the prefix
             ParseTagName(tagName, indexPrefixMappings, out _, out localName, out ns);
@@ -398,7 +398,7 @@ namespace System.Xml.Xsl.Runtime
             ValidateNames.ParseQNameThrow(tagName, out prefix, out localName);
 
             // Map the prefix to a namespace URI
-            ns = null;
+            ns = null!;
             foreach (StringPair pair in _prefixMappingsList[idxPrefixMappings])
             {
                 if (prefix == pair.Left)
@@ -534,7 +534,7 @@ namespace System.Xml.Xsl.Runtime
                             if (item.IsNode)
                             {
                                 // Node or Rtf
-                                RtfNavigator rtf = item as RtfNavigator;
+                                RtfNavigator? rtf = item as RtfNavigator;
                                 if (rtf != null)
                                     value = rtf.ToNavigator();
                                 else
@@ -571,7 +571,7 @@ namespace System.Xml.Xsl.Runtime
         /// Convert from the Clr type of "value" to the default Clr type that ILGen uses to represent the xml type, using
         /// the conversion rules of the xml type.
         /// </summary>
-        internal object ChangeTypeXsltResult(XmlQueryType xmlType, object value)
+        internal object ChangeTypeXsltResult(XmlQueryType xmlType, object? value)
         {
             if (value == null)
                 throw new XslTransformException(SR.Xslt_ItemNull, string.Empty);
@@ -592,18 +592,18 @@ namespace System.Xml.Xsl.Runtime
                 case XmlTypeCode.Node:
                     if (!xmlType.IsSingleton)
                     {
-                        XPathArrayIterator iter = value as XPathArrayIterator;
+                        XPathArrayIterator? iter = value as XPathArrayIterator;
 
                         // Special-case XPathArrayIterator in order to avoid copies
-                        if (iter != null && iter.AsList is XmlQueryNodeSequence)
+                        if (iter != null && iter.AsList is XmlQueryNodeSequence sequence)
                         {
-                            value = iter.AsList as XmlQueryNodeSequence;
+                            value = sequence;
                         }
                         else
                         {
                             // Iterate over list and ensure it only contains nodes
                             XmlQueryNodeSequence seq = new XmlQueryNodeSequence();
-                            IList list = value as IList;
+                            IList? list = value as IList;
 
                             if (list != null)
                             {
@@ -627,7 +627,7 @@ namespace System.Xml.Xsl.Runtime
                 case XmlTypeCode.Item:
                     {
                         Type sourceType = value.GetType();
-                        IXPathNavigable navigable;
+                        IXPathNavigable? navigable;
 
                         // If static type is item, then infer type based on dynamic value
                         switch (XsltConvert.InferXsltType(sourceType).TypeCode)
@@ -664,10 +664,10 @@ namespace System.Xml.Xsl.Runtime
                                 navigable = value as IXPathNavigable;
                                 if (navigable != null)
                                 {
-                                    if (value is XPathNavigator)
-                                        value = new XmlQueryNodeSequence((XPathNavigator)value);
+                                    if (value is XPathNavigator navigator)
+                                        value = new XmlQueryNodeSequence(navigator);
                                     else
-                                        value = new XmlQueryNodeSequence(navigable.CreateNavigator());
+                                        value = new XmlQueryNodeSequence(navigable.CreateNavigator()!);
                                     break;
                                 }
 
@@ -685,9 +685,9 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Ensure that "value" is a navigator and not null.
         /// </summary>
-        private static XPathNavigator EnsureNavigator(object value)
+        private static XPathNavigator EnsureNavigator(object? value)
         {
-            XPathNavigator nav = value as XPathNavigator;
+            XPathNavigator? nav = value as XPathNavigator;
 
             if (nav == null)
                 throw new XslTransformException(SR.Xslt_ItemNull, string.Empty);
@@ -748,7 +748,7 @@ namespace System.Xml.Xsl.Runtime
         {
             // All atomic type codes appear after AnyAtomicType
             if (code > XmlTypeCode.AnyAtomicType)
-                return !item.IsNode && item.XmlType.TypeCode == code;
+                return !item.IsNode && item.XmlType!.TypeCode == code;
 
             // Handle node code and AnyAtomicType
             switch (code)
@@ -787,7 +787,7 @@ namespace System.Xml.Xsl.Runtime
             if (item.IsNode)
             {
                 // Rtf
-                RtfNavigator rtf = item as RtfNavigator;
+                RtfNavigator? rtf = item as RtfNavigator;
                 if (rtf != null)
                     return XmlQueryTypeFactory.Node;
 
@@ -800,7 +800,7 @@ namespace System.Xml.Xsl.Runtime
                         if (nav.XmlType == null)
                             return XmlQueryTypeFactory.Type(nav.NodeType, XmlQualifiedNameTest.New(nav.LocalName, nav.NamespaceURI), XmlSchemaComplexType.UntypedAnyType, false);
 
-                        return XmlQueryTypeFactory.Type(nav.NodeType, XmlQualifiedNameTest.New(nav.LocalName, nav.NamespaceURI), nav.XmlType, nav.SchemaInfo.SchemaElement.IsNillable);
+                        return XmlQueryTypeFactory.Type(nav.NodeType, XmlQualifiedNameTest.New(nav.LocalName, nav.NamespaceURI), nav.XmlType, nav.SchemaInfo!.SchemaElement!.IsNillable);
 
                     case XPathNodeType.Attribute:
                         if (nav.XmlType == null)
@@ -813,7 +813,7 @@ namespace System.Xml.Xsl.Runtime
             }
 
             // Atomic value
-            return XmlQueryTypeFactory.Type((XmlSchemaSimpleType)item.XmlType, true);
+            return XmlQueryTypeFactory.Type((XmlSchemaSimpleType)item.XmlType!, true);
         }
 
 
@@ -833,7 +833,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Create a collation from a string.
         /// </summary>
-        public XmlCollation CreateCollation(string collation)
+        public XmlCollation? CreateCollation(string collation)
         {
             return XmlCollation.Create(collation);
         }
@@ -896,16 +896,16 @@ namespace System.Xml.Xsl.Runtime
             // Search pre-existing indexes in order to determine whether the specified index has already been created
             if (_indexes != null && indexId < _indexes.Length)
             {
-                docIndexes = (ArrayList)_indexes[indexId];
+                docIndexes = _indexes[indexId];
                 if (docIndexes != null)
                 {
                     // Search for an index defined over the specified document
                     for (int i = 0; i < docIndexes.Count; i += 2)
                     {
                         // If we find a matching document, then return the index saved in the next slot
-                        if (((XPathNavigator)docIndexes[i]).IsSamePosition(navRoot))
+                        if (((XPathNavigator)docIndexes[i]!).IsSamePosition(navRoot))
                         {
-                            index = (XmlILIndex)docIndexes[i + 1];
+                            index = (XmlILIndex)docIndexes[i + 1]!;
                             return true;
                         }
                     }
@@ -986,7 +986,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public IList<XPathItem> EndSequenceConstruction(out XmlQueryOutput output)
         {
-            IList<XPathItem> seq = ((XmlCachedSequenceWriter)_output.SequenceWriter).ResultSequence;
+            IList<XPathItem> seq = ((XmlCachedSequenceWriter)_output.SequenceWriter!).ResultSequence;
 
             // Restore previous XmlQueryOutput
             output = _output = _stkOutput.Pop();
@@ -1013,7 +1013,7 @@ namespace System.Xml.Xsl.Runtime
         {
             XmlEventCache events;
 
-            events = (XmlEventCache)_output.Writer;
+            events = (XmlEventCache)_output.Writer!;
 
             // Restore previous XmlQueryOutput
             output = _output = _stkOutput.Pop();
@@ -1056,7 +1056,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Position navThis to the same location as navThat.
         /// </summary>
-        internal static XPathNavigator SyncToNavigator(XPathNavigator navigatorThis, XPathNavigator navigatorThat)
+        internal static XPathNavigator SyncToNavigator(XPathNavigator? navigatorThis, XPathNavigator navigatorThat)
         {
             if (navigatorThis == null || !navigatorThis.MoveTo(navigatorThat))
                 return navigatorThat.Clone();
@@ -1069,7 +1069,7 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         public static int OnCurrentNodeChanged(XPathNavigator currentNode)
         {
-            IXmlLineInfo lineInfo = currentNode as IXmlLineInfo;
+            IXmlLineInfo? lineInfo = currentNode as IXmlLineInfo;
 
             // In case of a namespace node, check whether it is inherited or locally defined
             if (lineInfo != null && !(currentNode.NodeType == XPathNodeType.Namespace && IsInheritedNamespace(currentNode)))

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQuerySequence.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQuerySequence.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -242,7 +241,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return item at the specified index.
         /// </summary>
-        object System.Collections.IList.this[int index]
+        object? System.Collections.IList.this[int index]
         {
             get
             {
@@ -257,7 +256,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Items may not be added through the IList interface.
         /// </summary>
-        int System.Collections.IList.Add(object value)
+        int System.Collections.IList.Add(object? value)
         {
             throw new NotSupportedException();
         }
@@ -273,23 +272,23 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Returns true if the specified value is in the sequence.
         /// </summary>
-        bool System.Collections.IList.Contains(object value)
+        bool System.Collections.IList.Contains(object? value)
         {
-            return Contains((T)value);
+            return Contains((T)value!);
         }
 
         /// <summary>
         /// Returns the index of the specified value in the sequence.
         /// </summary>
-        int System.Collections.IList.IndexOf(object value)
+        int System.Collections.IList.IndexOf(object? value)
         {
-            return IndexOf((T)value);
+            return IndexOf((T)value!);
         }
 
         /// <summary>
         /// Items may not be added through the IList interface.
         /// </summary>
-        void System.Collections.IList.Insert(int index, object value)
+        void System.Collections.IList.Insert(int index, object? value)
         {
             throw new NotSupportedException();
         }
@@ -297,7 +296,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Items may not be removed through the IList interface.
         /// </summary>
-        void System.Collections.IList.Remove(object value)
+        void System.Collections.IList.Remove(object? value)
         {
             throw new NotSupportedException();
         }
@@ -496,7 +495,7 @@ namespace System.Xml.Xsl.Runtime
     {
         public static new readonly XmlQueryNodeSequence Empty = new XmlQueryNodeSequence();
 
-        private XmlQueryNodeSequence _docOrderDistinct;
+        private XmlQueryNodeSequence? _docOrderDistinct;
 
         /// <summary>
         /// If "seq" is non-null, then clear it and reuse it.  Otherwise, create a new XmlQueryNodeSequence.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryStaticData.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryStaticData.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -24,14 +23,14 @@ namespace System.Xml.Xsl.Runtime
         private const int CurrentFormatVersion = (0 << 8) | 0;
 
         private readonly XmlWriterSettings _defaultWriterSettings;
-        private readonly IList<WhitespaceRule> _whitespaceRules;
-        private readonly string[] _names;
-        private readonly StringPair[][] _prefixMappingsList;
-        private readonly Int32Pair[] _filters;
-        private readonly XmlQueryType[] _types;
-        private readonly XmlCollation[] _collations;
-        private readonly string[] _globalNames;
-        private readonly EarlyBoundInfo[] _earlyBound;
+        private readonly IList<WhitespaceRule>? _whitespaceRules;
+        private readonly string[]? _names;
+        private readonly StringPair[][]? _prefixMappingsList;
+        private readonly Int32Pair[]? _filters;
+        private readonly XmlQueryType[]? _types;
+        private readonly XmlCollation[]? _collations;
+        private readonly string[]? _globalNames;
+        private readonly EarlyBoundInfo[]? _earlyBound;
 
         /// <summary>
         /// Constructor.
@@ -53,7 +52,7 @@ namespace System.Xml.Xsl.Runtime
 #if DEBUG
             // Round-trip check
             byte[] data;
-            Type[] ebTypes;
+            Type[]? ebTypes;
             this.GetObjectData(out data, out ebTypes);
             XmlQueryStaticData copy = new XmlQueryStaticData(data, ebTypes);
 
@@ -73,9 +72,9 @@ namespace System.Xml.Xsl.Runtime
         /// Deserialize XmlQueryStaticData object from a byte array.
         /// </summary>
         [RequiresUnreferencedCode("This method will create EarlyBoundInfo from passed in ebTypes array which cannot be statically analyzed.")]
-        public XmlQueryStaticData(byte[] data, Type[] ebTypes)
+        public XmlQueryStaticData(byte[] data, Type[]? ebTypes)
         {
-            MemoryStream dataStream = new MemoryStream(data, /*writable:*/false);
+            MemoryStream dataStream = new MemoryStream(data, writable: false);
             XmlQueryDataReader dataReader = new XmlQueryDataReader(dataStream);
             int length;
 
@@ -178,7 +177,7 @@ namespace System.Xml.Xsl.Runtime
                 _earlyBound = new EarlyBoundInfo[length];
                 for (int idx = 0; idx < length; idx++)
                 {
-                    _earlyBound[idx] = new EarlyBoundInfo(dataReader.ReadString(), ebTypes[idx]);
+                    _earlyBound[idx] = new EarlyBoundInfo(dataReader.ReadString(), ebTypes![idx]);
                 }
             }
 
@@ -189,7 +188,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Serialize XmlQueryStaticData object into a byte array.
         /// </summary>
-        public void GetObjectData(out byte[] data, out Type[] ebTypes)
+        public void GetObjectData(out byte[] data, out Type[]? ebTypes)
         {
             MemoryStream dataStream = new MemoryStream(4096);
             XmlQueryDataWriter dataWriter = new XmlQueryDataWriter(dataStream);
@@ -337,7 +336,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return the rules used for whitespace stripping/preservation.
         /// </summary>
-        public IList<WhitespaceRule> WhitespaceRules
+        public IList<WhitespaceRule>? WhitespaceRules
         {
             get { return _whitespaceRules; }
         }
@@ -345,7 +344,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return array of names used by this query.
         /// </summary>
-        public string[] Names
+        public string[]? Names
         {
             get { return _names; }
         }
@@ -353,7 +352,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return array of prefix mappings used by this query.
         /// </summary>
-        public StringPair[][] PrefixMappingsList
+        public StringPair[][]? PrefixMappingsList
         {
             get { return _prefixMappingsList; }
         }
@@ -361,7 +360,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return array of name filter specifications used by this query.
         /// </summary>
-        public Int32Pair[] Filters
+        public Int32Pair[]? Filters
         {
             get { return _filters; }
         }
@@ -369,7 +368,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return array of types used by this query.
         /// </summary>
-        public XmlQueryType[] Types
+        public XmlQueryType[]? Types
         {
             get { return _types; }
         }
@@ -377,7 +376,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return array of collations used by this query.
         /// </summary>
-        public XmlCollation[] Collations
+        public XmlCollation[]? Collations
         {
             get { return _collations; }
         }
@@ -385,7 +384,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return names of all global variables and parameters used by this query.
         /// </summary>
-        public string[] GlobalNames
+        public string[]? GlobalNames
         {
             get { return _globalNames; }
         }
@@ -393,7 +392,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Return array of early bound object information related to this query.
         /// </summary>
-        public EarlyBoundInfo[] EarlyBound
+        public EarlyBoundInfo[]? EarlyBound
         {
             get { return _earlyBound; }
         }
@@ -409,7 +408,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Read a string value from the stream. Value can be null.
         /// </summary>
-        public string ReadStringQ()
+        public string? ReadStringQ()
         {
             return ReadBoolean() ? ReadString() : null;
         }
@@ -439,7 +438,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Write a string value to the stream. Value can be null.
         /// </summary>
-        public void WriteStringQ(string value)
+        public void WriteStringQ(string? value)
         {
             Write(value != null);
             if (value != null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlRawWriterWrapper.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlRawWriterWrapper.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.IO;
 using System.Xml;
@@ -27,22 +26,22 @@ namespace System.Xml.Xsl.Runtime
         // XmlWriter interface
         //-----------------------------------------------
 
-        public override XmlWriterSettings Settings
+        public override XmlWriterSettings? Settings
         {
             get { return _wrapped.Settings; }
         }
 
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
         {
             _wrapped.WriteDocType(name, pubid, sysid, subset);
         }
 
-        public override void WriteStartElement(string prefix, string localName, string ns)
+        public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
             _wrapped.WriteStartElement(prefix, localName, ns);
         }
 
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
             _wrapped.WriteStartAttribute(prefix, localName, ns);
         }
@@ -52,27 +51,27 @@ namespace System.Xml.Xsl.Runtime
             _wrapped.WriteEndAttribute();
         }
 
-        public override void WriteCData(string text)
+        public override void WriteCData(string? text)
         {
             _wrapped.WriteCData(text);
         }
 
-        public override void WriteComment(string text)
+        public override void WriteComment(string? text)
         {
             _wrapped.WriteComment(text);
         }
 
-        public override void WriteProcessingInstruction(string name, string text)
+        public override void WriteProcessingInstruction(string name, string? text)
         {
             _wrapped.WriteProcessingInstruction(name, text);
         }
 
-        public override void WriteWhitespace(string ws)
+        public override void WriteWhitespace(string? ws)
         {
             _wrapped.WriteWhitespace(ws);
         }
 
-        public override void WriteString(string text)
+        public override void WriteString(string? text)
         {
             _wrapped.WriteString(text);
         }
@@ -122,7 +121,7 @@ namespace System.Xml.Xsl.Runtime
             _wrapped.WriteValue(value);
         }
 
-        public override void WriteValue(string value)
+        public override void WriteValue(string? value)
         {
             _wrapped.WriteValue(value);
         }
@@ -206,7 +205,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Forward to WriteEndElement().
         /// </summary>
-        internal override void WriteEndElement(string prefix, string localName, string ns)
+        internal override void WriteEndElement(string? prefix, string localName, string? ns)
         {
             _wrapped.WriteEndElement();
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlSequenceWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlSequenceWriter.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -37,7 +36,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Start construction of a new Xml tree (document or fragment).
         /// </summary>
-        public abstract XmlRawWriter StartTree(XPathNodeType rootType, IXmlNamespaceResolver nsResolver, XmlNameTable nameTable);
+        public abstract XmlRawWriter StartTree(XPathNodeType rootType, IXmlNamespaceResolver? nsResolver, XmlNameTable nameTable);
 
         /// <summary>
         /// End construction of a new Xml tree (document or fragment).
@@ -57,8 +56,8 @@ namespace System.Xml.Xsl.Runtime
     internal sealed class XmlCachedSequenceWriter : XmlSequenceWriter
     {
         private readonly XmlQueryItemSequence _seqTyped;
-        private XPathDocument _doc;
-        private XmlRawWriter _writer;
+        private XPathDocument? _doc;
+        private XmlRawWriter? _writer;
 
         /// <summary>
         /// Constructor.
@@ -79,7 +78,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Start construction of a new Xml tree (document or fragment).
         /// </summary>
-        public override XmlRawWriter StartTree(XPathNodeType rootType, IXmlNamespaceResolver nsResolver, XmlNameTable nameTable)
+        public override XmlRawWriter StartTree(XPathNodeType rootType, IXmlNamespaceResolver? nsResolver, XmlNameTable nameTable)
         {
             // Build XPathDocument
             // If rootType != XPathNodeType.Root, then build an XQuery fragment
@@ -95,8 +94,8 @@ namespace System.Xml.Xsl.Runtime
         public override void EndTree()
         {
             // Add newly constructed document to sequence
-            _writer.Close();
-            _seqTyped.Add(_doc.CreateNavigator());
+            _writer!.Close();
+            _seqTyped.Add(_doc!.CreateNavigator());
         }
 
         /// <summary>
@@ -136,7 +135,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Start construction of a new Xml tree (document or fragment).
         /// </summary>
-        public override XmlRawWriter StartTree(XPathNodeType rootType, IXmlNamespaceResolver nsResolver, XmlNameTable nameTable)
+        public override XmlRawWriter StartTree(XPathNodeType rootType, IXmlNamespaceResolver? nsResolver, XmlNameTable nameTable)
         {
             if (rootType == XPathNodeType.Attribute || rootType == XPathNodeType.Namespace)
                 throw new XslTransformException(SR.XmlIl_TopLevelAttrNmsp, string.Empty);
@@ -162,7 +161,7 @@ namespace System.Xml.Xsl.Runtime
         {
             if (item.IsNode)
             {
-                XPathNavigator nav = item as XPathNavigator;
+                XPathNavigator nav = (item as XPathNavigator)!;
 
                 if (nav.NodeType == XPathNodeType.Attribute || nav.NodeType == XPathNodeType.Namespace)
                     throw new XslTransformException(SR.XmlIl_TopLevelAttrNmsp, string.Empty);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlSortKey.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlSortKey.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -15,7 +14,7 @@ namespace System.Xml.Xsl.Runtime
     internal abstract class XmlSortKey : IComparable
     {
         private int _priority;           // Original input ordering used to ensure that sort is stable
-        private XmlSortKey _nextKey;     // Next sort key if there are multiple keys (null otherwise)
+        private XmlSortKey? _nextKey;     // Next sort key if there are multiple keys (null otherwise)
 
         /// <summary>
         /// Get or set this key's index, relative to other keys involved in a sort.  This priority will
@@ -27,7 +26,7 @@ namespace System.Xml.Xsl.Runtime
             set
             {
                 // All linked keys have same priority
-                XmlSortKey key = this;
+                XmlSortKey? key = this;
 
                 while (key != null)
                 {
@@ -80,9 +79,9 @@ namespace System.Xml.Xsl.Runtime
         /// Compare a non-empty key (this) to an empty key (obj).  The empty sequence always sorts either before all
         /// other values, or after all other values.
         /// </summary>
-        protected int CompareToEmpty(object obj)
+        protected int CompareToEmpty(object? obj)
         {
-            XmlEmptySortKey that = obj as XmlEmptySortKey;
+            XmlEmptySortKey? that = obj as XmlEmptySortKey;
             Debug.Assert(that != null && !(this is XmlEmptySortKey));
             return that.IsEmptyGreatest ? -1 : 1;
         }
@@ -90,7 +89,7 @@ namespace System.Xml.Xsl.Runtime
         /// <summary>
         /// Base internal class is abstract and doesn't actually implement CompareTo; derived classes must do this.
         /// </summary>
-        public abstract int CompareTo(object that);
+        public abstract int CompareTo(object? that);
     }
 
 
@@ -116,15 +115,15 @@ namespace System.Xml.Xsl.Runtime
             get { return _isEmptyGreatest; }
         }
 
-        public override int CompareTo(object obj)
+        public override int CompareTo(object? obj)
         {
-            XmlEmptySortKey that = obj as XmlEmptySortKey;
+            XmlEmptySortKey? that = obj as XmlEmptySortKey;
 
             if (that == null)
             {
                 // Empty compared to non-empty
                 Debug.Assert(obj is XmlSortKey);
-                return -(obj as XmlSortKey).CompareTo(this);
+                return -(obj as XmlSortKey)!.CompareTo(this);
             }
 
             // Empty compared to empty
@@ -146,9 +145,9 @@ namespace System.Xml.Xsl.Runtime
             _decVal = collation.DescendingOrder ? -value : value;
         }
 
-        public override int CompareTo(object obj)
+        public override int CompareTo(object? obj)
         {
-            XmlDecimalSortKey that = obj as XmlDecimalSortKey;
+            XmlDecimalSortKey? that = obj as XmlDecimalSortKey;
             int cmp;
 
             if (that == null)
@@ -176,9 +175,9 @@ namespace System.Xml.Xsl.Runtime
             _longVal = collation.DescendingOrder ? ~value : value;
         }
 
-        public override int CompareTo(object obj)
+        public override int CompareTo(object? obj)
         {
-            XmlIntegerSortKey that = obj as XmlIntegerSortKey;
+            XmlIntegerSortKey? that = obj as XmlIntegerSortKey;
 
             if (that == null)
                 return CompareToEmpty(obj);
@@ -204,9 +203,9 @@ namespace System.Xml.Xsl.Runtime
             _intVal = collation.DescendingOrder ? ~value : value;
         }
 
-        public override int CompareTo(object obj)
+        public override int CompareTo(object? obj)
         {
-            XmlIntSortKey that = obj as XmlIntSortKey;
+            XmlIntSortKey? that = obj as XmlIntSortKey;
 
             if (that == null)
                 return CompareToEmpty(obj);
@@ -223,8 +222,8 @@ namespace System.Xml.Xsl.Runtime
     /// </summary>
     internal sealed class XmlStringSortKey : XmlSortKey
     {
-        private readonly SortKey _sortKey;
-        private readonly byte[] _sortKeyBytes;
+        private readonly SortKey? _sortKey;
+        private readonly byte[]? _sortKeyBytes;
         private readonly bool _descendingOrder;
 
         public XmlStringSortKey(SortKey sortKey, bool descendingOrder)
@@ -239,9 +238,9 @@ namespace System.Xml.Xsl.Runtime
             _descendingOrder = descendingOrder;
         }
 
-        public override int CompareTo(object obj)
+        public override int CompareTo(object? obj)
         {
-            XmlStringSortKey that = obj as XmlStringSortKey;
+            XmlStringSortKey? that = obj as XmlStringSortKey;
             int idx, cntCmp, result;
 
             if (that == null)
@@ -318,15 +317,15 @@ namespace System.Xml.Xsl.Runtime
             }
         }
 
-        public override int CompareTo(object obj)
+        public override int CompareTo(object? obj)
         {
-            XmlDoubleSortKey that = obj as XmlDoubleSortKey;
+            XmlDoubleSortKey? that = obj as XmlDoubleSortKey;
 
             if (that == null)
             {
                 // Compare to empty sequence
                 if (_isNaN)
-                    return BreakSortingTie(obj as XmlSortKey);
+                    return BreakSortingTie((obj as XmlSortKey)!);
 
                 return CompareToEmpty(obj);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlSortKeyAccumulator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlSortKeyAccumulator.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -15,7 +14,7 @@ namespace System.Xml.Xsl.Runtime
     [EditorBrowsable(EditorBrowsableState.Never)]
     public struct XmlSortKeyAccumulator
     {
-        private XmlSortKey[] _keys;
+        private XmlSortKey?[] _keys;
         private int _pos;
 
 #if DEBUG
@@ -99,7 +98,7 @@ namespace System.Xml.Xsl.Runtime
             if (_keys[_pos] == null)
                 _keys[_pos] = key;
             else
-                _keys[_pos].AddSortKey(key);
+                _keys[_pos]!.AddSortKey(key);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XslNumber.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XslNumber.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -14,7 +13,7 @@ namespace System.Xml.Xsl.Runtime
     {
         public char startChar;      // First element of numbering sequence for format token
         public int startIdx;       // Start index of separator token
-        public string formatString;   // Format string for separator token
+        public string? formatString;   // Format string for separator token
         public int length;         // Length of separator token, or minimum length of decimal numbers for format token
 
         // Instances of this internal class must be created via CreateFormat and CreateSeparator
@@ -117,7 +116,7 @@ namespace System.Xml.Xsl.Runtime
         private readonly string _groupingSeparator;
         private readonly int _groupingSize;
 
-        private readonly List<TokenInfo> _tokens;
+        private readonly List<TokenInfo?>? _tokens;
 
         public const char DefaultStartChar = '1';
         private static readonly TokenInfo s_defaultFormat = TokenInfo.CreateFormat("0", 0, 1);
@@ -139,7 +138,7 @@ namespace System.Xml.Xsl.Runtime
                 return;
             }
 
-            _tokens = new List<TokenInfo>();
+            _tokens = new List<TokenInfo?>();
             int idxStart = 0;
             bool isAlphaNumeric = CharUtil.IsAlphaNumeric(formatString[idxStart]);
 
@@ -211,7 +210,7 @@ namespace System.Xml.Xsl.Runtime
             else
             {
                 int cFormats = _tokens.Count;
-                TokenInfo prefix = _tokens[0], suffix;
+                TokenInfo? prefix = _tokens[0], suffix;
 
                 if (cFormats % 2 == 0)
                 {
@@ -222,8 +221,8 @@ namespace System.Xml.Xsl.Runtime
                     suffix = _tokens[--cFormats];
                 }
 
-                TokenInfo periodicSeparator = 2 < cFormats ? _tokens[cFormats - 2] : s_defaultSeparator;
-                TokenInfo periodicFormat = 0 < cFormats ? _tokens[cFormats - 1] : s_defaultFormat;
+                TokenInfo? periodicSeparator = 2 < cFormats ? _tokens[cFormats - 2] : s_defaultSeparator;
+                TokenInfo? periodicFormat = 0 < cFormats ? _tokens[cFormats - 1] : s_defaultFormat;
 
                 if (prefix != null)
                 {
@@ -239,13 +238,13 @@ namespace System.Xml.Xsl.Runtime
 
                     if (i > 0)
                     {
-                        TokenInfo thisSeparator = haveFormat ? _tokens[formatIndex + 0] : periodicSeparator;
-                        thisSeparator.AssertSeparator(true);
+                        TokenInfo? thisSeparator = haveFormat ? _tokens[formatIndex + 0] : periodicSeparator;
+                        thisSeparator!.AssertSeparator(true);
                         sb.Append(thisSeparator.formatString, thisSeparator.startIdx, thisSeparator.length);
                     }
 
-                    TokenInfo thisFormat = haveFormat ? _tokens[formatIndex + 1] : periodicFormat;
-                    thisFormat.AssertSeparator(false);
+                    TokenInfo? thisFormat = haveFormat ? _tokens[formatIndex + 1] : periodicFormat;
+                    thisFormat!.AssertSeparator(false);
                     FormatItem(sb, val[i], thisFormat.startChar, thisFormat.length);
                 }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltConvert.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -160,7 +159,7 @@ namespace System.Xml.Xsl.Runtime
                 return doc.CreateNavigator();
             }
 
-            RtfNavigator rtf = item as RtfNavigator;
+            RtfNavigator? rtf = item as RtfNavigator;
             if (rtf != null)
                 return rtf.ToNavigator();
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltFunctions.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltFunctions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.IO;
 using System.Text;
 using System.Reflection;
@@ -104,7 +103,7 @@ namespace System.Xml.Xsl.Runtime
 
         public static string NormalizeSpace(string value)
         {
-            StringBuilder sb = null;
+            StringBuilder? sb = null;
             int idx, idxStart = 0, idxSpace = 0;
 
             for (idx = 0; idx < value.Length; idx++)
@@ -248,7 +247,7 @@ namespace System.Xml.Xsl.Runtime
 
         public static string OuterXml(XPathNavigator navigator)
         {
-            RtfNavigator rtf = navigator as RtfNavigator;
+            RtfNavigator? rtf = navigator as RtfNavigator;
             if (rtf == null)
             {
                 return navigator.OuterXml;
@@ -380,11 +379,7 @@ namespace System.Xml.Xsl.Runtime
                 DateTime dt = xdt.ToZulu();
 
                 // If format is the empty string or not specified, use the default format for the given locale
-                if (format.Length == 0)
-                {
-                    format = null;
-                }
-                return dt.ToString(format, new CultureInfo(locale));
+                return dt.ToString(format.Length != 0 ? format : null, new CultureInfo(locale));
             }
             catch (ArgumentException)
             { // Operations with DateTime can throw this exception eventualy
@@ -517,7 +512,7 @@ namespace System.Xml.Xsl.Runtime
             {
                 return string.Empty;
             }
-            string ns = currentNode.LookupNamespace(prefix);
+            string? ns = currentNode.LookupNamespace(prefix);
             if (ns != null)
             {
                 return ns;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltLibrary.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltLibrary.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Collections.Specialized;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -18,70 +17,70 @@ namespace System.Xml.Xsl.Runtime
     internal static class XsltMethods
     {
         // Formatting error messages
-        public static readonly MethodInfo FormatMessage = typeof(XsltLibrary).GetMethod("FormatMessage");
+        public static readonly MethodInfo FormatMessage = typeof(XsltLibrary).GetMethod("FormatMessage")!;
 
         // Runtime type checks and casts
-        public static readonly MethodInfo EnsureNodeSet = typeof(XsltConvert).GetMethod("EnsureNodeSet", new[] { typeof(IList<XPathItem>) });
+        public static readonly MethodInfo EnsureNodeSet = typeof(XsltConvert).GetMethod("EnsureNodeSet", new[] { typeof(IList<XPathItem>) })!;
 
         // Comparisons
-        public static readonly MethodInfo EqualityOperator = typeof(XsltLibrary).GetMethod("EqualityOperator");
-        public static readonly MethodInfo RelationalOperator = typeof(XsltLibrary).GetMethod("RelationalOperator");
+        public static readonly MethodInfo EqualityOperator = typeof(XsltLibrary).GetMethod("EqualityOperator")!;
+        public static readonly MethodInfo RelationalOperator = typeof(XsltLibrary).GetMethod("RelationalOperator")!;
 
         // XPath functions
-        public static readonly MethodInfo StartsWith = typeof(XsltFunctions).GetMethod("StartsWith");
-        public static readonly MethodInfo Contains = typeof(XsltFunctions).GetMethod("Contains");
-        public static readonly MethodInfo SubstringBefore = typeof(XsltFunctions).GetMethod("SubstringBefore");
-        public static readonly MethodInfo SubstringAfter = typeof(XsltFunctions).GetMethod("SubstringAfter");
-        public static readonly MethodInfo Substring2 = typeof(XsltFunctions).GetMethod("Substring", new[] { typeof(string), typeof(double) });
-        public static readonly MethodInfo Substring3 = typeof(XsltFunctions).GetMethod("Substring", new[] { typeof(string), typeof(double), typeof(double) });
-        public static readonly MethodInfo NormalizeSpace = typeof(XsltFunctions).GetMethod("NormalizeSpace");
-        public static readonly MethodInfo Translate = typeof(XsltFunctions).GetMethod("Translate");
-        public static readonly MethodInfo Lang = typeof(XsltFunctions).GetMethod("Lang");
-        public static readonly MethodInfo Floor = typeof(Math).GetMethod("Floor", new[] { typeof(double) });
-        public static readonly MethodInfo Ceiling = typeof(Math).GetMethod("Ceiling", new[] { typeof(double) });
-        public static readonly MethodInfo Round = typeof(XsltFunctions).GetMethod("Round");
+        public static readonly MethodInfo StartsWith = typeof(XsltFunctions).GetMethod("StartsWith")!;
+        public static readonly MethodInfo Contains = typeof(XsltFunctions).GetMethod("Contains")!;
+        public static readonly MethodInfo SubstringBefore = typeof(XsltFunctions).GetMethod("SubstringBefore")!;
+        public static readonly MethodInfo SubstringAfter = typeof(XsltFunctions).GetMethod("SubstringAfter")!;
+        public static readonly MethodInfo Substring2 = typeof(XsltFunctions).GetMethod("Substring", new[] { typeof(string), typeof(double) })!;
+        public static readonly MethodInfo Substring3 = typeof(XsltFunctions).GetMethod("Substring", new[] { typeof(string), typeof(double), typeof(double) })!;
+        public static readonly MethodInfo NormalizeSpace = typeof(XsltFunctions).GetMethod("NormalizeSpace")!;
+        public static readonly MethodInfo Translate = typeof(XsltFunctions).GetMethod("Translate")!;
+        public static readonly MethodInfo Lang = typeof(XsltFunctions).GetMethod("Lang")!;
+        public static readonly MethodInfo Floor = typeof(Math).GetMethod("Floor", new[] { typeof(double) })!;
+        public static readonly MethodInfo Ceiling = typeof(Math).GetMethod("Ceiling", new[] { typeof(double) })!;
+        public static readonly MethodInfo Round = typeof(XsltFunctions).GetMethod("Round")!;
 
         // XSLT functions and helper methods (static)
-        public static readonly MethodInfo SystemProperty = typeof(XsltFunctions).GetMethod("SystemProperty");
-        public static readonly MethodInfo BaseUri = typeof(XsltFunctions).GetMethod("BaseUri");
-        public static readonly MethodInfo OuterXml = typeof(XsltFunctions).GetMethod("OuterXml");
-        public static readonly MethodInfo OnCurrentNodeChanged = typeof(XmlQueryRuntime).GetMethod("OnCurrentNodeChanged");
+        public static readonly MethodInfo SystemProperty = typeof(XsltFunctions).GetMethod("SystemProperty")!;
+        public static readonly MethodInfo BaseUri = typeof(XsltFunctions).GetMethod("BaseUri")!;
+        public static readonly MethodInfo OuterXml = typeof(XsltFunctions).GetMethod("OuterXml")!;
+        public static readonly MethodInfo OnCurrentNodeChanged = typeof(XmlQueryRuntime).GetMethod("OnCurrentNodeChanged")!;
 
         // MSXML extension functions
-        public static readonly MethodInfo MSFormatDateTime = typeof(XsltFunctions).GetMethod("MSFormatDateTime");
-        public static readonly MethodInfo MSStringCompare = typeof(XsltFunctions).GetMethod("MSStringCompare");
-        public static readonly MethodInfo MSUtc = typeof(XsltFunctions).GetMethod("MSUtc");
-        public static readonly MethodInfo MSNumber = typeof(XsltFunctions).GetMethod("MSNumber");
-        public static readonly MethodInfo MSLocalName = typeof(XsltFunctions).GetMethod("MSLocalName");
-        public static readonly MethodInfo MSNamespaceUri = typeof(XsltFunctions).GetMethod("MSNamespaceUri");
+        public static readonly MethodInfo MSFormatDateTime = typeof(XsltFunctions).GetMethod("MSFormatDateTime")!;
+        public static readonly MethodInfo MSStringCompare = typeof(XsltFunctions).GetMethod("MSStringCompare")!;
+        public static readonly MethodInfo MSUtc = typeof(XsltFunctions).GetMethod("MSUtc")!;
+        public static readonly MethodInfo MSNumber = typeof(XsltFunctions).GetMethod("MSNumber")!;
+        public static readonly MethodInfo MSLocalName = typeof(XsltFunctions).GetMethod("MSLocalName")!;
+        public static readonly MethodInfo MSNamespaceUri = typeof(XsltFunctions).GetMethod("MSNamespaceUri")!;
 
         // EXSLT functions
-        public static readonly MethodInfo EXslObjectType = typeof(XsltFunctions).GetMethod("EXslObjectType");
+        public static readonly MethodInfo EXslObjectType = typeof(XsltFunctions).GetMethod("EXslObjectType")!;
 
         // XSLT functions and helper methods (non-static)
-        public static readonly MethodInfo CheckScriptNamespace = typeof(XsltLibrary).GetMethod("CheckScriptNamespace");
+        public static readonly MethodInfo CheckScriptNamespace = typeof(XsltLibrary).GetMethod("CheckScriptNamespace")!;
         public static readonly MethodInfo FunctionAvailable = GetFunctionAvailableMethod();
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "Supressing warning about not having the RequiresUnreferencedCode attribute since this code path " +
             "will only be emitting IL that will later be called by Transform() method which is already annotated as RequiresUnreferencedCode")]
-        private static MethodInfo GetFunctionAvailableMethod() => typeof(XsltLibrary).GetMethod("FunctionAvailable");
-        public static readonly MethodInfo ElementAvailable = typeof(XsltLibrary).GetMethod("ElementAvailable");
-        public static readonly MethodInfo RegisterDecimalFormat = typeof(XsltLibrary).GetMethod("RegisterDecimalFormat");
-        public static readonly MethodInfo RegisterDecimalFormatter = typeof(XsltLibrary).GetMethod("RegisterDecimalFormatter");
-        public static readonly MethodInfo FormatNumberStatic = typeof(XsltLibrary).GetMethod("FormatNumberStatic");
-        public static readonly MethodInfo FormatNumberDynamic = typeof(XsltLibrary).GetMethod("FormatNumberDynamic");
-        public static readonly MethodInfo IsSameNodeSort = typeof(XsltLibrary).GetMethod("IsSameNodeSort");
-        public static readonly MethodInfo LangToLcid = typeof(XsltLibrary).GetMethod("LangToLcid");
-        public static readonly MethodInfo NumberFormat = typeof(XsltLibrary).GetMethod("NumberFormat");
+        private static MethodInfo GetFunctionAvailableMethod() => typeof(XsltLibrary).GetMethod("FunctionAvailable")!;
+        public static readonly MethodInfo ElementAvailable = typeof(XsltLibrary).GetMethod("ElementAvailable")!;
+        public static readonly MethodInfo RegisterDecimalFormat = typeof(XsltLibrary).GetMethod("RegisterDecimalFormat")!;
+        public static readonly MethodInfo RegisterDecimalFormatter = typeof(XsltLibrary).GetMethod("RegisterDecimalFormatter")!;
+        public static readonly MethodInfo FormatNumberStatic = typeof(XsltLibrary).GetMethod("FormatNumberStatic")!;
+        public static readonly MethodInfo FormatNumberDynamic = typeof(XsltLibrary).GetMethod("FormatNumberDynamic")!;
+        public static readonly MethodInfo IsSameNodeSort = typeof(XsltLibrary).GetMethod("IsSameNodeSort")!;
+        public static readonly MethodInfo LangToLcid = typeof(XsltLibrary).GetMethod("LangToLcid")!;
+        public static readonly MethodInfo NumberFormat = typeof(XsltLibrary).GetMethod("NumberFormat")!;
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class XsltLibrary
     {
         private readonly XmlQueryRuntime _runtime;
-        private HybridDictionary _functionsAvail;
-        private Dictionary<XmlQualifiedName, DecimalFormat> _decimalFormats;
-        private List<DecimalFormatter> _decimalFormatters;
+        private HybridDictionary? _functionsAvail;
+        private Dictionary<XmlQualifiedName, DecimalFormat>? _decimalFormats;
+        private List<DecimalFormatter>? _decimalFormatters;
 
         internal XsltLibrary(XmlQueryRuntime runtime)
         {
@@ -124,7 +123,7 @@ namespace System.Xml.Xsl.Runtime
             }
             else
             {
-                object obj = _functionsAvail[name];
+                object? obj = _functionsAvail[name];
                 if (obj != null)
                 {
                     return (bool)obj;
@@ -194,13 +193,13 @@ namespace System.Xml.Xsl.Runtime
         public string FormatNumberStatic(double value, double decimalFormatterIndex)
         {
             int idx = (int)decimalFormatterIndex;
-            Debug.Assert(0 <= idx && idx < _decimalFormatters.Count, "Value of decimalFormatterIndex is out of range");
+            Debug.Assert(_decimalFormatters != null && 0 <= idx && idx < _decimalFormatters.Count, "Value of decimalFormatterIndex is out of range");
             return _decimalFormatters[idx].Format(value);
         }
 
         public string FormatNumberDynamic(double value, string formatPicture, XmlQualifiedName decimalFormatName, string errorMessageName)
         {
-            DecimalFormat format;
+            DecimalFormat? format;
             if (_decimalFormats == null || !_decimalFormats.TryGetValue(decimalFormatName, out format))
             {
                 throw new XslTransformException(SR.Xslt_NoDecimalFormat, errorMessageName);
@@ -226,7 +225,7 @@ namespace System.Xml.Xsl.Runtime
             return LangToLcidInternal(lang, forwardCompatibility, null);
         }
 
-        internal static int LangToLcidInternal(string lang, bool forwardCompatibility, IErrorHelper errorHelper)
+        internal static int LangToLcidInternal(string lang, bool forwardCompatibility, IErrorHelper? errorHelper)
         {
             int lcid = InvariantCultureLcid;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
@@ -352,7 +352,7 @@ namespace System.Xml.Xsl
         public void CreateTypeInitializer(XmlQueryStaticData staticData)
         {
             byte[] data;
-            Type[] ebTypes;
+            Type[]? ebTypes;
             FieldInfo fldInitData, fldData, fldTypes;
             ConstructorInfo cctor;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGeneratorEnv.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGeneratorEnv.cs
@@ -252,7 +252,7 @@ namespace System.Xml.Xsl.Xslt
                 }
             }
 
-            return _f.XsltInvokeEarlyBound(name, scrFunc.Method, scrFunc.XmlReturnType, args);
+            return _f.XsltInvokeEarlyBound(name, scrFunc.Method!, scrFunc.XmlReturnType!, args);
         }
 
         private string ResolvePrefixThrow(bool ignoreDefaultNs, string prefix)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Scripts.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Scripts.cs
@@ -67,7 +67,7 @@ namespace System.Xml.Xsl.Xslt
 
             public bool ContainsKey(string key) => _backingDictionary.ContainsKey(key);
 
-            public bool TryGetValue(string key, [MaybeNullWhen(false)] out Type? value) => _backingDictionary.TryGetValue(key, out value);
+            public bool TryGetValue(string key, [MaybeNullWhen(false)] out Type value) => _backingDictionary.TryGetValue(key, out value);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XslAstAnalyzer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XslAstAnalyzer.cs
@@ -1139,7 +1139,7 @@ namespace System.Xml.Xsl.Xslt
                             XmlExtensionFunction? scrFunc = _compiler.Scripts.ResolveFunction(name, ns, args.Count, default(NullErrorHelper));
                             if (scrFunc != null)
                             {
-                                XmlQueryType xt = scrFunc.XmlReturnType;
+                                XmlQueryType? xt = scrFunc.XmlReturnType;
                                 if (xt == TypeFactory.StringX)
                                 {
                                     funcFlags = XslFlags.String;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_NmTokens.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_NmTokens.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using Xunit;
 using Xunit.Abstractions;
 using System.IO;

--- a/src/libraries/System.Security.AccessControl/src/System/Security/Policy/Evidence.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/Policy/Evidence.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections;
 
 namespace System.Security.Policy

--- a/src/libraries/System.Security.AccessControl/src/System/Security/Policy/EvidenceBase.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/Policy/EvidenceBase.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace System.Security.Policy
 {
     public abstract partial class EvidenceBase

--- a/src/libraries/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <NoWarn>$(NoWarn);CA1850</NoWarn> <!-- CA1850 suppressed due to multitargeting -->
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, "XML-Signature Syntax and Processing", described at http://www.w3.org/TR/xmldsig-core/.

--- a/src/libraries/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/libraries/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides types supporting Code Access Security (CAS).</PackageDescription>
   </PropertyGroup>

--- a/src/libraries/System.ServiceModel.Syndication/src/System.ServiceModel.Syndication.csproj
+++ b/src/libraries/System.ServiceModel.Syndication/src/System.ServiceModel.Syndication.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides classes related to service model syndication.</PackageDescription>


### PR DESCRIPTION
We had dozens of uses of `#nullable disable` left in source in places we shouldn't have, resulting in lack of annotation in sources we'd declared NRT-enabled.  We also had dozens of use of `#nullable enable` in source it shouldn't have been in, resulting in us actually shipping public annotations in code we didn't fully review for that purpose (e.g. some types in CodeDom).  This cleans all of that up, removing unnecessary #nullables in the source.

This also now defaults test projects to `<Nullable>annotations</Nullable>`.  Test projects often include annotated files shared with product source, and while we generally don't require test projects be NRT-enabled, they can be tolerant of the annotations; we don't ship them, so we don't need to be concerned about what annotations show up on public types in test assemblies.