### PR TITLE
[wasm][debugger] Fix test regressions

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -675,9 +675,9 @@ namespace DebuggerTests
         }
 
         [ConditionalTheory(nameof(RunningOnChrome))]
-        [InlineData(false, "Debugger.stepInto", "RunStepThrough", "StepThrougUserBp", 841, 8, "RunStepThrough", 848, 4)]
+        [InlineData(false, "Debugger.stepInto", "RunStepThrough", "StepThroughUserBp", 841, 8, "RunStepThrough", 848, 4)]
         [InlineData(true, "Debugger.stepInto", "RunStepThrough", "RunStepThrough", -1, 8, "RunStepThrough", -1, 4)]
-        [InlineData(false, "Debugger.resume", "RunStepThrough", "StepThrougUserBp", 841, 8, "RunStepThrough", 848, 4)]
+        [InlineData(false, "Debugger.resume", "RunStepThrough", "StepThroughUserBp", 841, 8, "RunStepThrough", 848, 4)]
         [InlineData(true, "Debugger.resume", "RunStepThrough", "RunStepThrough", -1, 8, "RunStepThrough", -1, 4)]
         [InlineData(false, "Debugger.stepInto", "RunNonUserCode",  "NonUserCodeUserBp", 860, 4, "NonUserCodeUserBp", 861, 8)]
         [InlineData(true, "Debugger.stepInto", "RunNonUserCode", "RunNonUserCode", -1, 8, "RunNonUserCode", -1, 4)]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -611,8 +611,8 @@ namespace DebuggerTests
         }
 
         [ConditionalTheory(nameof(RunningOnChrome))]
-        [InlineData(false, "RunStepThrough", "StepThrougBp", "", 846, 8)]
-        [InlineData(true, "RunStepThrough", "StepThrougBp", "RunStepThrough", 847, 8)]
+        [InlineData(false, "RunStepThrough", "StepThroughBp", "", 846, 8)]
+        [InlineData(true, "RunStepThrough", "StepThroughBp", "RunStepThrough", 847, 8)]
         [InlineData(false, "RunNonUserCode", "NonUserCodeBp", "NonUserCodeBp", 852, 4)]
         [InlineData(true, "RunNonUserCode", "NonUserCodeBp", "RunNonUserCode", 867, 8)]
         [InlineData(false, "RunStepThroughWithNonUserCode", "StepThroughWithNonUserCodeBp", "", 932, 8)]
@@ -645,8 +645,8 @@ namespace DebuggerTests
         }
 
         [ConditionalTheory(nameof(RunningOnChrome))]
-        [InlineData(false, "RunStepThrough", "StepThrougBp")]
-        [InlineData(true, "RunStepThrough", "StepThrougBp")]
+        [InlineData(false, "RunStepThrough", "StepThroughBp")]
+        [InlineData(true, "RunStepThrough", "StepThroughBp")]
         [InlineData(true, "RunNonUserCode", "NonUserCodeBp")]
         [InlineData(false, "RunNonUserCode", "NonUserCodeBp")]
         [InlineData(false, "RunStepThroughWithNonUserCode", "StepThroughWithNonUserCodeBp")]


### PR DESCRIPTION
```
DebuggerTests.BreakpointTests.StepThroughOrNonUserCodeAttributeWithUserBp(justMyCodeEnabled: False, debuggingFunction: "Debugger.stepInto", evalFunName: "RunStepThrough", functionNameCheck1: "StepThrougUserBp", line1: 841, col1: 8, functionNameCheck2: "RunStepThrough", line2: 848, col2: 4) [FAIL]
..
Expected: DebuggerAttribute.StepThrougUserBp
Actual:   DebuggerAttribute.StepThroughUserBp
```

And
```
[xUnit.net 00:08:39.10]     DebuggerTests.BreakpointTests.StepThroughOrNonUserCodeAttributeResumeWithBp(justMyCodeEnabled: False, evalFunName: "RunStepThrough", decoratedFunName: "StepThrougBp") [FAIL]
  Failed DebuggerTests.BreakpointTests.StepThroughOrNonUserCodeAttributeResumeWithBp(justMyCodeEnabled: False, evalFunName: "RunStepThrough", decoratedFunName: "StepThrougBp") [80 ms]
  Error Message:
   Assert.True() Failure
Expected: True
Actual:   False
  Stack Trace:
     at DebuggerTests.DebuggerTestBase.SetBreakpointInMethod(String assembly, String type, String method, Int32 lineOffset, Int32 col, String condition) in /_/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs:line 1096
   at DebuggerTests.BreakpointTests.StepThroughOrNonUserCodeAttributeResumeWithBp(Boolean justMyCodeEnabled, String evalFunName, String decoratedFunName) in /_/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs:line 668
--- End of stack trace from previous location ---
```

Caused by:
```
commit 9d6396deb02161f5ee47af72ccac52c2e1bae458
Author: Adeel Mujahid <3840695+am11@users.noreply.github.com>
Date:   Sun Jul 24 06:24:28 2022 +0300

    Fix typos (#72709)
```