### PR TITLE
[iOS] Skip test suites that take too long to build on helix

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -286,10 +286,15 @@
     <!--
       Test apps that are too large and take too long to build 
       Keep here until aggressive trimming targets can work on helix.
+
+      https://github.com/dotnet/runtime/issues/72834
+      https://github.com/dotnet/runtime/issues/72836
     -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\UnitTests\System.Text.RegularExpressions.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\FunctionalTests\System.Text.RegularExpressions.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Abstractions\tests\Microsoft.Extensions.Logging.Generators.Tests\Microsoft.Extensions.Logging.Generators.Roslyn4.0.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Unit.Tests\System.Text.Json.SourceGeneration.Roslyn4.0.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Tests\System.Text.Json.SourceGeneration.Roslyn4.0.Tests.csproj" />
-
 
     <!-- Functional tests on devices have problems with return codes from mlaunch -->
     <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\$(TargetOS)\Device\**\*.Test.csproj" />


### PR DESCRIPTION
System.Text.RegularExpressions, Microsoft.Extensions.Logging.Generators.Roslyn4.0.Tests, and STJ source generator tests take too long to build on helix and time out before any tests are run. This is due in part to the amount of aot'd code, which ends up ballooning the app size to around 1GB.  The solution is to enable aggressive trimming targets that are in tests.mobile.targets as this will shrink the app size considerably. Skipping until that happens.

Addresses https://github.com/dotnet/runtime/issues/72834

Addresses https://github.com/dotnet/runtime/issues/72836