### PR TITLE
[HTTP/3] Fixed stress error System.Exception: Completed unexpectedly

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -531,7 +531,6 @@ public sealed partial class QuicStream
     }
     private unsafe int HandleEventPeerSendAborted(ref PEER_SEND_ABORTED data)
     {
-        _receiveBuffers.SetFinal();
         _receiveTcs.TrySetException(ThrowHelper.GetStreamAbortedException((long)data.ErrorCode), final: true);
         return QUIC_STATUS_SUCCESS;
     }


### PR DESCRIPTION
Fixed stress error:
```
System.Exception: Completed unexpectedly
   at HttpStress.ClientOperations.<>c.<<get_Operations>b__1_4>d.MoveNext() in /home/manicka/repositories/runtime.2/src/libraries/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs:line 290
--- End of stack trace from previous location ---
   at HttpStress.StressClient.<>c__DisplayClass17_0.<<StartCore>g__RunWorker|0>d.MoveNext() in /home/manicka/repositories/runtime.2/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs:line 204
```
consistently happening for GET Aborted.