### PR TITLE
Correct nullable annotation on ICustomTypeDescriptor.GetConverter

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -289,7 +289,7 @@ namespace System.ComponentModel
         public virtual string? GetClassName() { throw null; }
         public virtual string? GetComponentName() { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.")]
-        public virtual System.ComponentModel.TypeConverter GetConverter() { throw null; }
+        public virtual System.ComponentModel.TypeConverter? GetConverter() { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The built-in EventDescriptor implementation uses Reflection which requires unreferenced code.")]
         public virtual System.ComponentModel.EventDescriptor? GetDefaultEvent() { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("PropertyDescriptor's PropertyType cannot be statically discovered.")]
@@ -584,7 +584,7 @@ namespace System.ComponentModel
         string? GetClassName();
         string? GetComponentName();
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.")]
-        System.ComponentModel.TypeConverter GetConverter();
+        System.ComponentModel.TypeConverter? GetConverter();
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The built-in EventDescriptor implementation uses Reflection which requires unreferenced code.")]
         System.ComponentModel.EventDescriptor? GetDefaultEvent();
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("PropertyDescriptor's PropertyType cannot be statically discovered.")]

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/CustomTypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/CustomTypeDescriptor.cs
@@ -70,7 +70,7 @@ namespace System.ComponentModel
         /// descriptor is representing.
         /// </summary>
         [RequiresUnreferencedCode(TypeConverter.RequiresUnreferencedCodeMessage)]
-        public virtual TypeConverter GetConverter()
+        public virtual TypeConverter? GetConverter()
         {
             if (_parent != null)
             {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ICustomTypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ICustomTypeDescriptor.cs
@@ -30,7 +30,7 @@ namespace System.ComponentModel
         /// Gets a type converter for this object.
         /// </summary>
         [RequiresUnreferencedCode(TypeConverter.RequiresUnreferencedCodeMessage)]
-        TypeConverter GetConverter();
+        TypeConverter? GetConverter();
 
         /// <summary>
         /// Gets the default event for this object.

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -599,7 +599,7 @@ namespace System.ComponentModel
                 return new AttributeCollection((Attribute[])null);
             }
 
-            AttributeCollection attributes = GetDescriptor(componentType, nameof(componentType))!.GetAttributes();
+            AttributeCollection attributes = GetDescriptor(componentType, nameof(componentType)).GetAttributes();
             return attributes;
         }
 
@@ -725,7 +725,7 @@ namespace System.ComponentModel
         public static string? GetClassName(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type componentType)
         {
-            return GetDescriptor(componentType, nameof(componentType))!.GetClassName();
+            return GetDescriptor(componentType, nameof(componentType)).GetClassName();
         }
 
         /// <summary>
@@ -757,7 +757,10 @@ namespace System.ComponentModel
         [RequiresUnreferencedCode(TypeConverter.RequiresUnreferencedCodeMessage + " The Type of component cannot be statically discovered.")]
         public static TypeConverter GetConverter(object component, bool noCustomTypeDesc)
         {
-            TypeConverter converter = GetDescriptor(component, noCustomTypeDesc)!.GetConverter();
+            TypeConverter? converter = GetDescriptor(component, noCustomTypeDesc)!.GetConverter();
+            // GetDescriptor will only return DefaultTypeDescriptor, or MergedTypeDescriptor with DefaultTypeDescriptor as the secondary,
+            // which will always return a non-null TypeConverter.
+            Debug.Assert(converter != null, "Unexpected null TypeConverter.");
             return converter;
         }
 
@@ -767,7 +770,7 @@ namespace System.ComponentModel
         [RequiresUnreferencedCode(TypeConverter.RequiresUnreferencedCodeMessage)]
         public static TypeConverter GetConverter([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
         {
-            return GetDescriptor(type, nameof(type))!.GetConverter();
+            return GetDescriptor(type, nameof(type)).GetConverter();
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
@@ -795,7 +798,7 @@ namespace System.ComponentModel
                 return null;
             }
 
-            return GetDescriptor(componentType, nameof(componentType))!.GetDefaultEvent();
+            return GetDescriptor(componentType, nameof(componentType)).GetDefaultEvent();
         }
 
         /// <summary>
@@ -833,7 +836,7 @@ namespace System.ComponentModel
                 return null;
             }
 
-            return GetDescriptor(componentType, nameof(componentType))!.GetDefaultProperty();
+            return GetDescriptor(componentType, nameof(componentType)).GetDefaultProperty();
         }
 
         /// <summary>
@@ -862,13 +865,13 @@ namespace System.ComponentModel
         /// Returns a custom type descriptor for the given type.
         /// Performs arg checking so callers don't have to.
         /// </summary>
-        internal static ICustomTypeDescriptor? GetDescriptor(
+        private static DefaultTypeDescriptor GetDescriptor(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type,
             string typeName)
         {
-            ArgumentNullException.ThrowIfNull(type);
+            ArgumentNullException.ThrowIfNull(type, typeName);
 
-            return NodeFor(type).GetTypeDescriptor(type);
+            return NodeFor(type).GetDefaultTypeDescriptor(type);
         }
 
         /// <summary>
@@ -942,7 +945,7 @@ namespace System.ComponentModel
         {
             ArgumentNullException.ThrowIfNull(editorBaseType);
 
-            return GetDescriptor(type, nameof(type))!.GetEditor(editorBaseType);
+            return GetDescriptor(type, nameof(type)).GetEditor(editorBaseType);
         }
 
         /// <summary>
@@ -975,7 +978,7 @@ namespace System.ComponentModel
                 return new EventDescriptorCollection(null, true);
             }
 
-            EventDescriptorCollection events = GetDescriptor(componentType, nameof(componentType))!.GetEvents(attributes);
+            EventDescriptorCollection events = GetDescriptor(componentType, nameof(componentType)).GetEvents(attributes);
 
             if (attributes != null && attributes.Length > 0)
             {
@@ -1185,7 +1188,7 @@ namespace System.ComponentModel
                 return new PropertyDescriptorCollection(null, true);
             }
 
-            return GetDescriptor(componentType, nameof(componentType))!.GetProperties();
+            return GetDescriptor(componentType, nameof(componentType)).GetProperties();
         }
 
         /// <summary>
@@ -1203,7 +1206,7 @@ namespace System.ComponentModel
                 return new PropertyDescriptorCollection(null, true);
             }
 
-            PropertyDescriptorCollection properties = GetDescriptor(componentType, nameof(componentType))!.GetProperties(attributes);
+            PropertyDescriptorCollection properties = GetDescriptor(componentType, nameof(componentType)).GetProperties(attributes);
 
             if (attributes != null && attributes.Length > 0)
             {
@@ -2890,7 +2893,7 @@ namespace System.ComponentModel
             [RequiresUnreferencedCode(TypeConverter.RequiresUnreferencedCodeMessage)]
             TypeConverter ICustomTypeDescriptor.GetConverter()
             {
-                TypeConverter converter = _primary.GetConverter() ?? _secondary.GetConverter();
+                TypeConverter? converter = _primary.GetConverter() ?? _secondary.GetConverter();
 
                 Debug.Assert(converter != null, "Someone should have handled this");
                 return converter;
@@ -3116,6 +3119,11 @@ namespace System.ComponentModel
                 return new DefaultTypeDescriptor(this, objectType, instance);
             }
 
+            internal DefaultTypeDescriptor GetDefaultTypeDescriptor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type objectType)
+            {
+                return new DefaultTypeDescriptor(this, objectType, instance: null);
+            }
+
             public override bool IsSupportedType(Type type)
             {
                 ArgumentNullException.ThrowIfNull(type);
@@ -3226,7 +3234,7 @@ namespace System.ComponentModel
 
                     ICustomTypeDescriptor desc = p.GetExtendedTypeDescriptor(_instance);
                     if (desc == null) throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetExtendedTypeDescriptor"));
-                    TypeConverter converter = desc.GetConverter();
+                    TypeConverter? converter = desc.GetConverter();
                     if (converter == null) throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetConverter"));
                     return converter;
                 }
@@ -3415,350 +3423,350 @@ namespace System.ComponentModel
                     return owner;
                 }
             }
+        }
+
+        /// <summary>
+        /// The default type descriptor.
+        /// </summary>
+        private readonly struct DefaultTypeDescriptor : ICustomTypeDescriptor
+        {
+            private readonly TypeDescriptionNode _node;
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+            private readonly Type _objectType;
+            private readonly object? _instance;
 
             /// <summary>
-            /// The default type descriptor.
+            /// Creates a new WalkingTypeDescriptor.
             /// </summary>
-            private readonly struct DefaultTypeDescriptor : ICustomTypeDescriptor
+            internal DefaultTypeDescriptor(
+                TypeDescriptionNode node,
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type objectType,
+                object? instance)
             {
-                private readonly TypeDescriptionNode _node;
-                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-                private readonly Type _objectType;
-                private readonly object? _instance;
+                _node = node;
+                _objectType = objectType;
+                _instance = instance;
+            }
 
-                /// <summary>
-                /// Creates a new WalkingTypeDescriptor.
-                /// </summary>
-                internal DefaultTypeDescriptor(
-                    TypeDescriptionNode node,
-                    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type objectType,
-                    object? instance)
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            public AttributeCollection GetAttributes()
+            {
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                AttributeCollection attrs;
+                if (p is ReflectTypeDescriptionProvider rp)
                 {
-                    _node = node;
-                    _objectType = objectType;
-                    _instance = instance;
+                    attrs = rp.GetAttributes(_objectType);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    attrs = desc.GetAttributes();
+                    if (attrs == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetAttributes"));
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                AttributeCollection ICustomTypeDescriptor.GetAttributes()
-                {
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    AttributeCollection attrs;
-                    if (p is ReflectTypeDescriptionProvider rp)
-                    {
-                        attrs = rp.GetAttributes(_objectType);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        attrs = desc.GetAttributes();
-                        if (attrs == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetAttributes"));
-                    }
+                return attrs;
+            }
 
-                    return attrs;
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            public string? GetClassName()
+            {
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                string? name;
+                if (p is ReflectTypeDescriptionProvider rp)
+                {
+                    name = rp.GetClassName(_objectType);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    name = desc.GetClassName() ?? _objectType.FullName;
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                string? ICustomTypeDescriptor.GetClassName()
-                {
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    string? name;
-                    if (p is ReflectTypeDescriptionProvider rp)
-                    {
-                        name = rp.GetClassName(_objectType);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        name = desc.GetClassName() ?? _objectType.FullName;
-                    }
+                return name;
+            }
 
-                    return name;
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            string? ICustomTypeDescriptor.GetComponentName()
+            {
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                string? name;
+                if (p is ReflectTypeDescriptionProvider)
+                {
+                    name = ReflectTypeDescriptionProvider.GetComponentName(_instance);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    name = desc.GetComponentName();
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                string? ICustomTypeDescriptor.GetComponentName()
-                {
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    string? name;
-                    if (p is ReflectTypeDescriptionProvider)
-                    {
-                        name = ReflectTypeDescriptionProvider.GetComponentName(_instance);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        name = desc.GetComponentName();
-                    }
+                return name;
+            }
 
-                    return name;
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            [RequiresUnreferencedCode(TypeConverter.RequiresUnreferencedCodeMessage)]
+            public TypeConverter GetConverter()
+            {
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                TypeConverter? converter;
+                if (p is ReflectTypeDescriptionProvider rp)
+                {
+                    converter = rp.GetConverter(_objectType, _instance);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    converter = desc.GetConverter();
+                    if (converter == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetConverter"));
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                [RequiresUnreferencedCode(TypeConverter.RequiresUnreferencedCodeMessage)]
-                TypeConverter ICustomTypeDescriptor.GetConverter()
-                {
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    TypeConverter converter;
-                    if (p is ReflectTypeDescriptionProvider rp)
-                    {
-                        converter = rp.GetConverter(_objectType, _instance);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        converter = desc.GetConverter();
-                        if (converter == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetConverter"));
-                    }
+                return converter;
+            }
 
-                    return converter;
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            [RequiresUnreferencedCode(EventDescriptor.RequiresUnreferencedCodeMessage)]
+            public EventDescriptor? GetDefaultEvent()
+            {
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                EventDescriptor? defaultEvent;
+                if (p is ReflectTypeDescriptionProvider rp)
+                {
+                    defaultEvent = rp.GetDefaultEvent(_objectType, _instance);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    defaultEvent = desc.GetDefaultEvent();
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                [RequiresUnreferencedCode(EventDescriptor.RequiresUnreferencedCodeMessage)]
-                EventDescriptor? ICustomTypeDescriptor.GetDefaultEvent()
-                {
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    EventDescriptor? defaultEvent;
-                    if (p is ReflectTypeDescriptionProvider rp)
-                    {
-                        defaultEvent = rp.GetDefaultEvent(_objectType, _instance);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        defaultEvent = desc.GetDefaultEvent();
-                    }
+                return defaultEvent;
+            }
 
-                    return defaultEvent;
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            [RequiresUnreferencedCode(PropertyDescriptor.PropertyDescriptorPropertyTypeMessage)]
+            public PropertyDescriptor? GetDefaultProperty()
+            {
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                PropertyDescriptor? defaultProperty;
+                if (p is ReflectTypeDescriptionProvider rp)
+                {
+                    defaultProperty = rp.GetDefaultProperty(_objectType, _instance);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    defaultProperty = desc.GetDefaultProperty();
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                [RequiresUnreferencedCode(PropertyDescriptor.PropertyDescriptorPropertyTypeMessage)]
-                PropertyDescriptor? ICustomTypeDescriptor.GetDefaultProperty()
-                {
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    PropertyDescriptor? defaultProperty;
-                    if (p is ReflectTypeDescriptionProvider rp)
-                    {
-                        defaultProperty = rp.GetDefaultProperty(_objectType, _instance);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        defaultProperty = desc.GetDefaultProperty();
-                    }
+                return defaultProperty;
+            }
 
-                    return defaultProperty;
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            [RequiresUnreferencedCode(EditorRequiresUnreferencedCode)]
+            public object? GetEditor(Type editorBaseType)
+            {
+                ArgumentNullException.ThrowIfNull(editorBaseType);
+
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                object? editor;
+                if (p is ReflectTypeDescriptionProvider rp)
+                {
+                    editor = rp.GetEditor(_objectType, _instance, editorBaseType);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    editor = desc.GetEditor(editorBaseType);
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                [RequiresUnreferencedCode(EditorRequiresUnreferencedCode)]
-                object? ICustomTypeDescriptor.GetEditor(Type editorBaseType)
+                return editor;
+            }
+
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            public EventDescriptorCollection GetEvents()
+            {
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                EventDescriptorCollection events;
+                if (p is ReflectTypeDescriptionProvider rp)
                 {
-                    ArgumentNullException.ThrowIfNull(editorBaseType);
-
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    object? editor;
-                    if (p is ReflectTypeDescriptionProvider rp)
-                    {
-                        editor = rp.GetEditor(_objectType, _instance, editorBaseType);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        editor = desc.GetEditor(editorBaseType);
-                    }
-
-                    return editor;
+                    events = rp.GetEvents(_objectType);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    events = desc.GetEvents();
+                    if (events == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetEvents"));
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                EventDescriptorCollection ICustomTypeDescriptor.GetEvents()
-                {
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    EventDescriptorCollection events;
-                    if (p is ReflectTypeDescriptionProvider rp)
-                    {
-                        events = rp.GetEvents(_objectType);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        events = desc.GetEvents();
-                        if (events == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetEvents"));
-                    }
+                return events;
+            }
 
-                    return events;
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            [RequiresUnreferencedCode(AttributeCollection.FilterRequiresUnreferencedCodeMessage)]
+            public EventDescriptorCollection GetEvents(Attribute[]? attributes)
+            {
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                EventDescriptorCollection events;
+                if (p is ReflectTypeDescriptionProvider rp)
+                {
+                    events = rp.GetEvents(_objectType);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    events = desc.GetEvents(attributes);
+                    if (events == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetEvents"));
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                [RequiresUnreferencedCode(AttributeCollection.FilterRequiresUnreferencedCodeMessage)]
-                EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[]? attributes)
-                {
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    EventDescriptorCollection events;
-                    if (p is ReflectTypeDescriptionProvider rp)
-                    {
-                        events = rp.GetEvents(_objectType);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        events = desc.GetEvents(attributes);
-                        if (events == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetEvents"));
-                    }
+                return events;
+            }
 
-                    return events;
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            [RequiresUnreferencedCode(PropertyDescriptor.PropertyDescriptorPropertyTypeMessage)]
+            public PropertyDescriptorCollection GetProperties()
+            {
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                PropertyDescriptorCollection properties;
+                if (p is ReflectTypeDescriptionProvider rp)
+                {
+                    properties = rp.GetProperties(_objectType);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    properties = desc.GetProperties();
+                    if (properties == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetProperties"));
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                [RequiresUnreferencedCode(PropertyDescriptor.PropertyDescriptorPropertyTypeMessage)]
-                PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties()
-                {
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    PropertyDescriptorCollection properties;
-                    if (p is ReflectTypeDescriptionProvider rp)
-                    {
-                        properties = rp.GetProperties(_objectType);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        properties = desc.GetProperties();
-                        if (properties == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetProperties"));
-                    }
+                return properties;
+            }
 
-                    return properties;
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            [RequiresUnreferencedCode(PropertyDescriptor.PropertyDescriptorPropertyTypeMessage + " " + AttributeCollection.FilterRequiresUnreferencedCodeMessage)]
+            public PropertyDescriptorCollection GetProperties(Attribute[]? attributes)
+            {
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                PropertyDescriptorCollection properties;
+                if (p is ReflectTypeDescriptionProvider rp)
+                {
+                    properties = rp.GetProperties(_objectType);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    properties = desc.GetProperties(attributes);
+                    if (properties == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetProperties"));
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                [RequiresUnreferencedCode(PropertyDescriptor.PropertyDescriptorPropertyTypeMessage + " " + AttributeCollection.FilterRequiresUnreferencedCodeMessage)]
-                PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[]? attributes)
-                {
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    PropertyDescriptorCollection properties;
-                    if (p is ReflectTypeDescriptionProvider rp)
-                    {
-                        properties = rp.GetProperties(_objectType);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        properties = desc.GetProperties(attributes);
-                        if (properties == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetProperties"));
-                    }
+                return properties;
+            }
 
-                    return properties;
+            /// <summary>
+            /// ICustomTypeDescriptor implementation.
+            /// </summary>
+            object? ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor? pd)
+            {
+                // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
+                // If so, we can call on it directly rather than creating another
+                // custom type descriptor
+                TypeDescriptionProvider p = _node.Provider;
+                object? owner;
+                if (p is ReflectTypeDescriptionProvider)
+                {
+                    owner = ReflectTypeDescriptionProvider.GetPropertyOwner(_objectType, _instance!, pd);
+                }
+                else
+                {
+                    ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
+                    if (desc == null)
+                        throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
+                    owner = desc.GetPropertyOwner(pd) ?? _instance;
                 }
 
-                /// <summary>
-                /// ICustomTypeDescriptor implementation.
-                /// </summary>
-                object? ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor? pd)
-                {
-                    // Check to see if the provider we get is a ReflectTypeDescriptionProvider.
-                    // If so, we can call on it directly rather than creating another
-                    // custom type descriptor
-                    TypeDescriptionProvider p = _node.Provider;
-                    object? owner;
-                    if (p is ReflectTypeDescriptionProvider)
-                    {
-                        owner = ReflectTypeDescriptionProvider.GetPropertyOwner(_objectType, _instance!, pd);
-                    }
-                    else
-                    {
-                        ICustomTypeDescriptor? desc = p.GetTypeDescriptor(_objectType, _instance);
-                        if (desc == null)
-                            throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        owner = desc.GetPropertyOwner(pd) ?? _instance;
-                    }
-
-                    return owner;
-                }
+                return owner;
             }
         }
 

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
@@ -318,9 +318,9 @@ namespace System.Data.Common
         }
 
         [RequiresUnreferencedCode("Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.")]
-        TypeConverter ICustomTypeDescriptor.GetConverter()
+        TypeConverter? ICustomTypeDescriptor.GetConverter()
         {
-            return null!;
+            return null;
         }
 
         [RequiresUnreferencedCode("The built-in EventDescriptor implementation uses Reflection which requires unreferenced code.")]

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbDataRecord.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbDataRecord.cs
@@ -77,7 +77,7 @@ namespace System.Data.Common
         string? ICustomTypeDescriptor.GetComponentName() => null;
 
         [RequiresUnreferencedCode("Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.")]
-        TypeConverter ICustomTypeDescriptor.GetConverter() => null!;
+        TypeConverter? ICustomTypeDescriptor.GetConverter() => null;
 
         [RequiresUnreferencedCode("The built-in EventDescriptor implementation uses Reflection which requires unreferenced code.")]
         EventDescriptor? ICustomTypeDescriptor.GetDefaultEvent() => null;

--- a/src/libraries/System.Data.Common/src/System/Data/DataRowView.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataRowView.cs
@@ -234,7 +234,7 @@ namespace System.Data
         string? ICustomTypeDescriptor.GetComponentName() => null;
 
         [RequiresUnreferencedCode("Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.")]
-        TypeConverter ICustomTypeDescriptor.GetConverter() => null!;
+        TypeConverter? ICustomTypeDescriptor.GetConverter() => null;
 
         [RequiresUnreferencedCode("The built-in EventDescriptor implementation uses Reflection which requires unreferenced code.")]
         EventDescriptor? ICustomTypeDescriptor.GetDefaultEvent() => null;

--- a/src/libraries/System.Data.Common/src/System/Data/DataViewManagerListItemTypeDescriptor.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataViewManagerListItemTypeDescriptor.cs
@@ -49,7 +49,7 @@ namespace System.Data
         /// Retrieves the type converter for this object.
         /// </summary>
         [RequiresUnreferencedCode("Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.")]
-        TypeConverter ICustomTypeDescriptor.GetConverter() => null!;
+        TypeConverter? ICustomTypeDescriptor.GetConverter() => null;
 
         /// <summary>
         /// Retrieves the default event.


### PR DESCRIPTION
The documentation, and even some of our own code, return null for this method. Correcting the nullable annotation to indicate that null can be returned.

Fix #69229

(Note it is probably best to review with whitespace changes ignored, since I moved one type out a level.)