### PR TITLE
Fix finding the Python location if the %TEMP% path contains a space

### DIFF
--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -275,9 +275,9 @@ set __IntermediatesEventingDir=%__ArtifactsIntermediatesDir%\Eventing\%__TargetA
 
 REM Find python and set it to the variable PYTHON
 set _C=-c "import sys; sys.stdout.write(sys.executable)"
-(py -3 %_C% || py -2 %_C% || python3 %_C% || python2 %_C% || python %_C%) > %TEMP%\pythonlocation.txt 2> NUL
+(py -3 %_C% || py -2 %_C% || python3 %_C% || python2 %_C% || python %_C%) > "%TEMP%\pythonlocation.txt" 2> NUL
 set _C=
-set /p PYTHON=<%TEMP%\pythonlocation.txt
+set /p PYTHON=<"%TEMP%\pythonlocation.txt"
 
 if NOT DEFINED PYTHON (
     echo %__ErrMsgPrefix%%__MsgPrefix%Error: Could not find a Python installation.


### PR DESCRIPTION
If a user has a space in their user directory the %TEMP% location will also have a space, causing python executable lookup to fail.