### PR TITLE
[iOS] Fix ZipPackage_CreateWithFileAccessWrite test

### DIFF
--- a/src/libraries/System.IO.Packaging/tests/Tests.cs
+++ b/src/libraries/System.IO.Packaging/tests/Tests.cs
@@ -3698,7 +3698,7 @@ namespace System.IO.Packaging.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop doesn't support Package.Open with FileAccess.Write")]
         public void ZipPackage_CreateWithFileAccessWrite()
         {
-            string packageName = "test.zip";
+            string packageName = Path.Combine(TestDirectory, "test.zip");
 
             using (Package package = Package.Open(packageName, FileMode.Create, FileAccess.Write))
             {


### PR DESCRIPTION
On iOS, this test was failing due to not being able to write files in the app root directory.  The fix is to write a file in the TestDirectory, which is a subdirectory under the app root and is writeable.

Fixes https://github.com/dotnet/runtime/issues/72837