### PR TITLE
Allow reading more than the minimum number when filling buffer in XmlBufferReader

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -231,7 +231,7 @@ namespace System.Xml
                 }
                 int needed = newOffsetMax - _offsetMax;
                 DiagnosticUtility.DebugAssert(needed > 0, "");
-                int read = _stream.ReadAtLeast(_buffer.AsSpan(_offsetMax, needed), needed, throwOnEndOfStream: false);
+                int read = _stream.ReadAtLeast(_buffer.AsSpan(_offsetMax), needed, throwOnEndOfStream: false);
                 _offsetMax += read;
 
                 if (read < needed)


### PR DESCRIPTION
 Read as much as possible into the buffer without limiting to minimum count
Affects at least XmlDictionaryReader

The current code looked a bit odd with ReadAtLeast while still limiting number of bytes read to the minimum number of bytes to read. 