### PR TITLE
 Ldap search crashes on Linux when timeout specified

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
@@ -122,7 +122,7 @@ internal static partial class Interop
             [MarshalAs(UnmanagedType.Bool)] bool attributeOnly,
             IntPtr servercontrol,
             IntPtr clientcontrol,
-            int timelimit,
+            in LDAP_TIMEVAL timelimit,
             int sizelimit,
             ref int messageNumber);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
@@ -97,6 +97,11 @@ namespace System.DirectoryServices.Protocols
                 tv_sec = timelimit
             };
 
+            //zero must not be passed otherwise libldap runtime returns LDAP_PARAM_ERROR
+            if (searchTimeout.tv_sec < 1)
+                //-1 means no time limit
+                searchTimeout.tv_sec = -1;
+
             return Interop.Ldap.ldap_search(ldapHandle, dn, scope, filter, attributes, attributeOnly, servercontrol, clientcontrol, searchTimeout, sizelimit, ref messageNumber);
         }
         internal static int SetBoolOption(ConnectionHandle ld, LdapOption option, bool value) => Interop.Ldap.ldap_set_option_bool(ld, option, value);

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
@@ -90,9 +90,15 @@ namespace System.DirectoryServices.Protocols
 
         internal static int ResultToErrorCode(ConnectionHandle ldapHandle, IntPtr result, int freeIt) => Interop.Ldap.ldap_result2error(ldapHandle, result, freeIt);
 
-        internal static int SearchDirectory(ConnectionHandle ldapHandle, string dn, int scope, string filter, IntPtr attributes, bool attributeOnly, IntPtr servercontrol, IntPtr clientcontrol, int timelimit, int sizelimit, ref int messageNumber) =>
-                                Interop.Ldap.ldap_search(ldapHandle, dn, scope, filter, attributes, attributeOnly, servercontrol, clientcontrol, timelimit, sizelimit, ref messageNumber);
+        internal static int SearchDirectory(ConnectionHandle ldapHandle, string dn, int scope, string filter, IntPtr attributes, bool attributeOnly, IntPtr servercontrol, IntPtr clientcontrol, int timelimit, int sizelimit, ref int messageNumber)
+        {
+            LDAP_TIMEVAL searchTimeout = new LDAP_TIMEVAL
+            {
+                tv_sec = timelimit
+            };
 
+            return Interop.Ldap.ldap_search(ldapHandle, dn, scope, filter, attributes, attributeOnly, servercontrol, clientcontrol, searchTimeout, sizelimit, ref messageNumber);
+        }
         internal static int SetBoolOption(ConnectionHandle ld, LdapOption option, bool value) => Interop.Ldap.ldap_set_option_bool(ld, option, value);
 
         // This option is not supported in Linux, so it would most likely throw.

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -83,9 +83,16 @@ namespace System.DirectoryServices.Protocols.Tests
             using LdapConnection connection = GetConnection();
 
             var searchRequest = new SearchRequest(LdapConfiguration.Configuration.SearchDn, "(objectClass=*)", SearchScope.Subtree);
-            searchRequest.TimeLimit = TimeSpan.FromSeconds(timeLimit);
-            _ = (SearchResponse)connection.SendRequest(searchRequest);
-            // Shall succeed
+            if (timeLimit < 0)
+            {
+                Assert.Throws<ArgumentException>(() => searchRequest.TimeLimit = TimeSpan.FromSeconds(timeLimit));
+            }
+            else
+            {
+                searchRequest.TimeLimit = TimeSpan.FromSeconds(timeLimit);
+                _ = (SearchResponse)connection.SendRequest(searchRequest);
+                // Shall succeed
+            }
         }
 
         [ConditionalFact(nameof(IsLdapConfigurationExist))]

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -74,6 +74,18 @@ namespace System.DirectoryServices.Protocols.Tests
             _ = (SearchResponse) connection.SendRequest(searchRequest);
             // Does not throw
         }
+        [InlineData(60)]
+        [InlineData(0)]
+        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        public void TestSearchWithTimeLimit(int timeLimit)
+        {
+            using LdapConnection connection = GetConnection();
+
+            var searchRequest = new SearchRequest(LdapConfiguration.Configuration.SearchDn, "(objectClass=*)", SearchScope.Subtree);
+            searchRequest.TimeLimit = TimeSpan.FromSeconds(timeLimit);
+            _ = (SearchResponse)connection.SendRequest(searchRequest);
+            // Shall succeed
+        }
 
         [ConditionalFact(nameof(IsLdapConfigurationExist))]
         public void TestAddingOU()

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -76,6 +76,7 @@ namespace System.DirectoryServices.Protocols.Tests
         }
         [InlineData(60)]
         [InlineData(0)]
+        [InlineData(-60)]
         [ConditionalTheory(nameof(IsLdapConfigurationExist))]
         public void TestSearchWithTimeLimit(int timeLimit)
         {

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -76,7 +76,7 @@ namespace System.DirectoryServices.Protocols.Tests
         }
         [InlineData(60)]
         [InlineData(0)]
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalTheory(nameof(IsLdapConfigurationExist))]
         public void TestSearchWithTimeLimit(int timeLimit)
         {
             using LdapConnection connection = GetConnection();


### PR DESCRIPTION
This is proposed fix for issue #70648 and #66652
On Linux, search timeout is expressed as LDAP_TIMEVAL instead of int - see [source](https://github.com/openldap/openldap/blob/4528bdb3f37f0e457850095ad7f003bc9853df68/libraries/libldap/search.c#L65)

Thanks,
Jiri