### PR TITLE
Enable the ConvertToLibraryImport diagnostic by default

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Interop.Analyzers
                 GetResourceString(nameof(SR.ConvertToLibraryImportMessage)),
                 Category,
                 DiagnosticSeverity.Info,
-                isEnabledByDefault: false,
+                isEnabledByDefault: true,
                 description: GetResourceString(nameof(SR.ConvertToLibraryImportDescription)));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ConvertToLibraryImport);


### PR DESCRIPTION
We want to enable this diagnostic by default so that users can see it in VS as a suggestion. Otherwise, users will not see the code fix to convert to source-generated interop unless they add an .editorconfig file and modify it to explicitly set a severity for the diagnostic.