### PR TITLE
Fix nativeaot arm64 build on macOS

### DIFF
--- a/src/coreclr/nativeaot/Runtime/arm64/AllocFast.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/AllocFast.S
@@ -59,14 +59,14 @@ OFFSETOF__Thread__m_alloc_context__alloc_limit      = OFFSETOF__Thread__m_rgbAll
 
 RhpNewFast_RarePath:
         mov         x1, #0
-        b           RhpNewObject
+        b           C_FUNC(RhpNewObject)
     LEAF_END RhpNewFast, _TEXT
 
 // Allocate non-array object with finalizer.
 //  x0 == MethodTable
     LEAF_ENTRY RhpNewFinalizable, _TEXT
         mov         x1, #GC_ALLOC_FINALIZE
-        b           RhpNewObject
+        b           C_FUNC(RhpNewObject)
     LEAF_END RhpNewFinalizable, _TEXT
 
 // Allocate non-array object.
@@ -85,7 +85,7 @@ RhpNewFast_RarePath:
 
         // Call the rest of the allocation helper.
         // void* RhpGcAlloc(MethodTable *pEEType, uint32_t uFlags, uintptr_t numElements, void * pTransitionFrame)
-        bl          RhpGcAlloc
+        bl          C_FUNC(RhpGcAlloc)
 
         // Set the new objects MethodTable pointer on success.
         cbz         x0, NewOutOfMemory
@@ -101,7 +101,7 @@ NewOutOfMemory:
         mov         x1, 0              // Indicate that we should throw OOM.
 
         POP_COOP_PINVOKE_FRAME
-        b RhExceptionHandling_FailedAllocation
+        b C_FUNC(RhExceptionHandling_FailedAllocation)
 
     NESTED_END RhpNewObject, _TEXT
 
@@ -139,7 +139,7 @@ NewOutOfMemory:
         add         x2, x2, x12
         ldr         x12, [x3, #OFFSETOF__Thread__m_alloc_context__alloc_limit]
         cmp         x2, x12
-        bhi         RhpNewArrayRare
+        bhi         C_FUNC(RhpNewArrayRare)
 
         // Reload new object address into r12.
         ldr         x12, [x3, #OFFSETOF__Thread__m_alloc_context__alloc_ptr]
@@ -163,7 +163,7 @@ StringSizeOverflow:
 
         // x0 holds MethodTable pointer already
         mov         x1, #1                  // Indicate that we should throw OverflowException
-        b           RhExceptionHandling_FailedAllocation
+        b           C_FUNC(RhExceptionHandling_FailedAllocation)
     LEAF_END    RhNewString, _Text
 
 // Allocate one dimensional, zero based array (SZARRAY).
@@ -204,7 +204,7 @@ StringSizeOverflow:
         add         x2, x2, x12
         ldr         x12, [x3, #OFFSETOF__Thread__m_alloc_context__alloc_limit]
         cmp         x2, x12
-        bhi         RhpNewArrayRare
+        bhi         C_FUNC(RhpNewArrayRare)
 
         // Reload new object address into x12.
         ldr         x12, [x3, #OFFSETOF__Thread__m_alloc_context__alloc_ptr]
@@ -228,7 +228,7 @@ ArraySizeOverflow:
 
         // x0 holds MethodTable pointer already
         mov         x1, #1                  // Indicate that we should throw OverflowException
-        b           RhExceptionHandling_FailedAllocation
+        b           C_FUNC(RhExceptionHandling_FailedAllocation)
     LEAF_END    RhpNewArray, _TEXT
 
 // Allocate one dimensional, zero based array (SZARRAY) using the slow path that calls a runtime helper.
@@ -251,7 +251,7 @@ ArraySizeOverflow:
         mov         x1, #0              // uFlags
 
         // void* RhpGcAlloc(MethodTable *pEEType, uint32_t uFlags, uintptr_t numElements, void * pTransitionFrame)
-        bl          RhpGcAlloc
+        bl          C_FUNC(RhpGcAlloc)
 
         // Set the new objects MethodTable pointer and length on success.
         cbz         x0, ArrayOutOfMemory
@@ -267,6 +267,6 @@ ArrayOutOfMemory:
         mov         x1, 0               // Indicate that we should throw OOM.
 
         POP_COOP_PINVOKE_FRAME
-        b RhExceptionHandling_FailedAllocation
+        b C_FUNC(RhExceptionHandling_FailedAllocation)
 
     NESTED_END RhpNewArrayRare, _TEXT

--- a/src/coreclr/nativeaot/Runtime/arm64/ExceptionHandling.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/ExceptionHandling.S
@@ -201,7 +201,7 @@
 
 .macro GetThreadX2
     stp x0, x1, [sp, -16]!
-    bl RhpGetThread
+    bl C_FUNC(RhpGetThread)
     mov x2, x0
     ldp x0, x1, [sp], 16
 .endm
@@ -243,7 +243,7 @@
 
         // w0: exception code
         // x1: ExInfo*
-        bl          RhThrowHwEx
+        bl          C_FUNC(RhThrowHwEx)
 
     EXPORT_POINTER_TO_ADDRESS PointerToRhpThrowHwEx2
 
@@ -330,7 +330,7 @@ NotHijacked:
 
         // x0: exception object
         // x1: ExInfo*
-        bl          RhThrowEx
+        bl          C_FUNC(RhThrowEx)
 
     EXPORT_POINTER_TO_ADDRESS PointerToRhpThrowEx2
 
@@ -375,7 +375,7 @@ NotHijacked:
 
         // x0 contains the currently active ExInfo
         // x1 contains the address of the new ExInfo
-        bl          RhRethrow
+        bl          C_FUNC(RhRethrow)
 
     EXPORT_POINTER_TO_ADDRESS PointerToRhpRethrow2
 
@@ -417,7 +417,7 @@ NotHijacked:
         // clear the DoNotTriggerGc flag, trashes x4-x6
         //
 
-        bl RhpGetThread
+        bl C_FUNC(RhpGetThread)
         str x0, [sp, rsp_CatchFunclet_offset_thread]
         mov x5,x0
         ldp x0, x1,   [sp, #0x40]
@@ -469,7 +469,7 @@ ClearSuccess_Catch:
         ldr         x0, [sp, rsp_CatchFunclet_offset_thread]    // x0 <- Thread*
         ldr         x1, [sp, #rsp_offset_x3]                    // x1 <- current ExInfo*
         ldr         x2, [x2, #OFFSETOF__REGDISPLAY__SP]         // x2 <- resume SP value
-        bl          RhpValidateExInfoPop
+        bl          C_FUNC(RhpValidateExInfoPop)
 
         ldr         x2, [sp, rsp_offset_x2]                             // x2 <- REGDISPLAY*
 
@@ -510,7 +510,7 @@ DonePopping:
         mov         x1, x0                                     // x1 <- continuation address as exception PC
         mov         w0, #STATUS_REDHAWK_THREAD_ABORT
         mov         sp, x2
-        b           RhpThrowHwEx
+        b           C_FUNC(RhpThrowHwEx)
 
 NoAbort:
         // reset SP and jump to continuation address
@@ -552,7 +552,7 @@ NoAbort:
         // clear the DoNotTriggerGc flag, trashes x2-x4
         //
 
-        bl RhpGetThread
+        bl C_FUNC(RhpGetThread)
         str x0, [sp, rsp_FinallyFunclet_offset_thread]
         mov x2, x0
         ldp x0, x1, [sp, #0x40]

--- a/src/coreclr/nativeaot/Runtime/arm64/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/GcProbe.S
@@ -4,17 +4,17 @@
 #include <unixasmmacros.inc>
 #include "AsmOffsets.inc"
 
-    .global RhpGcPoll2
+    .global C_FUNC(RhpGcPoll2)
 
     LEAF_ENTRY RhpGcPoll
         PREPARE_EXTERNAL_VAR_INDIRECT_W RhpTrapThreads, 0
-        cbnz    w0, RhpGcPollRare // TrapThreadsFlags_None = 0
+        cbnz    w0, C_FUNC(RhpGcPollRare) // TrapThreadsFlags_None = 0
         ret
     LEAF_END RhpGcPoll
 
     NESTED_ENTRY RhpGcPollRare, _TEXT, NoHandler
         PUSH_COOP_PINVOKE_FRAME x0
-        bl RhpGcPoll2
+        bl C_FUNC(RhpGcPoll2)
         POP_COOP_PINVOKE_FRAME
         ret
     NESTED_END RhpGcPollRare

--- a/src/coreclr/nativeaot/Runtime/arm64/StubDispatch.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/StubDispatch.S
@@ -47,7 +47,7 @@
     .endr
 
         // x11 still contains the indirection cell address.
-        b RhpInterfaceDispatchSlow
+        b C_FUNC(RhpInterfaceDispatchSlow)
 
     NESTED_END "RhpInterfaceDispatch\entries", _TEXT
 
@@ -80,7 +80,7 @@
         ldr     xzr, [x0]
 
         // Just tail call to the cache miss helper.
-        b RhpInterfaceDispatchSlow
+        b C_FUNC(RhpInterfaceDispatchSlow)
     LEAF_END RhpInitialInterfaceDispatch, _TEXT
 
 //
@@ -113,7 +113,7 @@
         //  xip1: parameter of the thunk's target
         PREPARE_EXTERNAL_VAR RhpCidResolve, xip0
         mov xip1, x11
-        b       RhpUniversalTransition_DebugStepTailCall
+        b       C_FUNC(RhpUniversalTransition_DebugStepTailCall)
     LEAF_END RhpInterfaceDispatchSlow, _TEXT
 
 #endif // FEATURE_CACHED_INTERFACE_DISPATCH

--- a/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
@@ -201,7 +201,7 @@
 
         mov     x14, x0                     ; x14 = dst
         mov     x15, x1                     ; x15 = val
-        b       RhpCheckedAssignRefArm64
+        b       C_FUNC(RhpCheckedAssignRefArm64)
 
 LEAF_END RhpCheckedAssignRef, _TEXT
 
@@ -221,7 +221,7 @@ LEAF_ENTRY RhpAssignRef, _TEXT
 
         mov     x14, x0                     ; x14 = dst
         mov     x15, x1                     ; x15 = val
-        b       RhpAssignRefArm64
+        b       C_FUNC(RhpAssignRefArm64)
 
 LEAF_END RhpAssignRef, _TEXT
 

--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosarm64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosarm64.inc
@@ -6,8 +6,11 @@
 .macro NESTED_ENTRY Name, Section, Handler
         LEAF_ENTRY \Name, \Section
         .ifnc \Handler, NoHandler
+#if defined(__APPLE__)
+        .cfi_personality 0x9b, C_FUNC(\Handler) // 0x9b == DW_EH_PE_indirect | DW_EH_PE_pcrel | DW_EH_PE_sdata4
+#else
         .cfi_personality 0x1b, C_FUNC(\Handler) // 0x1b == DW_EH_PE_pcrel | DW_EH_PE_sdata4
-        // @TODO: Check if we have systems that use indirect personality 0x9b == DW_EH_PE_indirect | DW_EH_PE_pcrel | DW_EH_PE_sdata4
+#endif
         .endif
 .endm
 
@@ -22,42 +25,68 @@ C_FUNC(\Name):
 
 .macro ALTERNATE_ENTRY Name
         .global C_FUNC(\Name)
+#if !defined(__APPLE__)
         .hidden C_FUNC(\Name)
+#endif
 C_FUNC(\Name):
 .endm
 
 .macro LABELED_RETURN_ADDRESS Name
         .global C_FUNC(\Name)
+#if !defined(__APPLE__)
         .hidden C_FUNC(\Name)
+#endif
 C_FUNC(\Name):
 .endm
 
 .macro LEAF_ENTRY Name, Section
         .global C_FUNC(\Name)
+#if defined(__APPLE__)
+        .text
+        .p2align        2
+#else
         .hidden C_FUNC(\Name)
         .type \Name, %function
+#endif
 C_FUNC(\Name):
         .cfi_startproc
 .endm
 
 .macro LEAF_END Name, Section
+#if !defined(__APPLE__)
         .size \Name, .-\Name
+#endif
         .cfi_endproc
 .endm
 
 .macro PREPARE_EXTERNAL_VAR Name, HelperReg
+#if defined(__APPLE__)
+        adrp \HelperReg, C_FUNC(\Name)@GOTPAGE
+        ldr  \HelperReg, [\HelperReg, C_FUNC(\Name)@GOTPAGEOFF]
+#else
         adrp \HelperReg, C_FUNC(\Name)
         add  \HelperReg, \HelperReg, :lo12:C_FUNC(\Name)
+#endif
 .endm
 
 .macro PREPARE_EXTERNAL_VAR_INDIRECT Name, HelperReg
+#if defined(__APPLE__)
+        adrp \HelperReg, C_FUNC(\Name)@GOTPAGE
+        ldr  \HelperReg, [\HelperReg, C_FUNC(\Name)@GOTPAGEOFF]
+#else
         adrp \HelperReg, C_FUNC(\Name)
         ldr  \HelperReg, [\HelperReg, :lo12:C_FUNC(\Name)]
+#endif
 .endm
 
 .macro PREPARE_EXTERNAL_VAR_INDIRECT_W Name, HelperReg
+#if defined(__APPLE__)
+        adrp x\HelperReg, C_FUNC(\Name)@GOTPAGE
+        ldr  w\HelperReg, [x\HelperReg, C_FUNC(\Name)@GOTPAGEOFF]
+#else
         adrp x\HelperReg, C_FUNC(\Name)
         ldr  w\HelperReg, [x\HelperReg, :lo12:C_FUNC(\Name)]
+#endif
 .endm
 
 
@@ -199,21 +228,33 @@ C_FUNC(\Name):
 
     // This sequence of instructions is recognized and potentially patched
     // by the linker (GD->IE/LE relaxation).
+#if defined(__APPLE__)
+    adrp    x0, \var@TLVPPAGE
+    ldr     x0, [x0, \var@TLVPPAGEOFF]
+    ldr     \target, [x0]
+
+    blr     \target
+    // End of the sequence
+
+    mov     \target, x0
+#else
     adrp    x0, :tlsdesc:\var
     ldr     \target, [x0, #:tlsdesc_lo12:\var]
     add     x0, x0, :tlsdesc_lo12:\var
-.tlsdesccall \var
+    .tlsdesccall \var
     blr     \target
     // End of the sequence
 
     mrs     \target, tpidr_el0
     add     \target, \target, x0
+#endif
+
     ldp     x0, lr, [sp],#0x10
 .endm
 
 // Inlined version of RhpGetThread. Target cannot be x0.
 .macro INLINE_GETTHREAD target
-    INLINE_GET_TLS_VAR \target, tls_CurrentThread
+    INLINE_GET_TLS_VAR \target, C_FUNC(tls_CurrentThread)
 .endm
 
 // Do not use these ETLS macros in functions that already create a stack frame.
@@ -223,7 +264,7 @@ C_FUNC(\Name):
     PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -32           // ;; Push down stack pointer and store FP and LR
     str         x0,  [sp, #0x10]
 
-    bl RhpGetThread
+    bl C_FUNC(RhpGetThread)
     mov x1, x0
 
     ldr         x0,  [sp, #0x10]
@@ -235,7 +276,7 @@ C_FUNC(\Name):
     stp         x0, x1, [sp, #0x10]
     str         x2,  [sp, #0x20]
 
-    bl RhpGetThread
+    bl C_FUNC(RhpGetThread)
     mov x3, x0
 
     ldp         x0, x1, [sp, #0x10]
@@ -290,7 +331,9 @@ C_FUNC(\Name):
 C_FUNC(\Name):
         .quad       1b
         .global     C_FUNC(\Name)
+#if !defined(__APPLE__)
         .hidden     C_FUNC(\Name)
+#endif
         .text
 .endm
 


### PR DESCRIPTION
It fixes this sort of assembler errors during the `clr` subset build:

```
...
<instantiation>:2:9: error: unknown directive
        .hidden _RhpNewFast
        ^
/runtime/src/coreclr/nativeaot/Runtime/arm64/AllocFast.S:21:5: note: while in macro instantiation
    LEAF_ENTRY RhpNewFast, _TEXT
    ^
<instantiation>:3:9: error: unknown directive
        .type RhpNewFast, %function
        ^
/runtime/src/coreclr/nativeaot/Runtime/arm64/AllocFast.S:21:5: note: while in macro instantiation
    LEAF_ENTRY RhpNewFast, _TEXT
    ^
...
```

nativeaot build is still disabled for osx-arm64 in configs. This helps implementing support on top of latest main.

Part of #67232 (some other parts of WIP patch have already been merged / squashed in https://github.com/dotnet/runtime/commit/8c7165193f164422429f2bf6a9136a8b7bf2c92a, https://github.com/dotnet/runtime/commit/17b3c56aed62d75ecb2c9d3ce7330b6dd92d957f and https://github.com/dotnet/runtime/commit/41def7c0cf6f848784a0d00f33abd5dc608bbfea) 