### PR TITLE
Clear list in Enumerable.Chunk prior to yielding

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Chunk.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Chunk.cs
@@ -55,7 +55,8 @@ namespace System.Linq
             if (e.MoveNext())
             {
                 List<TSource> chunkBuilder = new();
-                while (true)
+                int lastLength;
+                do
                 {
                     do
                     {
@@ -63,14 +64,12 @@ namespace System.Linq
                     }
                     while (chunkBuilder.Count < size && e.MoveNext());
 
-                    yield return chunkBuilder.ToArray();
-
-                    if (chunkBuilder.Count < size || !e.MoveNext())
-                    {
-                        yield break;
-                    }
+                    TSource[] array = chunkBuilder.ToArray();
                     chunkBuilder.Clear();
+                    lastLength = array.Length;
+                    yield return array;
                 }
+                while (lastLength >= size && e.MoveNext());
             }
         }
     }


### PR DESCRIPTION
To avoid the iterator keeping alive references unnecessarily.  If the consumer takes their time in processing the resulting array and nulls out values as they go, we don't want the list referenced by the enumerator still keeping those objects referenced.

Fixes https://github.com/dotnet/runtime/issues/72577