### PR TITLE
Allow trimming away `ScopedRefAttribute`.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
@@ -305,6 +305,9 @@
     <type fullname="System.Runtime.CompilerServices.NativeIntegerAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
+    <type fullname="System.Runtime.CompilerServices.ScopedRefAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
 
     <!-- Microsoft.CodeAnalysis -->
     <type fullname="Microsoft.CodeAnalysis.EmbeddedAttribute">


### PR DESCRIPTION
Ref: dotnet/roslyn#62838.