### PR TITLE
[release/6.0] Include EventLog.Messages in WindowsDesktop pack

### DIFF
--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -8,7 +8,7 @@
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
-    <!-- Enable when the package shipped with NET6. -->
+    <!-- Enable when PackageValidation supports comparing multiple assemblies. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <PackageDescription>Internal transport package to provide windowsdesktop with the assemblies from dotnet/runtime that make up the Microsoft.WindowsDesktop.App shared framework.</PackageDescription>
     <!-- Reference elements are missing from the nuspec: https://github.com/NuGet/Home/issues/8684. -->
@@ -20,6 +20,12 @@
   <ItemGroup>
     <!-- Requires Private=true to calculate ReferenceCopyLocalPaths items.
          ReferringTargetFramework is set to $(NetCoreAppCurrent)-windows so that we pack the Windows specific implementation assemblies -->
-    <ProjectReference Include="@(WindowsDesktopCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj')" ReferringTargetFramework="$(NetCoreAppCurrent)-windows" PrivateAssets="all" Pack="true" Private="true" IncludeReferenceAssemblyInPackage="true" />
+    <ProjectReference Include="@(WindowsDesktopCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj');
+                               $(LibrariesProjectRoot)System.Diagnostics.EventLog\src\Messages\System.Diagnostics.EventLog.Messages.csproj"
+                      ReferringTargetFramework="$(NetCoreAppCurrent)-windows"
+                      PrivateAssets="all"
+                      Pack="true"
+                      Private="true"
+                      IncludeReferenceAssemblyInPackage="true" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/72280

The System.Diagnostics.EventLog.Messages assembly is missing from the WindowsDesktop transport package. Adding it to the package and also making sure that it gets the right assembly version in servicing by adding it to the NetCoreAppLibrary.props file.

## Customer Impact

Messages sent to Event Log as per the [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.eventlog?view=dotnet-plat-ext-6.0) do not look as expected. Instead of the string supplied to EventLog. WriteEntry() verbatim, a consumer sees the following:

> The description for Event ID <id> from source <source> cannot be found. Either the component that raises this event is not installed on your local computer or the installation is corrupted. You can install or repair the component on the local computer.
If the event originated on another computer, the display information had to be saved with the event.
The following information was included with the event: `<message>`
The message resource is present but the message was not found in the message table

This regressed in .NET 6 because the System.Diagnostics.EventLog.Messages was inadvertently dropped from the WindowsDesktop pack. This was not previously noticed as it is a special assembly specifically only for formatting event log messages.

## Testing

Verified that the assembly is now part of the package and that WindowsDesktop picks it up.

## Risk

Low to Medium: The added EventLog.Messages assembly is a direct dependency of System.Diagnostics.EventLog and the change's impact is scoped to it.