### PR TITLE
Fix HttpListenerRequestUriBuilder.GetPath's search for `?`

### DIFF
--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequestUriBuilder.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequestUriBuilder.cs
@@ -413,7 +413,7 @@ namespace System.Net
             // - the first '#' character: This is never the case here, since http.sys won't accept
             //   Uris containing fragments. Also, RFC2616 doesn't allow fragments in request Uris.
             // - end of Uri string
-            int queryIndex = uriString.IndexOf('?');
+            int queryIndex = uriString.IndexOf('?', pathStartIndex);
             if (queryIndex == -1)
             {
                 queryIndex = uriString.Length;

--- a/src/libraries/System.Net.HttpListener/tests/InvalidClientRequestTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/InvalidClientRequestTests.cs
@@ -94,6 +94,9 @@ namespace System.Net.Tests
             // No body
             yield return new object[] { "POST {path} HTTP/1.1", null, null, null, "Length Required" };
             yield return new object[] { "PUT {path} HTTP/1.1", null, null, null, "Length Required" };
+
+            // ? prior to path and query.  This may or may not fail, depending on the OS, but in either case it shouldn't crash.
+            yield return new object[] { "GET http://ab?cd{path} HTTP/1.1", null, null, null, "" };
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/2284", TestRuntimes.Mono)]


### PR DESCRIPTION
It's intended to only be searching in the path, but earlier logic may have detected the path to start beyond 0.

Fixes https://github.com/dotnet/runtime/issues/72748