### PR TITLE
Disable NamedPipeTest_ServerInOut_ClientInOut_Synchronous test configuration

### DIFF
--- a/src/libraries/System.IO.Pipes/tests/PipeStreamConformanceTests.cs
+++ b/src/libraries/System.IO.Pipes/tests/PipeStreamConformanceTests.cs
@@ -804,12 +804,11 @@ namespace System.IO.Pipes.Tests
         protected override PipeOptions Options => PipeOptions.Asynchronous;
     }
 
-    // [ActiveIssue("https://github.com/dotnet/runtime/issues/72526")]
-    // Multiple tests hang in this configuration.
-    //public sealed class NamedPipeTest_ServerInOut_ClientInOut_Synchronous : NamedPipeTest_ServerInOut_ClientInOut
-    //{
-    //    protected override PipeOptions Options => PipeOptions.None;
-    //}
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/72526")]
+    public sealed class NamedPipeTest_ServerInOut_ClientInOut_Synchronous : NamedPipeTest_ServerInOut_ClientInOut
+    {
+        protected override PipeOptions Options => PipeOptions.None;
+    }
 
     public sealed class NamedPipeTest_ServerInOut_ClientInOut_Asynchronous : NamedPipeTest_ServerInOut_ClientInOut
     {

--- a/src/libraries/System.IO.Pipes/tests/PipeStreamConformanceTests.cs
+++ b/src/libraries/System.IO.Pipes/tests/PipeStreamConformanceTests.cs
@@ -804,15 +804,12 @@ namespace System.IO.Pipes.Tests
         protected override PipeOptions Options => PipeOptions.Asynchronous;
     }
 
-    public sealed class NamedPipeTest_ServerInOut_ClientInOut_Synchronous : NamedPipeTest_ServerInOut_ClientInOut
-    {
-        protected override PipeOptions Options => PipeOptions.None;
-
-        // TODO https://github.com/dotnet/runtime/issues/72526:
-        // The ConcurrentBidirectionalReadsWrites_Success test hangs on Windows with PipeOptions.None and InOut named pipes.
-        // Disabling for now.
-        protected override bool SupportsConcurrentBidirectionalUse => !OperatingSystem.IsWindows();
-    }
+    // [ActiveIssue("https://github.com/dotnet/runtime/issues/72526")]
+    // Multiple tests hang in this configuration.
+    //public sealed class NamedPipeTest_ServerInOut_ClientInOut_Synchronous : NamedPipeTest_ServerInOut_ClientInOut
+    //{
+    //    protected override PipeOptions Options => PipeOptions.None;
+    //}
 
     public sealed class NamedPipeTest_ServerInOut_ClientInOut_Asynchronous : NamedPipeTest_ServerInOut_ClientInOut
     {


### PR DESCRIPTION
This variation was named pipes stream conformance tests was just introduced and appears to be unstable, resulting in multiple tests hanging frequently.