### PR TITLE
Improve String.EndsWith for OrdinalIgnoreCase

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -570,9 +570,10 @@ namespace System
                     return (uint)offset <= (uint)this.Length && this.AsSpan(offset).SequenceEqual(value);
 
                 case StringComparison.OrdinalIgnoreCase:
-                    return this.Length < value.Length ?
-                            false :
-                            (Ordinal.CompareStringIgnoreCase(ref Unsafe.Add(ref this.GetRawStringData(), this.Length - value.Length), value.Length, ref value.GetRawStringData(), value.Length) == 0);
+                    return Length >= value.Length &&
+                        Ordinal.EqualsIgnoreCase(ref Unsafe.Add(ref GetRawStringData(), Length - value.Length),
+                                                 ref value.GetRawStringData(),
+                                                 value.Length);
 
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));


### PR DESCRIPTION
Use Equals instead of Compare. The same method is used for `String.StartsWith`

```csharp
static readonly string TestStr = typeof(object).Assembly.Location;

[Benchmark]
public bool EndsWith_small() => 
    TestStr.EndsWith(".DLL", StringComparison.OrdinalIgnoreCase);

[Benchmark]
public bool EndsWith_large() => 
    TestStr.EndsWith("system.private.corelib.dll", StringComparison.OrdinalIgnoreCase);
```

|         Method |                   Toolchain |      Mean |     Error |    StdDev | Ratio |
|--------------- |---------------------------- |----------:|----------:|----------:|------:|
| EndsWith_small |      \Core_Root\corerun.exe |  4.502 ns | 0.0076 ns | 0.0064 ns |  0.54 |
| EndsWith_small | \Core_Root_base\corerun.exe |  8.368 ns | 0.0113 ns | 0.0106 ns |  1.00 |
|                |                             |           |           |           |       |
| EndsWith_large |      \Core_Root\corerun.exe | 12.669 ns | 0.0456 ns | 0.0404 ns |  0.60 |
| EndsWith_large | \Core_Root_base\corerun.exe | 21.006 ns | 0.0429 ns | 0.0358 ns |  1.00 |