### PR TITLE
Removing the PublishAot check from the SDK

### DIFF
--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/sdk/Sdk.props
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/sdk/Sdk.props
@@ -17,6 +17,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!-- Only import the build props if the NativeAot package isn't referenced via NuGet. -->
-  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.DotNet.ILCompiler.props" Condition="'$(PublishAot)' == 'true' and '$(ILCompilerTargetsPath)' == ''" />
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.DotNet.ILCompiler.props" Condition="'$(ILCompilerTargetsPath)' == ''" />
 
 </Project>


### PR DESCRIPTION
The SDK properties have precedence over application project properties. Hence, setting the `PublishAot` property in the `csproj` project file will not become effective when the SDK tries to import the project `Microsoft.DotNet.ILCompiler.props` (it will work if `PublishAot` is set via command line). 

Changing the condition so that the `Microsoft.DotNet.ILCompiler.props` will get imported even if the `PublishAot` is set in application project file. The SDK target file, `Microsoft.NET.Sdk.targets`, will have the `PublishAot` check to ensure that the AOT targets get imported only for AOT applications.