### PR TITLE
Include libnethost.pdb in implementation packages

### DIFF
--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
@@ -23,16 +23,22 @@
         The symbols file is also shipped to enable users to fully debug
         binaries that link against the static version. -->
     <NativeBinary Include="$(DotNetHostBinDir)/libnethost.lib" />
-    <NativeBinary Include="$(DotNetHostBinDir)/PDB/libnethost.pdb" />
+    <_SymbolsToIncludeAlways Include="$(DotNetHostBinDir)PDB/libnethost.pdb" />
     <NativeBinary Include="$(DotNetHostBinDir)/libhostfxr.lib" />
-    <NativeBinary Include="$(DotNetHostBinDir)/PDB/libhostfxr.pdb" />
+    <_SymbolsToIncludeAlways Include="$(DotNetHostBinDir)PDB/libhostfxr.pdb" />
+
+    <!-- By default, the packaging infrastructure excludes all PDBs from implementation packages.
+        Explicitly set the excludes such that we exclude symbols corresponding to our native binaries
+        except for the ones we explicity want to include. -->
+    <LibPackageExcludes Include="@(NativeBinary -> '%2A%2A\%(Filename).pdb')" />
+    <LibPackageExcludes Remove="@(_SymbolsToIncludeAlways -> '%2A%2A\%(Filename).pdb')" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' != 'windows'">
     <NativeBinary Include="$(DotNetHostBinDir)/$(LibPrefix)hostfxr$(StaticLibSuffix)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
-    <File Include="@(NativeBinary)">
+    <File Include="@(NativeBinary);@(_SymbolsToIncludeAlways)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsNative>true</IsNative>
     </File>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
@@ -35,6 +35,12 @@
     <NativeRuntimeAsset Include="$(DotNetHostBinDir)/ijwhost.dll" />
     <NativeRuntimeAsset Include="$(DotNetHostBinDir)/ijwhost.lib" />
     <NativeRuntimeAsset Include="$(DotNetHostBinDir)/libnethost.lib" />
+
+    <!-- Always include the static library PDB. When consuming the static library on Windows,
+        the linker needs the PDB to produce complete debug information for whatever is linking
+        in the static library. Without the PDB, consumers will hit LNK4099. -->
+    <_SymbolsToIncludeAlways Include="$(DotNetHostBinDir)PDB/libnethost.pdb" />
+    <NativeRuntimeAsset Include="@(_SymbolsToIncludeAlways)" IncludeAlways="true" />
   </ItemGroup>
 
   <ItemGroup>
@@ -46,6 +52,9 @@
                     Include="@(NativeRuntimeAsset->'%(RootDir)%(Directory)PDB/%(Filename)%(Extension)%(SymbolsSuffix)')"
                     IsSymbolFile="true"
                     IsNative="true" />
+
+    <!-- Remove symbols that are explicitly shipped with implementation package -->
+    <_SymbolFiles Remove="@(_SymbolsToIncludeAlways)" />
   </ItemGroup>
 
   <Target Name="AddSymbolFiles" BeforeTargets="GetFilesToPackage">


### PR DESCRIPTION
Include `libnethost.pdb` in implementation packages for host runtime pack and nuget package - `Microsoft.NETCore.App.Host.sfxproj` and `Microsoft.NETCore.DotNetAppHost.pkgproj` - instead of just symbol packages.

Fixes https://github.com/dotnet/runtime/issues/63602

cc @vitek-karas 