### PR TITLE
Introduce a default synchronization context for wasm

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
@@ -61,6 +61,8 @@
     <Compile Include="System\Runtime\InteropServices\JavaScript\Marshaling\JSMarshalerArgument.JSObject.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\Marshaling\JSMarshalerArgument.String.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\Marshaling\JSMarshalerArgument.Exception.cs" />
+
+    <Compile Include="System\Runtime\InteropServices\JavaScript\JSSynchronizationContext.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />
@@ -69,6 +71,8 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Threading" />
+    <Reference Include="System.Threading.Thread" />
+    <Reference Include="System.Threading.Channels" />
   </ItemGroup>
   <ItemGroup>
     <AnalyzerReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj" />

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -193,6 +193,21 @@ namespace System.Runtime.InteropServices.JavaScript
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)] // https://github.com/dotnet/runtime/issues/71425
+        // the marshaled signature is:
+        // void InstallSynchronizationContext()
+        public static void InstallSynchronizationContext (JSMarshalerArgument* arguments_buffer) {
+            ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
+            try
+            {
+                JSSynchronizationContext.Install();
+            }
+            catch (Exception ex)
+            {
+                arg_exc.ToJS(ex);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)] // https://github.com/dotnet/runtime/issues/71425
         public static void StopProfile()
         {
         }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
@@ -1,0 +1,148 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Runtime;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using QueueType = System.Threading.Channels.Channel<System.Runtime.InteropServices.JavaScript.JSSynchronizationContext.WorkItem>;
+
+namespace System.Runtime.InteropServices.JavaScript {
+    internal sealed unsafe class JSSynchronizationContext : SynchronizationContext {
+        public readonly Thread MainThread;
+
+        internal readonly struct WorkItem {
+            public readonly SendOrPostCallback Callback;
+            public readonly object? Data;
+            public readonly ManualResetEventSlim? Signal;
+
+            public WorkItem (SendOrPostCallback callback, object? data, ManualResetEventSlim? signal) {
+                Callback = callback;
+                Data = data;
+                Signal = signal;
+            }
+        }
+
+        private static JSSynchronizationContext? MainThreadSynchronizationContext;
+        private readonly QueueType Queue;
+        private readonly Action _DataIsAvailable;
+
+        private JSSynchronizationContext (Thread mainThread)
+            : this (
+                mainThread,
+                Channel.CreateUnbounded<WorkItem>(
+                    new UnboundedChannelOptions { SingleWriter = false, SingleReader = true, AllowSynchronousContinuations = true }
+                )
+            )
+        {
+        }
+
+        private JSSynchronizationContext (Thread mainThread, QueueType queue) {
+            MainThread = mainThread;
+            Queue = queue;
+            _DataIsAvailable = DataIsAvailable;
+        }
+
+        public override SynchronizationContext CreateCopy () {
+            return new JSSynchronizationContext(MainThread, Queue);
+        }
+
+        private void AwaitNewData () {
+            var vt = Queue.Reader.WaitToReadAsync();
+            if (vt.IsCompleted) {
+                DataIsAvailable();
+                return;
+            }
+
+            // Once data is added to the queue, vt will be completed on the thread that added the data
+            //  because we created the channel with AllowSynchronousContinuations = true. We want to
+            //  fire a callback that will schedule a background job to pump the queue on the main thread.
+            var awaiter = vt.AsTask().ConfigureAwait(false).GetAwaiter();
+            // UnsafeOnCompleted avoids spending time flowing the execution context (we don't need it.)
+            awaiter.UnsafeOnCompleted(_DataIsAvailable);
+        }
+
+        private void DataIsAvailable () {
+            // While we COULD pump here, we don't want to. We want the pump to happen on the next event loop turn.
+            // Otherwise we could get a chain where a pump generates a new work item and that makes us pump again, forever.
+            ScheduleBackgroundJob((void*)(delegate* unmanaged[Cdecl]<void>)&BackgroundJobHandler);
+        }
+
+        public override void Post (SendOrPostCallback d, object? state) {
+            var workItem = new WorkItem(d, state, null);
+            if (!Queue.Writer.TryWrite(workItem))
+                throw new Exception("Internal error");
+        }
+
+        // This path can only run when threading is enabled
+        #pragma warning disable CA1416
+
+        public override void Send (SendOrPostCallback d, object? state) {
+            if (Thread.CurrentThread == MainThread) {
+                d(state);
+                return;
+            }
+
+            using (var signal = new ManualResetEventSlim(false)) {
+                var workItem = new WorkItem(d, state, signal);
+                if (!Queue.Writer.TryWrite(workItem))
+                    throw new Exception("Internal error");
+
+                signal.Wait();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)] // https://github.com/dotnet/runtime/issues/71425
+        // the marshaled signature is:
+        // void InstallSynchronizationContext()
+        internal static void InstallSynchronizationContext (JSMarshalerArgument* arguments_buffer) {
+            // For linker reasons we perform a dummy call to this method elsewhere in the runtime, this is used to ignore it
+            if (arguments_buffer == null)
+                return;
+
+            ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
+            try
+            {
+                if (MainThreadSynchronizationContext == null)
+                    MainThreadSynchronizationContext = new JSSynchronizationContext(Thread.CurrentThread);
+
+                SynchronizationContext.SetSynchronizationContext(MainThreadSynchronizationContext);
+                MainThreadSynchronizationContext.AwaitNewData();
+            }
+            catch (Exception ex)
+            {
+                arg_exc.ToJS(ex);
+            }
+        }
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        internal static extern unsafe void ScheduleBackgroundJob(void* callback);
+
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
+        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+        private static unsafe void BackgroundJobHandler () {
+            MainThreadSynchronizationContext!.Pump();
+        }
+
+        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+        private static unsafe void RequestPumpCallback () {
+            ScheduleBackgroundJob((void*)(delegate* unmanaged[Cdecl]<void>)&BackgroundJobHandler);
+        }
+
+        private void Pump () {
+            while (Queue.Reader.TryRead(out var item)) {
+                try {
+                    item.Callback(item.Data);
+                    // While we would ideally have a catch block here and do something to dispatch/forward unhandled
+                    //  exceptions, the standard threadpool (and thus standard synchronizationcontext) have zero
+                    //  error handling, so for consistency with them we do nothing. Don't throw in SyncContext callbacks.
+                } finally {
+                    item.Signal?.Set();
+                }
+            }
+            AwaitNewData();
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
@@ -94,27 +94,12 @@ namespace System.Runtime.InteropServices.JavaScript {
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)] // https://github.com/dotnet/runtime/issues/71425
-        // the marshaled signature is:
-        // void InstallSynchronizationContext()
-        internal static void InstallSynchronizationContext (JSMarshalerArgument* arguments_buffer) {
-            // For linker reasons we perform a dummy call to this method elsewhere in the runtime, this is used to ignore it
-            if (arguments_buffer == null)
-                return;
+        internal static void Install () {
+            if (MainThreadSynchronizationContext == null)
+                MainThreadSynchronizationContext = new JSSynchronizationContext(Thread.CurrentThread);
 
-            ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
-            try
-            {
-                if (MainThreadSynchronizationContext == null)
-                    MainThreadSynchronizationContext = new JSSynchronizationContext(Thread.CurrentThread);
-
-                SynchronizationContext.SetSynchronizationContext(MainThreadSynchronizationContext);
-                MainThreadSynchronizationContext.AwaitNewData();
-            }
-            catch (Exception ex)
-            {
-                arg_exc.ToJS(ex);
-            }
+            SynchronizationContext.SetSynchronizationContext(MainThreadSynchronizationContext);
+            MainThreadSynchronizationContext.AwaitNewData();
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Legacy/Runtime.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Legacy/Runtime.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
@@ -9,11 +9,6 @@ namespace System.Runtime.InteropServices.JavaScript
     [Obsolete]
     public static class Runtime
     {
-        static unsafe Runtime () {
-            // HACK: For some reason the linker trims this class even if I set all the attributes to disable trimming.
-            JSSynchronizationContext.InstallSynchronizationContext(null);
-        }
-
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "System.Runtime.InteropServices.JavaScript.JavaScriptExports", "System.Runtime.InteropServices.JavaScript")]
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "System.Runtime.InteropServices.JavaScript.LegacyExports", "System.Runtime.InteropServices.JavaScript")]
         public static object GetGlobalObject(string str)

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Legacy/Runtime.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Legacy/Runtime.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
@@ -9,6 +9,11 @@ namespace System.Runtime.InteropServices.JavaScript
     [Obsolete]
     public static class Runtime
     {
+        static unsafe Runtime () {
+            // HACK: For some reason the linker trims this class even if I set all the attributes to disable trimming.
+            JSSynchronizationContext.InstallSynchronizationContext(null);
+        }
+
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "System.Runtime.InteropServices.JavaScript.JavaScriptExports", "System.Runtime.InteropServices.JavaScript")]
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "System.Runtime.InteropServices.JavaScript.LegacyExports", "System.Runtime.InteropServices.JavaScript")]
         public static object GetGlobalObject(string str)

--- a/src/mono/sample/wasm/browser-threads/Program.cs
+++ b/src/mono/sample/wasm/browser-threads/Program.cs
@@ -30,7 +30,16 @@ namespace Sample
         {
             var comp = new ExpensiveComputation(n);
             comp.Start();
+            #pragma warning disable CS4014
+            WaitForCompletion(comp);
             _demo = new Demo(UpdateProgress, comp);
+        }
+
+        public static async Task WaitForCompletion (ExpensiveComputation comp) {
+            Console.WriteLine($"WaitForCompletion started on thread {Thread.CurrentThread.ManagedThreadId}");
+            await comp.Completion;
+            Console.WriteLine($"WaitForCompletion completed on thread {Thread.CurrentThread.ManagedThreadId}");
+            UpdateProgress("✌︎");
         }
 
         [JSExport]
@@ -135,16 +144,12 @@ public class Demo
 
     public bool Progress()
     {
-        _animation.Step($"{_expensiveComputation.CallCounter} calls");
-        if (_expensiveComputation.Completion.IsCompleted)
+        if (!_expensiveComputation.Completion.IsCompleted)
         {
-            _updateProgress("✌︎");
-            return true;
+            _animation.Step($"{_expensiveComputation.CallCounter} calls");
         }
-        else
-        {
-            return false;
-        }
+
+        return _expensiveComputation.Completion.IsCompleted;
     }
 
     public int Result => _expensiveComputation.Completion.Result;

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -449,6 +449,9 @@ get_native_to_interp (MonoMethod *method, void *extra_arg)
 	return addr;
 }
 
+typedef void (*background_job_cb)(void);
+void mono_threads_schedule_background_job (background_job_cb cb);
+
 void mono_initialize_internals ()
 {
 	// Blazor specific custom routines - see dotnet_support.js for backing code
@@ -458,6 +461,7 @@ void mono_initialize_internals ()
 	core_initialize_internals();
 #endif
 
+	mono_add_internal_call ("System.Runtime.InteropServices.JavaScript.JSSynchronizationContext::ScheduleBackgroundJob", mono_threads_schedule_background_job);
 }
 
 EMSCRIPTEN_KEEPALIVE void
@@ -542,7 +546,7 @@ mono_wasm_load_runtime (const char *unused, int debug_level)
 
 	mono_dl_fallback_register (wasm_dl_load, wasm_dl_symbol, NULL, NULL);
 	mono_wasm_install_get_native_to_interp_tramp (get_native_to_interp);
-	
+
 #ifdef GEN_PINVOKE
 	mono_wasm_install_interp_to_native_callback (mono_wasm_interp_to_native_callback);
 #endif

--- a/src/mono/wasm/runtime/managed-exports.ts
+++ b/src/mono/wasm/runtime/managed-exports.ts
@@ -3,27 +3,12 @@
 
 import { GCHandle, MarshalerToCs, MarshalerToJs, MonoMethod, mono_assert } from "./types";
 import cwraps from "./cwraps";
-import { Module, runtimeHelpers } from "./imports";
+import { Module, runtimeHelpers, ENVIRONMENT_IS_PTHREAD } from "./imports";
 import { alloc_stack_frame, get_arg, get_arg_gc_handle, MarshalerType, set_arg_type, set_gc_handle } from "./marshal";
 import { invoke_method_and_handle_exception } from "./invoke-cs";
 import { marshal_array_to_cs_impl, marshal_exception_to_cs, marshal_intptr_to_cs } from "./marshal-to-cs";
 import { marshal_int32_to_js, marshal_task_to_js } from "./marshal-to-js";
-
-// in all the exported internals methods, we use the same data structures for stack frame as normal full blow interop
-// see src\libraries\System.Runtime.InteropServices.JavaScript\src\System\Runtime\InteropServices\JavaScript\Interop\JavaScriptExports.cs
-export interface JavaScriptExports {
-    // the marshaled signature is: void ReleaseJSOwnedObjectByGCHandle(GCHandle gcHandle)
-    release_js_owned_object_by_gc_handle(gc_handle: GCHandle): void;
-    // the marshaled signature is: GCHandle CreateTaskCallback()
-    create_task_callback(): GCHandle;
-    // the marshaled signature is: void CompleteTask<T>(GCHandle holder, Exception? exceptionResult, T? result)
-    complete_task(holder_gc_handle: GCHandle, error?: any, data?: any, res_converter?: MarshalerToCs): void;
-    // the marshaled signature is: TRes? CallDelegate<T1,T2,T3TRes>(GCHandle callback, T1? arg1, T2? arg2, T3? arg3)
-    call_delegate(callback_gc_handle: GCHandle, arg1_js: any, arg2_js: any, arg3_js: any,
-        res_converter?: MarshalerToJs, arg1_converter?: MarshalerToCs, arg2_converter?: MarshalerToCs, arg3_converter?: MarshalerToCs): any;
-    // the marshaled signature is: Task<int>? CallEntrypoint(MonoMethod* entrypointPtr, string[] args)
-    call_entry_point(entry_point: MonoMethod, args?: string[]): Promise<number>;
-}
+import { mono_method_resolve } from "./net6-legacy/method-binding";
 
 export function init_managed_exports(): void {
     const anyModule = Module as any;
@@ -38,6 +23,23 @@ export function init_managed_exports(): void {
     if (!runtimeHelpers.runtime_interop_exports_class)
         throw "Can't find " + runtimeHelpers.runtime_interop_namespace + "." + runtimeHelpers.runtime_interop_exports_classname + " class";
 
+    const install_sync_context = mono_method_resolve(
+        "[System.Runtime.InteropServices.JavaScript] System.Runtime.InteropServices.JavaScript.JSSynchronizationContext:InstallSynchronizationContext"
+    );
+    mono_assert(install_sync_context, "Can't find InstallSynchronizationContext method");
+    runtimeHelpers.javaScriptExports.install_synchronization_context = () => {
+        const sp = anyModule.stackSave();
+        try {
+            const args = alloc_stack_frame(2);
+            invoke_method_and_handle_exception(install_sync_context, args);
+        } finally {
+            anyModule.stackRestore(sp);
+        }
+    };
+
+    if (!ENVIRONMENT_IS_PTHREAD)
+        // Install our sync context so that async continuations will migrate back to this thread (the main thread) automatically
+        runtimeHelpers.javaScriptExports.install_synchronization_context();
 
     const call_entry_point = get_method("CallEntrypoint");
     mono_assert(call_entry_point, "Can't find CallEntrypoint method");

--- a/src/mono/wasm/runtime/managed-exports.ts
+++ b/src/mono/wasm/runtime/managed-exports.ts
@@ -8,7 +8,6 @@ import { alloc_stack_frame, get_arg, get_arg_gc_handle, MarshalerType, set_arg_t
 import { invoke_method_and_handle_exception } from "./invoke-cs";
 import { marshal_array_to_cs_impl, marshal_exception_to_cs, marshal_intptr_to_cs } from "./marshal-to-cs";
 import { marshal_int32_to_js, marshal_task_to_js } from "./marshal-to-js";
-import { mono_method_resolve } from "./net6-legacy/method-binding";
 
 export function init_managed_exports(): void {
     const anyModule = Module as any;
@@ -23,24 +22,8 @@ export function init_managed_exports(): void {
     if (!runtimeHelpers.runtime_interop_exports_class)
         throw "Can't find " + runtimeHelpers.runtime_interop_namespace + "." + runtimeHelpers.runtime_interop_exports_classname + " class";
 
-    const install_sync_context = mono_method_resolve(
-        "[System.Runtime.InteropServices.JavaScript] System.Runtime.InteropServices.JavaScript.JSSynchronizationContext:InstallSynchronizationContext"
-    );
+    const install_sync_context = get_method("InstallSynchronizationContext");
     mono_assert(install_sync_context, "Can't find InstallSynchronizationContext method");
-    runtimeHelpers.javaScriptExports.install_synchronization_context = () => {
-        const sp = anyModule.stackSave();
-        try {
-            const args = alloc_stack_frame(2);
-            invoke_method_and_handle_exception(install_sync_context, args);
-        } finally {
-            anyModule.stackRestore(sp);
-        }
-    };
-
-    if (!ENVIRONMENT_IS_PTHREAD)
-        // Install our sync context so that async continuations will migrate back to this thread (the main thread) automatically
-        runtimeHelpers.javaScriptExports.install_synchronization_context();
-
     const call_entry_point = get_method("CallEntrypoint");
     mono_assert(call_entry_point, "Can't find CallEntrypoint method");
     const release_js_owned_object_by_gc_handle_method = get_method("ReleaseJSOwnedObjectByGCHandle");
@@ -151,6 +134,19 @@ export function init_managed_exports(): void {
             anyModule.stackRestore(sp);
         }
     };
+    runtimeHelpers.javaScriptExports.install_synchronization_context = () => {
+        const sp = anyModule.stackSave();
+        try {
+            const args = alloc_stack_frame(2);
+            invoke_method_and_handle_exception(install_sync_context, args);
+        } finally {
+            anyModule.stackRestore(sp);
+        }
+    };
+
+    if (!ENVIRONMENT_IS_PTHREAD)
+        // Install our sync context so that async continuations will migrate back to this thread (the main thread) automatically
+        runtimeHelpers.javaScriptExports.install_synchronization_context();
 }
 
 export function get_method(method_name: string): MonoMethod {

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -454,7 +454,6 @@ export function bindings_init(): void {
         initialize_marshalers_to_js();
         initialize_marshalers_to_cs();
         runtimeHelpers._i52_error_scratch_buffer = <any>Module._malloc(4);
-
     } catch (err) {
         _print_error("MONO_WASM: Error in bindings_init", err);
         throw err;

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -361,6 +361,9 @@ export interface JavaScriptExports {
 
     // the marshaled signature is: Task<int>? CallEntrypoint(MonoMethod* entrypointPtr, string[] args)
     call_entry_point(entry_point: MonoMethod, args?: string[]): Promise<number>;
+
+    // the marshaled signature is: void InstallSynchronizationContext()
+    install_synchronization_context(): void;
 }
 
 export type MarshalerToJs = (arg: JSMarshalerArgument, sig?: JSMarshalerType, res_converter?: MarshalerToJs, arg1_converter?: MarshalerToCs, arg2_converter?: MarshalerToCs) => any;


### PR DESCRIPTION
This PR introduces a JSSynchronizationContext that is installed automatically on the main thread when we initialize the bindings. It implements both Send and Post on top of emscripten's main thread call proxying API when you use it from workers, and on the main thread it just invokes the callback immediately.

I tried to keep the implementation as simple as possible without making it slow enough to produce a meaningful performance regression, since things like await will use this by default once it's merged. The queue of jobs is maintained in managed code and pumped by a dispatcher, and if we notice that the dispatcher is not currently waiting to run when we add something to the queue, we kick off a request to run the dispatcher. This means that worst-case we will run the dispatcher once per work item, but if a bunch of work items end up in the queue, they can get serviced efficiently by a single invocation of the dispatcher. And for calls from the main thread the performance should be equivalent to what it was before due to the fast-path.