### PR TITLE
[QUIC] Return connection dispose in H3loopback connection

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
@@ -69,19 +69,20 @@ namespace System.Net.Test.Common
                 await stream.DisposeAsync().ConfigureAwait(false);
             }
 
-            // We don't dispose the connection currently, because this causes races when the server connection is closed before
-            // the client has received and handled all response data.
-            // See discussion in https://github.com/dotnet/runtime/pull/57223#discussion_r687447832
-#if false
             // Dispose the connection
             // If we already waited for graceful shutdown from the client, then the connection is already closed and this will simply release the handle.
             // If not, then this will silently abort the connection.
-            _connection.Dispose();
+            await _connection.DisposeAsync();
 
             // Dispose control streams so that we release their handles too.
-            await _inboundControlStream?.DisposeAsync().ConfigureAwait(false);
-            await _outboundControlStream?.DisposeAsync().ConfigureAwait(false);
-#endif
+            if (_inboundControlStream is not null)
+            {
+                await _inboundControlStream.DisposeAsync().ConfigureAwait(false);
+            }
+            if (_outboundControlStream is not null)
+            {
+                await _outboundControlStream.DisposeAsync().ConfigureAwait(false);
+            }
         }
 
         public Task CloseAsync(long errorCode) => _connection.CloseAsync(errorCode).AsTask();

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -625,7 +625,7 @@ namespace System.Net.Quic.Tests
             };
 
             (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection(null, listenerOptions);
-            await AssertThrowsQuicExceptionAsync(QuicError.ConnectionAborted, async () => await serverConnection.AcceptInboundStreamAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(100)));
+            await AssertThrowsQuicExceptionAsync(QuicError.ConnectionIdle, async () => await serverConnection.AcceptInboundStreamAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(100)));
             await serverConnection.DisposeAsync();
             await clientConnection.DisposeAsync();
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/57779

Seems like everything is working as it should. We do have `WaitForClientDisconnectAsync` as part of H3Loopback connection shutdown.