### PR TITLE
Fix a couple of issues when using textual PGO input

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -22852,7 +22852,7 @@ void Compiler::considerGuardedDevirtualization(GenTreeCall*            call,
         // resolve call above for class-based GDV.
         if ((likelyMethodAttribs & CORINFO_FLG_STATIC) != 0)
         {
-            assert(call->IsDelegateInvoke());
+            assert((fgPgoSource != ICorJitInfo::PgoSource::Dynamic) || call->IsDelegateInvoke());
             JITDUMP("Cannot currently handle devirtualizing static delegate calls, sorry\n");
             return;
         }

--- a/src/coreclr/vm/pgo.cpp
+++ b/src/coreclr/vm/pgo.cpp
@@ -878,7 +878,10 @@ HRESULT PgoManager::getPgoInstrumentationResults(MethodDesc* pMD, BYTE** pAlloca
                                                     if (!th.IsNull())
                                                     {
                                                         MethodDesc* pMD = MemberLoader::FindMethodByName(th.GetMethodTable(), methodString.GetUTF8());
-                                                        newPtr = (INT_PTR)pMD;
+                                                        if (pMD != nullptr && !pMD->IsGenericMethodDefinition())
+                                                        {
+                                                            newPtr = (INT_PTR)pMD;
+                                                        }
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
The textual PGO format currently just describes methods by name and does
not include signature information/generic instantiations. This means we
may see various edge cases here. These particular cases would hit asserts.