### PR TITLE
Add new version of the ContentionStart event

### DIFF
--- a/src/coreclr/gc/env/etmdummy.h
+++ b/src/coreclr/gc/env/etmdummy.h
@@ -98,9 +98,9 @@
 #define FireEtwExceptionThrownStop() 0
 #define FireEtwContention() 0
 #define FireEtwContentionStart_V1(ContentionFlags, ClrInstanceID) 0
-#define FireEtwContentionStart_V2(ContentionFlags, ClrInstanceID, LockObjectID, LockOwnerThreadID) 0
+#define FireEtwContentionStart_V2(ContentionFlags, ClrInstanceID, LockID, AssociatedObjectID, LockOwnerThreadID) 0
 #define FireEtwContentionStop(ContentionFlags, ClrInstanceID) 0
-#define FireEtwLockCreated(AwareLockID, ClrInstanceID) 0
+#define FireEtwLockCreated(LockID, AssociatedObjectID, ClrInstanceID) 0
 #define FireEtwCLRStackWalk(ClrInstanceID, Reserved1, Reserved2, FrameCount, Stack) 0
 #define FireEtwAppDomainMemAllocated(AppDomainID, Allocated, ClrInstanceID) 0
 #define FireEtwAppDomainMemSurvived(AppDomainID, Survived, ProcessSurvived, ClrInstanceID) 0

--- a/src/coreclr/gc/env/etmdummy.h
+++ b/src/coreclr/gc/env/etmdummy.h
@@ -98,6 +98,7 @@
 #define FireEtwExceptionThrownStop() 0
 #define FireEtwContention() 0
 #define FireEtwContentionStart_V1(ContentionFlags, ClrInstanceID) 0
+#define FireEtwContentionStart_V2(ContentionFlags, ClrInstanceID, LockObjectID, LockOwnerThreadID) 0
 #define FireEtwContentionStop(ContentionFlags, ClrInstanceID) 0
 #define FireEtwCLRStackWalk(ClrInstanceID, Reserved1, Reserved2, FrameCount, Stack) 0
 #define FireEtwAppDomainMemAllocated(AppDomainID, Allocated, ClrInstanceID) 0

--- a/src/coreclr/gc/env/etmdummy.h
+++ b/src/coreclr/gc/env/etmdummy.h
@@ -100,6 +100,7 @@
 #define FireEtwContentionStart_V1(ContentionFlags, ClrInstanceID) 0
 #define FireEtwContentionStart_V2(ContentionFlags, ClrInstanceID, LockObjectID, LockOwnerThreadID) 0
 #define FireEtwContentionStop(ContentionFlags, ClrInstanceID) 0
+#define FireEtwAwareLockCreated(AwareLockID, ClrInstanceID) 0
 #define FireEtwCLRStackWalk(ClrInstanceID, Reserved1, Reserved2, FrameCount, Stack) 0
 #define FireEtwAppDomainMemAllocated(AppDomainID, Allocated, ClrInstanceID) 0
 #define FireEtwAppDomainMemSurvived(AppDomainID, Survived, ProcessSurvived, ClrInstanceID) 0

--- a/src/coreclr/gc/env/etmdummy.h
+++ b/src/coreclr/gc/env/etmdummy.h
@@ -100,7 +100,7 @@
 #define FireEtwContentionStart_V1(ContentionFlags, ClrInstanceID) 0
 #define FireEtwContentionStart_V2(ContentionFlags, ClrInstanceID, LockObjectID, LockOwnerThreadID) 0
 #define FireEtwContentionStop(ContentionFlags, ClrInstanceID) 0
-#define FireEtwAwareLockCreated(AwareLockID, ClrInstanceID) 0
+#define FireEtwLockCreated(AwareLockID, ClrInstanceID) 0
 #define FireEtwCLRStackWalk(ClrInstanceID, Reserved1, Reserved2, FrameCount, Stack) 0
 #define FireEtwAppDomainMemAllocated(AppDomainID, Allocated, ClrInstanceID) 0
 #define FireEtwAppDomainMemSurvived(AppDomainID, Survived, ProcessSurvived, ClrInstanceID) 0

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -1746,7 +1746,7 @@
                         <data name="ContentionFlags" inType="win:UInt8" map="ContentionFlagsMap" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
                         <data name="LockID" inType="win:Pointer" />
-                        <data name="LockOwnerThreadID" inType="win:Pointer" />
+                        <data name="LockOwnerThreadID" inType="win:UInt64" />
                         <UserData>
                             <Contention xmlns="myNs">
                                 <ContentionFlags> %1 </ContentionFlags>

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -1746,7 +1746,7 @@
                         <data name="ContentionFlags" inType="win:UInt8" map="ContentionFlagsMap" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
                         <data name="LockID" inType="win:Pointer" />
-                        <data name="LockOwnerThreadID" inType="win:UInt64" />
+                        <data name="LockOwnerThreadID" inType="win:Pointer" />
                         <UserData>
                             <Contention xmlns="myNs">
                                 <ContentionFlags> %1 </ContentionFlags>

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -1746,13 +1746,15 @@
                         <data name="ContentionFlags" inType="win:UInt8" map="ContentionFlagsMap" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
                         <data name="LockID" inType="win:Pointer" />
+                        <data name="AssociatedObjectID" inType="win:Pointer" />
                         <data name="LockOwnerThreadID" inType="win:UInt64" />
                         <UserData>
                             <Contention xmlns="myNs">
                                 <ContentionFlags> %1 </ContentionFlags>
                                 <ClrInstanceID> %2 </ClrInstanceID>
                                 <LockID> %3 </LockID>
-                                <LockOwnerThreadID> %4 </LockOwnerThreadID>
+                                <AssociatedObjectID> %4 </AssociatedObjectID>
+                                <LockOwnerThreadID> %5 </LockOwnerThreadID>
                             </Contention>
                         </UserData>
                     </template>
@@ -3112,11 +3114,13 @@
 
                     <template tid="LockCreated">
                         <data name="LockID" inType="win:Pointer" />
+                        <data name="AssociatedObjectID" inType="win:Pointer" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
                         <UserData>
                             <LockCreated xmlns="myNs">
                                 <LockID> %1 </LockID>
-                                <ClrInstanceID> %2 </ClrInstanceID>
+                                <AssociatedObjectID> %2 </AssociatedObjectID>
+                                <ClrInstanceID> %3 </ClrInstanceID>
                             </LockCreated>
                         </UserData>
                     </template>
@@ -8470,10 +8474,10 @@
                 <string id="RuntimePublisher.ExceptionExceptionHandlingNoneEventMessage" value="NONE" />
                 <string id="RuntimePublisher.ContentionStartEventMessage" value="NONE" />
                 <string id="RuntimePublisher.ContentionStart_V1EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2"/>
-                <string id="RuntimePublisher.ContentionStart_V2EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;%LockID=%3;%LockOwnerThreadID=%4"/>
+                <string id="RuntimePublisher.ContentionStart_V2EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;%nLockID=%3;%nAssociatedObjectID=%4;%nLockOwnerThreadID=%5"/>
                 <string id="RuntimePublisher.ContentionStopEventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2"/>
                 <string id="RuntimePublisher.ContentionStop_V1EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;DurationNs=%3"/>
-                <string id="RuntimePublisher.LockCreatedEventMessage" value="LockID=%1;%nClrInstanceID=%2"/>
+                <string id="RuntimePublisher.LockCreatedEventMessage" value="LockID=%1;%nAssociatedObjectID=%2;%nClrInstanceID=%3"/>
                 <string id="RuntimePublisher.DCStartCompleteEventMessage" value="NONE" />
                 <string id="RuntimePublisher.DCEndCompleteEventMessage" value="NONE" />
                 <string id="RuntimePublisher.MethodDCStartEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6" />

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -1742,6 +1742,21 @@
                         </UserData>
                     </template>
 
+                    <template tid="ContentionStart_V2">
+                        <data name="ContentionFlags" inType="win:UInt8" map="ContentionFlagsMap" />
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="LockObjectID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="LockOwnerThreadID" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <Contention xmlns="myNs">
+                                <ContentionFlags> %1 </ContentionFlags>
+                                <ClrInstanceID> %2 </ClrInstanceID>
+                                <LockObjectID> %3 </LockObjectID>
+                                <LockOwnerThreadID> %4 </LockOwnerThreadID>
+                            </Contention>
+                        </UserData>
+                    </template>
+
                     <template tid="ContentionStop_V1">
                         <data name="ContentionFlags" inType="win:UInt8" map="ContentionFlagsMap" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
@@ -3641,6 +3656,11 @@
                            keywords ="ContentionKeyword"  opcode="win:Start"
                            task="Contention"
                            symbol="ContentionStart_V1" message="$(string.RuntimePublisher.ContentionStart_V1EventMessage)"/>
+
+                    <event value="81" version="2" level="win:Informational"  template="ContentionStart_V2"
+                           keywords ="ContentionKeyword"  opcode="win:Start"
+                           task="Contention"
+                           symbol="ContentionStart_V2" message="$(string.RuntimePublisher.ContentionStart_V2EventMessage)"/>
 
                     <event value="91" version="0" level="win:Informational"  template="Contention"
                            keywords ="ContentionKeyword"  opcode="win:Stop"
@@ -8432,6 +8452,7 @@
                 <string id="RuntimePublisher.ExceptionExceptionHandlingNoneEventMessage" value="NONE" />
                 <string id="RuntimePublisher.ContentionStartEventMessage" value="NONE" />
                 <string id="RuntimePublisher.ContentionStart_V1EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2"/>
+                <string id="RuntimePublisher.ContentionStart_V2EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;%LockObjectID=%3;%LockOwnerThreadID=%4"/>
                 <string id="RuntimePublisher.ContentionStopEventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2"/>
                 <string id="RuntimePublisher.ContentionStop_V1EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;DurationNs=%3"/>
                 <string id="RuntimePublisher.DCStartCompleteEventMessage" value="NONE" />

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -211,7 +211,6 @@
                           value="8" eventGUID="{561410f5-a138-4ab3-945e-516483cddfbc}"
                           message="$(string.RuntimePublisher.ContentionTaskMessage)">
                         <opcodes>
-                            <opcode name="AwareLockCreated" message="$(string.RuntimePublisher.AwareLockCreatedOpcodeMessage)" symbol="CLR_AWARELOCK_CREATED_OPCODE" value="10"> </opcode>
                         </opcodes>
                     </task>
 
@@ -3111,14 +3110,14 @@
                       </UserData>
                     </template>
 
-                    <template tid="AwareLockCreated">
+                    <template tid="LockCreated">
                         <data name="LockID" inType="win:Pointer" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
                         <UserData>
-                            <AwareLockCreated xmlns="myNs">
+                            <LockCreated xmlns="myNs">
                                 <LockID> %1 </LockID>
                                 <ClrInstanceID> %2 </ClrInstanceID>
-                            </AwareLockCreated>
+                            </LockCreated>
                         </UserData>
                     </template>
 
@@ -3685,10 +3684,10 @@
                            task="Contention"
                            symbol="ContentionStop_V1" message="$(string.RuntimePublisher.ContentionStop_V1EventMessage)"/>
 
-                    <event value="414" version="0" level="win:Informational"  template="AwareLockCreated"
-                           keywords ="ContentionKeyword"  opcode="AwareLockCreated"
+                    <event value="90" version="0" level="win:Informational"  template="LockCreated"
+                           keywords ="ContentionKeyword"  opcode="win:Info"
                            task="Contention"
-                           symbol="AwareLockCreated" message="$(string.RuntimePublisher.AwareLockEventMessage)"/>
+                           symbol="LockCreated" message="$(string.RuntimePublisher.LockCreatedEventMessage)"/>
 
 
                     <!-- CLR Stack events -->
@@ -8474,7 +8473,7 @@
                 <string id="RuntimePublisher.ContentionStart_V2EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;%LockID=%3;%LockOwnerThreadID=%4"/>
                 <string id="RuntimePublisher.ContentionStopEventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2"/>
                 <string id="RuntimePublisher.ContentionStop_V1EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;DurationNs=%3"/>
-                <string id="RuntimePublisher.AwareLockEventMessage" value="LockID=%1;%nClrInstanceID=%2"/>
+                <string id="RuntimePublisher.LockCreatedEventMessage" value="LockID=%1;%nClrInstanceID=%2"/>
                 <string id="RuntimePublisher.DCStartCompleteEventMessage" value="NONE" />
                 <string id="RuntimePublisher.DCEndCompleteEventMessage" value="NONE" />
                 <string id="RuntimePublisher.MethodDCStartEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6" />
@@ -9251,8 +9250,6 @@
                 <string id="RundownPublisher.ModuleRangeDCEndOpcodeMessage" value="ModuleRangeDCEnd" />
                 <string id="RundownPublisher.TieredCompilationSettingsDCStartOpcodeMessage" value="SettingsDCStart" />
                 <string id="RundownPublisher.ExecutionCheckpointDCEndOpcodeMessage" value="ExecutionCheckpointDCEnd" />
-
-                <string id="RundownPublisher.AwareLockCreatedOpcodeMessage" value="AwareLockCreated" />
 
                 <string id="PrivatePublisher.FailFastOpcodeMessage" value="FailFast" />
 

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -1746,13 +1746,13 @@
                     <template tid="ContentionStart_V2">
                         <data name="ContentionFlags" inType="win:UInt8" map="ContentionFlagsMap" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
-                        <data name="LockObjectID" inType="win:Pointer" />
-                        <data name="LockOwnerThreadID" inType="win:Pointer" />
+                        <data name="LockID" inType="win:Pointer" />
+                        <data name="LockOwnerThreadID" inType="win:UInt64" />
                         <UserData>
                             <Contention xmlns="myNs">
                                 <ContentionFlags> %1 </ContentionFlags>
                                 <ClrInstanceID> %2 </ClrInstanceID>
-                                <LockObjectID> %3 </LockObjectID>
+                                <LockID> %3 </LockID>
                                 <LockOwnerThreadID> %4 </LockOwnerThreadID>
                             </Contention>
                         </UserData>
@@ -3112,11 +3112,11 @@
                     </template>
 
                     <template tid="AwareLockCreated">
-                        <data name="AwareLockID" inType="win:Pointer" />
+                        <data name="LockID" inType="win:Pointer" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
                         <UserData>
                             <AwareLockCreated xmlns="myNs">
-                                <AwareLockID> %1 </AwareLockID>
+                                <LockID> %1 </LockID>
                                 <ClrInstanceID> %2 </ClrInstanceID>
                             </AwareLockCreated>
                         </UserData>
@@ -8471,10 +8471,10 @@
                 <string id="RuntimePublisher.ExceptionExceptionHandlingNoneEventMessage" value="NONE" />
                 <string id="RuntimePublisher.ContentionStartEventMessage" value="NONE" />
                 <string id="RuntimePublisher.ContentionStart_V1EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2"/>
-                <string id="RuntimePublisher.ContentionStart_V2EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;%LockObjectID=%3;%LockOwnerThreadID=%4"/>
+                <string id="RuntimePublisher.ContentionStart_V2EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;%LockID=%3;%LockOwnerThreadID=%4"/>
                 <string id="RuntimePublisher.ContentionStopEventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2"/>
                 <string id="RuntimePublisher.ContentionStop_V1EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;DurationNs=%3"/>
-                <string id="RuntimePublisher.AwareLockEventMessage" value="AwareLockID=%1;%nClrInstanceID=%2"/>
+                <string id="RuntimePublisher.AwareLockEventMessage" value="LockID=%1;%nClrInstanceID=%2"/>
                 <string id="RuntimePublisher.DCStartCompleteEventMessage" value="NONE" />
                 <string id="RuntimePublisher.DCEndCompleteEventMessage" value="NONE" />
                 <string id="RuntimePublisher.MethodDCStartEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6" />

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -1745,8 +1745,8 @@
                     <template tid="ContentionStart_V2">
                         <data name="ContentionFlags" inType="win:UInt8" map="ContentionFlagsMap" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
-                        <data name="LockObjectID" inType="win:UInt64" outType="win:HexInt64" />
-                        <data name="LockOwnerThreadID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="LockObjectID" inType="win:Pointer" />
+                        <data name="LockOwnerThreadID" inType="win:Pointer" />
                         <UserData>
                             <Contention xmlns="myNs">
                                 <ContentionFlags> %1 </ContentionFlags>

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -211,6 +211,7 @@
                           value="8" eventGUID="{561410f5-a138-4ab3-945e-516483cddfbc}"
                           message="$(string.RuntimePublisher.ContentionTaskMessage)">
                         <opcodes>
+                            <opcode name="AwareLockCreated" message="$(string.RuntimePublisher.AwareLockCreatedOpcodeMessage)" symbol="CLR_AWARELOCK_CREATED_OPCODE" value="10"> </opcode>
                         </opcodes>
                     </task>
 
@@ -3109,6 +3110,18 @@
                         </Settings>
                       </UserData>
                     </template>
+
+                    <template tid="AwareLockCreated">
+                        <data name="AwareLockID" inType="win:Pointer" />
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <UserData>
+                            <AwareLockCreated xmlns="myNs">
+                                <AwareLockID> %1 </AwareLockID>
+                                <ClrInstanceID> %2 </ClrInstanceID>
+                            </AwareLockCreated>
+                        </UserData>
+                    </template>
+
                 </templates>
 
                 <events>
@@ -3671,6 +3684,12 @@
                            keywords ="ContentionKeyword"  opcode="win:Stop"
                            task="Contention"
                            symbol="ContentionStop_V1" message="$(string.RuntimePublisher.ContentionStop_V1EventMessage)"/>
+
+                    <event value="414" version="0" level="win:Informational"  template="AwareLockCreated"
+                           keywords ="ContentionKeyword"  opcode="AwareLockCreated"
+                           task="Contention"
+                           symbol="AwareLockCreated" message="$(string.RuntimePublisher.AwareLockEventMessage)"/>
+
 
                     <!-- CLR Stack events -->
                     <event value="82" version="0" level="win:LogAlways"  template="ClrStackWalk"
@@ -8455,6 +8474,7 @@
                 <string id="RuntimePublisher.ContentionStart_V2EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;%LockObjectID=%3;%LockOwnerThreadID=%4"/>
                 <string id="RuntimePublisher.ContentionStopEventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2"/>
                 <string id="RuntimePublisher.ContentionStop_V1EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;DurationNs=%3"/>
+                <string id="RuntimePublisher.AwareLockEventMessage" value="AwareLockID=%1;%nClrInstanceID=%2"/>
                 <string id="RuntimePublisher.DCStartCompleteEventMessage" value="NONE" />
                 <string id="RuntimePublisher.DCEndCompleteEventMessage" value="NONE" />
                 <string id="RuntimePublisher.MethodDCStartEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6" />
@@ -9231,6 +9251,8 @@
                 <string id="RundownPublisher.ModuleRangeDCEndOpcodeMessage" value="ModuleRangeDCEnd" />
                 <string id="RundownPublisher.TieredCompilationSettingsDCStartOpcodeMessage" value="SettingsDCStart" />
                 <string id="RundownPublisher.ExecutionCheckpointDCEndOpcodeMessage" value="ExecutionCheckpointDCEnd" />
+
+                <string id="RundownPublisher.AwareLockCreatedOpcodeMessage" value="AwareLockCreated" />
 
                 <string id="PrivatePublisher.FailFastOpcodeMessage" value="FailFast" />
 

--- a/src/coreclr/vm/ClrEtwAllMeta.lst
+++ b/src/coreclr/vm/ClrEtwAllMeta.lst
@@ -185,6 +185,7 @@ noclrinstanceid:Exception:::ExceptionThrown
 nomac:Contention:::Contention
 noclrinstanceid:Contention:::Contention
 nomac:Contention:::ContentionStart_V1
+nomac:Contention:::ContentionStart_V2
 nostack:Contention:::ContentionStop
 nomac:Contention:::ContentionStop
 nostack:Contention:::ContentionStop_V1

--- a/src/coreclr/vm/ClrEtwAllMeta.lst
+++ b/src/coreclr/vm/ClrEtwAllMeta.lst
@@ -190,7 +190,7 @@ nostack:Contention:::ContentionStop
 nomac:Contention:::ContentionStop
 nostack:Contention:::ContentionStop_V1
 nomac:Contention:::ContentionStop_V1
-nomac:Contention:::AwareLockCreated
+nomac:Contention:::LockCreated
 
 ##################
 # StackWalk events

--- a/src/coreclr/vm/ClrEtwAllMeta.lst
+++ b/src/coreclr/vm/ClrEtwAllMeta.lst
@@ -190,7 +190,6 @@ nostack:Contention:::ContentionStop
 nomac:Contention:::ContentionStop
 nostack:Contention:::ContentionStop_V1
 nomac:Contention:::ContentionStop_V1
-nostack:Contention:::AwareLockCreated
 nomac:Contention:::AwareLockCreated
 
 ##################

--- a/src/coreclr/vm/ClrEtwAllMeta.lst
+++ b/src/coreclr/vm/ClrEtwAllMeta.lst
@@ -190,6 +190,8 @@ nostack:Contention:::ContentionStop
 nomac:Contention:::ContentionStop
 nostack:Contention:::ContentionStop_V1
 nomac:Contention:::ContentionStop_V1
+nostack:Contention:::AwareLockCreated
+nomac:Contention:::AwareLockCreated
 
 ##################
 # StackWalk events

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -2237,9 +2237,13 @@ SyncBlock *ObjHeader::GetSyncBlock()
 
                 LEAVE_SPIN_LOCK(this);
             }
-            // SyncBlockCache::LockHolder goes out of scope here
         }
+        // SyncBlockCache::LockHolder goes out of scope here
     }
+
+    // Fire the LockCreated event last, such that it is outside the FAULT_FORBID region above and outside the SyncBlockCache
+    // lock. The eventing system may need to allocate.
+    syncBlock->FireLockCreatedEvent();
 
     RETURN syncBlock;
 }
@@ -2541,12 +2545,7 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
     // the object associated with this lock.
     _ASSERTE(pCurThread->PreemptiveGCDisabled());
 
-    LogContention();
-    Thread::IncrementMonitorLockContentionCount(pCurThread);
-
-    OBJECTREF obj = GetOwningObject();
-
-    BOOLEAN isContentionKeywordEnabled = IsContentionKeywordEnabled();
+    bool isContentionKeywordEnabled = IsContentionKeywordEnabled();
     LARGE_INTEGER startTicks = { {0} };
 
     if (isContentionKeywordEnabled)
@@ -2554,8 +2553,17 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
         QueryPerformanceCounter(&startTicks);
 
         // Fire a contention start event for a managed contention
-        FireEtwContentionStart_V2(ETW::ContentionLog::ContentionStructs::ManagedContention, GetClrInstanceId(), this, m_HoldingThread->GetOSThreadId64());
+        FireEtwContentionStart_V2(
+            ETW::ContentionLog::ContentionStructs::ManagedContention,
+            GetClrInstanceId(),
+            this,
+            m_HoldingThread);
     }
+
+    LogContention();
+    Thread::IncrementMonitorLockContentionCount(pCurThread);
+
+    OBJECTREF obj = GetOwningObject();
 
     // We cannot allow the AwareLock to be cleaned up underneath us by the GC.
     IncrementTransientPrecious();
@@ -2765,9 +2773,21 @@ BOOL AwareLock::OwnedByCurrentThread()
     return (GetThread() == m_HoldingThread);
 }
 
-BOOLEAN AwareLock::IsContentionKeywordEnabled() const
+/* static */
+bool AwareLock::IsContentionKeywordEnabled()
 {
+    WRAPPER_NO_CONTRACT;
     return ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, TRACE_LEVEL_INFORMATION, CLR_CONTENTION_KEYWORD);
+}
+
+void AwareLock::FireLockCreatedEvent() const
+{
+    WRAPPER_NO_CONTRACT;
+
+    if (IsContentionKeywordEnabled())
+    {
+        FireEtwLockCreated(this, GetClrInstanceId());
+    }
 }
 
 // ***************************************************************************

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -2546,15 +2546,15 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
 
     OBJECTREF obj = GetOwningObject();
 
-    BOOLEAN IsContentionKeywordEnabled = ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, TRACE_LEVEL_INFORMATION, CLR_CONTENTION_KEYWORD);
+    BOOLEAN isContentionKeywordEnabled = IsContentionKeywordEnabled();
     LARGE_INTEGER startTicks = { {0} };
 
-    if (IsContentionKeywordEnabled)
+    if (isContentionKeywordEnabled)
     {
         QueryPerformanceCounter(&startTicks);
 
         // Fire a contention start event for a managed contention
-        FireEtwContentionStart_V2(ETW::ContentionLog::ContentionStructs::ManagedContention, GetClrInstanceId(), OBJECTREFToObject(obj), m_HoldingThread);
+        FireEtwContentionStart_V2(ETW::ContentionLog::ContentionStructs::ManagedContention, GetClrInstanceId(), OBJECTREFToObject(obj), this);
     }
 
     // We cannot allow the AwareLock to be cleaned up underneath us by the GC.
@@ -2684,7 +2684,7 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
     GCPROTECT_END();
     DecrementTransientPrecious();
 
-    if (IsContentionKeywordEnabled)
+    if (isContentionKeywordEnabled)
     {
         LARGE_INTEGER endTicks;
         QueryPerformanceCounter(&endTicks);
@@ -2765,6 +2765,10 @@ BOOL AwareLock::OwnedByCurrentThread()
     return (GetThread() == m_HoldingThread);
 }
 
+BOOLEAN AwareLock::IsContentionKeywordEnabled() const
+{
+    return ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, TRACE_LEVEL_INFORMATION, CLR_CONTENTION_KEYWORD);
+}
 
 // ***************************************************************************
 //

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -2554,7 +2554,7 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
         QueryPerformanceCounter(&startTicks);
 
         // Fire a contention start event for a managed contention
-        FireEtwContentionStart_V2(ETW::ContentionLog::ContentionStructs::ManagedContention, GetClrInstanceId(), OBJECTREFToObject(obj), this);
+        FireEtwContentionStart_V2(ETW::ContentionLog::ContentionStructs::ManagedContention, GetClrInstanceId(), this, m_HoldingThread->GetOSThreadId64());
     }
 
     // We cannot allow the AwareLock to be cleaned up underneath us by the GC.

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -2554,7 +2554,7 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
         QueryPerformanceCounter(&startTicks);
 
         // Fire a contention start event for a managed contention
-        FireEtwContentionStart_V2(ETW::ContentionLog::ContentionStructs::ManagedContention, GetClrInstanceId(), (ObjectID)OBJECTREFToObject(obj), (ThreadID)m_HoldingThread);
+        FireEtwContentionStart_V2(ETW::ContentionLog::ContentionStructs::ManagedContention, GetClrInstanceId(), OBJECTREFToObject(obj), m_HoldingThread);
     }
 
     // We cannot allow the AwareLock to be cleaned up underneath us by the GC.

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -466,11 +466,6 @@ private:
           m_waiterStarvationStartTimeMs(0)
     {
         LIMITED_METHOD_CONTRACT;
-        
-        if (IsContentionKeywordEnabled())
-        {
-            FireEtwLockCreated(this, GetClrInstanceId());
-        }
     }
 
     ~AwareLock()
@@ -607,8 +602,10 @@ public:
         return m_HoldingThread;
     }
 
-    BOOLEAN IsContentionKeywordEnabled() const;
-
+private:
+    static bool IsContentionKeywordEnabled();
+public:
+    void FireLockCreatedEvent() const;
 };
 
 #ifdef FEATURE_COMINTEROP
@@ -1153,6 +1150,12 @@ class SyncBlock
     {
         LIMITED_METHOD_CONTRACT;
         // We've already destructed.  But retain the memory.
+    }
+
+    void FireLockCreatedEvent() const
+    {
+        WRAPPER_NO_CONTRACT;
+        m_Monitor.FireLockCreatedEvent();
     }
 
     void EnterMonitor()

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -452,6 +452,7 @@ private:
     CLREvent        m_SemEvent;
 
     DWORD m_waiterStarvationStartTimeMs;
+    int m_emittedLockCreatedEvent;
 
     static const DWORD WaiterStarvationDurationMsBeforeStoppingPreemptingWaiters = 100;
 
@@ -465,7 +466,8 @@ private:
           m_HoldingOSThreadId(0),
           m_TransientPrecious(0),
           m_dwSyncIndex(indx),
-          m_waiterStarvationStartTimeMs(0)
+          m_waiterStarvationStartTimeMs(0),
+          m_emittedLockCreatedEvent(0)
     {
         LIMITED_METHOD_CONTRACT;
     }
@@ -604,11 +606,6 @@ public:
         LIMITED_METHOD_CONTRACT;
         return m_HoldingThread;
     }
-
-private:
-    static bool IsContentionKeywordEnabled();
-public:
-    void FireLockCreatedEvent() const;
 };
 
 #ifdef FEATURE_COMINTEROP
@@ -1153,12 +1150,6 @@ class SyncBlock
     {
         LIMITED_METHOD_CONTRACT;
         // We've already destructed.  But retain the memory.
-    }
-
-    void FireLockCreatedEvent() const
-    {
-        WRAPPER_NO_CONTRACT;
-        m_Monitor.FireLockCreatedEvent();
     }
 
     void EnterMonitor()

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -466,6 +466,11 @@ private:
           m_waiterStarvationStartTimeMs(0)
     {
         LIMITED_METHOD_CONTRACT;
+        
+        if (IsContentionKeywordEnabled())
+        {
+            FireEtwAwareLockCreated(this, GetClrInstanceId());
+        }
     }
 
     ~AwareLock()
@@ -601,6 +606,9 @@ public:
         LIMITED_METHOD_CONTRACT;
         return m_HoldingThread;
     }
+
+    BOOLEAN IsContentionKeywordEnabled() const;
+
 };
 
 #ifdef FEATURE_COMINTEROP

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -469,7 +469,7 @@ private:
         
         if (IsContentionKeywordEnabled())
         {
-            FireEtwAwareLockCreated(this, GetClrInstanceId());
+            FireEtwLockCreated(this, GetClrInstanceId());
         }
     }
 

--- a/src/coreclr/vm/syncblk.inl
+++ b/src/coreclr/vm/syncblk.inl
@@ -478,6 +478,7 @@ FORCEINLINE bool AwareLock::TryEnterHelper(Thread* pCurThread)
     if (m_lockState.InterlockedTryLock())
     {
         m_HoldingThread = pCurThread;
+        m_HoldingOSThreadId = pCurThread->GetOSThreadId64();
         m_Recursion = 1;
         return true;
     }
@@ -523,6 +524,7 @@ FORCEINLINE AwareLock::EnterHelperResult AwareLock::TryEnterBeforeSpinLoopHelper
 
         // Lock was acquired and the spinner was not registered
         m_HoldingThread = pCurThread;
+        m_HoldingOSThreadId = pCurThread->GetOSThreadId64();
         m_Recursion = 1;
         return EnterHelperResult_Entered;
     }
@@ -554,6 +556,7 @@ FORCEINLINE AwareLock::EnterHelperResult AwareLock::TryEnterInsideSpinLoopHelper
 
     // Lock was acquired and spinner was unregistered
     m_HoldingThread = pCurThread;
+    m_HoldingOSThreadId = pCurThread->GetOSThreadId64();
     m_Recursion = 1;
     return EnterHelperResult_Entered;
 }
@@ -576,6 +579,7 @@ FORCEINLINE bool AwareLock::TryEnterAfterSpinLoopHelper(Thread *pCurThread)
 
     // Spinner was unregistered and the lock was acquired
     m_HoldingThread = pCurThread;
+    m_HoldingOSThreadId = pCurThread->GetOSThreadId64();
     m_Recursion = 1;
     return true;
 }
@@ -694,6 +698,7 @@ FORCEINLINE AwareLock::LeaveHelperAction AwareLock::LeaveHelper(Thread* pCurThre
     if (--m_Recursion == 0)
     {
         m_HoldingThread = NULL;
+        m_HoldingOSThreadId = 0;
 
         // Clear lock bit and determine whether we must signal a waiter to wake
         if (!m_lockState.InterlockedUnlock())


### PR DESCRIPTION
The goal of this PR is to enrich the information provided in the ContentionStart event.

Today, we have the callstack (attached to the ContentionStart event), the contention duration (with the ContentionEnd event).

By adding the ObjectID of the lock object and the ThreadID of the thread that currently holds the lock, we will be able to build the view `which thread is blocking other threads on which lock object`.
