### PR TITLE
[release/6.0] Support zero-byte reads on raw response streams in SocketsHttpHandler

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1749,7 +1749,7 @@ namespace System.Net.Http
             // If the caller provided buffer, and thus the amount of data desired to be read,
             // is larger than the internal buffer, there's no point going through the internal
             // buffer, so just do an unbuffered read.
-            return destination.Length >= _readBuffer.Length ?
+            return destination.Length == 0 || destination.Length >= _readBuffer.Length ?
                 ReadAsync(destination) :
                 ReadBufferedAsyncCore(destination);
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -45,9 +45,9 @@ namespace System.Net.Http
                 CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                 HttpConnection? connection = _connection;
-                if (connection == null || buffer.Length == 0)
+                if (connection == null)
                 {
-                    // Response body fully consumed or the caller didn't ask for any data
+                    // Response body fully consumed
                     return 0;
                 }
 
@@ -74,7 +74,7 @@ namespace System.Net.Http
                     }
                 }
 
-                if (bytesRead == 0)
+                if (bytesRead == 0 && buffer.Length != 0)
                 {
                     // A cancellation request may have caused the EOF.
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);


### PR DESCRIPTION
Backporting a minimal change to support zero-byte reads for 1.1 WebSockets (contributes to #61475).
Product change is 25029a768caa064eb3dd8ebc31dd030a38bb2813 from #61913. It skips changing zero-byte reads for non-WebSockets HTTP (1.x, 2, 3).

## Customer Impact

Zero-byte reads are a way of deferring memory allocations while waiting for data to become available.
Their use can significantly reduce memory usage in networking scenarios where idle connections are common.
WebSocket connections represent a scenario that benefits greatly from this.

Zero-byte reads also allow us to avoid pinning large buffers for extended periods of time, avoiding heap fragmentation.
An internal partner facing memory issues due to fragmentation saw a 10x reduction in memory usage with this patch.

## Testing

A targeted test case has been added and the patch was validated by an internal party in production.

## Risk

Low.

The change is limited in scope to only HTTP/1.1 WebSocket connections.
It has been tested in 7.0 previews for more than half a year with no reported issues.

In order for the user to observe any changes after this patch, they must be explicitly issuing zero-byte reads, which has been uncommon so far (and always a no-op with HttpClient before 7.0).