### PR TITLE
Set IsDynamicCodeCompiled as a managed constant to help

### DIFF
--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.iOS.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.iOS.xml
@@ -1,7 +1,0 @@
-<linker>
-  <assembly fullname="System.Private.CoreLib">
-    <type fullname="System.Runtime.CompilerServices.RuntimeFeature">
-      <method signature="System.Boolean get_IsDynamicCodeCompiled()" body="stub" value="false" />
-    </type>
-  </assembly>
-</linker>

--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.wasm.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.wasm.xml
@@ -6,8 +6,5 @@
     <type fullname="System.Environment">
       <method signature="System.Int32 get_ProcessorCount()" body="stub" value="1" />
     </type>
-    <type fullname="System.Runtime.CompilerServices.RuntimeFeature">
-      <method signature="System.Boolean get_IsDynamicCodeCompiled()" body="stub" value="false" />
-    </type>
   </assembly>
 </linker>

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.Mono.cs
@@ -14,8 +14,12 @@ namespace System.Runtime.CompilerServices
 
         public static bool IsDynamicCodeCompiled
         {
+#if TARGET_BROWSER || TARGET_IOS || TARGET_TVOS
+            get => false;
+#else
             [Intrinsic]  // the JIT/AOT compiler will change this flag to false for FullAOT scenarios, otherwise true
             get => IsDynamicCodeCompiled;
+#endif
         }
     }
 }

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.Mono.cs
@@ -14,7 +14,7 @@ namespace System.Runtime.CompilerServices
 
         public static bool IsDynamicCodeCompiled
         {
-#if TARGET_BROWSER || TARGET_IOS || TARGET_TVOS
+#if TARGET_BROWSER || TARGET_IOS || TARGET_TVOS || TARGET_MACCATALYST
             get => false;
 #else
             [Intrinsic]  // the JIT/AOT compiler will change this flag to false for FullAOT scenarios, otherwise true


### PR DESCRIPTION
with trimming on platforms where it's always false