### PR TITLE
Annoating Net.Quic & Net.Security libraries to be AOT safe

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
+++ b/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Threading;
@@ -97,7 +98,11 @@ namespace System.Net.Http
                     return null;
                 }
 
-                Type taskOfHttpResponseMessageType = typeof(Task<>).MakeGenericType(httpResponseMessageType);
+                [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+                   Justification = "The type, httpResponseMessageType, will be available during runtime")]
+                static Type GetTaskOfHttpResponseMessageType(Type? httpResponseMessageType) => typeof(Task<>).MakeGenericType(httpResponseMessageType!);
+
+                Type taskOfHttpResponseMessageType = GetTaskOfHttpResponseMessageType(httpResponseMessageType);
 
                 // Get the methods on those types.
                 ConstructorInfo? socketsHttpHandlerCtor = socketsHttpHandlerType.GetConstructor(Type.EmptyTypes);

--- a/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
+++ b/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
@@ -99,7 +99,7 @@ namespace System.Net.Http
                 }
 
                 [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-                   Justification = "The type, httpResponseMessageType, will be available during runtime")]
+                   Justification = "The type HttpResponseMessage is a reference type")]
                 static Type GetTaskOfHttpResponseMessageType(Type? httpResponseMessageType) => typeof(Task<>).MakeGenericType(httpResponseMessageType!);
 
                 Type taskOfHttpResponseMessageType = GetTaskOfHttpResponseMessageType(httpResponseMessageType);

--- a/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
+++ b/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
@@ -98,9 +98,11 @@ namespace System.Net.Http
                     return null;
                 }
 
+                // Workaround until https://github.com/dotnet/runtime/issues/72833 is fixed
                 [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
                    Justification = "The type HttpResponseMessage is a reference type")]
-                static Type GetTaskOfHttpResponseMessageType(Type? httpResponseMessageType) => typeof(Task<>).MakeGenericType(httpResponseMessageType!);
+                [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+                static Type GetTaskOfHttpResponseMessageType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? httpResponseMessageType) => typeof(Task<>).MakeGenericType(httpResponseMessageType!);
 
                 Type taskOfHttpResponseMessageType = GetTaskOfHttpResponseMessageType(httpResponseMessageType);
 

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-FreeBSD;$(NetCoreAppCurrent)</TargetFrameworks>
+    <EnableAOTAnalyzer>true</EnableAOTAnalyzer>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-FreeBSD;$(NetCoreAppCurrent)-Android;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)</TargetFrameworks>
     <!-- This is needed so that code for TlsCipherSuite will have no namespace (causes compile errors) when used within T4 template  -->
     <DefineConstants>$(DefineConstants);PRODUCT</DefineConstants>
+    <EnableAOTAnalyzer>true</EnableAOTAnalyzer>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>


### PR DESCRIPTION
Suppressed [MakeGenericType](https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs#L100) locally since the type, [taskOfHttpResponseMessageType](https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs#L89), should be available during runtime.