### PR TITLE
Fix MemoryCache test failures due to race

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/ICacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/ICacheEntry.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Caching.Memory
 {
     /// <summary>
     /// Represents an entry in the <see cref="IMemoryCache"/> implementation.
+    /// When Disposed, is committed to the cache.
     /// </summary>
     public interface ICacheEntry : IDisposable
     {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -627,12 +627,12 @@ namespace Microsoft.Extensions.Caching.Memory
         ///
         /// Entries may have various sizes. If a size limit has been set, the cache keeps track of the aggregate of all the entries' sizes
         /// in order to trigger compaction when the size limit is exceeded.
-        /// Because the overall size is used only to trigger compaction, it is not necessary to update it atomically with the collection,
-        /// so long as it is always eventually consistent. So instead of locking around updates to the collection and the overall size,
-        /// the size is updated after the collection, using an Interlocked operation.
+        ///
+        /// For performance reasons, the size is not updated atomically with the collection, but is only made eventually consistent.
         ///
         /// When the memory cache is cleared, it replaces the backing collection entirely. This may occur in parallel with operations
         /// like add, set, remove, and compact which may modify the collection and thus its overall size.
+        ///
         /// To keep the overall size eventually consistent, therefore, the collection and the overall size are wrapped in this CoherentState
         /// object. Individual operations take a local reference to this wrapper object while they work, and make size updates to this object.
         /// Clearing the cache simply replaces the object, so that any still in progress updates do not affect the overall size value for

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -426,6 +426,10 @@ namespace Microsoft.Extensions.Caching.Memory
             }
         }
 
+        /// <summary>
+        /// Returns true if increasing the cache size by the size of entry would
+        /// cause it to exceed any size limit on the cache, otherwise, returns false.
+        /// </summary>
         private bool UpdateCacheSizeExceedsCapacity(CacheEntry entry, CoherentState coherentState)
         {
             long sizeLimit = _options.SizeLimitValue;

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -110,7 +110,6 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33993")]
         public async Task DoNotAddIfSizeOverflows()
         {
             var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = long.MaxValue });
@@ -143,7 +142,6 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33993")]
         public async Task ExceedsCapacityCompacts()
         {
             var cache = new MemoryCache(new MemoryCacheOptions
@@ -237,7 +235,6 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33993")]
         public async Task AddingReplacementWhenTotalSizeExceedsCapacityDoesNotUpdateRemovesOldEntryAndTriggersCompaction()
         {
             var cache = new MemoryCache(new MemoryCacheOptions
@@ -307,7 +304,6 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33993")]
         public async Task ExpiringEntryDecreasesCacheSize()
         {
             var cache = new MemoryCache(new MemoryCacheOptions
@@ -378,7 +374,6 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33993")]
         public async Task CompactsToLessThanLowWatermarkUsingLRUWhenHighWatermarkExceeded()
         {
             var testClock = new TestClock();

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -72,11 +72,11 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
 
             cache.Set("key", "value", new MemoryCacheEntryOptions { Size = 5 });
 
-            Assert.Equal(5, cache.Size);
+            AssertCacheSize(5, cache);
         }
 
         [Fact]
@@ -84,11 +84,11 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             var cache = new MemoryCache(new MemoryCacheOptions());
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
 
             cache.Set("key", "value", new MemoryCacheEntryOptions { Size = 5 });
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
         }
 
         [Fact]
@@ -96,17 +96,17 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
 
             cache.Set("key", "value", new MemoryCacheEntryOptions { Size = 4 });
 
             Assert.Equal("value", cache.Get("key"));
-            Assert.Equal(4, cache.Size);
+            AssertCacheSize(4, cache);
 
             cache.Set("key2", "value2", new MemoryCacheEntryOptions { Size = 7 });
 
             Assert.Null(cache.Get("key2"));
-            Assert.Equal(4, cache.Size);
+            AssertCacheSize(4, cache);
         }
 
         [Fact]
@@ -122,12 +122,12 @@ namespace Microsoft.Extensions.Caching.Memory
                 State = null
             });
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
 
             cache.Set("key", "value", entryOptions);
 
             Assert.Equal("value", cache.Get("key"));
-            Assert.Equal(long.MaxValue, cache.Size);
+            AssertCacheSize(long.MaxValue, cache);
 
             cache.Set("key1", "value1", new MemoryCacheEntryOptions { Size = long.MaxValue });
             // Do not add the new item
@@ -138,7 +138,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
             // Compaction removes old item
             Assert.Null(cache.Get("key"));
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
         }
 
         [Fact]
@@ -159,12 +159,12 @@ namespace Microsoft.Extensions.Caching.Memory
                 State = null
             });
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
 
             cache.Set("key", "value", entryOptions);
 
             Assert.Equal("value", cache.Get("key"));
-            Assert.Equal(6, cache.Size);
+            AssertCacheSize(6, cache);
 
             cache.Set("key2", "value2", new MemoryCacheEntryOptions { Size = 5 });
 
@@ -173,7 +173,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
             Assert.Null(cache.Get("key"));
             Assert.Null(cache.Get("key2"));
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
         }
 
         [Fact]
@@ -181,17 +181,17 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
 
             cache.Set("key", "value", new MemoryCacheEntryOptions { Size = 2 });
 
             Assert.Equal("value", cache.Get("key"));
-            Assert.Equal(2, cache.Size);
+            AssertCacheSize(2, cache);
 
             cache.Set("key", "value1", new MemoryCacheEntryOptions { Size = 3 });
 
             Assert.Equal("value1", cache.Get("key"));
-            Assert.Equal(3, cache.Size);
+            AssertCacheSize(3, cache);
         }
 
         [Fact]
@@ -199,17 +199,17 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
 
             cache.Set("key", "value", new MemoryCacheEntryOptions { Size = 2 });
 
             Assert.Equal("value", cache.Get("key"));
-            Assert.Equal(2, cache.Size);
+            AssertCacheSize(2, cache);
 
             cache.Set("key", "value1", new MemoryCacheEntryOptions { Size = 1 });
 
             Assert.Equal("value1", cache.Get("key"));
-            Assert.Equal(1, cache.Size);
+            AssertCacheSize(1, cache);
         }
 
         [Fact]
@@ -221,17 +221,17 @@ namespace Microsoft.Extensions.Caching.Memory
                 CompactionPercentage = 0.5
             });
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
 
             cache.Set("key", "value", new MemoryCacheEntryOptions { Size = 5 });
 
             Assert.Equal("value", cache.Get("key"));
-            Assert.Equal(5, cache.Size);
+            AssertCacheSize(5, cache);
 
             cache.Set("key", "value1", new MemoryCacheEntryOptions { Size = 6 });
 
             Assert.Null(cache.Get("key"));
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
         }
 
         [Fact]
@@ -251,12 +251,12 @@ namespace Microsoft.Extensions.Caching.Memory
                 State = null
             });
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
 
             cache.Set("key", "value", entryOptions);
 
             Assert.Equal("value", cache.Get("key"));
-            Assert.Equal(6, cache.Size);
+            AssertCacheSize(6, cache);
 
             cache.Set("key", "value1", new MemoryCacheEntryOptions { Size = 5 });
 
@@ -264,7 +264,7 @@ namespace Microsoft.Extensions.Caching.Memory
             Assert.True(await sem.WaitAsync(TimeSpan.FromSeconds(10)));
 
             Assert.Null(cache.Get("key"));
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
         }
 
         [Fact]
@@ -276,17 +276,18 @@ namespace Microsoft.Extensions.Caching.Memory
                 CompactionPercentage = 0.5
             });
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
 
             cache.Set("key", "value", new MemoryCacheEntryOptions { Size = 6 });
 
             Assert.Equal("value", cache.Get("key"));
-            Assert.Equal(6, cache.Size);
+
+            AssertCacheSize(6, cache);
 
             cache.Set("key", "value1", new MemoryCacheEntryOptions { Size = 11 });
 
             Assert.Null(cache.Get("key"));
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache); // addition was rejected due to size, and previous item with the same key removed
         }
 
         [Fact]
@@ -296,11 +297,11 @@ namespace Microsoft.Extensions.Caching.Memory
 
             cache.Set("key", "value", new MemoryCacheEntryOptions { Size = 5 });
 
-            Assert.Equal(5, cache.Size);
+            AssertCacheSize(5, cache);
 
             cache.Remove("key");
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
         }
 
         [Fact]
@@ -324,7 +325,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
             cache.Set("key", "value", entryOptions);
 
-            Assert.Equal(5, cache.Size);
+            AssertCacheSize(5, cache);
 
             // Expire entry
             changeToken.Fire();
@@ -335,7 +336,7 @@ namespace Microsoft.Extensions.Caching.Memory
             // Wait for compaction to complete
             Assert.True(await sem.WaitAsync(TimeSpan.FromSeconds(10)));
 
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
         }
 
         [Fact]
@@ -351,9 +352,9 @@ namespace Microsoft.Extensions.Caching.Memory
             };
 
             cache.Set("key", "value", entryOptions);
-            
+
             Assert.Null(cache.Get("key"));
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
         }
 
         [Fact]
@@ -368,9 +369,9 @@ namespace Microsoft.Extensions.Caching.Memory
             };
 
             cache.Set("key", "value", entryOptions);
-            
+
             Assert.Null(cache.Get("key"));
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
         }
 
         [Fact]
@@ -444,14 +445,23 @@ namespace Microsoft.Extensions.Caching.Memory
         public void ClearZeroesTheSize()
         {
             var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
 
             cache.Set("key", "value", new MemoryCacheEntryOptions { Size = 5 });
-            Assert.Equal(5, cache.Size);
+            AssertCacheSize(5, cache);
 
             cache.Clear();
-            Assert.Equal(0, cache.Size);
+            AssertCacheSize(0, cache);
             Assert.Equal(0, cache.Count);
+        }
+
+        internal static void AssertCacheSize(long size, MemoryCache cache)
+        {
+            // Size is only eventually consistent, so retry a few times
+            RetryHelper.Execute(() =>
+            {
+                Assert.Equal(size, cache.Size);
+            }, maxAttempts: 12, (iteration) => (int)Math.Pow(2, iteration)); // 2ms, 4ms.. 4096 ms. Not observed to need over 0.5 sec.
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Extensions.Caching.Memory
             RetryHelper.Execute(() =>
             {
                 Assert.Equal(size, cache.Size);
-            }, maxAttempts: 12, (iteration) => (int)Math.Pow(2, iteration)); // 2ms, 4ms.. 4096 ms. Not observed to need over 0.5 sec.
+            }, maxAttempts: 12, (iteration) => (int)Math.Pow(2, iteration)); // 2ms, 4ms.. 4096 ms. In practice, retries are rarely needed.
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheSetAndRemoveTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheSetAndRemoveTests.cs
@@ -543,7 +543,6 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33993")]
         public void GetAndSet_AreThreadSafe_AndUpdatesNeverLeavesNullValues()
         {
             var cache = CreateCache();
@@ -597,7 +596,6 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33993")]
         public void OvercapacityPurge_AreThreadSafe()
         {
             var cache = new MemoryCache(new MemoryCacheOptions
@@ -663,7 +661,6 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33993")]
         public void AddAndReplaceEntries_AreThreadSafe()
         {
             var cache = new MemoryCache(new MemoryCacheOptions

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheSetAndRemoveTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheSetAndRemoveTests.cs
@@ -655,7 +655,7 @@ namespace Microsoft.Extensions.Caching.Memory
             Assert.Equal(TaskStatus.RanToCompletion, task1.Status);
             Assert.Equal(TaskStatus.RanToCompletion, task2.Status);
             Assert.Equal(TaskStatus.RanToCompletion, task3.Status);
-            Assert.Equal(cache.Count, cache.Size);
+            CapacityTests.AssertCacheSize(cache.Count, cache);
             Assert.InRange(cache.Count, 0, 10);
             Assert.False(limitExceeded);
         }
@@ -716,7 +716,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 cacheSize += cache.Get<int>(i);
             }
 
-            Assert.Equal(cacheSize, cache.Size);
+            CapacityTests.AssertCacheSize(cacheSize, cache);
             Assert.InRange(cache.Count, 0, 20);
         }
 


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/45868
Fix #33993
Related https://github.com/dotnet/runtime/issues/50270

MemoryCache entries may have arbitrary size (weight); if the cache has an overall size limit set on it, the cache maintains a sum of the sizes of its entries ("Size") in order to trigger potential compaction and to reject oversize additions. As an implementation decision, presumably for performance, it does not update the Size atomically with updates to the entries in the collection; the Size is made eventually consistent, potentially on another thread. Size is exposed for unit tests only. These tests were assuming Size was immediately consistent, so they were occasionally failing.

* Verified failures reproduce by adding a sleep before updating the size. (I cannot repro locally without sleeps, but we know that lab machines can be much slower, busier, unluckier, etc)
* Add retries to all reads of Size, verified failures no longer reproduce.
* Remove sleeps again.
* Un-disabled all tests disabled against #33993 and verified all tests pass.
* Add some comments where I was confused by the implementation.

Note that at least one test disabled against #33993 did not actually read the size. It would have failed due to some unrelated reason - back in 2020. I'm going to assume it was fixed by another change such as possibly #42355.

Thanks @vonzshik for help.