### PR TITLE
Allow not finding attribute data for more cases that we don't care about

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/SyntaxExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/SyntaxExtensions.cs
@@ -42,7 +42,11 @@ namespace Microsoft.Interop.Analyzers
                         return null;
                 }
             }
-            return targetSymbol.GetAttributes().First(attributeSyntaxLocationMatches);
+            // Sometimes an attribute is put on a symbol that is nested within the containing symbol.
+            // For example, the ContainingSymbol for an AttributeSyntax on a parameter have a ContainingSymbol of the method.
+            // Since this method is internal and the callers don't care about attributes on parameters, we just allow
+            // this method to return null in those cases.
+            return targetSymbol.GetAttributes().FirstOrDefault(attributeSyntaxLocationMatches);
 
             bool attributeSyntaxLocationMatches(AttributeData attrData)
             {

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/NativeMarshallingAttributeAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/NativeMarshallingAttributeAnalyzerTests.cs
@@ -258,14 +258,22 @@ namespace LibraryImportGenerator.UnitTests
         }
 
         [Fact]
-        public async Task UnrelatedAssemblyOrModuleTargetDiagnostic_DoesNotCauseException()
+        public async Task UnrelatedAttributes_DoesNotCauseException()
         {
             string source = """
                 using System.Reflection;
                 using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
 
                 [assembly:AssemblyMetadata("MyKey", "MyValue")]
                 [module:SkipLocalsInit]
+                
+                public class X
+                {
+                    void Foo([MarshalAs(UnmanagedType.I4)] int i)
+                    {
+                    }
+                }
                 """;
 
             await VerifyCS.VerifyAnalyzerAsync(source);


### PR DESCRIPTION
This will fix the upstream repo intake of dotnet/runtime by allowing us to fall back to null for cases where Roslyn does things that we aren't expecting with the "ContainingSymbol" value.

Fixes https://github.com/dotnet/runtime/issues/72622