### PR TITLE
System.Text.Json - Emit XML comments for public source-generated APIs

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -1073,7 +1073,7 @@ private void {serializeMethodName}({Utf8JsonWriterTypeRef} {WriterVarName}, {val
 
                 return @$"private {typeInfoPropertyTypeRef}? _{typeFriendlyName};
 /// <summary>
-/// JSON-related serialization metadata for a type.
+/// Defines the source generated JSON serialization contract metadata for a given type.
 /// </summary>
 public {typeInfoPropertyTypeRef} {typeFriendlyName}
 {{

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -1430,8 +1430,8 @@ private static readonly {JsonEncodedTextTypeRef} {name_varName_pair.Value} = {Js
                         return GetFriendlyName(t.Name);
                     }
                     string typeName = t.Name;
-                    int tildeIndex = typeName.IndexOf('`');
-                    string typeNameWithoutGenericArity = typeName.Substring(0, tildeIndex);
+                    int backTickIndex = typeName.IndexOf('`');
+                    string typeNameWithoutGenericArity = typeName.Substring(0, backTickIndex);
                     StringBuilder sb = new(typeNameWithoutGenericArity);
                     sb.Append("&lt;");
                     bool addSeparator = false;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
@@ -31,7 +31,8 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             string source,
             MetadataReference[] additionalReferences = null,
             string assemblyName = "TestAssembly",
-            bool includeSTJ = true)
+            bool includeSTJ = true,
+            Func<CSharpParseOptions, CSharpParseOptions> configureParseOptions = null)
         {
 
             List<MetadataReference> references = new List<MetadataReference> {
@@ -63,9 +64,11 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 }
             }
 
+            configureParseOptions ??= (options) => options;
+            var parseOptions = configureParseOptions(s_parseOptions);
             return CSharpCompilation.Create(
                 assemblyName,
-                syntaxTrees: new[] { CSharpSyntaxTree.ParseText(source, s_parseOptions) },
+                syntaxTrees: new[] { CSharpSyntaxTree.ParseText(source, parseOptions) },
                 references: references.ToArray(),
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
             );
@@ -278,7 +281,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             return CreateCompilation(source);
         }
-        
+
         public static Compilation CreateCompilationWithInitOnlyProperties()
         {
             string source = @"
@@ -335,7 +338,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             return CreateCompilation(source);
         }
-        
+
         public static Compilation CreateCompilationWithMixedInitOnlyProperties()
         {
             string source = @"
@@ -363,7 +366,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             return CreateCompilation(source);
         }
-        
+
         public static Compilation CreateCompilationWithRecordPositionalParameters()
         {
             string source = @"
@@ -393,7 +396,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             return CreateCompilation(source);
         }
-        
+
         public static Compilation CreateCompilationWithInaccessibleJsonIncludeProperties()
         {
             string source = @"
@@ -451,9 +454,9 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             return CreateCompilation(source);
         }
 
-            public static Compilation CreateReferencedSimpleLibRecordCompilation()
-            {
-                string source = @"
+        public static Compilation CreateReferencedSimpleLibRecordCompilation()
+        {
+            string source = @"
             using System.Text.Json.Serialization;
 
             namespace ReferencedAssembly
@@ -475,7 +478,32 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             }
 ";
 
-                return CreateCompilation(source);
+            return CreateCompilation(source);
+        }
+
+        public static Compilation CreateReferencedModelWithFullyDocumentedProperties()
+        {
+            string source = @"
+            namespace ReferencedAssembly
+            {
+                /// <summary>
+                /// Documentation
+                /// </summary>
+                public class Model
+                {
+                    /// <summary>
+                    /// Documentation
+                    /// </summary>
+                    public int Property1 { get; set; }
+
+                    /// <summary>
+                    /// Documentation
+                    /// </summary>
+                    public int Property2 { get; set; }
+                }
+            }";
+
+            return CreateCompilation(source);
         }
 
         internal static void CheckDiagnosticMessages(


### PR DESCRIPTION
Fixes #61379.

I'd love to get this into NET 7.0 if possible, but realise that I may have left it slightly too late to find the time to make this fix.

I was in two minds about adding a test that verifies the contents of the documentation itself. In the end I just added a test that verifies that the diagnostic mentioned in #61379 is not produced as I thought that verifying the comments themselves would just be a maintenance burden every time the API surface changes or is updated.

~Some examples of the comments emitted during source generation are included below. I've used `<see cref="type" />` where possible, but for any closed generic types I've just emitted a best attempt at a friendly version of that type, as we can't reference closed generic types in `cref` attributes.~

Edit: Simplified the emitted comments, following the feedback on the change.

<details>
<summary>
Examples of the comments emitted
</summary>

Constructor:
![image](https://user-images.githubusercontent.com/30874283/180823604-d56b0847-6b85-40fe-ace9-62356e96dd81.png)

Default context:
![image](https://user-images.githubusercontent.com/30874283/180824254-9358398f-e5a1-4795-ac95-3c1c87bd8a39.png)

GeneratedSerializerOptions:
![image](https://user-images.githubusercontent.com/30874283/180724916-0b2aa776-ba6e-49d9-ae64-ecaa493314ef.png)

GetTypeInfo:
![image](https://user-images.githubusercontent.com/30874283/180724413-cb536b74-c4f7-4cac-ad4f-04db9e0a9027.png)

JsonTypeInfo:
![image](https://user-images.githubusercontent.com/30874283/180823419-4db91f5e-066d-44c6-a968-420682d3f9d3.png)
</details>
