### PR TITLE
Avoid warning on shlibdeps for symbol log2: it's probably a plugin (Ubuntu building)

### DIFF
--- a/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
+++ b/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
@@ -10,6 +10,7 @@ macro(append_extra_compression_libs NativeLibsExtra)
       set(ZLIB_LIBRARIES z m)
   else ()
       find_package(ZLIB REQUIRED)
+      set(ZLIB_LIBRARIES ${ZLIB_LIBRARIES} m)
   endif ()
   list(APPEND ${NativeLibsExtra} ${ZLIB_LIBRARIES})
 


### PR DESCRIPTION
Hi! 

This PR comes from a patch I'm using on v6.0 (it arose here https://github.com/dotnet/runtime/issues/68212 ). In the thread, I was encouraged to make the PR against 7.0+, but I can make it also for v6.0 if anyone finds it useful.

Thanks in advance for considering this.

