### PR TITLE
fixed mono_arch_init when use INTERP_ONLY execute mode

### DIFF
--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -266,10 +266,10 @@ mono_arch_init (void)
 #ifdef MONO_ARCH_ENABLE_PTRAUTH
 	enable_ptrauth = TRUE;
 #endif
-
+ #ifndef DISABLE_JIT 
 	if (!mono_aot_only)
 		bp_trampoline = mini_get_breakpoint_trampoline ();
-
+#endif
 	mono_arm_gsharedvt_init ();
 }
 


### PR DESCRIPTION
do as mono-amd64.c:
https://github.com/dotnet/runtime/blob/4cbe6f99d23e04c56a89251d49de1b0f14000427/src/mono/mono/mini/mini-amd64.c#L1428

it will hit assert when set `MONO_AOT_MODE_INTERP_ONLY` execute mode.

![image](https://user-images.githubusercontent.com/5187024/181008882-81a846af-00c2-4eb9-a537-b94f88973b59.png)

Assertion: should not be reached at /Users/unrealmono/Documents/runtime/src/mono/mono/mini/tramp-arm64.c:865
