### PR TITLE
Avoid AsyncLocal read in Activity.set_Current when CurrentChanged isn't handled

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Current.net46.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Current.net46.cs
@@ -27,9 +27,17 @@ namespace System.Diagnostics
 
         private static void SetCurrent(Activity? activity)
         {
-            Activity? previous = s_current.Value;
-            s_current.Value = activity;
-            CurrentChanged?.Invoke(null, new ActivityChangedEventArgs(previous, activity));
+            EventHandler<ActivityChangedEventArgs>? handler = CurrentChanged;
+            if (handler is null)
+            {
+                s_current.Value = activity;
+            }
+            else
+            {
+                Activity? previous = s_current.Value;
+                s_current.Value = activity;
+                handler.Invoke(null, new ActivityChangedEventArgs(previous, activity));
+            }
         }
     }
 }


### PR DESCRIPTION
Should fix https://github.com/dotnet/perf-autofiling-issues/issues/5202.

cc: @EgorBo, @tarekgh, @noahfalk 