### PR TITLE
Fix overflow check for parsing format strings

### DIFF
--- a/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -700,19 +700,19 @@ namespace System.Globalization
                             }
                         }
 
-                        // Fallback for symbol and any length digits.  The digits value must be >= 0 && <= 99,
-                        // but it can begin with any number of 0s, and thus we may need to check more than two
+                        // Fallback for symbol and any length digits.  The digits value must be >= 0 && <= 999_999_999,
+                        // but it can begin with any number of 0s, and thus we may need to check more than 9
                         // digits.  Further, for compat, we need to stop when we hit a null char.
                         int n = 0;
                         int i = 1;
                         while ((uint)i < (uint)format.Length && char.IsAsciiDigit(format[i]))
                         {
-                            int temp = (n * 10) + format[i++] - '0';
-                            if (temp < n)
+                            // Check if we are about to overflow past our limit of 9 digits
+                            if (n >= 100_000_000)
                             {
                                 throw new FormatException(SR.Argument_BadFormatSpecifier);
                             }
-                            n = temp;
+                            n = ((n * 10) + format[i++] - '0');
                         }
 
                         // If we're at the end of the digits rather than having stopped because we hit something

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -2331,7 +2331,6 @@ namespace System
                             throw new FormatException(SR.Argument_BadFormatSpecifier);
                         }
                         n = ((n * 10) + format[i++] - '0');
-
                     }
 
                     // If we're at the end of the digits rather than having stopped because we hit something

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -2318,25 +2318,20 @@ namespace System
                         }
                     }
 
-                    // Fallback for symbol and any length digits.  The digits value must be >= 0 && <= 2147483647,
-                    // but it can begin with any number of 0s, and thus we may need to check more than two
+                    // Fallback for symbol and any length digits.  The digits value must be >= 0 && <= 999_999_999,
+                    // but it can begin with any number of 0s, and thus we may need to check more than 9
                     // digits.  Further, for compat, we need to stop when we hit a null char.
                     int n = 0;
                     int i = 1;
                     while ((uint)i < (uint)format.Length && char.IsAsciiDigit(format[i]))
                     {
-                        // Quickly check if we are about to overflow
-                        if (n >= 214748364)
+                        // Check if we are about to overflow past our limit of 9 digits
+                        if (n >= 100_000_000)
                         {
-                            // if n is 214748364, we might still have a valid input in the range (2147483640,2147483647),
-                            // so we should continue. Otherwise, throw FormatException.
-                            bool potentialValidFormat = (n == 214748364 && format[i] <= '7');
-                            if (!potentialValidFormat)
-                            {
-                                throw new FormatException(SR.Argument_BadFormatSpecifier);
-                            }
+                            throw new FormatException(SR.Argument_BadFormatSpecifier);
                         }
                         n = ((n * 10) + format[i++] - '0');
+
                     }
 
                     // If we're at the end of the digits rather than having stopped because we hit something

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -854,7 +854,6 @@ namespace System.Numerics
             }
         }
 
-        // This function is consistent with VM\COMNumber.cpp!COMNumber::ParseFormatSpecifier
         internal static char ParseFormatSpecifier(ReadOnlySpan<char> format, out int digits)
         {
             digits = -1;
@@ -867,22 +866,23 @@ namespace System.Numerics
             char ch = format[i];
             if (char.IsAsciiLetter(ch))
             {
+                // The digits value must be >= 0 && <= 999_999_999,
+                // but it can begin with any number of 0s, and thus we may need to check more than 9
+                // digits.  Further, for compat, we need to stop when we hit a null char.
                 i++;
-                int n = -1;
-
-                if (i < format.Length && char.IsAsciiDigit(format[i]))
+                int n = 0;
+                while ((uint)i < (uint)format.Length && char.IsAsciiDigit(format[i]))
                 {
-                    n = format[i++] - '0';
-                    while (i < format.Length && char.IsAsciiDigit(format[i]))
+                    // Check if we are about to overflow past our limit of 9 digits
+                    if (n >= 100_000_000)
                     {
-                        int temp = n * 10 + (format[i++] - '0');
-                        if (temp < n)
-                        {
-                            throw new FormatException(SR.Argument_BadFormatSpecifier);
-                        }
-                        n = temp;
+                        throw new FormatException(SR.Argument_BadFormatSpecifier);
                     }
+                    n = ((n * 10) + format[i++] - '0');
                 }
+
+                // If we're at the end of the digits rather than having stopped because we hit something
+                // other than a digit or overflowed, return the standard format info.
                 if (i >= format.Length || format[i] == '\0')
                 {
                     digits = n;

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -463,6 +463,7 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        [OuterLoop("Takes a long time, allocates a lot of memory")]
         public static void ToString_ValidLargeFormat()
         {
             BigInteger b = new BigInteger(123456789000m);

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -439,6 +439,45 @@ namespace System.Numerics.Tests
             RunCustomFormatToStringTests(s_random, "#\u2030000000", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 6, PerMilleSymbolFormatter);
         }
 
+        [Fact]
+        public static void ToString_InvalidFormat_ThrowsFormatException()
+        {
+            BigInteger b = new BigInteger(123456789000m);
+
+            // Format precision limit is 999_999_999 (9 digits). Anything larger should throw.
+            // Check ParseFormatSpecifier in FormatProvider.Number.cs with `E` format
+            Assert.Throws<FormatException>(() => b.ToString("E" + int.MaxValue.ToString()));
+            long intMaxPlus1 = (long)int.MaxValue + 1;
+            string intMaxPlus1String = intMaxPlus1.ToString();
+            Assert.Throws<FormatException>(() => b.ToString("E" + intMaxPlus1String));
+            Assert.Throws<FormatException>(() => b.ToString("E4772185890"));
+            Assert.Throws<FormatException>(() => b.ToString("E1000000000"));
+            Assert.Throws<FormatException>(() => b.ToString("E000001000000000"));
+
+            // Check ParseFormatSpecifier in BigNumber.cs with `G` format
+            Assert.Throws<FormatException>(() => b.ToString("G" + int.MaxValue.ToString()));
+            Assert.Throws<FormatException>(() => b.ToString("G" + intMaxPlus1String));
+            Assert.Throws<FormatException>(() => b.ToString("G4772185890"));
+            Assert.Throws<FormatException>(() => b.ToString("G1000000000"));
+            Assert.Throws<FormatException>(() => b.ToString("G000001000000000"));
+        }
+
+        [Fact]
+        public static void ToString_ValidLargeFormat()
+        {
+            BigInteger b = new BigInteger(123456789000m);
+
+            // Format precision limit is 999_999_999 (9 digits). Anything larger should throw.
+
+            // Check ParseFormatSpecifier in FormatProvider.Number.cs with `E` format
+            b.ToString("E999999999"); // Should not throw
+            b.ToString("E00000999999999"); // Should not throw
+
+            // Check ParseFormatSpecifier in BigNumber.cs with `G` format
+            b.ToString("G999999999"); // Should not throw
+            b.ToString("G00000999999999"); // Should not throw
+        }
+
         private static void RunSimpleProviderToStringTests(Random random, string format, NumberFormatInfo provider, int precision, StringFormatter formatter)
         {
             string test;

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -839,6 +839,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [OuterLoop("Takes a long time, allocates a lot of memory")]
         public static void ToString_ValidLargeFormat()
         {
             double d = 123.0;

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -830,6 +830,9 @@ namespace System.Tests
             long intMaxPlus1 = (long)int.MaxValue + 1;
             string intMaxPlus1String = intMaxPlus1.ToString();
             Assert.Throws<FormatException>(() => d.ToString("E" + intMaxPlus1String));
+
+            // Check larger overflowed value
+            Assert.Throws<FormatException>(() => d.ToString("EG4772185890"));
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.IO;
 using System.IO.Tests;
 using System.Linq;
-using System.Numerics;
 using Xunit;
 
 #pragma warning disable xUnit1025 // reporting duplicate test cases due to not distinguishing 0.0 from -0.0, NaN from -NaN

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Tests;
 using System.Linq;
+using System.Numerics;
 using Xunit;
 
 #pragma warning disable xUnit1025 // reporting duplicate test cases due to not distinguishing 0.0 from -0.0, NaN from -NaN
@@ -834,10 +835,19 @@ namespace System.Tests
             string intMaxPlus1String = intMaxPlus1.ToString();
             Assert.Throws<FormatException>(() => d.ToString("E" + intMaxPlus1String));
             Assert.Throws<FormatException>(() => d.ToString("E4772185890"));
-            d.ToString("E999999999"); // Should not throw
-            d.ToString("E00000999999999"); // Should not throw
             Assert.Throws<FormatException>(() => d.ToString("E1000000000"));
             Assert.Throws<FormatException>(() => d.ToString("E000001000000000"));
+        }
+
+        [Fact]
+        public static void ToString_ValidLargeFormat()
+        {
+            double d = 123.0;
+
+            // Format precision limit is 999_999_999 (9 digits). Anything larger should throw.
+            d.ToString("E999999999"); // Should not throw
+            d.ToString("E00000999999999"); // Should not throw
+
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -827,12 +827,17 @@ namespace System.Tests
             double d = 123.0;
             Assert.Throws<FormatException>(() => d.ToString("Y")); // Invalid format
             Assert.Throws<FormatException>(() => d.ToString("Y", null)); // Invalid format
+
+            // Format precision limit is 999_999_999 (9 digits). Anything larger should throw.
+            Assert.Throws<FormatException>(() => d.ToString("E" + int.MaxValue.ToString()));
             long intMaxPlus1 = (long)int.MaxValue + 1;
             string intMaxPlus1String = intMaxPlus1.ToString();
             Assert.Throws<FormatException>(() => d.ToString("E" + intMaxPlus1String));
-
-            // Check larger overflowed value
-            Assert.Throws<FormatException>(() => d.ToString("EG4772185890"));
+            Assert.Throws<FormatException>(() => d.ToString("E4772185890"));
+            d.ToString("E999999999"); // Should not throw
+            d.ToString("E00000999999999"); // Should not throw
+            Assert.Throws<FormatException>(() => d.ToString("E1000000000"));
+            Assert.Throws<FormatException>(() => d.ToString("E000001000000000"));
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #67891

Limiting the precision to int.MaxValue ended up causing issues, so we are going to limit to `999_999_999` (9 digits) instead. As discussed in the above issue, that should be more than enough precision for every type we support and plan to support.

Do we need to update this article, or any other documentation? https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings