### PR TITLE
Disable failing System.Text.Json tests on Android x86 and on Browser with threading enabled

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -38,7 +38,8 @@ namespace System
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
         public static bool IsAndroid => RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
         public static bool IsNotAndroid => !IsAndroid;
-        public static bool IsNotAndroidX86 => !(IsAndroid && IsX86Process);
+        public static bool IsAndroidX86 => IsAndroid && IsX86Process;
+        public static bool IsNotAndroidX86 => !IsAndroidX86;
         public static bool IsiOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"));
         public static bool IstvOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"));
         public static bool IsMacCatalyst => RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Cache.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Cache.cs
@@ -22,6 +22,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72101", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public async Task MultipleThreads()
         {
             // Verify the test class has >32 properties since that is a threshold for using the fallback dictionary.
@@ -104,6 +105,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72101", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public async Task PropertyCacheWithMinInputsLast()
         {
             // Use local options to avoid obtaining already cached metadata from the default options.

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Stream.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Stream.cs
@@ -66,6 +66,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72101", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public async Task ReadSimpleObjectWithTrailingTriviaAsync()
         {
             if (StreamingSerializer is null)

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Stream.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Stream.cs
@@ -12,6 +12,7 @@ namespace System.Text.Json.Serialization.Tests
     {
         [Fact]
         [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72101", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public async Task ReadSimpleObjectAsync()
         {
             if (StreamingSerializer is null)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
@@ -86,7 +86,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Equal(new Guid("1B33498A-7B7D-4DDA-9C13-F6AA4AB449A6"), (Guid)jObject["MyGuid"]);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotX86Process))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72101", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public static void ExplicitOperators_FromValues()
         {
             Assert.Equal(1, (short)(JsonNode)(short)1);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
@@ -86,6 +86,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Equal(new Guid("1B33498A-7B7D-4DDA-9C13-F6AA4AB449A6"), (Guid)jObject["MyGuid"]);
         }
 
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/72101", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public static void ExplicitOperators_FromValues()
         {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ContinuationTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ContinuationTests.cs
@@ -124,6 +124,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [MemberData(nameof(TestData), /* enumeratePayloadTweaks: */ false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/42677", platforms: TestPlatforms.Windows, runtimes: TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72101", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public static async Task ShouldWorkAtAnyPosition_Stream(
             string json,
             int bufferSize,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ContinuationTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ContinuationTests.cs
@@ -182,6 +182,7 @@ namespace System.Text.Json.Serialization.Tests
         [MemberData(nameof(TestData), /* enumeratePayloadTweaks: */ false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/42677", platforms: TestPlatforms.Windows, runtimes: TestRuntimes.Mono)]
         [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72101", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public static void ShouldWorkAtAnyPosition_Sequence(
             string json,
             int bufferSize,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
@@ -61,7 +61,11 @@ namespace System.Text.Json.Serialization.Tests
             RunAsRootTypeTest(JsonNumberTestData.UInts);
             RunAsRootTypeTest(JsonNumberTestData.ULongs);
             RunAsRootTypeTest(JsonNumberTestData.Floats);
-            RunAsRootTypeTest(JsonNumberTestData.Doubles);
+            // https://github.com/dotnet/runtime/issues/72101
+            if (!PlatformDetection.IsAndroidX86)
+            {
+                RunAsRootTypeTest(JsonNumberTestData.Doubles);
+            }
             RunAsRootTypeTest(JsonNumberTestData.Decimals);
             RunAsRootTypeTest(JsonNumberTestData.NullableBytes);
             RunAsRootTypeTest(JsonNumberTestData.NullableSBytes);
@@ -72,7 +76,11 @@ namespace System.Text.Json.Serialization.Tests
             RunAsRootTypeTest(JsonNumberTestData.NullableUInts);
             RunAsRootTypeTest(JsonNumberTestData.NullableULongs);
             RunAsRootTypeTest(JsonNumberTestData.NullableFloats);
-            RunAsRootTypeTest(JsonNumberTestData.NullableDoubles);
+            // https://github.com/dotnet/runtime/issues/72101
+            if (!PlatformDetection.IsAndroidX86)
+            {
+                RunAsRootTypeTest(JsonNumberTestData.NullableDoubles);
+            }
             RunAsRootTypeTest(JsonNumberTestData.NullableDecimals);
         }
 
@@ -380,7 +388,11 @@ namespace System.Text.Json.Serialization.Tests
             RunAsCollectionElementTest(JsonNumberTestData.UInts);
             RunAsCollectionElementTest(JsonNumberTestData.ULongs);
             RunAsCollectionElementTest(JsonNumberTestData.Floats);
-            RunAsCollectionElementTest(JsonNumberTestData.Doubles);
+            // https://github.com/dotnet/runtime/issues/72101
+            if (!PlatformDetection.IsAndroidX86)
+            {
+                RunAsCollectionElementTest(JsonNumberTestData.Doubles);
+            }
             RunAsCollectionElementTest(JsonNumberTestData.Decimals);
 
             // https://github.com/dotnet/runtime/issues/66220
@@ -395,7 +407,11 @@ namespace System.Text.Json.Serialization.Tests
                 RunAsCollectionElementTest(JsonNumberTestData.NullableUInts);
                 RunAsCollectionElementTest(JsonNumberTestData.NullableULongs);
                 RunAsCollectionElementTest(JsonNumberTestData.NullableFloats);
-                RunAsCollectionElementTest(JsonNumberTestData.NullableDoubles);
+                // https://github.com/dotnet/runtime/issues/72101
+                if (!PlatformDetection.IsAndroidX86)
+                {
+                    RunAsCollectionElementTest(JsonNumberTestData.NullableDoubles);
+                }
                 RunAsCollectionElementTest(JsonNumberTestData.NullableDecimals);
             }
         }
@@ -621,7 +637,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             RunAllDictionariessRoundTripTest(JsonNumberTestData.ULongs);
             RunAllDictionariessRoundTripTest(JsonNumberTestData.Floats);
-            RunAllDictionariessRoundTripTest(JsonNumberTestData.Doubles);
+            // https://github.com/dotnet/runtime/issues/72101
+            if (!PlatformDetection.IsAndroidX86)
+            {
+                RunAllDictionariessRoundTripTest(JsonNumberTestData.Doubles);
+            }
         }
 
         private static void RunAllDictionariessRoundTripTest<T>(List<T> numbers)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.cs
@@ -15,6 +15,7 @@ namespace System.Text.Json.Tests
     public static partial class Utf8JsonReaderTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72101", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public static void TestingNumbers_TryGetMethods()
         {
             byte[] dataUtf8 = JsonNumberTestData.JsonData;
@@ -153,6 +154,7 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72101", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public static void TestingNumbers_GetMethods()
         {
             byte[] dataUtf8 = JsonNumberTestData.JsonData;

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -359,6 +359,13 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\wasm\System.Net.WebSockets.Client.Wasm.Tests.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(WasmEnableThreads)' == 'true' and '$(RunDisabledWasmTests)' != 'true'">
+    <!-- https://github.com/dotnet/runtime/issues/72101 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Tests\System.Text.Json.SourceGeneration.Roslyn3.11.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Tests\System.Text.Json.SourceGeneration.Roslyn4.0.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" />
+  </ItemGroup>
+
   <!-- Aggressive Trimming related failures -->
   <ItemGroup Condition="('$(TargetOS)' != 'Browser' and '$(RunAOTCompilation)' == 'true' and '$(MonoForceInterpreter)' != 'true') or ('$(TargetOS)' == 'Browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true')">
   </ItemGroup>


### PR DESCRIPTION
On Android x86, there is a problem with deserialization of doubles.
On Browser with multi-threading enabled, the System.Text.Json tests are timeouting.

This PR disables these tests.

Ref #72101
Ref #65723

/cc @radical 