### PR TITLE
Fix HttpConnectionPool timers race on disposal

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1133,10 +1133,10 @@ namespace System.Net.Http
                 {
                     var value = (AltSvcHeaderValue?)parsedValue;
 
-                    lock (SyncObj)
+                    // 'clear' should be the only value present.
+                    if (value == AltSvcHeaderValue.Clear)
                     {
-                        // 'clear' should be the only value present.
-                        if (value == AltSvcHeaderValue.Clear)
+                        lock (SyncObj)
                         {
                             ExpireAltSvcAuthority();
                             Debug.Assert(_authorityExpireTimer != null || _disposed);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1133,13 +1133,16 @@ namespace System.Net.Http
                 {
                     var value = (AltSvcHeaderValue?)parsedValue;
 
-                    // 'clear' should be the only value present.
-                    if (value == AltSvcHeaderValue.Clear)
+                    lock (SyncObj)
                     {
-                        ExpireAltSvcAuthority();
-                        Debug.Assert(_authorityExpireTimer != null);
-                        _authorityExpireTimer.Change(Timeout.Infinite, Timeout.Infinite);
-                        break;
+                        // 'clear' should be the only value present.
+                        if (value == AltSvcHeaderValue.Clear)
+                        {
+                            ExpireAltSvcAuthority();
+                            Debug.Assert(_authorityExpireTimer != null || _disposed);
+                            _authorityExpireTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+                            break;
+                        }
                     }
 
                     if (nextAuthority == null && value != null && value.AlpnProtocolName == "h3")
@@ -1181,7 +1184,7 @@ namespace System.Net.Http
 
                 lock (SyncObj)
                 {
-                    if (_authorityExpireTimer == null)
+                    if (_authorityExpireTimer == null && !_disposed) // _authorityExpireTimer is nulled out on disposal
                     {
                         var thisRef = new WeakReference<HttpConnectionPool>(this);
 
@@ -1210,7 +1213,7 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        _authorityExpireTimer.Change(nextAuthorityMaxAge, Timeout.InfiniteTimeSpan);
+                        _authorityExpireTimer?.Change(nextAuthorityMaxAge, Timeout.InfiniteTimeSpan);
                     }
 
                     _http3Authority = nextAuthority;
@@ -1274,6 +1277,12 @@ namespace System.Net.Http
             {
                 lock (SyncObj)
                 {
+                    if (_disposed)
+                    {
+                        // avoid creating _altSvcBlocklistTimerCancellation after disposal
+                        return;
+                    }
+
                     altSvcBlocklist = _altSvcBlocklist;
                     if (altSvcBlocklist == null)
                     {
@@ -1297,36 +1306,46 @@ namespace System.Net.Http
                 }
             }
 
+            CancellationToken altSvcBlocklistTimerCt;
+
             lock (SyncObj)
             {
+                if (_disposed)
+                {
+                    // avoid touching _authorityExpireTimer and _altSvcBlocklistTimerCancellation after disposal
+                    return;
+                }
+
                 if (_http3Authority == badAuthority)
                 {
                     ExpireAltSvcAuthority();
                     Debug.Assert(_authorityExpireTimer != null);
                     _authorityExpireTimer.Change(Timeout.Infinite, Timeout.Infinite);
                 }
+
+                Debug.Assert(_altSvcBlocklistTimerCancellation != null);
+                altSvcBlocklistTimerCt = _altSvcBlocklistTimerCancellation.Token;
             }
 
-            Debug.Assert(_altSvcBlocklistTimerCancellation != null);
             if (added)
             {
-                _ = Task.Delay(AltSvcBlocklistTimeoutInMilliseconds)
+                _ = Task.Delay(AltSvcBlocklistTimeoutInMilliseconds, altSvcBlocklistTimerCt)
                     .ContinueWith(t =>
                     {
                         lock (altSvcBlocklist)
                         {
                             altSvcBlocklist.Remove(badAuthority);
                         }
-                    }, _altSvcBlocklistTimerCancellation.Token, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                    }, altSvcBlocklistTimerCt, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             }
 
             if (disabled)
             {
-                _ = Task.Delay(AltSvcBlocklistTimeoutInMilliseconds)
+                _ = Task.Delay(AltSvcBlocklistTimeoutInMilliseconds, altSvcBlocklistTimerCt)
                     .ContinueWith(t =>
                     {
                         _altSvcEnabled = true;
-                    }, _altSvcBlocklistTimerCancellation.Token, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                    }, altSvcBlocklistTimerCt, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             }
         }
 
@@ -1337,8 +1356,8 @@ namespace System.Net.Http
                 if (_http3Authority != null && _persistAuthority == false)
                 {
                     ExpireAltSvcAuthority();
-                    Debug.Assert(_authorityExpireTimer != null);
-                    _authorityExpireTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                    Debug.Assert(_authorityExpireTimer != null || _disposed);
+                    _authorityExpireTimer?.Change(Timeout.Infinite, Timeout.Infinite);
                 }
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1184,7 +1184,13 @@ namespace System.Net.Http
 
                 lock (SyncObj)
                 {
-                    if (_authorityExpireTimer == null && !_disposed) // _authorityExpireTimer is nulled out on disposal
+                    if (_disposed)
+                    {
+                        // avoid creating or touching _authorityExpireTimer after disposal
+                        return;
+                    }
+
+                    if (_authorityExpireTimer == null)
                     {
                         var thisRef = new WeakReference<HttpConnectionPool>(this);
 
@@ -1213,7 +1219,7 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        _authorityExpireTimer?.Change(nextAuthorityMaxAge, Timeout.InfiniteTimeSpan);
+                        _authorityExpireTimer.Change(nextAuthorityMaxAge, Timeout.InfiniteTimeSpan);
                     }
 
                     _http3Authority = nextAuthority;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -820,7 +820,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Contains("ConnectTimeout", connectTimeoutException.Message);
 
             Assert.Null(connectTimeoutException.InnerException);
-            Assert.DoesNotContain("42", e.ToString());
+            Assert.DoesNotContain("HttpClient.Timeout", e.ToString());
         }
 
         [Fact]
@@ -836,7 +836,7 @@ namespace System.Net.Http.Functional.Tests
 
             Assert.Null(e.InnerException);
             Assert.Equal("Foo", e.Message);
-            Assert.DoesNotContain("42", e.ToString());
+            Assert.DoesNotContain("HttpClient.Timeout", e.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Access _authorityExpireTimer and _altSvcBlocklistTimerCancellation under lock and check for disposed.

Fixes #66782.