### PR TITLE
Bail ThreadAbort redirection after catch handlers on Unix

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -784,7 +784,11 @@ UINT_PTR ExceptionTracker::FinishSecondPass(
     {
         CopyOSContext(pThread->m_OSContext, pContextRecord);
         SetIP(pThread->m_OSContext, (PCODE)uResumePC);
+#ifdef TARGET_UNIX
+        uAbortAddr = NULL;
+#else
         uAbortAddr = (UINT_PTR)COMPlusCheckForAbort(uResumePC);
+#endif
     }
 
     if (uAbortAddr)


### PR DESCRIPTION
Fixes #12739 to prevent crashes.

The redirection stub was never implemented, leading to crashes in scenarios like Debugger Function Evaluations. Instead of rethrowing the exception after the catch clause, this allows the `ThreadAbortException` to flow as any usual exception and hopefully surface through other points that call mechanisms like `Thread::HandleThreadAbort`. This is a behavior difference between Unix and non-Unix plaforms with some observable side effects, but `Thread.Abort` is not supported in core. Most commonly the debugger is the major scenario where ThreadAbort gets used, and this prevents the crash. 

I've opened https://github.com/dotnet/runtime/issues/72703 to amend the behavior. 