### PR TITLE
Fix running HTTP stress tests on local docker

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/run-docker-compose.ps1
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/run-docker-compose.ps1
@@ -73,7 +73,11 @@ finally {
 
 if (!$buildOnly)
 {
-    $env:DUMPS_SHARE_MOUNT_ROOT="C:/dumps-share"
+    if ($useWindowsContainers) {
+        $env:DUMPS_SHARE_MOUNT_ROOT="C:/dumps-share"
+    } else {
+        $env:DUMPS_SHARE_MOUNT_ROOT="/dumps-share"
+    }
     if (!$env:CLIENT_DUMPS_SHARE) {
         $env:CLIENT_DUMPS_SHARE=Join-Path $env:Temp $(New-Guid)
     }


### PR DESCRIPTION
Otherwise, it would try to use windows-like path inside linux container and will fail on mounting

```
ERROR: for httpstress_server_1  Cannot create container for service server: mount denied:
the source path "\\Users\\knatalia\\AppData\\Local\\Temp\\fbfc6dc2-8df5-42f7-8f7c-a50ce42f6775:C:/dumps-share:rw"
too many colons
```