### PR TITLE
Move host changes from liveBuilds to externals

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -118,16 +118,6 @@
       <MonoIncludeFiles Include="$(MonoArtifactsPath)\include\**\*.*" />
     </ItemGroup>
 
-    <!-- Host files. Mobile uses a different hosting model, so we don't include the .NET host components there. -->
-    <ItemGroup Condition="'$(TargetsMobile)' != 'true' and Exists('$(DotNetHostBinDir)')">
-      <RuntimeFiles Include="$(DotNetHostBinDir)\$(LibPrefix)hostpolicy$(LibSuffix)">
-        <IsNative>true</IsNative>
-      </RuntimeFiles>
-      <RuntimeFiles Include="$(DotNetHostBinDir)\$(LibPrefix)hostfxr$(LibSuffix)">
-        <IsNative>true</IsNative>
-      </RuntimeFiles>
-    </ItemGroup>
-
     <Error Condition="'@(RuntimeFiles)' == ''" Text="The '$(RuntimeFlavor)' subset must be built before building this project." />
   </Target>
 

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -220,7 +220,7 @@ jobs:
 
     - name: BuildArguments
       value: >-
-        -subset host+packs -ci
+        -subset host+libs.pretest+packs -ci
         $(BuildAction)
         /p:CrossBuild=${{ parameters.crossBuild }}
         /p:PortableBuild=$(_PortableBuild)

--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -75,12 +75,24 @@
           DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences"
           Condition="'$(RuntimeFlavor)' != 'Mono' and '$(TestNativeAot)' != 'true'">
+
+    <!-- Host files. Mobile uses a different hosting model, so we don't include the .NET host components there. -->
+    <ItemGroup Condition="'$(TargetsMobile)' != 'true' and Exists('$(DotNetHostBinDir)')">
+      <RuntimeFiles Include="$(DotNetHostBinDir)\$(LibPrefix)hostpolicy$(LibSuffix)">
+        <IsNative>true</IsNative>
+      </RuntimeFiles>
+      <RuntimeFiles Include="$(DotNetHostBinDir)\$(LibPrefix)hostfxr$(LibSuffix)">
+        <IsNative>true</IsNative>
+      </RuntimeFiles>
+    </ItemGroup>
+
     <ItemGroup>
       <!-- CoreRun is not used for testing anymore, but we still use it for benchmarking and profiling -->
       <RuntimeFiles Include="$(CoreCLRArtifactsPath)\corerun*" />
       <RuntimeFiles Include="$(CoreCLRArtifactsPath)\PDB\corerun*" />
       <ReferenceCopyLocalPaths Include="@(RuntimeFiles)" />
     </ItemGroup>
+
     <ItemGroup Condition="'$(SwapNativeForIL)' == 'true'">
       <CoreCLRILFiles Include="$(CoreCLRArtifactsPath)\IL\*.*" />
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRILFiles->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />


### PR DESCRIPTION
The changes in liveBuilds affected the package construction, causing the
host files (hostfxr and hostpolicy) to be included in the runtime shared
framework package, which they should not be. This later caused issues
because Red Hat doesn't allow multiple packages to ship identical binaries
with debugging information.