### PR TITLE
Disable long running ReadAsync_CancelPendingTask_ThrowsCancellationException tests for some Http1 cases

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamConformanceTests.cs
@@ -20,6 +20,17 @@ namespace System.Net.Http.Functional.Tests
             Assert.True(pair.Stream2.CanRead);
             return pair;
         }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(100)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72586")]
+#pragma warning disable xUnit1026 // unused parameter
+        public override Task ReadAsync_CancelPendingTask_ThrowsCancellationException(int cancellationDelay)
+        {
+            return Task.CompletedTask;
+        }
+#pragma warning restore xUnit1026
     }
 
     public sealed class Http1RawResponseStreamConformanceTests : ResponseConnectedStreamConformanceTests
@@ -33,6 +44,17 @@ namespace System.Net.Http.Functional.Tests
             Assert.True(pair.Stream2.CanRead);
             return pair;
         }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(100)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72586")]
+#pragma warning disable xUnit1026 // unused parameter
+        public override Task ReadAsync_CancelPendingTask_ThrowsCancellationException(int cancellationDelay)
+        {
+            return Task.CompletedTask;
+        }
+#pragma warning restore xUnit1026
     }
 
     public sealed class Http1ContentLengthResponseStreamConformanceTests : ResponseStandaloneStreamConformanceTests


### PR DESCRIPTION
Contributes to #72586.