### PR TITLE
Utilize new C# support for nameof in attributes in same signature

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -37,7 +37,7 @@ namespace System.Runtime.CompilerServices
         // Of course, reference types are not cloned.
         //
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [return: NotNullIfNotNull("obj")]
+        [return: NotNullIfNotNull(nameof(obj))]
         public static extern object? GetObjectValue(object? obj);
 
         // RunClassConstructor causes the class constructor for the given type to be triggered

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -580,7 +580,7 @@ namespace System.Runtime.InteropServices
         /// </summary>
         [SupportedOSPlatform("windows")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [return: NotNullIfNotNull("o")]
+        [return: NotNullIfNotNull(nameof(o))]
         public static object? CreateWrapperOfType(object? o, Type t)
         {
             if (!IsBuiltInComSupported)

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Interlocked.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Interlocked.CoreCLR.cs
@@ -82,8 +82,8 @@ namespace System.Threading
         /// <returns>The original value of <paramref name="location1"/>.</returns>
         /// <exception cref="NullReferenceException">The address of location1 is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [return: NotNullIfNotNull("location1")]
-        public static extern object? Exchange([NotNullIfNotNull("value")] ref object? location1, object? value);
+        [return: NotNullIfNotNull(nameof(location1))]
+        public static extern object? Exchange([NotNullIfNotNull(nameof(value))] ref object? location1, object? value);
 
         // The below whole method reduces to a single call to Exchange(ref object, object) but
         // the JIT thinks that it will generate more native code than it actually does.
@@ -95,8 +95,8 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of location1 is a null pointer.</exception>
         /// <typeparam name="T">The type to be used for <paramref name="location1"/> and <paramref name="value"/>. This type must be a reference type.</typeparam>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NotNullIfNotNull("location1")]
-        public static T Exchange<T>([NotNullIfNotNull("value")] ref T location1, T value) where T : class? =>
+        [return: NotNullIfNotNull(nameof(location1))]
+        public static T Exchange<T>([NotNullIfNotNull(nameof(value))] ref T location1, T value) where T : class? =>
             Unsafe.As<T>(Exchange(ref Unsafe.As<T, object?>(ref location1), value));
         #endregion
 
@@ -146,7 +146,7 @@ namespace System.Threading
         /// <returns>The original value in <paramref name="location1"/>.</returns>
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [return: NotNullIfNotNull("location1")]
+        [return: NotNullIfNotNull(nameof(location1))]
         public static extern object? CompareExchange(ref object? location1, object? value, object? comparand);
 
         // Note that getILIntrinsicImplementationForInterlocked() in vm\jitinterface.cpp replaces
@@ -166,7 +166,7 @@ namespace System.Threading
         /// <returns>The original value in <paramref name="location1"/>.</returns>
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         /// <typeparam name="T">The type to be used for <paramref name="location1"/>, <paramref name="value"/>, and <paramref name="comparand"/>. This type must be a reference type.</typeparam>
-        [return: NotNullIfNotNull("location1")]
+        [return: NotNullIfNotNull(nameof(location1))]
         [Intrinsic]
         public static T CompareExchange<T>(ref T location1, T value, T comparand) where T : class? =>
             Unsafe.As<T>(CompareExchange(ref Unsafe.As<T, object?>(ref location1), value, comparand));

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -669,7 +669,7 @@ namespace System.Runtime
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhpCheckedXchg")]
-        internal static extern object InterlockedExchange([NotNullIfNotNull("value")] ref object? location1, object? value);
+        internal static extern object InterlockedExchange([NotNullIfNotNull(nameof(value))] ref object? location1, object? value);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhpMemoryBarrier")]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Interlocked.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Interlocked.cs
@@ -44,14 +44,14 @@ namespace System.Threading
 
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NotNullIfNotNull("location1")]
+        [return: NotNullIfNotNull(nameof(location1))]
         public static T CompareExchange<T>(ref T location1, T value, T comparand) where T : class?
         {
             return Unsafe.As<T>(RuntimeImports.InterlockedCompareExchange(ref Unsafe.As<T, object?>(ref location1), value, comparand));
         }
 
         [Intrinsic]
-        [return: NotNullIfNotNull("location1")]
+        [return: NotNullIfNotNull(nameof(location1))]
         public static object? CompareExchange(ref object? location1, object? value, object? comparand)
         {
             return RuntimeImports.InterlockedCompareExchange(ref location1, value, comparand);
@@ -105,15 +105,15 @@ namespace System.Threading
 
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NotNullIfNotNull("location1")]
-        public static T Exchange<T>([NotNullIfNotNull("value")] ref T location1, T value) where T : class?
+        [return: NotNullIfNotNull(nameof(location1))]
+        public static T Exchange<T>([NotNullIfNotNull(nameof(value))] ref T location1, T value) where T : class?
         {
             return Unsafe.As<T>(RuntimeImports.InterlockedExchange(ref Unsafe.As<T, object?>(ref location1), value));
         }
 
         [Intrinsic]
-        [return: NotNullIfNotNull("location1")]
-        public static object? Exchange([NotNullIfNotNull("value")] ref object? location1, object? value)
+        [return: NotNullIfNotNull(nameof(location1))]
+        public static object? Exchange([NotNullIfNotNull(nameof(value))] ref object? location1, object? value)
         {
             return RuntimeImports.InterlockedExchange(ref location1, value);
         }

--- a/src/libraries/Common/src/Extensions/TypeNameHelper/TypeNameHelper.cs
+++ b/src/libraries/Common/src/Extensions/TypeNameHelper/TypeNameHelper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Extensions.Internal
             { typeof(ushort), "ushort" }
         };
 
-        [return: NotNullIfNotNull("item")]
+        [return: NotNullIfNotNull(nameof(item))]
         public static string? GetTypeDisplayName(object? item, bool fullName = true)
         {
             return item == null ? null : GetTypeDisplayName(item.GetType(), fullName);

--- a/src/libraries/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.Unix.cs
@@ -33,7 +33,7 @@ namespace System.IO
         /// <summary>
         /// Normalize separators in the given path. Compresses forward slash runs.
         /// </summary>
-        [return: NotNullIfNotNull("path")]
+        [return: NotNullIfNotNull(nameof(path))]
         internal static string? NormalizeDirectorySeparators(string? path)
         {
             if (string.IsNullOrEmpty(path))

--- a/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
@@ -88,7 +88,7 @@ namespace System.IO
         /// away from paths during normalization, but if we see such a path at this point it should be
         /// normalized and has retained the final characters. (Typically from one of the *Info classes)
         /// </summary>
-        [return: NotNullIfNotNull("path")]
+        [return: NotNullIfNotNull(nameof(path))]
         internal static string? EnsureExtendedPrefixIfNeeded(string? path)
         {
             if (path != null && (path.Length >= MaxShortPath || EndsWithPeriodOrSpace(path)))
@@ -312,7 +312,7 @@ namespace System.IO
         ///   3. Doesn't play nice with string logic
         ///   4. Isn't a cross-plat friendly concept/behavior
         /// </remarks>
-        [return: NotNullIfNotNull("path")]
+        [return: NotNullIfNotNull(nameof(path))]
         internal static string? NormalizeDirectorySeparators(string? path)
         {
             if (string.IsNullOrEmpty(path))

--- a/src/libraries/Common/src/System/IO/PathInternal.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.cs
@@ -215,7 +215,7 @@ namespace System.IO
         /// <summary>
         /// Trims one trailing directory separator beyond the root of the path.
         /// </summary>
-        [return: NotNullIfNotNull("path")]
+        [return: NotNullIfNotNull(nameof(path))]
         internal static string? TrimEndingDirectorySeparator(string? path) =>
             EndsInDirectorySeparator(path) && !IsRoot(path.AsSpan()) ?
                 path!.Substring(0, path.Length - 1) :

--- a/src/libraries/Common/src/System/Security/Cryptography/EccKeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/EccKeyFormatHelper.cs
@@ -507,7 +507,7 @@ namespace System.Security.Cryptography
             return KeyFormatHelper.WritePkcs8(algorithmIdentifier, ecPrivateKey, attributeWriter);
         }
 
-        [return: NotNullIfNotNull("attributes")]
+        [return: NotNullIfNotNull(nameof(attributes))]
         private static AsnWriter? WritePrivateKeyInfoAttributes(AttributeAsn[]? attributes)
         {
             if (attributes == null)

--- a/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
@@ -42,7 +42,7 @@ namespace Internal.Cryptography
             true;
 #endif
 
-        [return: NotNullIfNotNull("src")]
+        [return: NotNullIfNotNull(nameof(src))]
         public static byte[]? CloneByteArray(this byte[]? src)
         {
             if (src == null)

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.Configuration
         public static string Combine(System.Collections.Generic.IEnumerable<string> pathSegments) { throw null; }
         public static string Combine(params string[] pathSegments) { throw null; }
         public static string? GetParentPath(string? path) { throw null; }
-        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("path")]
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("path")]
         public static string? GetSectionKey(string? path) { throw null; }
     }
     public static partial class ConfigurationRootExtensions

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationPath.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationPath.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Extensions.Configuration
         /// </summary>
         /// <param name="path">The path.</param>
         /// <returns>The last path segment of the path.</returns>
-        [return: NotNullIfNotNull("path")]
+        [return: NotNullIfNotNull(nameof(path))]
         public static string? GetSectionKey(string? path)
         {
             if (string.IsNullOrEmpty(path))

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/DependencyInjectionEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/DependencyInjectionEventSource.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             public int NodeCount { get; private set; }
 
-            [return: NotNullIfNotNull("e")]
+            [return: NotNullIfNotNull(nameof(e))]
             public override Expression? Visit(Expression? e)
             {
                 base.Visit(e);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public IServiceScope CreateScope() => RootProvider.CreateScope();
 
-        [return: NotNullIfNotNull("service")]
+        [return: NotNullIfNotNull(nameof(service))]
         internal object? CaptureDisposable(object? service)
         {
             if (ReferenceEquals(this, service) || !(service is IDisposable || service is IAsyncDisposable))

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextJsonReader.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextJsonReader.cs
@@ -841,7 +841,7 @@ namespace Microsoft.Extensions.DependencyModel
             }
         }
 
-        [return: NotNullIfNotNull("s")]
+        [return: NotNullIfNotNull(nameof(s))]
         private string? Pool(string? s)
         {
             if (s == null)

--- a/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
@@ -645,7 +645,7 @@ namespace Microsoft.VisualBasic
         public static string? Join(object?[] SourceArray, string? Delimiter = " ") { throw null; }
         public static string? Join(string?[] SourceArray, string? Delimiter = " ") { throw null; }
         public static char LCase(char Value) { throw null; }
-        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("Value")]
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("Value")]
         public static string? LCase(string? Value) { throw null; }
         public static string Left(string? str, int Length) { throw null; }
         public static int Len(bool Expression) { throw null; }
@@ -820,7 +820,7 @@ namespace Microsoft.VisualBasic.CompilerServices
         public static decimal ToDecimal(string? Value) { throw null; }
         public static double ToDouble(object? Value) { throw null; }
         public static double ToDouble(string? Value) { throw null; }
-        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("Value")]
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("Value")]
         public static T? ToGenericParameter<T>(object? Value) { throw null; }
         public static int ToInteger(object? Value) { throw null; }
         public static int ToInteger(string? Value) { throw null; }
@@ -1192,7 +1192,7 @@ namespace Microsoft.VisualBasic.CompilerServices
         public static string FromDouble(double Value, System.Globalization.NumberFormatInfo? NumberFormat) { throw null; }
         public static string FromInteger(int Value) { throw null; }
         public static string FromLong(long Value) { throw null; }
-        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("Value")]
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("Value")]
         public static string? FromObject(object? Value) { throw null; }
         public static string FromShort(short Value) { throw null; }
         public static string FromSingle(float Value) { throw null; }

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/SerializableCompositionElement.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/SerializableCompositionElement.cs
@@ -27,7 +27,7 @@ namespace System.ComponentModel.Composition.Primitives
 
         public ICompositionElement? Origin => _origin;
 
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static ICompositionElement? FromICompositionElement(ICompositionElement? element)
         {
             if (element == null)

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/GenericServices.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/GenericServices.cs
@@ -88,7 +88,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
             return genericSpecialization;
         }
 
-        [return: NotNullIfNotNull("types")]
+        [return: NotNullIfNotNull(nameof(types))]
         public static IEnumerable<Type>? CreateTypeSpecializations(this Type[]? types, Type[] specializationTypes)
         {
             if (types == null)

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/GenericSpecializationPartCreationInfo.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/GenericSpecializationPartCreationInfo.cs
@@ -238,7 +238,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
             return membersTable;
         }
 
-        [return: NotNullIfNotNull("parameters")]
+        [return: NotNullIfNotNull(nameof(parameters))]
         private Dictionary<Lazy<ParameterInfo>, ParameterInfo>? BuildParametersTable(List<Lazy<ParameterInfo>>? parameters)
         {
             if (parameters != null)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ArrayConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ArrayConverter.cs
@@ -29,7 +29,7 @@ namespace System.ComponentModel
         /// Gets a collection of properties for the type of array specified by the value parameter.
         /// </summary>
         [RequiresUnreferencedCode("The Type of value cannot be statically discovered. " + AttributeCollection.FilterRequiresUnreferencedCodeMessage)]
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public override PropertyDescriptorCollection? GetProperties(ITypeDescriptorContext? context, object? value, Attribute[]? attributes)
         {
             if (value == null)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2549,7 +2549,7 @@ namespace System.ComponentModel
             /// Implements GetTypeDescriptor. This creates a custom type
             /// descriptor that walks the linked list for each of its calls.
             /// </summary>
-            [return: NotNullIfNotNull("instance")]
+            [return: NotNullIfNotNull(nameof(instance))]
             public override ICustomTypeDescriptor? GetTypeDescriptor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type objectType, object? instance)
             {
                 ArgumentNullException.ThrowIfNull(objectType);
@@ -2830,7 +2830,7 @@ namespace System.ComponentModel
                 _comNativeDescriptor = (TypeDescriptionProvider)Activator.CreateInstance(realComNativeDescriptor)!;
             }
 
-            [return: NotNullIfNotNull("instance")]
+            [return: NotNullIfNotNull(nameof(instance))]
             public override ICustomTypeDescriptor? GetTypeDescriptor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type objectType, object? instance)
             {
                 return _comNativeDescriptor.GetTypeDescriptor(objectType, instance);

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DBCommandBuilder.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DBCommandBuilder.cs
@@ -1364,7 +1364,7 @@ namespace System.Data.Common
             return GetColumnValue(row, GetDataColumn(columnName, mappings, row), version);
         }
 
-        [return: NotNullIfNotNull("column")]
+        [return: NotNullIfNotNull(nameof(column))]
         private static object? GetColumnValue(DataRow row, DataColumn? column, DataRowVersion version)
         {
             object? value = null;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/ClientUtils.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/ClientUtils.cs
@@ -125,7 +125,7 @@ namespace System.Drawing
 
             public override int GetHashCode() => base.GetHashCode();
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             private static WeakRefObject? CreateWeakRefObject(object? value)
             {
                 if (value == null)

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Font.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Font.cs
@@ -661,7 +661,7 @@ namespace System.Drawing
             GC.SuppressFinalize(_fontFamily);
         }
 
-        [return: NotNullIfNotNull("familyName")]
+        [return: NotNullIfNotNull(nameof(familyName))]
         private static string? StripVerticalName(string? familyName)
         {
             if (familyName?.Length > 1 && familyName[0] == '@')

--- a/src/libraries/System.Drawing.Common/src/misc/DpiHelper.cs
+++ b/src/libraries/System.Drawing.Common/src/misc/DpiHelper.cs
@@ -194,7 +194,7 @@ namespace System.Windows.Forms
         /// </summary>
         /// <param name="logicalImage">The image to scale from logical units to device units</param>
         /// <param name="targetImageSize">The size to scale image to</param>
-        [return: NotNullIfNotNull("logicalImage")]
+        [return: NotNullIfNotNull(nameof(logicalImage))]
         public static Bitmap? CreateResizedBitmap(Bitmap? logicalImage, Size targetImageSize)
         {
             if (logicalImage == null)
@@ -211,7 +211,7 @@ namespace System.Windows.Forms
         /// Note: this method should be called only inside an if (DpiHelper.IsScalingRequired) clause
         /// </summary>
         /// <param name="logicalBitmap">The image to scale from logical units to device units</param>
-        public static void ScaleBitmapLogicalToDevice([NotNullIfNotNull("logicalBitmap")]ref Bitmap? logicalBitmap)
+        public static void ScaleBitmapLogicalToDevice([NotNullIfNotNull(nameof(logicalBitmap))]ref Bitmap? logicalBitmap)
         {
             if (logicalBitmap == null)
             {

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
@@ -32,7 +32,7 @@ namespace System.Linq.Expressions.Compiler
         {
         }
 
-        [return: NotNullIfNotNull("node")]
+        [return: NotNullIfNotNull(nameof(node))]
         public override Expression? Visit(Expression? node)
         {
             // When compiling deep trees, we run the risk of triggering a terminating StackOverflowException,

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
@@ -31,7 +31,7 @@ namespace System.Linq.Expressions
         /// <param name="node">The expression to visit.</param>
         /// <returns>The modified expression, if it or any subexpression was modified;
         /// otherwise, returns the original expression.</returns>
-        [return: NotNullIfNotNull("node")]
+        [return: NotNullIfNotNull(nameof(node))]
         public virtual Expression? Visit(Expression? node) => node?.Accept(this);
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace System.Linq.Expressions
         /// <returns>The modified expression, if it or any subexpression was modified;
         /// otherwise, returns the original expression.</returns>
         /// <exception cref="InvalidOperationException">The visit method for this node returned a different type.</exception>
-        [return: NotNullIfNotNull("node")]
+        [return: NotNullIfNotNull(nameof(node))]
         public T? VisitAndConvert<T>(T? node, string? callerName) where T : Expression
         {
             if (node == null)
@@ -317,7 +317,7 @@ namespace System.Linq.Expressions
         /// <param name="node">The expression to visit.</param>
         /// <returns>The modified expression, if it or any subexpression was modified;
         /// otherwise, returns the original expression.</returns>
-        [return: NotNullIfNotNull("node")]
+        [return: NotNullIfNotNull(nameof(node))]
         protected virtual LabelTarget? VisitLabelTarget(LabelTarget? node)
         {
             return node;

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
@@ -22,7 +22,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="locals">The actual hoisted local values.</param>
         /// <returns>The quoted expression.</returns>
         [Obsolete("RuntimeOps has been deprecated and is not supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
-        [return: NotNullIfNotNull("expression")]
+        [return: NotNullIfNotNull(nameof(expression))]
         public static Expression? Quote(Expression? expression, object hoistedLocals, object[] locals)
         {
             Debug.Assert(hoistedLocals != null && locals != null);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -629,7 +629,7 @@ namespace System.Net.Http.Headers
             }
         }
 
-        [return: NotNullIfNotNull("source")]
+        [return: NotNullIfNotNull(nameof(source))]
         private static object? CloneStringHeaderInfoValues(object? source)
         {
             if (source == null)

--- a/src/libraries/System.Net.Security/src/System/Security/Authentication/ExtendedProtection/ServiceNameCollection.cs
+++ b/src/libraries/System.Net.Security/src/System/Security/Authentication/ExtendedProtection/ServiceNameCollection.cs
@@ -158,7 +158,7 @@ namespace System.Security.Authentication.ExtendedProtection
         // prefix/host:port
         // prefix/host/DistinguishedName
         // prefix/host:port/DistinguishedName
-        [return: NotNullIfNotNull("inputServiceName")]
+        [return: NotNullIfNotNull(nameof(inputServiceName))]
         private static string? NormalizeServiceName(string? inputServiceName)
         {
             if (string.IsNullOrWhiteSpace(inputServiceName))

--- a/src/libraries/System.Net.WebClient/src/System/Net/WebClient.cs
+++ b/src/libraries/System.Net.WebClient/src/System/Net/WebClient.cs
@@ -1186,7 +1186,7 @@ namespace System.Net
                 "POST";
         }
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         private static string? UrlEncode(string? str)
         {
             if (str == null)

--- a/src/libraries/System.Private.CoreLib/src/Internal/Win32/RegistryKey.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Win32/RegistryKey.cs
@@ -218,7 +218,7 @@ namespace Internal.Win32
             return GetValue(name, null);
         }
 
-        [return: NotNullIfNotNull("defaultValue")]
+        [return: NotNullIfNotNull(nameof(defaultValue))]
         public object? GetValue(string name, object? defaultValue)
         {
             object? data = defaultValue;

--- a/src/libraries/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.cs
@@ -170,13 +170,13 @@ namespace System
         // object already has the given type code, in which case the object is
         // simply returned. Otherwise, the appropriate ToXXX() is invoked on the
         // object's implementation of IConvertible.
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static object? ChangeType(object? value, TypeCode typeCode)
         {
             return ChangeType(value, typeCode, CultureInfo.CurrentCulture);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static object? ChangeType(object? value, TypeCode typeCode, IFormatProvider? provider)
         {
             if (value == null && (typeCode == TypeCode.Empty || typeCode == TypeCode.String || typeCode == TypeCode.Object))
@@ -270,13 +270,13 @@ namespace System
             throw new InvalidCastException(SR.Format(SR.InvalidCast_FromTo, value.GetType().FullName, targetType.FullName));
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static object? ChangeType(object? value, Type conversionType)
         {
             return ChangeType(value, conversionType, CultureInfo.CurrentCulture);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static object? ChangeType(object? value, Type conversionType, IFormatProvider? provider)
         {
             ArgumentNullException.ThrowIfNull(conversionType);
@@ -2080,13 +2080,13 @@ namespace System
             return value.ToString(provider);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static string? ToString(string? value)
         {
             return value;
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static string? ToString(string? value, IFormatProvider? provider)
         {
             return value;

--- a/src/libraries/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Delegate.cs
@@ -12,8 +12,8 @@ namespace System
     {
         public virtual object Clone() => MemberwiseClone();
 
-        [return: NotNullIfNotNull("a")]
-        [return: NotNullIfNotNull("b")]
+        [return: NotNullIfNotNull(nameof(a))]
+        [return: NotNullIfNotNull(nameof(b))]
         public static Delegate? Combine(Delegate? a, Delegate? b)
         {
             if (a is null)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Debug.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Debug.cs
@@ -86,7 +86,7 @@ namespace System.Diagnostics
             Assert(condition, message, string.Empty);
 
         [Conditional("DEBUG")]
-        public static void Assert([DoesNotReturnIf(false)] bool condition, [InterpolatedStringHandlerArgument("condition")] ref AssertInterpolatedStringHandler message) =>
+        public static void Assert([DoesNotReturnIf(false)] bool condition, [InterpolatedStringHandlerArgument(nameof(condition))] ref AssertInterpolatedStringHandler message) =>
             Assert(condition, message.ToStringAndClear());
 
         [Conditional("DEBUG")]
@@ -99,7 +99,7 @@ namespace System.Diagnostics
         }
 
         [Conditional("DEBUG")]
-        public static void Assert([DoesNotReturnIf(false)] bool condition, [InterpolatedStringHandlerArgument("condition")] ref AssertInterpolatedStringHandler message, [InterpolatedStringHandlerArgument("condition")] ref AssertInterpolatedStringHandler detailMessage) =>
+        public static void Assert([DoesNotReturnIf(false)] bool condition, [InterpolatedStringHandlerArgument(nameof(condition))] ref AssertInterpolatedStringHandler message, [InterpolatedStringHandlerArgument(nameof(condition))] ref AssertInterpolatedStringHandler detailMessage) =>
             Assert(condition, message.ToStringAndClear(), detailMessage.ToStringAndClear());
 
         [Conditional("DEBUG")]
@@ -196,7 +196,7 @@ namespace System.Diagnostics
         }
 
         [Conditional("DEBUG")]
-        public static void WriteIf(bool condition, [InterpolatedStringHandlerArgument("condition")] ref WriteIfInterpolatedStringHandler message) =>
+        public static void WriteIf(bool condition, [InterpolatedStringHandlerArgument(nameof(condition))] ref WriteIfInterpolatedStringHandler message) =>
             WriteIf(condition, message.ToStringAndClear());
 
         [Conditional("DEBUG")]
@@ -218,7 +218,7 @@ namespace System.Diagnostics
         }
 
         [Conditional("DEBUG")]
-        public static void WriteIf(bool condition, [InterpolatedStringHandlerArgument("condition")] ref WriteIfInterpolatedStringHandler message, string? category) =>
+        public static void WriteIf(bool condition, [InterpolatedStringHandlerArgument(nameof(condition))] ref WriteIfInterpolatedStringHandler message, string? category) =>
             WriteIf(condition, message.ToStringAndClear(), category);
 
         [Conditional("DEBUG")]
@@ -258,7 +258,7 @@ namespace System.Diagnostics
         }
 
         [Conditional("DEBUG")]
-        public static void WriteLineIf(bool condition, [InterpolatedStringHandlerArgument("condition")] ref WriteIfInterpolatedStringHandler message) =>
+        public static void WriteLineIf(bool condition, [InterpolatedStringHandlerArgument(nameof(condition))] ref WriteIfInterpolatedStringHandler message) =>
             WriteLineIf(condition, message.ToStringAndClear());
 
         [Conditional("DEBUG")]
@@ -271,7 +271,7 @@ namespace System.Diagnostics
         }
 
         [Conditional("DEBUG")]
-        public static void WriteLineIf(bool condition, [InterpolatedStringHandlerArgument("condition")] ref WriteIfInterpolatedStringHandler message, string? category) =>
+        public static void WriteLineIf(bool condition, [InterpolatedStringHandlerArgument(nameof(condition))] ref WriteIfInterpolatedStringHandler message, string? category) =>
             WriteLineIf(condition, message.ToStringAndClear(), category);
 
         /// <summary>Provides an interpolated string handler for <see cref="Debug.Assert"/> that only performs formatting if the assert fails.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Nls.cs
@@ -199,7 +199,7 @@ namespace System.Globalization
         ///
         /// We don't build the stringbuilder unless we find something to change
         /// </summary>
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         internal static string? ReescapeWin32String(string? str)
         {
             // If we don't have data, then don't try anything
@@ -265,7 +265,7 @@ namespace System.Globalization
             return result.ToString();
         }
 
-        [return: NotNullIfNotNull("array")]
+        [return: NotNullIfNotNull(nameof(array))]
         internal static string[]? ReescapeWin32Strings(string[]? array)
         {
             if (array != null)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -38,7 +38,7 @@ namespace System.IO
         // returns null. If path does not contain a file extension,
         // the new file extension is appended to the path. If extension
         // is null, any existing extension is removed from path.
-        [return: NotNullIfNotNull("path")]
+        [return: NotNullIfNotNull(nameof(path))]
         public static string? ChangeExtension(string? path, string? extension)
         {
             if (path == null)
@@ -177,7 +177,7 @@ namespace System.IO
         /// The returned value is null if the given path is null or empty if the given path does not include an
         /// extension.
         /// </summary>
-        [return: NotNullIfNotNull("path")]
+        [return: NotNullIfNotNull(nameof(path))]
         public static string? GetExtension(string? path)
         {
             if (path == null)
@@ -217,7 +217,7 @@ namespace System.IO
         /// the characters of path that follow the last separator in path. The resulting string is
         /// null if path is null.
         /// </summary>
-        [return: NotNullIfNotNull("path")]
+        [return: NotNullIfNotNull(nameof(path))]
         public static string? GetFileName(string? path)
         {
             if (path == null)
@@ -249,7 +249,7 @@ namespace System.IO
             return path;
         }
 
-        [return: NotNullIfNotNull("path")]
+        [return: NotNullIfNotNull(nameof(path))]
         public static string? GetFileNameWithoutExtension(string? path)
         {
             if (path == null)

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -2429,7 +2429,7 @@ namespace System
         /// <param name="handler">The interpolated string.</param>
         /// <param name="charsWritten">The number of characters written to the span.</param>
         /// <returns>true if the entire interpolated string could be formatted successfully; otherwise, false.</returns>
-        public static bool TryWrite(this Span<char> destination, [InterpolatedStringHandlerArgument("destination")] ref TryWriteInterpolatedStringHandler handler, out int charsWritten)
+        public static bool TryWrite(this Span<char> destination, [InterpolatedStringHandlerArgument(nameof(destination))] ref TryWriteInterpolatedStringHandler handler, out int charsWritten)
         {
             // The span argument isn't used directly in the method; rather, it'll be used by the compiler to create the handler.
             // We could validate here that span == handler._destination, but that doesn't seem necessary.

--- a/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
@@ -30,7 +30,7 @@ namespace System.Net
 
         #region HtmlEncode / HtmlDecode methods
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static string? HtmlEncode(string? value)
         {
             if (string.IsNullOrEmpty(value))
@@ -175,7 +175,7 @@ namespace System.Net
             }
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static string? HtmlDecode(string? value)
         {
             if (string.IsNullOrEmpty(value))
@@ -387,7 +387,7 @@ namespace System.Net
 
         #region UrlEncode public methods
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static string? UrlEncode(string? value)
         {
             if (string.IsNullOrEmpty(value))
@@ -439,7 +439,7 @@ namespace System.Net
             return Encoding.UTF8.GetString(newBytes);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static byte[]? UrlEncodeToBytes(byte[]? value, int offset, int count)
         {
             if (!ValidateUrlEncodingParameters(value, offset, count))
@@ -479,7 +479,7 @@ namespace System.Net
 
         #region UrlDecode implementation
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         private static string? UrlDecodeInternal(string? value, Encoding encoding)
         {
             if (string.IsNullOrEmpty(value))
@@ -542,7 +542,7 @@ namespace System.Net
             return helper.GetString();
         }
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         private static byte[]? UrlDecodeInternal(byte[]? bytes, int offset, int count)
         {
             if (!ValidateUrlEncodingParameters(bytes, offset, count))
@@ -590,13 +590,13 @@ namespace System.Net
         #region UrlDecode public methods
 
 
-        [return: NotNullIfNotNull("encodedValue")]
+        [return: NotNullIfNotNull(nameof(encodedValue))]
         public static string? UrlDecode(string? encodedValue)
         {
             return UrlDecodeInternal(encodedValue, Encoding.UTF8);
         }
 
-        [return: NotNullIfNotNull("encodedValue")]
+        [return: NotNullIfNotNull(nameof(encodedValue))]
         public static byte[]? UrlDecodeToBytes(byte[]? encodedValue, int offset, int count)
         {
             return UrlDecodeInternal(encodedValue, offset, count);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -67,7 +67,7 @@ namespace System.Runtime.CompilerServices
         // Mono:As
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(o))]
         public static T As<T>(object? o) where T : class?
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecurityElement.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecurityElement.cs
@@ -318,7 +318,7 @@ namespace System.Security
             return c.ToString();
         }
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static string? Escape(string? str)
         {
             if (str == null)

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -328,7 +328,7 @@ namespace System
         /// <param name="provider">An object that supplies culture-specific formatting information.</param>
         /// <param name="handler">The interpolated string.</param>
         /// <returns>The string that results for formatting the interpolated string using the specified format provider.</returns>
-        public static string Create(IFormatProvider? provider, [InterpolatedStringHandlerArgument("provider")] ref DefaultInterpolatedStringHandler handler) =>
+        public static string Create(IFormatProvider? provider, [InterpolatedStringHandlerArgument(nameof(provider))] ref DefaultInterpolatedStringHandler handler) =>
             handler.ToStringAndClear();
 
         /// <summary>Creates a new string by using the specified provider to control the formatting of the specified interpolated string.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
@@ -135,7 +135,7 @@ namespace System.Threading
         /// <paramref name="target"/>. If <paramref name="syncLock"/> is null, and if the target hasn't already
         /// been initialized, a new object will be instantiated.</param>
         /// <returns>The initialized value of type <typeparamref name="T"/>.</returns>
-        public static T EnsureInitialized<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]T>([AllowNull] ref T target, ref bool initialized, [NotNullIfNotNull("syncLock")] ref object? syncLock)
+        public static T EnsureInitialized<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]T>([AllowNull] ref T target, ref bool initialized, [NotNullIfNotNull(nameof(syncLock))] ref object? syncLock)
         {
             // Fast path.
             if (Volatile.Read(ref initialized))
@@ -195,7 +195,7 @@ namespace System.Threading
         /// <param name="valueFactory">The <see cref="System.Func{T}"/> invoked to initialize the
         /// reference or value.</param>
         /// <returns>The initialized value of type <typeparamref name="T"/>.</returns>
-        public static T EnsureInitialized<T>([AllowNull] ref T target, ref bool initialized, [NotNullIfNotNull("syncLock")] ref object? syncLock, Func<T> valueFactory)
+        public static T EnsureInitialized<T>([AllowNull] ref T target, ref bool initialized, [NotNullIfNotNull(nameof(syncLock))] ref object? syncLock, Func<T> valueFactory)
         {
             // Fast path.
             if (Volatile.Read(ref initialized))
@@ -244,7 +244,7 @@ namespace System.Threading
         /// been initialized, a new object will be instantiated.</param>
         /// <param name="valueFactory">The <see cref="System.Func{T}"/> invoked to initialize the reference.</param>
         /// <returns>The initialized value of type <typeparamref name="T"/>.</returns>
-        public static T EnsureInitialized<T>([NotNull] ref T? target, [NotNullIfNotNull("syncLock")] ref object? syncLock, Func<T> valueFactory) where T : class =>
+        public static T EnsureInitialized<T>([NotNull] ref T? target, [NotNullIfNotNull(nameof(syncLock))] ref object? syncLock, Func<T> valueFactory) where T : class =>
             Volatile.Read(ref target!) ?? EnsureInitializedCore(ref target, ref syncLock, valueFactory);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -540,8 +540,8 @@ namespace System.Threading
         public static int VolatileRead(ref int address) => Volatile.Read(ref address);
         public static long VolatileRead(ref long address) => Volatile.Read(ref address);
         public static IntPtr VolatileRead(ref IntPtr address) => Volatile.Read(ref address);
-        [return: NotNullIfNotNull("address")]
-        public static object? VolatileRead([NotNullIfNotNull("address")] ref object? address) => Volatile.Read(ref address);
+        [return: NotNullIfNotNull(nameof(address))]
+        public static object? VolatileRead([NotNullIfNotNull(nameof(address))] ref object? address) => Volatile.Read(ref address);
         [CLSCompliant(false)]
         public static sbyte VolatileRead(ref sbyte address) => Volatile.Read(ref address);
         public static float VolatileRead(ref float address) => Volatile.Read(ref address);
@@ -559,7 +559,7 @@ namespace System.Threading
         public static void VolatileWrite(ref int address, int value) => Volatile.Write(ref address, value);
         public static void VolatileWrite(ref long address, long value) => Volatile.Write(ref address, value);
         public static void VolatileWrite(ref IntPtr address, IntPtr value) => Volatile.Write(ref address, value);
-        public static void VolatileWrite([NotNullIfNotNull("value")] ref object? address, object? value) => Volatile.Write(ref address, value);
+        public static void VolatileWrite([NotNullIfNotNull(nameof(value))] ref object? address, object? value) => Volatile.Write(ref address, value);
         [CLSCompliant(false)]
         public static void VolatileWrite(ref sbyte address, sbyte value) => Volatile.Write(ref address, value);
         public static void VolatileWrite(ref float address, float value) => Volatile.Write(ref address, value);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
@@ -217,13 +217,13 @@ namespace System.Threading
 
         [Intrinsic]
         [NonVersionable]
-        [return: NotNullIfNotNull("location")]
-        public static T Read<T>([NotNullIfNotNull("location")] ref T location) where T : class? =>
+        [return: NotNullIfNotNull(nameof(location))]
+        public static T Read<T>([NotNullIfNotNull(nameof(location))] ref T location) where T : class? =>
             Unsafe.As<T>(Unsafe.As<T, VolatileObject>(ref location).Value);
 
         [Intrinsic]
         [NonVersionable]
-        public static void Write<T>([NotNullIfNotNull("value")] ref T location, T value) where T : class? =>
+        public static void Write<T>([NotNullIfNotNull(nameof(value))] ref T location, T value) where T : class? =>
             Unsafe.As<T, VolatileObject>(ref location).Value = value;
         #endregion
     }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -2056,7 +2056,7 @@ namespace System.Runtime.Serialization
         }
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        internal static void CheckAndAdd(Type type, Dictionary<Type, Type> typesChecked, [NotNullIfNotNull("nameToDataContractTable")] ref DataContractDictionary? nameToDataContractTable)
+        internal static void CheckAndAdd(Type type, Dictionary<Type, Type> typesChecked, [NotNullIfNotNull(nameof(nameToDataContractTable))] ref DataContractDictionary? nameToDataContractTable)
         {
             type = DataContract.UnwrapNullableType(type);
             DataContract dataContract = DataContract.GetDataContract(type);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -491,7 +491,7 @@ namespace System.Runtime.Serialization
             return _rootType;
         }
 
-        [return: NotNullIfNotNull("oldObj")]
+        [return: NotNullIfNotNull(nameof(oldObj))]
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         internal static object? SurrogateToDataContractType(ISerializationSurrogateProvider serializationSurrogateProvider, object? oldObj, Type surrogatedDeclaredType, ref Type objType)
         {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSurrogateCaller.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSurrogateCaller.cs
@@ -19,7 +19,7 @@ namespace System.Runtime.Serialization
             return surrogateProvider.GetSurrogateType(type) ?? type;
         }
 
-        [return: NotNullIfNotNull("obj")]
+        [return: NotNullIfNotNull(nameof(obj))]
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         internal static object? GetObjectToSerialize(ISerializationSurrogateProvider surrogateProvider, object? obj, Type objType, Type membertype)
         {
@@ -30,7 +30,7 @@ namespace System.Runtime.Serialization
             return surrogateProvider.GetObjectToSerialize(obj, membertype);
         }
 
-        [return: NotNullIfNotNull("obj")]
+        [return: NotNullIfNotNull(nameof(obj))]
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         internal static object? GetDeserializedObject(ISerializationSurrogateProvider surrogateProvider, object? obj, Type objType, Type memberType)
         {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
@@ -341,7 +341,7 @@ namespace System.Runtime.Serialization.Json
             return XmlConvert.DecodeName(xmlName);
         }
 
-        [return: NotNullIfNotNull("xmlName")]
+        [return: NotNullIfNotNull(nameof(xmlName))]
         internal static XmlDictionaryString? ConvertXmlNameToJsonName(XmlDictionaryString? xmlName)
         {
             return (xmlName == null) ? null : new XmlDictionary().Add(ConvertXmlNameToJsonName(xmlName.Value));

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
@@ -1598,7 +1598,7 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        [return: NotNullIfNotNull("val")]
+        [return: NotNullIfNotNull(nameof(val))]
         private string? UnescapeJsonString(string? val)
         {
             if (val == null)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
@@ -337,7 +337,7 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        [return: NotNullIfNotNull("oldItemContract")]
+        [return: NotNullIfNotNull(nameof(oldItemContract))]
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         internal static DataContract? GetRevisedItemContract(DataContract oldItemContract)
         {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlReaderDelegator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlReaderDelegator.cs
@@ -468,7 +468,7 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         internal static byte[]? ReadContentAsBase64(string? str)
         {
             if (str == null)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryString.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryString.cs
@@ -33,7 +33,7 @@ namespace System.Xml
             _key = key;
         }
 
-        [return: NotNullIfNotNull("s")]
+        [return: NotNullIfNotNull(nameof(s))]
         internal static string? GetString(XmlDictionaryString? s)
         {
             if (s == null)

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -405,7 +405,7 @@ namespace System
         //
         // Uri(string, UriKind);
         //
-        public Uri([StringSyntax(StringSyntaxAttribute.Uri, "uriKind")] string uriString, UriKind uriKind)
+        public Uri([StringSyntax(StringSyntaxAttribute.Uri, nameof(uriKind))] string uriString, UriKind uriKind)
         {
             ArgumentNullException.ThrowIfNull(uriString);
 

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XAttribute.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XAttribute.cs
@@ -231,7 +231,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as a <see cref="string"/>.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator string?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -268,7 +268,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as a <see cref="bool"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator bool?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -305,7 +305,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as an <see cref="int"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator int?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -342,7 +342,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as an <see cref="uint"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator uint?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -379,7 +379,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as a <see cref="long"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator long?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -416,7 +416,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as an <see cref="ulong"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator ulong?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -453,7 +453,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as a <see cref="float"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator float?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -490,7 +490,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as a <see cref="double"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator double?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -527,7 +527,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as a <see cref="decimal"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator decimal?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -564,7 +564,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as a <see cref="DateTime"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator DateTime?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -601,7 +601,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as a <see cref="DateTimeOffset"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator DateTimeOffset?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -638,7 +638,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as a <see cref="TimeSpan"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator TimeSpan?(XAttribute? attribute)
         {
             if (attribute == null) return null;
@@ -675,7 +675,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XAttribute"/> as a <see cref="Guid"/>?.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("attribute")]
+        [return: NotNullIfNotNull(nameof(attribute))]
         public static explicit operator Guid?(XAttribute? attribute)
         {
             if (attribute == null) return null;

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
@@ -1367,7 +1367,7 @@ namespace System.Xml.Linq
             }
         }
 
-        [return: NotNullIfNotNull("content")]
+        [return: NotNullIfNotNull(nameof(content))]
         internal static object? GetContentSnapshot(object? content)
         {
             if (content is string || !(content is IEnumerable)) return content;

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
@@ -1338,7 +1338,7 @@ namespace System.Xml.Linq
         /// The content of this <see cref="XElement"/> as a <see cref="string"/>.
         /// </returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator string?(XElement? element)
         {
             if (element == null) return null;
@@ -1381,7 +1381,7 @@ namespace System.Xml.Linq
         /// Thrown if the element does not contain a valid boolean value.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator bool?(XElement? element)
         {
             if (element == null) return null;
@@ -1424,7 +1424,7 @@ namespace System.Xml.Linq
         /// Thrown if the specified element does not contain a valid integer value.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator int?(XElement? element)
         {
             if (element == null) return null;
@@ -1467,7 +1467,7 @@ namespace System.Xml.Linq
         /// Thrown if the specified element does not contain a valid unsigned integer value.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator uint?(XElement? element)
         {
             if (element == null) return null;
@@ -1510,7 +1510,7 @@ namespace System.Xml.Linq
         /// Thrown if the specified element does not contain a valid long integer value.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator long?(XElement? element)
         {
             if (element == null) return null;
@@ -1553,7 +1553,7 @@ namespace System.Xml.Linq
         /// Thrown if the specified element does not contain a valid unsigned long integer value.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator ulong?(XElement? element)
         {
             if (element == null) return null;
@@ -1596,7 +1596,7 @@ namespace System.Xml.Linq
         /// Thrown if the specified element does not contain a valid float value.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator float?(XElement? element)
         {
             if (element == null) return null;
@@ -1639,7 +1639,7 @@ namespace System.Xml.Linq
         /// Thrown if the specified element does not contain a valid double value.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator double?(XElement? element)
         {
             if (element == null) return null;
@@ -1682,7 +1682,7 @@ namespace System.Xml.Linq
         /// Thrown if the specified element does not contain a valid decimal value.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator decimal?(XElement? element)
         {
             if (element == null) return null;
@@ -1725,7 +1725,7 @@ namespace System.Xml.Linq
         /// Thrown if the specified element does not contain a valid <see cref="DateTime"/> value.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator DateTime?(XElement? element)
         {
             if (element == null) return null;
@@ -1768,7 +1768,7 @@ namespace System.Xml.Linq
         /// Thrown if the specified element does not contain a valid <see cref="DateTimeOffset"/> value.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator DateTimeOffset?(XElement? element)
         {
             if (element == null) return null;
@@ -1811,7 +1811,7 @@ namespace System.Xml.Linq
         /// Thrown if the specified element does not contain a valid <see cref="TimeSpan"/> value.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator TimeSpan?(XElement? element)
         {
             if (element == null) return null;
@@ -1854,7 +1854,7 @@ namespace System.Xml.Linq
         /// Thrown if the specified element does not contain a valid guid.
         /// </exception>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("element")]
+        [return: NotNullIfNotNull(nameof(element))]
         public static explicit operator Guid?(XElement? element)
         {
             if (element == null) return null;

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
@@ -101,7 +101,7 @@ namespace System.Xml.Linq
         /// <param name="expandedName">A string containing an expanded XML name in the format: {namespace}localname.</param>
         /// <returns>An XName object constructed from the expanded name.</returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("expandedName")]
+        [return: NotNullIfNotNull(nameof(expandedName))]
         public static implicit operator XName?(string? expandedName)
         {
             return expandedName != null ? Get(expandedName) : null;

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNamespace.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNamespace.cs
@@ -126,7 +126,7 @@ namespace System.Xml.Linq
         /// <param name="namespaceName">A string containing the namespace name.</param>
         /// <returns>An <see cref="XNamespace"/> constructed from the namespace name string.</returns>
         [CLSCompliant(false)]
-        [return: NotNullIfNotNull("namespaceName")]
+        [return: NotNullIfNotNull(nameof(namespaceName))]
         public static implicit operator XNamespace?(string? namespaceName)
         {
             return namespaceName != null ? Get(namespaceName) : null;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingWriter.cs
@@ -379,7 +379,7 @@ namespace System.Xml
             }
         }
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         private string? ReplaceNewLines(string? str)
         {
             if (str == null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.Unix.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.Unix.cs
@@ -7,7 +7,7 @@ namespace System.Xml
 {
     internal sealed partial class XmlTextReaderImpl
     {
-        static partial void ConvertAbsoluteUnixPathToAbsoluteUri([NotNullIfNotNull("url")] ref string? url, XmlResolver? resolver)
+        static partial void ConvertAbsoluteUnixPathToAbsoluteUri([NotNullIfNotNull(nameof(url))] ref string? url, XmlResolver? resolver)
         {
             // new Uri(uri, UriKind.RelativeOrAbsolute) returns a Relative Uri for absolute unix paths (e.g. /tmp).
             // We convert the native unix path to a 'file://' uri string to make it an Absolute Uri.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -9787,6 +9787,6 @@ namespace System.Xml
             Buffer.BlockCopy(src, srcOffset, dst, dstOffset, count);
         }
 
-        static partial void ConvertAbsoluteUnixPathToAbsoluteUri([NotNullIfNotNull("url")] ref string? url, XmlResolver? resolver);
+        static partial void ConvertAbsoluteUnixPathToAbsoluteUri([NotNullIfNotNull(nameof(url))] ref string? url, XmlResolver? resolver);
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplHelpers.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplHelpers.cs
@@ -469,11 +469,11 @@ namespace System.Xml
                 }
             }
 
-            [MemberNotNull("_value")]
-            [MemberNotNull("nameWPrefix")]
-            [MemberNotNull("localName")]
-            [MemberNotNull("prefix")]
-            [MemberNotNull("ns")]
+            [MemberNotNull(nameof(_value))]
+            [MemberNotNull(nameof(nameWPrefix))]
+            [MemberNotNull(nameof(localName))]
+            [MemberNotNull(nameof(prefix))]
+            [MemberNotNull(nameof(ns))]
             internal void Clear(XmlNodeType type)
             {
                 this.type = type;
@@ -484,10 +484,10 @@ namespace System.Xml
                 typedValue = null;
             }
 
-            [MemberNotNull("localName")]
-            [MemberNotNull("prefix")]
-            [MemberNotNull("ns")]
-            [MemberNotNull("nameWPrefix")]
+            [MemberNotNull(nameof(localName))]
+            [MemberNotNull(nameof(prefix))]
+            [MemberNotNull(nameof(ns))]
+            [MemberNotNull(nameof(nameWPrefix))]
             internal void ClearName()
             {
                 localName = string.Empty;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReader.cs
@@ -165,7 +165,7 @@ namespace System.Xml
             : this(reader, xmlResolver, readerSettings, null)
         { }
 
-        [MemberNotNull("_validator")]
+        [MemberNotNull(nameof(_validator))]
         private void SetupValidator(XmlReaderSettings readerSettings, XmlReader reader, XmlSchemaObject? partialValidationType)
         {
             _validator = new XmlSchemaValidator(_coreReaderNameTable, readerSettings.Schemas, _thisNSResolver, readerSettings.ValidationFlags);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlAttributeCollection.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlAttributeCollection.cs
@@ -111,7 +111,7 @@ namespace System.Xml
         }
 
         // Adds a XmlNode using its Name property
-        [return: NotNullIfNotNull("node")]
+        [return: NotNullIfNotNull(nameof(node))]
         public override XmlNode? SetNamedItem(XmlNode? node)
         {
             if (node == null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlElement.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlElement.cs
@@ -345,7 +345,7 @@ namespace System.Xml
 
         // Sets the value of the attribute with the specified name
         // and namespace.
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public virtual string? SetAttribute(string localName, string? namespaceURI, string? value)
         {
             XmlAttribute? attr = GetAttributeNode(localName, namespaceURI);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/Asttree.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/Asttree.cs
@@ -428,7 +428,7 @@ namespace System.Xml.Schema
         }
 
         // recursive here
-        [return: NotNullIfNotNull("axis")]
+        [return: NotNullIfNotNull(nameof(axis))]
         internal static DoubleLinkAxis? ConvertTree(Axis? axis)
         {
             if (axis == null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
@@ -1454,7 +1454,7 @@ namespace System.Xml.Schema
             }
         }
 
-        [return: NotNullIfNotNull("particle")]
+        [return: NotNullIfNotNull(nameof(particle))]
         private static XmlSchemaParticle? CanonicalizePointlessRoot(XmlSchemaParticle particle)
         {
             if (particle == null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAttribute.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAttribute.cs
@@ -113,7 +113,7 @@ namespace System.Xml.Schema
             get { return _attributeType; }
         }
 
-        [return: NotNullIfNotNull("schemaSet")]
+        [return: NotNullIfNotNull(nameof(schemaSet))]
         internal XmlReader? Validate(XmlReader reader, XmlResolver? resolver, XmlSchemaSet schemaSet, ValidationEventHandler valEventHandler)
         {
             if (schemaSet != null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaComplexType.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaComplexType.cs
@@ -452,7 +452,7 @@ namespace System.Xml.Schema
             return newParticles;
         }
 
-        [return: NotNullIfNotNull("particle")]
+        [return: NotNullIfNotNull(nameof(particle))]
         internal static XmlSchemaParticle? CloneParticle(XmlSchemaParticle? particle, XmlSchema? parentSchema)
         {
             XmlSchemaGroupBase? groupBase = particle as XmlSchemaGroupBase;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaElement.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaElement.cs
@@ -189,7 +189,7 @@ namespace System.Xml.Schema
             get { return _finalResolved; }
         }
 
-        [return: NotNullIfNotNull("schemaSet")]
+        [return: NotNullIfNotNull(nameof(schemaSet))]
         internal XmlReader? Validate(XmlReader reader, XmlResolver? resolver, XmlSchemaSet schemaSet, ValidationEventHandler valEventHandler)
         {
             if (schemaSet != null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaType.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaType.cs
@@ -203,7 +203,7 @@ namespace System.Xml.Schema
             }
         }
 
-        [return: NotNullIfNotNull("schemaSet")]
+        [return: NotNullIfNotNull(nameof(schemaSet))]
         internal XmlReader? Validate(XmlReader reader, XmlResolver? resolver, XmlSchemaSet schemaSet, ValidationEventHandler valEventHandler)
         {
             if (schemaSet != null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
@@ -273,7 +273,7 @@ namespace System.Xml.Serialization
 
         private static readonly char[] s_identifierSeparators = new char[] { '.', ',', '<', '>' };
 
-        [return: NotNullIfNotNull("identifier")]
+        [return: NotNullIfNotNull(nameof(identifier))]
         private static string? EscapeKeywords(string? identifier)
         {
             if (identifier == null || identifier.Length == 0) return identifier;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -561,7 +561,7 @@ namespace System.Xml.Serialization
             return xmlReader.IsStartElement(method.name!, method.ns!);
         }
 
-        [return: NotNullIfNotNull("encodingStyle")]
+        [return: NotNullIfNotNull(nameof(encodingStyle))]
         private string? ValidateEncodingStyle(string? encodingStyle, string methodKey)
         {
             if (encodingStyle != null && encodingStyle.Length > 0)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Mappings.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Mappings.cs
@@ -100,14 +100,14 @@ namespace System.Xml.Serialization
             set { _topLevelInSchema = value; }
         }
 
-        [return: NotNullIfNotNull("name")]
+        [return: NotNullIfNotNull(nameof(name))]
         internal static string? EscapeName(string? name)
         {
             if (name == null || name.Length == 0) return name;
             return XmlConvert.EncodeLocalName(name);
         }
 
-        [return: NotNullIfNotNull("name")]
+        [return: NotNullIfNotNull(nameof(name))]
         internal static string? EscapeQName(string? name)
         {
             if (name == null || name.Length == 0) return name;
@@ -122,7 +122,7 @@ namespace System.Xml.Serialization
             }
         }
 
-        [return: NotNullIfNotNull("name")]
+        [return: NotNullIfNotNull(nameof(name))]
         internal static string? UnescapeName(string? name)
         {
             return XmlConvert.DecodeName(name);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SchemaObjectWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SchemaObjectWriter.cs
@@ -224,7 +224,7 @@ namespace System.Xml.Serialization
             }
         }
 
-        [return: NotNullIfNotNull("list")]
+        [return: NotNullIfNotNull(nameof(list))]
         internal static string? ToString(NamespaceList? list)
         {
             if (list == null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSchemas.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSchemas.cs
@@ -478,7 +478,7 @@ namespace System.Xml.Serialization
             return XmlQualifiedName.Empty;
         }
 
-        [return: NotNullIfNotNull("o")]
+        [return: NotNullIfNotNull(nameof(o))]
         private static string? GetSchemaItem(XmlSchemaObject? o, string? ns, string? details)
         {
             if (o == null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationILGen.cs
@@ -128,7 +128,7 @@ namespace System.Xml.Serialization
             return b;
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? GetCSharpString(string? value)
         {
             return ReflectionAwareILGen.GetCSharpString(value);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -878,7 +878,7 @@ namespace System.Xml.Serialization
             return doc;
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         protected string? CollapseWhitespace(string? value)
         {
             if (value == null)
@@ -909,7 +909,7 @@ namespace System.Xml.Serialization
             return node;
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         protected static byte[]? ToByteArrayBase64(string? value)
         {
             return XmlCustomFormatter.ToByteArrayBase64(value);
@@ -924,7 +924,7 @@ namespace System.Xml.Serialization
             return ReadByteArray(true); //means use Base64
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         protected static byte[]? ToByteArrayHex(string? value)
         {
             return XmlCustomFormatter.ToByteArrayHex(value);
@@ -1106,25 +1106,25 @@ namespace System.Xml.Serialization
             return XmlCustomFormatter.ToEnum(value, h, typeName, true);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         protected static string? ToXmlName(string? value)
         {
             return XmlCustomFormatter.ToXmlName(value);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         protected static string? ToXmlNCName(string? value)
         {
             return XmlCustomFormatter.ToXmlNCName(value);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         protected static string? ToXmlNmToken(string? value)
         {
             return XmlCustomFormatter.ToXmlNmToken(value);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         protected static string? ToXmlNmTokens(string? value)
         {
             return XmlCustomFormatter.ToXmlNmTokens(value);
@@ -1362,13 +1362,13 @@ namespace System.Xml.Serialization
             return b;
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         protected string? ReadString(string? value)
         {
             return ReadString(value, false);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         protected string? ReadString(string? value, bool trim)
         {
             string str = _r.ReadString();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
@@ -109,7 +109,7 @@ namespace System.Xml.Serialization
             return DynamicAssemblies.Get(assemblyFullName);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         protected static string? FromByteArrayHex(byte[]? value)
         {
             return XmlCustomFormatter.FromByteArrayHex(value);
@@ -145,25 +145,25 @@ namespace System.Xml.Serialization
             return XmlCustomFormatter.FromEnum(value, values, ids, typeName);
         }
 
-        [return: NotNullIfNotNull("name")]
+        [return: NotNullIfNotNull(nameof(name))]
         protected static string? FromXmlName(string? name)
         {
             return XmlCustomFormatter.FromXmlName(name);
         }
 
-        [return: NotNullIfNotNull("ncName")]
+        [return: NotNullIfNotNull(nameof(ncName))]
         protected static string? FromXmlNCName(string? ncName)
         {
             return XmlCustomFormatter.FromXmlNCName(ncName);
         }
 
-        [return: NotNullIfNotNull("nmToken")]
+        [return: NotNullIfNotNull(nameof(nmToken))]
         protected static string? FromXmlNmToken(string? nmToken)
         {
             return XmlCustomFormatter.FromXmlNmToken(nmToken);
         }
 
-        [return: NotNullIfNotNull("nmTokens")]
+        [return: NotNullIfNotNull(nameof(nmTokens))]
         protected static string? FromXmlNmTokens(string? nmTokens)
         {
             return XmlCustomFormatter.FromXmlNmTokens(nmTokens);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
@@ -2600,12 +2600,12 @@ namespace System.Xml.Serialization
             ilg.Ceq();
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? GetQuotedCSharpString(string? value) =>
             value is null ? null :
             $"@\"{GetCSharpString(value)}\"";
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? GetCSharpString(string? value)
         {
             if (value == null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Xmlcustomformatter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Xmlcustomformatter.cs
@@ -33,7 +33,7 @@ namespace System.Xml.Serialization
             }
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? FromDefaultValue(object? value, string formatter)
         {
             if (value == null) return null;
@@ -110,25 +110,25 @@ namespace System.Xml.Serialization
             return XmlConvert.ToString((ushort)value);
         }
 
-        [return: NotNullIfNotNull("name")]
+        [return: NotNullIfNotNull(nameof(name))]
         internal static string? FromXmlName(string? name)
         {
             return XmlConvert.EncodeName(name);
         }
 
-        [return: NotNullIfNotNull("ncName")]
+        [return: NotNullIfNotNull(nameof(ncName))]
         internal static string? FromXmlNCName(string? ncName)
         {
             return XmlConvert.EncodeLocalName(ncName);
         }
 
-        [return: NotNullIfNotNull("nmToken")]
+        [return: NotNullIfNotNull(nameof(nmToken))]
         internal static string? FromXmlNmToken(string? nmToken)
         {
             return XmlConvert.EncodeNmToken(nmToken);
         }
 
-        [return: NotNullIfNotNull("nmTokens")]
+        [return: NotNullIfNotNull(nameof(nmTokens))]
         internal static string? FromXmlNmTokens(string? nmTokens)
         {
             if (nmTokens == null)
@@ -157,7 +157,7 @@ namespace System.Xml.Serialization
             writer.WriteBase64(inData, start, count);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? FromByteArrayHex(byte[]? value)
         {
             if (value == null)
@@ -399,31 +399,31 @@ namespace System.Xml.Serialization
             return (char)XmlConvert.ToUInt16(value);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? ToXmlName(string? value)
         {
             return XmlConvert.DecodeName(CollapseWhitespace(value));
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? ToXmlNCName(string? value)
         {
             return XmlConvert.DecodeName(CollapseWhitespace(value));
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? ToXmlNmToken(string? value)
         {
             return XmlConvert.DecodeName(CollapseWhitespace(value));
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? ToXmlNmTokens(string? value)
         {
             return XmlConvert.DecodeName(CollapseWhitespace(value));
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static byte[]? ToByteArrayBase64(string? value)
         {
             if (value == null) return null;
@@ -433,7 +433,7 @@ namespace System.Xml.Serialization
             return Convert.FromBase64String(value);
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static byte[]? ToByteArrayHex(string? value)
         {
             if (value == null) return null;
@@ -456,7 +456,7 @@ namespace System.Xml.Serialization
             return value;
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         private static string? CollapseWhitespace(string? value)
         {
             if (value == null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/Query.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/Query.cs
@@ -66,7 +66,7 @@ namespace MS.Internal.Xml.XPath
         public virtual QueryProps Properties { get { return QueryProps.Merge; } }
 
         // ----------------- Helper methods -------------
-        [return: NotNullIfNotNull("input")]
+        [return: NotNullIfNotNull(nameof(input))]
         public static Query? Clone(Query? input)
         {
             if (input != null)
@@ -76,7 +76,7 @@ namespace MS.Internal.Xml.XPath
             return null;
         }
 
-        [return: NotNullIfNotNull("input")]
+        [return: NotNullIfNotNull(nameof(input))]
         protected static XPathNodeIterator? Clone(XPathNodeIterator? input)
         {
             if (input != null)
@@ -86,7 +86,7 @@ namespace MS.Internal.Xml.XPath
             return null;
         }
 
-        [return: NotNullIfNotNull("input")]
+        [return: NotNullIfNotNull(nameof(input))]
         protected static XPathNavigator? Clone(XPathNavigator? input)
         {
             if (input != null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -42,7 +42,7 @@ namespace System.Xml
         ///       DataColumn names, that contain characters that are not permitted in
         ///       XML names to valid names.</para>
         /// </devdoc>
-        [return: NotNullIfNotNull("name")]
+        [return: NotNullIfNotNull(nameof(name))]
         public static string? EncodeName(string? name)
         {
             return EncodeName(name, true/*Name_not_NmToken*/, false/*Local?*/);
@@ -52,7 +52,7 @@ namespace System.Xml
         ///    <para> Verifies the name is valid
         ///       according to production [7] in the XML spec.</para>
         /// </devdoc>
-        [return: NotNullIfNotNull("name")]
+        [return: NotNullIfNotNull(nameof(name))]
         public static string? EncodeNmToken(string? name)
         {
             return EncodeName(name, false/*Name_not_NmToken*/, false/*Local?*/);
@@ -62,7 +62,7 @@ namespace System.Xml
         ///    <para>Converts names, such as DataTable or DataColumn names, that contain
         ///       characters that are not permitted in XML names to valid names.</para>
         /// </devdoc>
-        [return: NotNullIfNotNull("name")]
+        [return: NotNullIfNotNull(nameof(name))]
         public static string? EncodeLocalName(string? name)
         {
             return EncodeName(name, true/*Name_not_NmToken*/, true/*Local?*/);
@@ -72,7 +72,7 @@ namespace System.Xml
         ///    <para>
         ///       Transforms an XML name into an object name (such as DataTable or DataColumn).</para>
         /// </devdoc>
-        [return: NotNullIfNotNull("name")]
+        [return: NotNullIfNotNull(nameof(name))]
         public static string? DecodeName(string? name)
         {
             if (string.IsNullOrEmpty(name))
@@ -167,7 +167,7 @@ namespace System.Xml
             }
         }
 
-        [return: NotNullIfNotNull("name")]
+        [return: NotNullIfNotNull(nameof(name))]
         private static string? EncodeName(string? name, /*Name_not_NmToken*/ bool first, bool local)
         {
             if (string.IsNullOrEmpty(name))
@@ -415,7 +415,7 @@ namespace System.Xml
         ///    <para>
         ///    </para>
         /// </devdoc>
-        [return: NotNullIfNotNull("token")]
+        [return: NotNullIfNotNull(nameof(token))]
         public static string? VerifyTOKEN(string? token)
         {
             if (string.IsNullOrEmpty(token))

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILOptimizerVisitor.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILOptimizerVisitor.cs
@@ -165,7 +165,7 @@ namespace System.Xml.Xsl.IlGen
         /// <summary>
         /// Called when all replacements have already been made and all annotations are complete.
         /// </summary>
-        [return: NotNullIfNotNull("node")]
+        [return: NotNullIfNotNull(nameof(node))]
         protected override QilNode? NoReplace(QilNode? node)
         {
             // Calculate MaybeSideEffects pattern.  This is done here rather than using P because every node needs

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/QIL/QilPatternVisitor.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/QIL/QilPatternVisitor.cs
@@ -64,7 +64,7 @@ namespace System.Xml.Xsl.Qil
         /// <summary>
         /// Called when all replacements have already been made and all annotations are complete.
         /// </summary>
-        [return: NotNullIfNotNull("node")]
+        [return: NotNullIfNotNull(nameof(node))]
         protected virtual QilNode? NoReplace(QilNode? node)
         {
             return node;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/IXpathBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/IXpathBuilder.cs
@@ -14,7 +14,7 @@ namespace System.Xml.Xsl.XPath
         void StartBuild();
 
         // Should be called after build for result tree post-processing
-        [return: NotNullIfNotNull("result")]
+        [return: NotNullIfNotNull(nameof(result))]
         Node? EndBuild(Node? result);
 
         Node String(string value);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathBuilder.cs
@@ -69,7 +69,7 @@ namespace System.Xml.Xsl.XPath
             numFixupCurrent = numFixupPosition = numFixupLast = 0;
         }
 
-        [return: NotNullIfNotNull("result")]
+        [return: NotNullIfNotNull(nameof(result))]
         public virtual QilNode? EndBuild(QilNode? result)
         {
             if (result == null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/KeyMatchBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/KeyMatchBuilder.cs
@@ -34,7 +34,7 @@ namespace System.Xml.Xsl.Xslt
             _depth++;
         }
 
-        [return: NotNullIfNotNull("result")]
+        [return: NotNullIfNotNull(nameof(result))]
         public override QilNode? EndBuild(QilNode? result)
         {
             _depth--;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGenerator.cs
@@ -1054,7 +1054,7 @@ namespace System.Xml.Xsl.Xslt
             return result;
         }
 
-        [return: NotNullIfNotNull("avt")]
+        [return: NotNullIfNotNull(nameof(avt))]
         private QilNode? CompileStringAvt(string? avt)
         {
             if (avt == null)
@@ -1681,7 +1681,7 @@ namespace System.Xml.Xsl.Xslt
         /// returning "1" if AVT evaluates to value1, or "0" if AVT evaluates to value0 or any other value.
         /// If AVT evaluates to neither value0 nor value1 and fwdCompat == false, an error is reported.
         /// </returns>
-        [return: NotNullIfNotNull("attName")]
+        [return: NotNullIfNotNull(nameof(attName))]
         private QilNode CompileOrderAttribute(string attName, string? attValue, string value0, string value1, bool fwdCompat)
         {
             QilNode? result = CompileStringAvt(attValue);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternBuilder.cs
@@ -61,7 +61,7 @@ namespace System.Xml.Xsl.Xslt
             filter.Variable.Binding = newBinding;
         }
 
-        [return: NotNullIfNotNull("result")]
+        [return: NotNullIfNotNull(nameof(result))]
         public QilNode? EndBuild(QilNode? result)
         {
             Debug.Assert(_inTheBuild, "StartBuild() wasn't called");

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/NumberAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/NumberAction.cs
@@ -680,7 +680,7 @@ namespace System.Xml.Xsl.XsltOld
             (non-alphanumeric).
 
         */
-        [return: NotNullIfNotNull("formatString")]
+        [return: NotNullIfNotNull(nameof(formatString))]
         private static List<FormatInfo?>? ParseFormat(string? formatString)
         {
             if (formatString == null || formatString.Length == 0)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/XsltCompileContext.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/XsltCompileContext.cs
@@ -661,7 +661,7 @@ namespace System.Xml.Xsl.XsltOld
                 return string.Empty;
             }
 
-            [return: NotNullIfNotNull("argument")]
+            [return: NotNullIfNotNull(nameof(argument))]
             public static string? ToString(object argument)
             {
                 XPathNodeIterator? it = argument as XPathNodeIterator;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XsltException.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XsltException.cs
@@ -133,7 +133,7 @@ namespace System.Xml.Xsl
             }
         }
 
-        [return: NotNullIfNotNull("key")]
+        [return: NotNullIfNotNull(nameof(key))]
         private static string? FormatMessage(string? key, params string?[]? args)
         {
             string? message = key;

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.Projector.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.Projector.cs
@@ -46,7 +46,7 @@ namespace System.Reflection.Context
                     return value;
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override TypeInfo? ProjectType(Type? value)
             {
                 if (value == null)
@@ -57,7 +57,7 @@ namespace System.Reflection.Context
                 return new CustomType(value, ReflectionContext);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override Assembly? ProjectAssembly(Assembly? value)
             {
                 if (value == null)
@@ -68,7 +68,7 @@ namespace System.Reflection.Context
                 return new CustomAssembly(value, ReflectionContext);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override Module? ProjectModule(Module? value)
             {
                 if (value == null)
@@ -79,7 +79,7 @@ namespace System.Reflection.Context
                 return new CustomModule(value, ReflectionContext);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override FieldInfo? ProjectField(FieldInfo? value)
             {
                 if (value == null)
@@ -90,7 +90,7 @@ namespace System.Reflection.Context
                 return new CustomFieldInfo(value, ReflectionContext);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override EventInfo? ProjectEvent(EventInfo? value)
             {
                 if (value == null)
@@ -101,7 +101,7 @@ namespace System.Reflection.Context
                 return new CustomEventInfo(value, ReflectionContext);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override ConstructorInfo? ProjectConstructor(ConstructorInfo? value)
             {
                 if (value == null)
@@ -112,7 +112,7 @@ namespace System.Reflection.Context
                 return new CustomConstructorInfo(value, ReflectionContext);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override MethodInfo? ProjectMethod(MethodInfo? value)
             {
                 if (value == null)
@@ -123,7 +123,7 @@ namespace System.Reflection.Context
                 return new CustomMethodInfo(value, ReflectionContext);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override MethodBase? ProjectMethodBase(MethodBase? value)
             {
                 if (value == null)
@@ -140,7 +140,7 @@ namespace System.Reflection.Context
                 throw new InvalidOperationException(SR.Format(SR.InvalidOperation_InvalidMethodType, value.GetType()));
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override PropertyInfo? ProjectProperty(PropertyInfo? value)
             {
                 if (value == null)
@@ -151,7 +151,7 @@ namespace System.Reflection.Context
                 return new CustomPropertyInfo(value, ReflectionContext);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override ParameterInfo? ProjectParameter(ParameterInfo? value)
             {
                 if (value == null)
@@ -162,7 +162,7 @@ namespace System.Reflection.Context
                 return new CustomParameterInfo(value, ReflectionContext);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override MethodBody? ProjectMethodBody(MethodBody? value)
             {
                 if (value == null)
@@ -173,7 +173,7 @@ namespace System.Reflection.Context
                 return new ProjectingMethodBody(value, this);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override LocalVariableInfo? ProjectLocalVariable(LocalVariableInfo? value)
             {
                 if (value == null)
@@ -184,7 +184,7 @@ namespace System.Reflection.Context
                 return new ProjectingLocalVariableInfo(value, this);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override ExceptionHandlingClause? ProjectExceptionHandlingClause(ExceptionHandlingClause? value)
             {
                 if (value == null)
@@ -195,7 +195,7 @@ namespace System.Reflection.Context
                 return new ProjectingExceptionHandlingClause(value, this);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override CustomAttributeData? ProjectCustomAttributeData(CustomAttributeData? value)
             {
                 if (value == null)
@@ -206,7 +206,7 @@ namespace System.Reflection.Context
                 return new ProjectingCustomAttributeData(value, this);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override ManifestResourceInfo? ProjectManifestResource(ManifestResourceInfo? value)
             {
                 if (value == null)
@@ -217,7 +217,7 @@ namespace System.Reflection.Context
                 return new ProjectingManifestResourceInfo(value, this);
             }
 
-            [return: NotNullIfNotNull("value")]
+            [return: NotNullIfNotNull(nameof(value))]
             public override MemberInfo? ProjectMember(MemberInfo? value)
             {
                 if (value == null)

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/Projector.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/Projector.cs
@@ -9,7 +9,7 @@ namespace System.Reflection.Context.Projection
 {
     internal abstract class Projector
     {
-        [return: NotNullIfNotNull("values")]
+        [return: NotNullIfNotNull(nameof(values))]
         public IList<T>? Project<T>(IList<T>? values, Func<T, T> project)
         {
             if (values == null || values.Count == 0)
@@ -20,7 +20,7 @@ namespace System.Reflection.Context.Projection
             return Array.AsReadOnly(projected);
         }
 
-        [return: NotNullIfNotNull("values")]
+        [return: NotNullIfNotNull(nameof(values))]
         public T[]? Project<T>(T[]? values, Func<T, T> project)
         {
             if (values == null || values.Length == 0)
@@ -42,43 +42,43 @@ namespace System.Reflection.Context.Projection
             return value;
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract TypeInfo? ProjectType(Type? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract Assembly? ProjectAssembly(Assembly? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract Module? ProjectModule(Module? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract FieldInfo? ProjectField(FieldInfo? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract EventInfo? ProjectEvent(EventInfo? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract ConstructorInfo? ProjectConstructor(ConstructorInfo? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract MethodInfo? ProjectMethod(MethodInfo? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract MethodBase? ProjectMethodBase(MethodBase? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract PropertyInfo? ProjectProperty(PropertyInfo? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract ParameterInfo? ProjectParameter(ParameterInfo? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract MethodBody? ProjectMethodBody(MethodBody? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract LocalVariableInfo? ProjectLocalVariable(LocalVariableInfo? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract ExceptionHandlingClause? ProjectExceptionHandlingClause(ExceptionHandlingClause? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract CustomAttributeData? ProjectCustomAttributeData(CustomAttributeData? value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract ManifestResourceInfo? ProjectManifestResource(ManifestResourceInfo? value);
         public abstract CustomAttributeTypedArgument ProjectTypedArgument(CustomAttributeTypedArgument value);
         public abstract CustomAttributeNamedArgument ProjectNamedArgument(CustomAttributeNamedArgument value);
         public abstract InterfaceMapping ProjectInterfaceMapping(InterfaceMapping value);
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public abstract MemberInfo? ProjectMember(MemberInfo? value);
 
-        [return: NotNullIfNotNull("values")]
+        [return: NotNullIfNotNull(nameof(values))]
         public static Type[]? Unproject(Type[]? values)
         {
             if (values == null)
@@ -93,7 +93,7 @@ namespace System.Reflection.Context.Projection
             return newTypes;
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static Type? Unproject(Type? value)
         {
             if (value is ProjectingType projectingType)

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/Helpers.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/Helpers.cs
@@ -11,7 +11,7 @@ namespace System.Reflection.TypeLoading
 {
     internal static class Helpers
     {
-        [return: NotNullIfNotNull("original")]
+        [return: NotNullIfNotNull(nameof(original))]
         public static T[]? CloneArray<T>(this T[]? original)
         {
             if (original == null)

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12875,7 +12875,7 @@ namespace System.Runtime.CompilerServices
         [System.CLSCompliantAttribute(false)]
         public unsafe static ref T AsRef<T>(void* source) { throw null; }
         public static ref T AsRef<T>(scoped in T source) { throw null; }
-        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("o")]
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("o")]
         public static T? As<T>(object? o) where T : class? { throw null; }
         public static ref TTo As<TFrom, TTo>(ref TFrom source) { throw null; }
         public static System.IntPtr ByteOffset<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref T origin, [System.Diagnostics.CodeAnalysis.AllowNull] ref T target) { throw null; }

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -825,7 +825,7 @@ namespace System.Reflection.Tests
             Assert.Equal(NullabilityState.NotNull, maybeNullWhen.WriteState);
             Assert.Equal(NullabilityState.Nullable, nullabilityContext.Create(maybeNullParameters[1]).ReadState);
 
-            // string? AllowNullParameter([AllowNull] string allowNull, [NotNullIfNotNull("allowNull")] string? notNullIfNotNull)
+            // string? AllowNullParameter([AllowNull] string allowNull, [NotNullIfNotNull(nameof(allowNull))] string? notNullIfNotNull)
             ParameterInfo[] allowNullParameter = type.GetMethod("AllowNullParameter", flags)!.GetParameters();
             NullabilityInfo allowNull = nullabilityContext.Create(allowNullParameter[0]);
             NullabilityInfo notNullIfNotNull = nullabilityContext.Create(allowNullParameter[1]);
@@ -835,7 +835,7 @@ namespace System.Reflection.Tests
             Assert.Equal(NullabilityState.Nullable, notNullIfNotNull.WriteState);
             Assert.Equal(NullabilityState.Nullable, nullabilityContext.Create(allowNullParameter[1]).ReadState);
 
-            // [return: NotNullIfNotNull("nullable")] public string? NullableNotNullIfNotNullReturn(string? nullable, [NotNull] ref string? readNotNull)
+            // [return: NotNullIfNotNull(nameof(nullable))] public string? NullableNotNullIfNotNullReturn(string? nullable, [NotNull] ref string? readNotNull)
             ParameterInfo[] nullableNotNullIfNotNullReturn = type.GetMethod("NullableNotNullIfNotNullReturn", flags)!.GetParameters();
             NullabilityInfo returnNotNullIfNotNull = nullabilityContext.Create(type.GetMethod("NullableNotNullIfNotNullReturn", flags)!.ReturnParameter);
             NullabilityInfo readNotNull = nullabilityContext.Create(nullableNotNullIfNotNullReturn[1]);
@@ -1169,8 +1169,8 @@ namespace System.Reflection.Tests
         public string PropertyEnabledNonNullable { get; set; } = null!;
         bool NotNullWhenParameter([DisallowNull] string? disallowNull, [NotNullWhen(true)] ref string? notNullWhen, Type? nullableType) { return false; }
         public bool MaybeNullParameters([MaybeNull] string maybeNull, [MaybeNullWhen(false)] out string maybeNullWhen, Type? nullableType) { maybeNullWhen = null; return false; }
-        public string? AllowNullParameter([AllowNull] string allowNull, [NotNullIfNotNull("allowNull")] string? notNullIfNotNull) { return null; }
-        [return: NotNullIfNotNull("nullable")] public string? NullableNotNullIfNotNullReturn(string? nullable, [NotNull] ref string? readNotNull) { readNotNull = string.Empty; return null!; }
+        public string? AllowNullParameter([AllowNull] string allowNull, [NotNullIfNotNull(nameof(allowNull))] string? notNullIfNotNull) { return null; }
+        [return: NotNullIfNotNull(nameof(nullable))] public string? NullableNotNullIfNotNullReturn(string? nullable, [NotNull] ref string? readNotNull) { readNotNull = string.Empty; return null!; }
         public ref string? RefReturnNullable([AllowNull] ref string id) { return ref id!; }
         [return: MaybeNull] public ref string RefReturnMaybeNull([DisallowNull] ref string? id) { return ref id; }
         [return: NotNull] public ref string? RefReturnNotNull([NotNull] ref string? id) { id = string.Empty; return ref id!; }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
@@ -681,7 +681,7 @@ namespace Internal.Cryptography
 
         // Creates a defensive copy of an OID on platforms where OID
         // is mutable. On platforms where OID is immutable, return the OID as-is.
-        [return: NotNullIfNotNull("oid")]
+        [return: NotNullIfNotNull(nameof(oid))]
         public static Oid? CopyOid(this Oid? oid)
         {
             if (s_oidIsInitOnceOnly)

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9ContentType.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9ContentType.cs
@@ -46,7 +46,7 @@ namespace System.Security.Cryptography.Pkcs
         // Private methods.
         //
 
-        [return: NotNullIfNotNull("rawData")]
+        [return: NotNullIfNotNull(nameof(rawData))]
         private static Oid? Decode(byte[]? rawData)
         {
             if (rawData == null)

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentDescription.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentDescription.cs
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography.Pkcs
         // Private methods.
         //
 
-        [return: NotNullIfNotNull("rawData")]
+        [return: NotNullIfNotNull(nameof(rawData))]
         private static string? Decode(byte[]? rawData)
         {
             if (rawData == null)

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentName.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentName.cs
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography.Pkcs
         // Private methods.
         //
 
-        [return: NotNullIfNotNull("rawData")]
+        [return: NotNullIfNotNull(nameof(rawData))]
         private static string? Decode(byte[]? rawData)
         {
             if (rawData == null)

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9LocalKeyId.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9LocalKeyId.cs
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.Pkcs
             _lazyKeyId = null;
         }
 
-        [return: NotNullIfNotNull("rawData")]
+        [return: NotNullIfNotNull(nameof(rawData))]
         private static byte[]? Decode(byte[]? rawData)
         {
             if (rawData == null)

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9MessageDigest.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9MessageDigest.cs
@@ -45,7 +45,7 @@ namespace System.Security.Cryptography.Pkcs
         // Private methods.
         //
 
-        [return: NotNullIfNotNull("rawData")]
+        [return: NotNullIfNotNull(nameof(rawData))]
         private static byte[]? Decode(byte[]? rawData)
         {
             if (rawData == null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -77,7 +77,7 @@ namespace System.Text.Json
             return null;
         }
 
-        [return: NotNullIfNotNull("converter")]
+        [return: NotNullIfNotNull(nameof(converter))]
         internal JsonConverter? ExpandConverterFactory(JsonConverter? converter, Type typeToConvert)
         {
             if (converter is JsonConverterFactory factory)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitMemberAccessor.cs
@@ -397,7 +397,7 @@ namespace System.Text.Json.Serialization.Metadata
                 typeof(ReflectionEmitMemberAccessor).Module,
                 skipVisibility: true);
 
-        [return: NotNullIfNotNull("method")]
+        [return: NotNullIfNotNull(nameof(method))]
         private static T? CreateDelegate<T>(DynamicMethod? method) where T : Delegate =>
             (T?)method?.CreateDelegate(typeof(T));
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Count.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Count.cs
@@ -73,7 +73,7 @@ namespace System.Text.RegularExpressions
         /// <exception cref="ArgumentNullException"><paramref name="input"/> or <paramref name="pattern"/> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not a valid bitwise combination of RegexOptions values.</exception>
         /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
-        public static int Count(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) =>
+        public static int Count(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Count(input);
 
         /// <summary>Searches an input string for all occurrences of a regular expression and returns the number of matches.</summary>
@@ -85,7 +85,7 @@ namespace System.Text.RegularExpressions
         /// <exception cref="ArgumentNullException"><paramref name="input"/> or <paramref name="pattern"/> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not a valid bitwise combination of RegexOptions values, or <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.</exception>
         /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
-        public static int Count(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
+        public static int Count(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Count(input);
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace System.Text.RegularExpressions
         /// <returns>The number of matches.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not a valid bitwise combination of RegexOptions values.</exception>
         /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
-        public static int Count(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) =>
+        public static int Count(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Count(input);
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace System.Text.RegularExpressions
         /// <returns>The number of matches.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not a valid bitwise combination of RegexOptions values, or <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.</exception>
         /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
-        public static int Count(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
+        public static int Count(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Count(input);
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.EnumerateMatches.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.EnumerateMatches.cs
@@ -41,7 +41,7 @@ namespace System.Text.RegularExpressions
         /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not a valid bitwise combination of RegexOptions values.</exception>
         /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
-        public static ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) =>
+        public static ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).EnumerateMatches(input);
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace System.Text.RegularExpressions
         /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not a valid bitwise combination of RegexOptions values, or <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.</exception>
         /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
-        public static ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
+        public static ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).EnumerateMatches(input);
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.cs
@@ -30,7 +30,7 @@ namespace System.Text.RegularExpressions
         /// supplied in the pattern parameter with matching options supplied in the options
         /// parameter.
         /// </summary>
-        public static bool IsMatch(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) =>
+        public static bool IsMatch(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).IsMatch(input);
 
         /// <summary>
@@ -44,10 +44,10 @@ namespace System.Text.RegularExpressions
         /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <see langword="null"/></exception>
         /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not in a valid <see cref="RegexOptions"/> value.</exception>
-        public static bool IsMatch(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) =>
+        public static bool IsMatch(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).IsMatch(input);
 
-        public static bool IsMatch(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
+        public static bool IsMatch(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).IsMatch(input);
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace System.Text.RegularExpressions
         /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not in a valid <see cref="RegexOptions"/> value or <paramref name="matchTimeout"/> is negative,
         /// zero, or greater than approximately 24 days.</exception>
-        public static bool IsMatch(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
+        public static bool IsMatch(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).IsMatch(input);
 
         /// <summary>
@@ -125,10 +125,10 @@ namespace System.Text.RegularExpressions
         /// supplied in the pattern parameter. Matching is modified with an option
         /// string.
         /// </summary>
-        public static Match Match(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) =>
+        public static Match Match(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Match(input);
 
-        public static Match Match(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
+        public static Match Match(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Match(input);
 
         /// <summary>
@@ -181,10 +181,10 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Returns all the successful matches as if Match were called iteratively numerous times.
         /// </summary>
-        public static MatchCollection Matches(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) =>
+        public static MatchCollection Matches(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Matches(input);
 
-        public static MatchCollection Matches(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
+        public static MatchCollection Matches(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Matches(input);
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -24,10 +24,10 @@ namespace System.Text.RegularExpressions
         /// the <paramref name="pattern "/>with the <paramref name="replacement "/>
         /// pattern, starting at the first character in the input string.
         /// </summary>
-        public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, string replacement, RegexOptions options) =>
+        public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, string replacement, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Replace(input, replacement);
 
-        public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, string replacement, RegexOptions options, TimeSpan matchTimeout) =>
+        public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, string replacement, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Replace(input, replacement);
 
         /// <summary>
@@ -94,10 +94,10 @@ namespace System.Text.RegularExpressions
         /// Replaces all occurrences of the <paramref name="pattern"/> with the recent
         /// replacement pattern, starting at the first character.
         /// </summary>
-        public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, MatchEvaluator evaluator, RegexOptions options) =>
+        public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, MatchEvaluator evaluator, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Replace(input, evaluator);
 
-        public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, MatchEvaluator evaluator, RegexOptions options, TimeSpan matchTimeout) =>
+        public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, MatchEvaluator evaluator, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Replace(input, evaluator);
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
@@ -18,10 +18,10 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Splits the <paramref name="input "/>string at the position defined by <paramref name="pattern"/>.
         /// </summary>
-        public static string[] Split(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) =>
+        public static string[] Split(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Split(input);
 
-        public static string[] Split(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
+        public static string[] Split(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Split(input);
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -56,12 +56,12 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Creates a regular expression object for the specified regular expression, with options that modify the pattern.
         /// </summary>
-        public Regex([StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) :
+        public Regex([StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) :
             this(pattern, options, s_defaultMatchTimeout, culture: null)
         {
         }
 
-        public Regex([StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, TimeSpan matchTimeout) :
+        public Regex([StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) :
             this(pattern, options, matchTimeout, culture: null)
         {
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGeneratorAttribute.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexGeneratorAttribute.cs
@@ -20,7 +20,7 @@ public sealed class RegexGeneratorAttribute : Attribute
     /// <summary>Initializes a new instance of the <see cref="RegexGeneratorAttribute"/> with the specified pattern and options.</summary>
     /// <param name="pattern">The regular expression pattern to match.</param>
     /// <param name="options">A bitwise combination of the enumeration values that modify the regular expression.</param>
-    public RegexGeneratorAttribute([StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) : this (pattern, options, Timeout.Infinite)
+    public RegexGeneratorAttribute([StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) : this (pattern, options, Timeout.Infinite)
     {
     }
 
@@ -28,7 +28,7 @@ public sealed class RegexGeneratorAttribute : Attribute
     /// <param name="pattern">The regular expression pattern to match.</param>
     /// <param name="options">A bitwise combination of the enumeration values that modify the regular expression.</param>
     /// <param name="matchTimeoutMilliseconds">A time-out interval (milliseconds), or <see cref="Timeout.Infinite"/> to indicate that the method should not time out.</param>
-    public RegexGeneratorAttribute([StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, int matchTimeoutMilliseconds)
+    public RegexGeneratorAttribute([StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, int matchTimeoutMilliseconds)
     {
         Pattern = pattern;
         Options = options;

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -133,67 +133,67 @@ namespace System.Web
             return result;
         }
 
-        [return: NotNullIfNotNull("s")]
+        [return: NotNullIfNotNull(nameof(s))]
         public static string? HtmlDecode(string? s) => HttpEncoder.HtmlDecode(s);
 
         public static void HtmlDecode(string? s, TextWriter output) => HttpEncoder.HtmlDecode(s, output);
 
-        [return: NotNullIfNotNull("s")]
+        [return: NotNullIfNotNull(nameof(s))]
         public static string? HtmlEncode(string? s) => HttpEncoder.HtmlEncode(s);
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         public static string? HtmlEncode(object? value) =>
             value == null ? null : HtmlEncode(Convert.ToString(value, CultureInfo.CurrentCulture) ?? string.Empty);
 
         public static void HtmlEncode(string? s, TextWriter output) => HttpEncoder.HtmlEncode(s, output);
 
-        [return: NotNullIfNotNull("s")]
+        [return: NotNullIfNotNull(nameof(s))]
         public static string? HtmlAttributeEncode(string? s) => HttpEncoder.HtmlAttributeEncode(s);
 
         public static void HtmlAttributeEncode(string? s, TextWriter output) => HttpEncoder.HtmlAttributeEncode(s, output);
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static string? UrlEncode(string? str) => UrlEncode(str, Encoding.UTF8);
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static string? UrlPathEncode(string? str) => HttpEncoder.UrlPathEncode(str);
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static string? UrlEncode(string? str, Encoding e) =>
             str == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(str, e));
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         public static string? UrlEncode(byte[]? bytes) => bytes == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(bytes));
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         public static string? UrlEncode(byte[]? bytes, int offset, int count) => bytes == null ? null : Encoding.ASCII.GetString(UrlEncodeToBytes(bytes, offset, count));
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static byte[]? UrlEncodeToBytes(string? str) => UrlEncodeToBytes(str, Encoding.UTF8);
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         public static byte[]? UrlEncodeToBytes(byte[]? bytes) => bytes == null ? null : UrlEncodeToBytes(bytes, 0, bytes.Length);
 
         [Obsolete("This method produces non-standards-compliant output and has interoperability issues. The preferred alternative is UrlEncodeToBytes(String).")]
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static byte[]? UrlEncodeUnicodeToBytes(string? str) => str == null ? null : Encoding.ASCII.GetBytes(UrlEncodeUnicode(str));
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static string? UrlDecode(string? str) => UrlDecode(str, Encoding.UTF8);
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         public static string? UrlDecode(byte[]? bytes, Encoding e) => bytes == null ? null : UrlDecode(bytes, 0, bytes.Length, e);
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static byte[]? UrlDecodeToBytes(string? str) => UrlDecodeToBytes(str, Encoding.UTF8);
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static byte[]? UrlDecodeToBytes(string? str, Encoding e) => str == null ? null : UrlDecodeToBytes(e.GetBytes(str));
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         public static byte[]? UrlDecodeToBytes(byte[]? bytes) => bytes == null ? null : UrlDecodeToBytes(bytes, 0, bytes.Length);
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static byte[]? UrlEncodeToBytes(string? str, Encoding e)
         {
             if (str == null)
@@ -205,21 +205,21 @@ namespace System.Web
             return HttpEncoder.UrlEncode(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
         }
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         public static byte[]? UrlEncodeToBytes(byte[]? bytes, int offset, int count) => HttpEncoder.UrlEncode(bytes, offset, count, alwaysCreateNewReturnValue: true);
 
         [Obsolete("This method produces non-standards-compliant output and has interoperability issues. The preferred alternative is UrlEncode(String).")]
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static string? UrlEncodeUnicode(string? str) => HttpEncoder.UrlEncodeUnicode(str);
 
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         public static string? UrlDecode(string? str, Encoding e) => HttpEncoder.UrlDecode(str, e);
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         public static string? UrlDecode(byte[]? bytes, int offset, int count, Encoding e) =>
             HttpEncoder.UrlDecode(bytes, offset, count, e);
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         public static byte[]? UrlDecodeToBytes(byte[]? bytes, int offset, int count) => HttpEncoder.UrlDecode(bytes, offset, count);
 
         public static string JavaScriptStringEncode(string? value) => HttpEncoder.JavaScriptStringEncode(value);

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -29,7 +29,7 @@ namespace System.Web.Util
                 || c == '\u2028'
                 || c == '\u2029';
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? HtmlAttributeEncode(string? value)
         {
             if (string.IsNullOrEmpty(value))
@@ -105,7 +105,7 @@ namespace System.Web.Util
             }
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? HtmlDecode(string? value) => string.IsNullOrEmpty(value) ? value : WebUtility.HtmlDecode(value);
 
         internal static void HtmlDecode(string? value, TextWriter output)
@@ -115,7 +115,7 @@ namespace System.Web.Util
             output.Write(WebUtility.HtmlDecode(value));
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? HtmlEncode(string? value) => string.IsNullOrEmpty(value) ? value : WebUtility.HtmlEncode(value);
 
         internal static void HtmlEncode(string? value, TextWriter output)
@@ -226,7 +226,7 @@ namespace System.Web.Util
             return b.ToString();
         }
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         internal static byte[]? UrlDecode(byte[]? bytes, int offset, int count)
         {
             if (!ValidateUrlEncodingParameters(bytes, offset, count))
@@ -272,7 +272,7 @@ namespace System.Web.Util
             return decodedBytes;
         }
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         internal static string? UrlDecode(byte[]? bytes, int offset, int count, Encoding encoding)
         {
             if (!ValidateUrlEncodingParameters(bytes, offset, count))
@@ -335,7 +335,7 @@ namespace System.Web.Util
             return Utf16StringValidator.ValidateString(helper.GetString());
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? UrlDecode(string? value, Encoding encoding)
         {
             if (value == null)
@@ -407,7 +407,7 @@ namespace System.Web.Util
             return Utf16StringValidator.ValidateString(helper.GetString());
         }
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         internal static byte[]? UrlEncode(byte[]? bytes, int offset, int count, bool alwaysCreateNewReturnValue)
         {
             byte[]? encoded = UrlEncode(bytes, offset, count);
@@ -417,7 +417,7 @@ namespace System.Web.Util
                 : encoded;
         }
 
-        [return: NotNullIfNotNull("bytes")]
+        [return: NotNullIfNotNull(nameof(bytes))]
         private static byte[]? UrlEncode(byte[]? bytes, int offset, int count)
         {
             if (!ValidateUrlEncodingParameters(bytes, offset, count))
@@ -540,7 +540,7 @@ namespace System.Web.Util
         }
 
         [Obsolete("This method produces non-standards-compliant output and has interoperability issues. The preferred alternative is UrlEncode(*).")]
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? UrlEncodeUnicode(string? value)
         {
             if (value == null)
@@ -585,7 +585,7 @@ namespace System.Web.Util
             return sb.ToString();
         }
 
-        [return: NotNullIfNotNull("value")]
+        [return: NotNullIfNotNull(nameof(value))]
         internal static string? UrlPathEncode(string? value)
         {
             if (string.IsNullOrEmpty(value))

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoderUtility.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoderUtility.cs
@@ -32,7 +32,7 @@ namespace System.Web.Util
         }
 
         //  Helper to encode spaces only
-        [return: NotNullIfNotNull("str")]
+        [return: NotNullIfNotNull(nameof(str))]
         internal static string? UrlEncodeSpaces(string? str) => str != null && str.Contains(' ') ? str.Replace(" ", "%20") : str;
     }
 }

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/DerivedTypes.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/DerivedTypes.Mono.cs
@@ -51,7 +51,7 @@ namespace System.Reflection.Emit
             this.m_baseType = elementType;
         }
 
-        [return: NotNullIfNotNull("elementName")]
+        [return: NotNullIfNotNull(nameof(elementName))]
         internal abstract string? FormatName(string? elementName);
 
         protected override bool IsArrayImpl()
@@ -412,7 +412,7 @@ namespace System.Reflection.Emit
             return (rank == 0) ? 1 : rank;
         }
 
-        [return: NotNullIfNotNull("elementName")]
+        [return: NotNullIfNotNull(nameof(elementName))]
         internal override string? FormatName(string? elementName)
         {
             if (elementName == null)
@@ -445,7 +445,7 @@ namespace System.Reflection.Emit
             return true;
         }
 
-        [return: NotNullIfNotNull("elementName")]
+        [return: NotNullIfNotNull(nameof(elementName))]
         internal override string? FormatName(string? elementName)
         {
             if (elementName == null)
@@ -491,7 +491,7 @@ namespace System.Reflection.Emit
             return true;
         }
 
-        [return: NotNullIfNotNull("elementName")]
+        [return: NotNullIfNotNull(nameof(elementName))]
         internal override string? FormatName(string? elementName)
         {
             if (elementName == null)

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
@@ -841,7 +841,7 @@ namespace System.Reflection.Emit
                     types[i] = ResolveUserType(types[i]);
         }
 
-        [return: NotNullIfNotNull("t")]
+        [return: NotNullIfNotNull(nameof(t))]
         internal static Type? ResolveUserType(Type? t)
         {
             if (t != null && ((t.GetType().Assembly != typeof(int).Assembly) || (t is TypeDelegator)))

--- a/src/mono/System.Private.CoreLib/src/System/Threading/Interlocked.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Interlocked.Mono.cs
@@ -14,10 +14,10 @@ namespace System.Threading
 
         [Intrinsic]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void CompareExchange(ref object? location1, ref object? value, ref object? comparand, [NotNullIfNotNull("location1")] ref object? result);
+        private static extern void CompareExchange(ref object? location1, ref object? value, ref object? comparand, [NotNullIfNotNull(nameof(location1))] ref object? result);
 
         [Intrinsic]
-        [return: NotNullIfNotNull("location1")]
+        [return: NotNullIfNotNull(nameof(location1))]
         public static object? CompareExchange(ref object? location1, object? value, object? comparand)
         {
             // This avoids coop handles, esp. on the output which would be particularly inefficient.
@@ -61,10 +61,10 @@ namespace System.Threading
         public static extern int Exchange(ref int location1, int value);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void Exchange([NotNullIfNotNull("value")] ref object? location1, ref object? value, [NotNullIfNotNull("location1")] ref object? result);
+        private static extern void Exchange([NotNullIfNotNull(nameof(value))] ref object? location1, ref object? value, [NotNullIfNotNull(nameof(location1))] ref object? result);
 
-        [return: NotNullIfNotNull("location1")]
-        public static object? Exchange([NotNullIfNotNull("value")] ref object? location1, object? value)
+        [return: NotNullIfNotNull(nameof(location1))]
+        public static object? Exchange([NotNullIfNotNull(nameof(value))] ref object? location1, object? value)
         {
             // See CompareExchange(object) for comments.
             object? result = null;
@@ -82,7 +82,7 @@ namespace System.Threading
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public static extern double CompareExchange(ref double location1, double value, double comparand);
 
-        [return: NotNullIfNotNull("location1")]
+        [return: NotNullIfNotNull(nameof(location1))]
         [Intrinsic]
         public static T CompareExchange<T>(ref T location1, T value, T comparand) where T : class?
         {
@@ -114,9 +114,9 @@ namespace System.Threading
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public static extern double Exchange(ref double location1, double value);
 
-        [return: NotNullIfNotNull("location1")]
+        [return: NotNullIfNotNull(nameof(location1))]
         [Intrinsic]
-        public static T Exchange<T>([NotNullIfNotNull("value")] ref T location1, T value) where T : class?
+        public static T Exchange<T>([NotNullIfNotNull(nameof(value))] ref T location1, T value) where T : class?
         {
             unsafe
             {

--- a/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -309,7 +309,7 @@ namespace System.Threading
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern ulong GetCurrentOSThreadId();
 
-        [MemberNotNull("self")]
+        [MemberNotNull(nameof(self))]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void InitInternal(Thread thread);
 


### PR DESCRIPTION
nameof can now be used in attributes on and in method signatures to refer to parameter names in the same signature.