### PR TITLE
Disable ThrowDuringProcessLog_ShutsDownGracefully test

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
@@ -120,6 +120,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
 
         [OuterLoop]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/71242")]
         public void ThrowDuringProcessLog_ShutsDownGracefully()
         {
             var console = new TimesWriteCalledConsole();


### PR DESCRIPTION
This test has been failing a few times a day. Disabling until it can be investigated to pass consistently.

See #71242