### PR TITLE
Fix ClonedServer_ActsAsOriginalServer test

### DIFF
--- a/src/libraries/System.IO.Pipes/tests/PipeStreamConformanceTests.cs
+++ b/src/libraries/System.IO.Pipes/tests/PipeStreamConformanceTests.cs
@@ -133,14 +133,15 @@ namespace System.IO.Pipes.Tests
                 Task<int> clientTask = readable.ReadAsync(received1, 0, received1.Length);
                 using (NamedPipeServerStream server = new NamedPipeServerStream(PipeDirection.Out, false, true, serverBase.SafePipeHandle))
                 {
-                    if (OperatingSystem.IsWindows())
-                    {
-                        Assert.Equal(1, ((NamedPipeClientStream)readable).NumberOfServerInstances);
-                    }
                     server.Write(msg1, 0, msg1.Length);
                     int receivedLength = await clientTask;
                     Assert.Equal(msg1.Length, receivedLength);
                     Assert.Equal(msg1, received1);
+
+                    if (OperatingSystem.IsWindows())
+                    {
+                        Assert.Equal(1, ((NamedPipeClientStream)readable).NumberOfServerInstances);
+                    }
                 }
             }
             else


### PR DESCRIPTION
We recently introduced a configuration of the pipe stream tests where named pipes are constructed with PipeOptions.None.  And in that configuration, the ClonedServer_ActsAsOriginalServer has started sporadically hanging.  It appears that the GetNamedPipeHandleStateW function called by NamedPipeClientStream.NumberOfServerInstances takes some lock that ReadFileW also holds while doing a synchronous read; as such, if the wrong interleaving of operations occurs, the queued work item that performs a read can end up blocking the assert check of NumberOfServerInstances from completing, and the test deadlocks.  The fix is simply to move the assert until after the write that satisifes the read.