### PR TITLE
Disable ReadAsync_CancelPendingValueTask_ThrowsCancellationException for Http1

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamConformanceTests.cs
@@ -31,6 +31,17 @@ namespace System.Net.Http.Functional.Tests
             return Task.CompletedTask;
         }
 #pragma warning restore xUnit1026
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(100)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72586")]
+#pragma warning disable xUnit1026 // unused parameter
+        public override Task ReadAsync_CancelPendingValueTask_ThrowsCancellationException(int cancellationDelay)
+        {
+            return Task.CompletedTask;
+        }
+#pragma warning restore xUnit1026
     }
 
     public sealed class Http1RawResponseStreamConformanceTests : ResponseConnectedStreamConformanceTests


### PR DESCRIPTION
Contributes to #72586.

I checked test result DB and it seems that only the variant in Http1CloseResponseStreamConformanceTests hangs.