### PR TITLE
Re-enable the ability to use in-build signing

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -51,14 +51,15 @@
     <FileSignInfo Update="@(FileSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="MicrosoftDotNet500" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(PrepareArtifacts)' == 'true' and '$(PostBuildSign)' == 'true'">
+  <ItemGroup Condition="'$(PrepareArtifacts)' == 'true'">
     <ItemsToSignWithPaths Include="$(DownloadDirectory)**\*.msi" />
     <ItemsToSignWithPaths Include="$(DownloadDirectory)**\*.exe" />
     <ItemsToSignWithPaths Include="$(DownloadDirectory)**\*.nupkg" />
     <ItemsToSignWithPaths Include="$(DownloadDirectory)**\*.zip" />
 
     <ItemsToSignWithoutPaths Include="@(ItemsToSignWithPaths->'%(Filename)%(Extension)')" />
-    <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" />
+    <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" Condition="'$(PostBuildSign)' == 'true'" />
+    <ItemsToSign Include="@(ItemsToSignWithPaths->Distinct())" Condition="'$(PostBuildSign)' != 'true'" />
   </ItemGroup>
 
   <Target Name="SetupFilesToSign">

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -12,7 +12,7 @@ jobs:
     name: NetCore1ESPool-Internal
     demands: ImageOverride -equals build.windows.amd64.vs2022
   # Double the default timeout.
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   workspace:
     clean: all
 

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -15,4 +15,11 @@
       want to ensure we use the correct packages. -->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
+
+  <!-- Construct the path to the sign project, so that signing can be called during prepare-artifacts -->
+  <PropertyGroup>
+    <ArcadeSdkMSBuildProjectDir>$([System.IO.Path]::GetDirectoryName('$(ArcadeSdkBuildTasksAssembly)'))\..\</ArcadeSdkMSBuildProjectDir>
+    <ArcadeSdkSignProject>$(ArcadeSdkMSBuildProjectDir)Sign.proj</ArcadeSdkSignProject>
+  </PropertyGroup>
+
 </Project>

--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -57,12 +57,26 @@
   </ItemGroup>
 
   <!--
+    Run Arcade's signing project directly. The 'eng/Signing.props' extensibility props file checks
+    if '$(<StageName>)' == 'true' and points Arcade to the correct files.
+  -->
+  <Target Name="SignArtifacts"
+          Condition="'$(PostBuildSign)' != 'true'" >
+    <MSBuild
+      Projects="$(ArcadeSdkSignProject)"
+      Targets="Sign"
+      Properties="
+        DownloadDirectory=$(DownloadDirectory);
+        PrepareArtifacts=$(PrepareArtifacts)" />
+  </Target>
+
+  <!--
     Take assets from the build jobs, prepare them for publishing (signing, arrangement) then upload
     them to the pipeline for Arcade and custom steps to publish.
   -->
   <Target Name="PreparePublishToAzureBlobFeed"
           AfterTargets="Build"
-          DependsOnTargets="GetProductVersions;FindDownloadedArtifacts;CreateChecksums">
+          DependsOnTargets="GetProductVersions;FindDownloadedArtifacts;SignArtifacts;CreateChecksums">
     <PropertyGroup>
       <AssetManifestFilename>Manifest.xml</AssetManifestFilename>
       <AssetManifestFile>$(ArtifactsLogDir)AssetManifest/$(AssetManifestFilename)</AssetManifestFile>


### PR DESCRIPTION
Re-enable in-build signing (as an option, not on by default yet). In constrast to how in-build signing was performed previously for any installer artifacts, the new in-build signing uses the same exact approach as post-build signing does today. Pass all top-level artifacts and wixpacks as ItemsToSign, and let the signing infrastructure do all the unpacking and repacking.

Also increase the timeout in the prepare-artifacts stage.