### PR TITLE
Fix x86 GCStress race with indirect calls before epilogs

### DIFF
--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -4282,7 +4282,7 @@ bool UnwindStackFrame(PREGDISPLAY     pContext,
          *  First, handle the epilog
          */
 
-        PTR_CBYTE epilogBase = (PTR_CBYTE) (breakPC - info->epilogOffs);
+        PTR_CBYTE epilogBase = methodStart + (curOffs - info->epilogOffs);
         UnwindEpilog(pContext, info, epilogBase, flags);
     }
     else if (!info->ebpFrame && !info->doubleAlign)


### PR DESCRIPTION
For partially interruptible methods there is a mismatch between where GC
stress runs GCs and where normal return address hijacking would run GCs.
GC stress runs the GC on the first instruction after a call returns,
where there for partially interruptible methods is no GC info that says
to protect GC pointers in return registers (thanks @jkotas for the explanation).
This means GC stress needs to do some special work to figure out that these
need to be protected.

The way it does that is the following:

* For direct call sites, in `GCCoverageInfo::SprinkleBreakpoints` it gets
  the target MD of each call site and places a special illegal
  instruction right after the call that the GC stress handler will use
  to figure out which (if any) registers have GC pointers that need
  protection

* For indirect call sites, in `GCCoverageInfo::SprinkleBreakpoint` it will
  first place an illegal instruction on the call instruction so that the
  GC stress handler will break there. Once the GC stress handler breaks,
  it computes the target address and gets the target MD from that, and
  then places the illegal instruction on the next instruction like
  above.

`GCCoverageInfo::SprinkleBreakpoints` runs right after jitting and should
therefore not race with anything. However, the GC stress handler can
race with any other thread accessing the same function. That makes the
latter problematic on x86 where unwinding reads the epilog code to work.
In this particular case thread A is about to unwind through the epilog
when thread B stops on an indirect call right before the epilog. Thread
B then overwrites the first instruction of the epilog, causing thread A
to unwind incorrectly.

The issue seems to be a long-standing one, but we are hitting it after
#65738 where we started using indirect calls more often.

`UnwindStackFrame` already has access to the GC stress saved code and is
actually already using it for other unwinding. To fix the issue, make it
use the saved code for unwinding epilogs as well.

Fix #68431