### PR TITLE
Fix ARM64 Unix debugging

### DIFF
--- a/src/coreclr/dlls/mscordbi/mscordbi.cpp
+++ b/src/coreclr/dlls/mscordbi/mscordbi.cpp
@@ -10,6 +10,12 @@
 //*****************************************************************************
 #include "stdafx.h"
 
+#if defined(HOST_ARM64) && defined(TARGET_UNIX)
+// Flag to check if atomics feature is available on
+// the machine
+bool g_arm64_atomics_present = false;
+#endif
+
 extern BOOL WINAPI DbgDllMain(HINSTANCE hInstance, DWORD dwReason,
                                          LPVOID lpReserved);
 
@@ -19,13 +25,6 @@ extern BOOL WINAPI DbgDllMain(HINSTANCE hInstance, DWORD dwReason,
 //*****************************************************************************
 extern "C"
 #ifdef TARGET_UNIX
-
-#if defined(HOST_ARM64)
-// Flag to check if atomics feature is available on
-// the machine
-bool g_arm64_atomics_present = false;
-#endif
-
 DLLEXPORT // For Win32 PAL LoadLibrary emulation
 #endif
 BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)


### PR DESCRIPTION
This global flag was defined in between the extern C qualifier and the export statement. This resulted in hidden visibility and a mangled symbol export. Pull it out of the signature.