### PR TITLE
Ensure JsonTypeInfo does not fail configuration for valid metadata originating from fast-path sourcegen

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -61,7 +61,7 @@ namespace System.Text.Json.Serialization.Converters
         }
 
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, ref ReadStack state, out T? value)
-            => Converter.OnTryRead(ref reader, typeToConvert, options, ref state, out value);
+             => Converter.OnTryRead(ref reader, typeToConvert, options, ref state, out value);
 
         internal override bool OnTryWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
         {
@@ -70,15 +70,17 @@ namespace System.Text.Json.Serialization.Converters
             Debug.Assert(options == jsonTypeInfo.Options);
 
             if (!state.SupportContinuation &&
+                jsonTypeInfo.HasSerializeHandler &&
                 jsonTypeInfo is JsonTypeInfo<T> info &&
-                info.SerializeHandler != null &&
                 !state.CurrentContainsMetadata && // Do not use the fast path if state needs to write metadata.
                 info.Options.SerializerContext?.CanUseSerializationLogic == true)
             {
+                Debug.Assert(info.SerializeHandler != null);
                 info.SerializeHandler(writer, value);
                 return true;
             }
 
+            jsonTypeInfo.ValidateCanBeUsedForMetadataSerialization();
             return Converter.OnTryWrite(writer, value, options, ref state);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -525,7 +525,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             JsonTypeInfo jsonTypeInfo = state.Current.JsonTypeInfo;
 
-            jsonTypeInfo.ValidateCanBeUsedForDeserialization();
+            jsonTypeInfo.ValidateCanBeUsedForMetadataSerialization();
 
             if (jsonTypeInfo.ParameterCount != jsonTypeInfo.ParameterCache!.Count)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -39,7 +39,7 @@ namespace System.Text.Json
         {
             Debug.Assert(writer != null);
 
-            if (jsonTypeInfo.HasSerialize &&
+            if (jsonTypeInfo.HasSerializeHandler &&
                 jsonTypeInfo is JsonTypeInfo<TValue> typedInfo &&
                 typedInfo.Options.SerializerContext?.CanUseSerializationLogic == true)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -97,7 +97,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             PropertyRef propertyRef;
 
-            ValidateCanBeUsedForDeserialization();
+            ValidateCanBeUsedForMetadataSerialization();
             ulong key = GetKey(propertyName);
 
             // Keep a local copy of the cache in case it changes by another thread.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -267,16 +267,16 @@ namespace System.Text.Json.Serialization.Metadata
         private JsonTypeInfo? _elementTypeInfo;
 
         // Avoids having to perform an expensive cast to JsonTypeInfo<T> to check if there is a Serialize method.
-        internal bool HasSerialize { get; private protected set; }
+        internal bool HasSerializeHandler { get; private protected set; }
 
         // Configure would normally have thrown why initializing properties for source gen but type had SerializeHandler
-        // so it is allowed to be used for serialization but it will throw if used for deserialization
-        internal bool ThrowOnDeserialize { get; private protected set; }
+        // so it is allowed to be used for fast-path serialization but it will throw if used for metadata-based serialization
+        internal bool MetadataSerializationNotSupported { get; private protected set; }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void ValidateCanBeUsedForDeserialization()
+        internal void ValidateCanBeUsedForMetadataSerialization()
         {
-            if (ThrowOnDeserialize)
+            if (MetadataSerializationNotSupported)
             {
                 ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(Options.TypeInfoResolver, Type);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -99,7 +99,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 Debug.Assert(!IsConfigured, "We should not mutate configured JsonTypeInfo");
                 _serialize = value;
-                HasSerialize = value != null;
+                HasSerializeHandler = value != null;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
@@ -107,8 +107,13 @@ namespace System.Text.Json.Serialization.Metadata
             JsonParameterInfoValues[] array;
             if (CtorParamInitFunc == null || (array = CtorParamInitFunc()) == null)
             {
-                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeCtorParams(Options.TypeInfoResolver, Type);
-                return null!;
+                if (SerializeHandler == null)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeCtorParams(Options.TypeInfoResolver, Type);
+                }
+
+                array = Array.Empty<JsonParameterInfoValues>();
+                MetadataSerializationNotSupported = true;
             }
 
             return array;
@@ -139,13 +144,12 @@ namespace System.Text.Json.Serialization.Metadata
                     return;
                 }
 
-                if (SerializeHandler != null && context?.CanUseSerializationLogic == true)
+                if (SerializeHandler == null)
                 {
-                    ThrowOnDeserialize = true;
-                    return;
+                    ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(Options.TypeInfoResolver, Type);
                 }
 
-                ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(Options.TypeInfoResolver, Type);
+                MetadataSerializationNotSupported = true;
                 return;
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -145,6 +145,60 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Equal("lastName", personInfo.Properties[1].Name);
         }
 
+        [Fact]
+        public static void FastPathSerialization_ResolvingJsonTypeInfo()
+        {
+            JsonSerializerOptions options = FastPathSerializationContext.Default.Options;
+
+            JsonTypeInfo<JsonMessage> jsonMessageInfo = (JsonTypeInfo<JsonMessage>)options.GetTypeInfo(typeof(JsonMessage));
+            Assert.NotNull(jsonMessageInfo.SerializeHandler);
+
+            var value = new JsonMessage { Message = "Hi" };
+            string expectedJson = """{"Message":"Hi","Length":2}""";
+
+            Assert.Equal(expectedJson, JsonSerializer.Serialize(value, jsonMessageInfo));
+            Assert.Equal(expectedJson, JsonSerializer.Serialize(value, options));
+
+            // Throws since deserialization without metadata is not supported
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<JsonMessage>(expectedJson, jsonMessageInfo));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<JsonMessage>(expectedJson, options));
+        }
+
+        [Fact]
+        public static void FastPathSerialization_CombinedContext_ThrowsInvalidOperationException()
+        {
+            // TODO change exception assertions once https://github.com/dotnet/runtime/issues/71933 is fixed.
+
+            var options = new JsonSerializerOptions
+            {
+                TypeInfoResolver = JsonTypeInfoResolver.Combine(FastPathSerializationContext.Default, new DefaultJsonTypeInfoResolver())
+            };
+
+            JsonTypeInfo<JsonMessage> jsonMessageInfo = (JsonTypeInfo<JsonMessage>)options.GetTypeInfo(typeof(JsonMessage));
+            Assert.NotNull(jsonMessageInfo.SerializeHandler);
+
+            var value = new JsonMessage { Message = "Hi" };
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(value, jsonMessageInfo));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(value, options));
+
+            JsonTypeInfo<ClassWithJsonMessage> classInfo = (JsonTypeInfo<ClassWithJsonMessage>)options.GetTypeInfo(typeof(ClassWithJsonMessage));
+            Assert.Null(classInfo.SerializeHandler);
+
+            var largerValue = new ClassWithJsonMessage { Message = value };
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(largerValue, classInfo));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(largerValue, options));
+        }
+
+        [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Serialization)]
+        [JsonSerializable(typeof(JsonMessage))]
+        public partial class FastPathSerializationContext : JsonSerializerContext
+        { }
+
+        public class ClassWithJsonMessage
+        {
+            public JsonMessage Message { get; set; }
+        }
+
         [Theory]
         [MemberData(nameof(GetCombiningContextsData))]
         public static void CombiningContexts_Serialization<T>(T value, string expectedJson)


### PR DESCRIPTION
Rearranges the configuration logic so that certain failure modes are surfaced at serialization time rather than configuration time.

Fix #72614.