### PR TITLE
[LoongArch64] amend the LoongArch64's ABI for GCstress and NullableObject.

### DIFF
--- a/src/coreclr/vm/callhelpers.cpp
+++ b/src/coreclr/vm/callhelpers.cpp
@@ -462,7 +462,7 @@ void MethodDescCallSite::CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *
 #elif defined(TARGET_LOONGARCH64)
             if (argDest.IsStructPassedInRegs())
             {
-                argDest.CopyStructToRegisters(pSrc, stackSize);
+                argDest.CopyStructToRegisters(pSrc, stackSize, 0);
             }
             else
 #endif // TARGET_LOONGARCH64

--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -1810,7 +1810,7 @@ bool GcInfoDecoder::IsScratchRegister(int regNum,  PREGDISPLAY pRD)
 {
     _ASSERTE(regNum >= 0 && regNum <= 31);
 
-    return (regNum <= 21 && regNum >= 4);
+    return (regNum <= 21 && ((regNum >= 4) || (regNum == 1)));
 }
 
 bool GcInfoDecoder::IsScratchStackSlot(INT32 spOffset, GcStackSlotBase spBase, PREGDISPLAY     pRD)

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -750,6 +750,7 @@ public:
     void CheckRunClassInitAsIfConstructingThrowing();
 
 #if defined(TARGET_LOONGARCH64)
+    static bool IsLoongArch64OnlyOneField(MethodTable * pMT);
     static int GetLoongArch64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE clh);
 #endif
 

--- a/src/coreclr/vm/object.cpp
+++ b/src/coreclr/vm/object.cpp
@@ -396,7 +396,7 @@ void STDCALL CopyValueClassArgUnchecked(ArgDestination *argDest, void* src, Meth
 
     if (argDest->IsStructPassedInRegs())
     {
-        argDest->CopyStructToRegisters(src, pMT->GetNumInstanceFieldBytes());
+        argDest->CopyStructToRegisters(src, pMT->GetNumInstanceFieldBytes(), destOffset);
         return;
     }
 


### PR DESCRIPTION
This is part of the issue #69705 to amend the LA's port.


Amends the LoongArch64's ABI for GCstress and NullableObject.

@HFDude Thanks for your helping fixing nullable testing.