### PR TITLE
Revert "Detect truncated GZip streams (#61768)"

### DIFF
--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -16,16 +16,6 @@ namespace System.IO.Compression
     {
         private const int TaskTimeout = 30 * 1000; // Generous timeout for official test runs
 
-        public enum TestScenario
-        {
-            ReadByte,
-            ReadByteAsync,
-            Read,
-            ReadAsync,
-            Copy,
-            CopyAsync,
-        }
-
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public virtual void FlushAsync_DuringWriteAsync()
         {
@@ -488,6 +478,7 @@ namespace System.IO.Compression
             Assert.True(optimalLength >= smallestLength);
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47563")]
         [Theory]
         [InlineData(TestScenario.ReadAsync)]
         [InlineData(TestScenario.Read)]
@@ -566,6 +557,16 @@ namespace System.IO.Compression
                 }
             }
         }
+    }
+
+    public enum TestScenario
+    {
+        ReadByte,
+        ReadByteAsync,
+        Read,
+        ReadAsync,
+        Copy,
+        CopyAsync
     }
 
     internal sealed class BadWrappedStream : MemoryStream

--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -64,7 +64,6 @@ namespace System.IO.Compression.Tests
                 bytesLeftToRead -= bytesRead;
             }
         }
-
         public static async Task<int> ReadAllBytesAsync(Stream stream, byte[] buffer, int offset, int count)
         {
             int bytesRead;
@@ -111,11 +110,6 @@ namespace System.IO.Compression.Tests
             StreamsEqual(ast, bst, -1);
         }
 
-        public static async Task StreamsEqualAsync(Stream ast, Stream bst)
-        {
-            await StreamsEqualAsync(ast, bst, -1);
-        }
-
         public static void StreamsEqual(Stream ast, Stream bst, int blocksToRead)
         {
             if (ast.CanSeek)
@@ -138,44 +132,8 @@ namespace System.IO.Compression.Tests
                 if (blocksToRead != -1 && blocksRead >= blocksToRead)
                     break;
 
-                ac = ReadAllBytes(ast, ad, 0, bufSize);
-                bc = ReadAllBytes(bst, bd, 0, bufSize);
-
-                if (ac != bc)
-                {
-                    bd = NormalizeLineEndings(bd);
-                }
-
-                Assert.True(ArraysEqual<byte>(ad, bd, ac), "Stream contents not equal: " + ast.ToString() + ", " + bst.ToString());
-
-                blocksRead++;
-            } while (ac == bufSize);
-        }
-
-        public static async Task StreamsEqualAsync(Stream ast, Stream bst, int blocksToRead)
-        {
-            if (ast.CanSeek)
-                ast.Seek(0, SeekOrigin.Begin);
-            if (bst.CanSeek)
-                bst.Seek(0, SeekOrigin.Begin);
-
-            const int bufSize = 4096;
-            byte[] ad = new byte[bufSize];
-            byte[] bd = new byte[bufSize];
-
-            int ac = 0;
-            int bc = 0;
-
-            int blocksRead = 0;
-
-            //assume read doesn't do weird things
-            do
-            {
-                if (blocksToRead != -1 && blocksRead >= blocksToRead)
-                    break;
-
-                ac = await ReadAllBytesAsync(ast, ad, 0, bufSize);
-                bc = await ReadAllBytesAsync(bst, bd, 0, bufSize);
+                ac = ReadAllBytes(ast, ad, 0, 4096);
+                bc = ReadAllBytes(bst, bd, 0, 4096);
 
                 if (ac != bc)
                 {

--- a/src/libraries/System.IO.Compression.Brotli/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression.Brotli/src/Resources/Strings.resx
@@ -175,9 +175,6 @@
   <data name="BrotliStream_Decompress_InvalidStream" xml:space="preserve">
     <value>BrotliStream.BaseStream returned more bytes than requested in Read.</value>
   </data>
-  <data name="BrotliStream_Decompress_TruncatedData" xml:space="preserve">
-    <value>Decoder ran into truncated data.</value>
-  </data>
   <data name="IOCompressionBrotli_PlatformNotSupported" xml:space="preserve">
     <value>System.IO.Compression.Brotli is not supported on this platform.</value>
   </data>

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
@@ -15,7 +15,6 @@ namespace System.IO.Compression
         private BrotliDecoder _decoder;
         private int _bufferOffset;
         private int _bufferCount;
-        private bool _nonEmptyInput;
 
         /// <summary>Reads a number of decompressed bytes into the specified byte array.</summary>
         /// <param name="buffer">The array used to store decompressed bytes.</param>
@@ -66,12 +65,9 @@ namespace System.IO.Compression
                 int bytesRead = _stream.Read(_buffer, _bufferCount, _buffer.Length - _bufferCount);
                 if (bytesRead <= 0)
                 {
-                    if (_nonEmptyInput && !buffer.IsEmpty)
-                        ThrowTruncatedInvalidData();
                     break;
                 }
 
-                _nonEmptyInput = true;
                 _bufferCount += bytesRead;
 
                 if (_bufferCount > _buffer.Length)
@@ -154,12 +150,9 @@ namespace System.IO.Compression
                         int bytesRead = await _stream.ReadAsync(_buffer.AsMemory(_bufferCount), cancellationToken).ConfigureAwait(false);
                         if (bytesRead <= 0)
                         {
-                            if (_nonEmptyInput && !buffer.IsEmpty)
-                                ThrowTruncatedInvalidData();
                             break;
                         }
 
-                        _nonEmptyInput = true;
                         _bufferCount += bytesRead;
 
                         if (_bufferCount > _buffer.Length)
@@ -238,8 +231,5 @@ namespace System.IO.Compression
             // The stream is either malicious or poorly implemented and returned a number of
             // bytes larger than the buffer supplied to it.
             throw new InvalidDataException(SR.BrotliStream_Decompress_InvalidStream);
-
-        private static void ThrowTruncatedInvalidData() =>
-            throw new InvalidDataException(SR.BrotliStream_Decompress_TruncatedData);
     }
 }

--- a/src/libraries/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
+++ b/src/libraries/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -21,7 +21,7 @@
     <Compile Include="$(CommonTestPath)System\IO\Compression\StreamHelpers.cs"
              Link="Common\System\IO\Compression\StreamHelpers.cs" />
     <Compile Include="$(CommonTestPath)System\IO\Compression\ZipTestHelper.cs"
-         Link="Common\System\IO\Compression\ZipTestHelper.cs" />
+             Link="Common\System\IO\Compression\ZipTestHelper.cs" />
     <Compile Include="$(CommonTestPath)System\IO\TempFile.cs"
              Link="Common\System\IO\TempFile.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs"

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Create.cs
@@ -46,30 +46,6 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
-        public async Task CreateFromDirectory_IncludeBaseDirectoryAsync()
-        {
-            string folderName = zfolder("normal");
-            string withBaseDir = GetTestFilePath();
-            ZipFile.CreateFromDirectory(folderName, withBaseDir, CompressionLevel.Optimal, true);
-
-            IEnumerable<string> expected = Directory.EnumerateFiles(zfolder("normal"), "*", SearchOption.AllDirectories);
-            using (ZipArchive actual_withbasedir = ZipFile.Open(withBaseDir, ZipArchiveMode.Read))
-            {
-                foreach (ZipArchiveEntry actualEntry in actual_withbasedir.Entries)
-                {
-                    string expectedFile = expected.Single(i => Path.GetFileName(i).Equals(actualEntry.Name));
-                    Assert.StartsWith("normal", actualEntry.FullName);
-                    Assert.Equal(new FileInfo(expectedFile).Length, actualEntry.Length);
-                    using (Stream expectedStream = File.OpenRead(expectedFile))
-                    using (Stream actualStream = actualEntry.Open())
-                    {
-                        await StreamsEqualAsync(expectedStream, actualStream);
-                    }
-                }
-            }
-        }
-
-        [Fact]
         public void CreateFromDirectoryUnicode()
         {
             string folderName = zfolder("unicode");

--- a/src/libraries/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression/src/Resources/Strings.resx
@@ -278,9 +278,6 @@
   <data name="SplitSpanned" xml:space="preserve">
     <value>Split or spanned archives are not supported.</value>
   </data>
-  <data name="TruncatedData" xml:space="preserve">
-    <value>Found truncated data while decoding.</value>
-  </data>
   <data name="UnexpectedEndOfStream" xml:space="preserve">
     <value>Zip file corrupt: unexpected end of stream reached.</value>
   </data>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -279,15 +279,6 @@ namespace System.IO.Compression
                     int n = _stream.Read(_buffer, 0, _buffer.Length);
                     if (n <= 0)
                     {
-                        // - Inflater didn't return any data although a non-empty output buffer was passed by the caller.
-                        // - More input is needed but there is no more input available.
-                        // - Inflation is not finished yet.
-                        // - Provided input wasn't completely empty
-                        // In such case, we are dealing with a truncated input stream.
-                        if (!buffer.IsEmpty && !_inflater.Finished() && _inflater.NonEmptyInput())
-                        {
-                            ThrowTruncatedInvalidData();
-                        }
                         break;
                     }
                     else if (n > _buffer.Length)
@@ -355,9 +346,6 @@ namespace System.IO.Compression
             // The stream is either malicious or poorly implemented and returned a number of
             // bytes < 0 || > than the buffer supplied to it.
             throw new InvalidDataException(SR.GenericInvalidData);
-
-        private static void ThrowTruncatedInvalidData() =>
-            throw new InvalidDataException(SR.TruncatedData);
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? asyncCallback, object? asyncState) =>
             TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
@@ -428,15 +416,6 @@ namespace System.IO.Compression
                             int n = await _stream.ReadAsync(new Memory<byte>(_buffer, 0, _buffer.Length), cancellationToken).ConfigureAwait(false);
                             if (n <= 0)
                             {
-                                // - Inflater didn't return any data although a non-empty output buffer was passed by the caller.
-                                // - More input is needed but there is no more input available.
-                                // - Inflation is not finished yet.
-                                // - Provided input wasn't completely empty
-                                // In such case, we are dealing with a truncated input stream.
-                                if (!_inflater.Finished() && _inflater.NonEmptyInput() && !buffer.IsEmpty)
-                                {
-                                    ThrowTruncatedInvalidData();
-                                }
                                 break;
                             }
                             else if (n > _buffer.Length)
@@ -457,7 +436,6 @@ namespace System.IO.Compression
                             // decompress into at least one byte of output, but it's a reasonable approximation for the 99% case.  If it's
                             // wrong, it just means that a caller using zero-byte reads as a way to delay getting a buffer to use for a
                             // subsequent call may end up getting one earlier than otherwise preferred.
-                            Debug.Assert(bytesRead == 0);
                             break;
                         }
                     }
@@ -915,10 +893,6 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     await _deflateStream._stream.CopyToAsync(this, _arrayPoolBuffer.Length, _cancellationToken).ConfigureAwait(false);
-                    if (!_deflateStream._inflater.Finished())
-                    {
-                        ThrowTruncatedInvalidData();
-                    }
                 }
                 finally
                 {
@@ -951,10 +925,6 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     _deflateStream._stream.CopyTo(this, _arrayPoolBuffer.Length);
-                    if (!_deflateStream._inflater.Finished())
-                    {
-                        ThrowTruncatedInvalidData();
-                    }
                 }
                 finally
                 {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -17,7 +17,6 @@ namespace System.IO.Compression
         private const int MinWindowBits = -15;              // WindowBits must be between -8..-15 to ignore the header, 8..15 for
         private const int MaxWindowBits = 47;               // zlib headers, 24..31 for GZip headers, or 40..47 for either Zlib or GZip
 
-        private bool _nonEmptyInput;                        // Whether there is any non empty input
         private bool _finished;                             // Whether the end of the stream has been reached
         private bool _isDisposed;                           // Prevents multiple disposals
         private readonly int _windowBits;                   // The WindowBits parameter passed to Inflater construction
@@ -35,7 +34,6 @@ namespace System.IO.Compression
         {
             Debug.Assert(windowBits >= MinWindowBits && windowBits <= MaxWindowBits);
             _finished = false;
-            _nonEmptyInput = false;
             _isDisposed = false;
             _windowBits = windowBits;
             InflateInit(windowBits);
@@ -178,8 +176,6 @@ namespace System.IO.Compression
 
         public bool NeedsInput() => _zlibStream.AvailIn == 0;
 
-        public bool NonEmptyInput() => _nonEmptyInput;
-
         public void SetInput(byte[] inputBuffer, int startIndex, int count)
         {
             Debug.Assert(NeedsInput(), "We have something left in previous input!");
@@ -204,7 +200,6 @@ namespace System.IO.Compression
                 _zlibStream.NextIn = (IntPtr)_inputBufferHandle.Pointer;
                 _zlibStream.AvailIn = (uint)inputBuffer.Length;
                 _finished = false;
-                _nonEmptyInput = true;
             }
         }
 

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.IO.Compression.Tests;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.IO.Compression.Tests;
 using Xunit;
 
 namespace System.IO.Compression
@@ -274,6 +274,8 @@ namespace System.IO.Compression
             }
         }
 
+
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47563")]
         [Fact]
         public void StreamCorruption_IsDetected()
         {

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.ZLib.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.ZLib.cs
@@ -19,6 +19,7 @@ namespace System.IO.Compression
         public override Stream BaseStream(Stream stream) => ((ZLibStream)stream).BaseStream;
         protected override string CompressedTestFile(string uncompressedPath) => Path.Combine("ZLibTestData", Path.GetFileName(uncompressedPath) + ".z");
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47563")]
         [Fact]
         public void StreamCorruption_IsDetected()
         {


### PR DESCRIPTION
Reverts https://github.com/dotnet/runtime/pull/61768, though I kept a couple unit tests from that PR and marked them ActiveIssue associated with the original issue, which I reopened.  I also added in a regression test that would fail with that PR.

Fixes https://github.com/dotnet/runtime/issues/72726