### PR TITLE
Revert "Always use live host"

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -51,7 +51,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools+host</DefaultCoreClrSubsets>
+    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools</DefaultCoreClrSubsets>
     <!-- Even on platforms that do not support the CoreCLR runtime, we still want to build ilasm/ildasm. -->
     <DefaultCoreClrSubsets Condition="'$(PrimaryRuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>
 
@@ -61,8 +61,7 @@
     <DefaultMonoSubsets Condition="'$(MonoAOTEnableLLVM)' == 'true' and '$(MonoAOTLLVMDir)' == ''">mono.llvm+</DefaultMonoSubsets>
     <DefaultMonoSubsets Condition="'$(TargetOS)' == 'Browser'">$(DefaultMonoSubsets)mono.wasmruntime+</DefaultMonoSubsets>
     <DefaultMonoSubsets Condition="'$(MonoCrossAOTTargetOS)' != ''">$(DefaultMonoSubsets)mono.aotcross+</DefaultMonoSubsets>
-    <DefaultMonoSubsets>$(DefaultMonoSubsets)mono.runtime+mono.corelib+mono.packages+</DefaultMonoSubsets>
-    <DefaultMonoSubsets Condition="'$(TargetsMobile)' != 'true'">$(DefaultMonoSubsets)host+</DefaultMonoSubsets>
+    <DefaultMonoSubsets>$(DefaultMonoSubsets)mono.runtime+mono.corelib+mono.packages</DefaultMonoSubsets>
 
     <DefaultLibrariesSubsets Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or
                                         '$(BuildTargetFramework)' == '' or

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -214,6 +214,14 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1967649721058a457157d4321af3e6fceaa5441b</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="7.0.0-preview.7.22358.7">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1967649721058a457157d4321af3e6fceaa5441b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="7.0.0-preview.7.22358.7">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1967649721058a457157d4321af3e6fceaa5441b</Sha>
+    </Dependency>
     <Dependency Name="runtime.native.System.IO.Ports" Version="7.0.0-preview.7.22358.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1967649721058a457157d4321af3e6fceaa5441b</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,6 +74,8 @@
     <NuGetBuildTasksPackVersion>6.0.0-preview.1.102</NuGetBuildTasksPackVersion>
     <!-- Installer dependencies -->
     <MicrosoftNETCoreAppRuntimewinx64Version>7.0.0-preview.7.22358.7</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftNETCoreDotNetHostVersion>7.0.0-preview.7.22358.7</MicrosoftNETCoreDotNetHostVersion>
+    <MicrosoftNETCoreDotNetHostPolicyVersion>7.0.0-preview.7.22358.7</MicrosoftNETCoreDotNetHostPolicyVersion>
     <MicrosoftExtensionsDependencyModelVersion>3.1.0</MicrosoftExtensionsDependencyModelVersion>
     <!-- CoreClr dependencies -->
     <MicrosoftNETCoreILAsmVersion>7.0.0-preview.7.22358.7</MicrosoftNETCoreILAsmVersion>

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -118,16 +118,6 @@
       <MonoIncludeFiles Include="$(MonoArtifactsPath)\include\**\*.*" />
     </ItemGroup>
 
-    <!-- Host files. Mobile uses a different hosting model, so we don't include the .NET host components there. -->
-    <ItemGroup Condition="'$(TargetsMobile)' != 'true' and Exists('$(DotNetHostBinDir)')">
-      <RuntimeFiles Include="$(DotNetHostBinDir)\$(LibPrefix)hostpolicy$(LibSuffix)">
-        <IsNative>true</IsNative>
-      </RuntimeFiles>
-      <RuntimeFiles Include="$(DotNetHostBinDir)\$(LibPrefix)hostfxr$(LibSuffix)">
-        <IsNative>true</IsNative>
-      </RuntimeFiles>
-    </ItemGroup>
-
     <Error Condition="'@(RuntimeFiles)' == ''" Text="The '$(RuntimeFlavor)' subset must be built before building this project." />
   </Target>
 

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -32,14 +32,13 @@ jobs:
       osGroup:  ${{ parameters.osGroup }}
       osSubgroup:  ${{ parameters.osSubgroup }}
       archType:  ${{ parameters.archType }}
-      crossBuild: ${{ parameters.crossBuild }}
       framework:  ${{ parameters.framework }}
       isOfficialBuild: ${{ parameters.isOfficialBuild }}
       liveRuntimeBuildConfig: ${{ parameters.liveRuntimeBuildConfig }}
       runtimeFlavor: ${{ parameters.runtimeFlavor }}
       runtimeVariant: ${{ parameters.runtimeVariant }}
       timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
-      container: ${{ parameters.container }}
+      container: '' # we just send to helix, no need to use a container.
       condition: ${{ parameters.condition }}
       testScope: ${{ parameters.testScope }}
       runTests: true
@@ -90,7 +89,7 @@ jobs:
 
         - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
           - script: $(_buildScript)
-                    -subset host+libs.pretest
+                    -subset libs.pretest
                     $(_buildArguments)
                     /p:RuntimeFlavor=${{ parameters.runtimeFlavor }}
                     /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/overrideRuntimeFromLiveDrop.binlog

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <VersionProp>HostVersion</VersionProp>
+    <InstallerName>dotnet-host</InstallerName>
+    <PackageDescription>Provides an executable implementation of the Microsoft DotNet Framework and SDK launcher module</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
+    <NativeBinary Include="$(DotNetHostBinDir)/dotnet$(ExeSuffix)" />
+    <File Include="@(NativeBinary)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
+    </File>
+  </ItemGroup>
+
+</Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <VersionProp>HostPolicyVersion</VersionProp>
+    <PackageDescription>Provides a CoreCLR hosting policy implementation -- configuration settings, assembly paths and assembly servicing</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Dependency Include="Microsoft.NETCore.DotNetHostResolver" VersionProp="HostResolverVersion" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
+    <NativeBinary Include="$(DotNetHostBinDir)/$(LibPrefix)hostpolicy$(LibSuffix)"/>
+    <File Include="@(NativeBinary)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
+    </File>
+  </ItemGroup>
+</Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <VersionProp>HostResolverVersion</VersionProp>
+    <InstallerName>dotnet-hostfxr</InstallerName>
+    <InstallerName Condition="'$(PgoInstrument)' != ''">$(InstallerName)-pgo</InstallerName>
+    <PackageDescription>Provides an implementation of framework resolution strategy used by Microsoft.NETCore.DotNetHost</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Dependency Include="Microsoft.NETCore.DotNetAppHost" VersionProp="AppHostVersion" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
+    <NativeBinary Include="$(DotNetHostBinDir)/$(LibPrefix)hostfxr$(LibSuffix)"/>
+    <File Include="@(NativeBinary)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
+    </File>
+  </ItemGroup>
+
+</Project>

--- a/src/installer/pkg/projects/host-packages.proj
+++ b/src/installer/pkg/projects/host-packages.proj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.Build.Traversal" DefaultTargets="Pack">
   <ItemGroup>
     <ProjectReference Include="Microsoft.NETCore.DotNetAppHost\Microsoft.NETCore.DotNetAppHost.pkgproj" />
+    <ProjectReference Include="Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHost.pkgproj" />
+    <ProjectReference Include="Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.pkgproj" />
+    <ProjectReference Include="Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.pkgproj" />
     <ProjectReference Include="@(ProjectReference)" AdditionalProperties="PackageTargetRuntime=$(OutputRid)" />
   </ItemGroup>
 </Project>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
@@ -53,6 +53,12 @@
     </ItemGroup>
   </Target>
 
+  <!-- Mobile uses a different hosting model, so we don't include the .NET host components. -->
+  <ItemGroup Condition="'$(TargetsMobile)' != 'true'">
+    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibPrefix)hostpolicy$(LibSuffix)" />
+    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibPrefix)hostfxr$(LibSuffix)" PackOnly="true" />
+  </ItemGroup>
+
   <Target Name="AddRuntimeFilesToPackage" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
     <ItemGroup>
       <RuntimeFiles Condition="'%(RuntimeFiles.IsNative)' == 'true'">

--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
+    <!-- Set the RuntimeIdentifier so that the DotNetHost and DotNetHostPolicy packages resolve for the corresponding runtime. -->
+    <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
     <SwapNativeForIL Condition="'$(SwapNativeForIL)' == '' and ('$(Configuration)' == 'Debug' or '$(Coverage)' == 'true') and '$(RuntimeFlavor)' != 'Mono'">true</SwapNativeForIL>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <!-- Binplace properties -->
@@ -7,6 +9,7 @@
     <BinPlaceNative>true</BinPlaceNative>
     <BinPlaceRuntime>false</BinPlaceRuntime>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <UseLiveBuiltDotNetHost Condition="'$(DotNetBuildFromSource)' == 'true' or '$(TargetArchitecture)' == 's390x' or '$(TargetArchitecture)' == 'ppc64le' or '$(TargetArchitecture)' == 'armv6' or '$(TargetsLinuxBionic)' == 'true'">true</UseLiveBuiltDotNetHost>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -18,16 +21,23 @@
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)coredistools.targets" Condition="$(CopyCoreDisToolsToCoreRoot)" />
-
+  
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <PackageReference Include="Microsoft.DiaSymReader.Native"
                       Version="$(MicrosoftDiaSymReaderNativeVersion)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetsMobile)' != 'true' and '$(UseLiveBuiltDotNetHost)' != 'true'">
+    <PackageReference Include="Microsoft.NETCore.DotNetHost"
+                      Version="$(MicrosoftNETCoreDotNetHostVersion)" />
+    <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy"
+                      Version="$(MicrosoftNETCoreDotNetHostPolicyVersion)" />
+  </ItemGroup>
+
   <!-- Setup the testing shared framework host -->
   <Target Name="SetupTestingHost"
           AfterTargets="AfterResolveReferences"
-          Condition="Exists('$(DotNetHostBinDir)') and '$(TestNativeAot)' != 'true'">
+          Condition="'$(TestNativeAot)' != 'true'">
     <PropertyGroup>
       <UseHardlink>true</UseHardlink>
     </PropertyGroup>
@@ -38,7 +48,13 @@
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'apphost'" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(UseLiveBuiltDotNetHost)' != 'true'">
+      <HostFxFile Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'hostfxr' or
+                                                                  '%(ReferenceCopyLocalPaths.Filename)' == 'libhostfxr'" />
+      <DotnetExe Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'dotnet'" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(UseLiveBuiltDotNetHost)' == 'true'">
       <CoreHostFiles Include="$(DotNetHostBinDir)*" />
       <HostFxFile Include="@(CoreHostFiles)" Condition="'%(CoreHostFiles.Filename)' == 'hostfxr' or
                                                           '%(CoreHostFiles.Filename)' == 'libhostfxr'" />
@@ -62,7 +78,7 @@
           SkipUnchangedFiles="true"
           UseHardlinksIfPossible="$(UseHardlink)" />
 
-    <Copy Condition="$(CopyCoreDisToolsToCoreRoot)"
+    <Copy Condition="$(CopyCoreDisToolsToCoreRoot)" 
           SourceFiles="$(CoreDisToolsLibrary)"
           DestinationFolder="$(NetCoreAppCurrentTestHostPath)shared\Microsoft.NETCore.App\$(ProductVersion)"
           SkipUnchangedFiles="true"


### PR DESCRIPTION
Reverts dotnet/runtime#71725

Unfortunately this causes the host to appear in the shared runtime, which it shouldn't. If I only copy it
over to the live runtimepack during libs.tests it doesn't appear in the installer hosts tests.