### PR TITLE
[wasm-ep] diagnostic server IPC fixups

### DIFF
--- a/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
+++ b/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MonoDiagnosticsMock Condition="'$(MonoDiagnosticsMock)' == ''">false</MonoDiagnosticsMock>
+    <MonoDiagnosticsMock Condition="'$(MonoDiagnosticsMock)' == '' and '$(Configuration)' == 'Debug' ">true</MonoDiagnosticsMock>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
+++ b/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MonoDiagnosticsMock Condition="'$(MonoDiagnosticsMock)' == '' and '$(Configuration)' == 'Debug' ">true</MonoDiagnosticsMock>
+    <MonoDiagnosticsMock Condition="('$(MonoDiagnosticsMock)' == '') and ('$(Configuration)' == 'Debug')">true</MonoDiagnosticsMock>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/runtime/diagnostics/server_pthread/ipc-protocol/base-parser.ts
+++ b/src/mono/wasm/runtime/diagnostics/server_pthread/ipc-protocol/base-parser.ts
@@ -124,11 +124,11 @@ const Parser = {
                     break;
                 }
             }
+            if (trailingNulStart >= 0)
+                result.splice(trailingNulStart);
         }
         const provisionalString = String.fromCharCode.apply(null, result);
 
-        if (trailingNulStart >= 0)
-            return provisionalString.substring(0, trailingNulStart);
         return provisionalString;
     }
 };

--- a/src/mono/wasm/runtime/diagnostics/server_pthread/ipc-protocol/base-parser.ts
+++ b/src/mono/wasm/runtime/diagnostics/server_pthread/ipc-protocol/base-parser.ts
@@ -116,20 +116,17 @@ const Parser = {
 
         /* Trim trailing nul character(s) that are added by the protocol */
         let trailingNulStart = -1;
-        if (result.length > 0) {
-            for (let i = result.length - 1; i >= 0; i--) {
-                if (result[i] === 0) {
-                    trailingNulStart = i;
-                } else {
-                    break;
-                }
+        for (let i = result.length - 1; i >= 0; i--) {
+            if (result[i] === 0) {
+                trailingNulStart = i;
+            } else {
+                break;
             }
-            if (trailingNulStart >= 0)
-                result.splice(trailingNulStart);
         }
-        const provisionalString = String.fromCharCode.apply(null, result);
+        if (trailingNulStart >= 0)
+            result.splice(trailingNulStart);
 
-        return provisionalString;
+        return String.fromCharCode.apply(null, result);
     }
 };
 

--- a/src/mono/wasm/runtime/diagnostics/server_pthread/ipc-protocol/base-parser.ts
+++ b/src/mono/wasm/runtime/diagnostics/server_pthread/ipc-protocol/base-parser.ts
@@ -113,7 +113,23 @@ const Parser = {
             result[i] = (buf[j + 2 * i + 1] << 8) | buf[j + 2 * i];
         }
         advancePos(pos, length * 2);
-        return String.fromCharCode.apply(null, result);
+
+        /* Trim trailing nul character(s) that are added by the protocol */
+        let trailingNulStart = -1;
+        if (result.length > 0) {
+            for (let i = result.length - 1; i >= 0; i--) {
+                if (result[i] === 0) {
+                    trailingNulStart = i;
+                } else {
+                    break;
+                }
+            }
+        }
+        const provisionalString = String.fromCharCode.apply(null, result);
+
+        if (trailingNulStart >= 0)
+            return provisionalString.substring(0, trailingNulStart);
+        return provisionalString;
     }
 };
 

--- a/src/mono/wasm/runtime/diagnostics/server_pthread/streaming-session.ts
+++ b/src/mono/wasm/runtime/diagnostics/server_pthread/streaming-session.ts
@@ -57,9 +57,16 @@ function providersStringFromObject(providers: EventPipeCollectTracingCommandProv
     function keywordsToHexString(k: [number, number]): string {
         const lo = k[0];
         const hi = k[1];
-        const lo_hex = lo.toString(16);
-        const hi_hex = hi.toString(16);
+        const lo_hex = leftPad(lo.toString(16), "0", 8);
+        const hi_hex = leftPad(hi.toString(16), "0", 8);
         return hi_hex + lo_hex;
+    }
+
+    function leftPad(s: string, fill: string, width: number): string {
+        if (s.length >= width)
+            return s;
+        const prefix = fill.repeat(width - s.length);
+        return prefix + s;
     }
 }
 


### PR DESCRIPTION
1. The protocol spec says there's a length and a nul terminator, but sending that literal UTF-16 nul to `ep_enable_2` means we use an incorrect name when looking for the provider.
2. When converting the 64-bit "keywords" mask to a string, pad both 32-bit halves with zeroes.
