### PR TITLE
Change RegexGenerator to produce limited implementation for C# < 11

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/DiagnosticDescriptors.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/DiagnosticDescriptors.cs
@@ -46,17 +46,8 @@ namespace System.Text.RegularExpressions.Generator
             isEnabledByDefault: true,
             customTags: WellKnownDiagnosticTags.NotConfigurable);
 
-        public static DiagnosticDescriptor InvalidLangVersion { get; } = new DiagnosticDescriptor(
-            id: "SYSLIB1044",
-            title: new LocalizableResourceString(nameof(SR.InvalidRegexGeneratorAttributeTitle), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
-            messageFormat: new LocalizableResourceString(nameof(SR.InvalidLangVersionMessage), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
-            category: Category,
-            DiagnosticSeverity.Error,
-            isEnabledByDefault: true,
-            customTags: WellKnownDiagnosticTags.NotConfigurable);
-
         public static DiagnosticDescriptor LimitedSourceGeneration { get; } = new DiagnosticDescriptor(
-            id: "SYSLIB1045",
+            id: "SYSLIB1044",
             title: new LocalizableResourceString(nameof(SR.LimitedSourceGenerationTitle), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.LimitedSourceGenerationMessage), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
             category: Category,
@@ -64,7 +55,7 @@ namespace System.Text.RegularExpressions.Generator
             isEnabledByDefault: true);
 
         public static DiagnosticDescriptor UseRegexSourceGeneration { get; } = new DiagnosticDescriptor(
-            id: "SYSLIB1046",
+            id: "SYSLIB1045",
             title: new LocalizableResourceString(nameof(SR.UseRegexSourceGeneratorTitle), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.UseRegexSourceGeneratorMessage), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
             category: Category,

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
@@ -111,11 +111,6 @@ namespace System.Text.RegularExpressions.Generator
                 return Diagnostic.Create(DiagnosticDescriptors.RegexMethodMustHaveValidSignature, methodSyntax.GetLocation());
             }
 
-            if (typeDec.SyntaxTree.Options is CSharpParseOptions { LanguageVersion: <= LanguageVersion.CSharp10 })
-            {
-                return Diagnostic.Create(DiagnosticDescriptors.InvalidLangVersion, methodSyntax.GetLocation());
-            }
-
             RegexOptions regexOptions = options is not null ? (RegexOptions)options : RegexOptions.None;
 
             // TODO: This is going to include the culture that's current at the time of compilation.

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -65,7 +65,7 @@ namespace System.Text.RegularExpressions.Generator
 
                     // If we're unable to generate a full implementation for this regex, report a diagnostic.
                     // We'll still output a limited implementation that just caches a new Regex(...).
-                    if (!SupportsCodeGeneration(regexMethod.Tree.Root, out string? reason))
+                    if (!SupportsCodeGeneration(regexMethod, out string? reason))
                     {
                         return (regexMethod, reason, Diagnostic.Create(DiagnosticDescriptors.LimitedSourceGeneration, regexMethod.MethodSyntax.GetLocation()));
                     }
@@ -262,11 +262,21 @@ namespace System.Text.RegularExpressions.Generator
             });
         }
 
-        // Determines whether the passed in node supports code generation strategy based on walking the tree.
-        // Also returns a human-readable string to explain the reason (it will be emitted by the source generator, hence
-        // there's no need to localize).
-        private static bool SupportsCodeGeneration(RegexNode node, [NotNullWhen(false)] out string? reason)
+        /// <summary>Determines whether the passed in node supports C# code generation.</summary>
+        /// <remarks>
+        // It also provides a human-readable string to explain the reason. It will be emitted by the source generator
+        // as a comment into the C# code, hence there's no need to localize.
+        /// </remarks>
+        private static bool SupportsCodeGeneration(RegexMethod method, [NotNullWhen(false)] out string? reason)
         {
+            if (method.MethodSyntax.SyntaxTree.Options is CSharpParseOptions { LanguageVersion: <= LanguageVersion.CSharp10 })
+            {
+                reason = "the language version must be C# 11 or higher.";
+                return false;
+            }
+
+            RegexNode node = method.Tree.Root;
+
             if (!node.SupportsCompilation(out reason))
             {
                 // If the pattern doesn't support Compilation, then code generation won't be supported either.

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
@@ -134,14 +134,11 @@
   <data name="RegexMethodMustHaveValidSignatureMessage" xml:space="preserve">
     <value>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</value>
   </data>
-  <data name="InvalidLangVersionMessage" xml:space="preserve">
-    <value>C# LangVersion of 11 or greater is required</value>
-  </data>
   <data name="LimitedSourceGenerationTitle" xml:space="preserve">
     <value>RegexGenerator limitation reached.</value>
   </data>
   <data name="LimitedSourceGenerationMessage" xml:space="preserve">
-    <value>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</value>
+    <value>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</value>
   </data>
   <data name="Generic" xml:space="preserve">
     <value>Regular expression parser error '{0}' at offset {1}.</value>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Nerozpoznaný seskupovací konstrukt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">Je požadována verze jazyku C# LangVersion 11 nebo vyšší.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">Zadaný regulární výraz je neplatný. {0}</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">RegexGenerator nemohl vygenerovat úplnou zdrojovou implementaci pro zadaný regulární výraz z důvodu interního omezení.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">RegexGenerator nemohl vygenerovat úplnou zdrojovou implementaci pro zadaný regulární výraz z důvodu interního omezení.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Unbekanntes Gruppierungskonstrukt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">C#-LangVersion 11 oder höher ist erforderlich</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">Der angegebene Regex ist ungültig. "{0}"</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">RegexGenerator konnte aufgrund einer internen Einschränkung keine vollständige Quellimplementierung für den angegebenen regulären Ausdruck generieren.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">RegexGenerator konnte aufgrund einer internen Einschränkung keine vollständige Quellimplementierung für den angegebenen regulären Ausdruck generieren.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Construcción de agrupación no reconocida.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">Se requiere C# LangVersion de 11 o superior</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">La expresión regular especificada no es válida. '{0}'</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">RegexGenerator no pudo generar una implementación de origen completa para la expresión regular especificada debido a una limitación interna.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">RegexGenerator no pudo generar una implementación de origen completa para la expresión regular especificada debido a una limitación interna.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Construction de regroupement non reconnue.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">C# LangVersion supérieur ou égal à 11 est requis.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">L’expression régulière spécifiée n’est pas valide. « {0} »</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">RegexGenerator n’a pas pu générer d’implémentation source complète pour l’expression régulière spécifiée en raison d’une limitation interne.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">RegexGenerator n’a pas pu générer d’implémentation source complète pour l’expression régulière spécifiée en raison d’une limitation interne.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Costrutto di raggruppamento non riconosciuto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">LangVersion di C# 11 o superiore obbligatoria</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">L'espressione regolare specificata non è valida. '{0}'</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">RegexGenerator non è riuscito a generare un'implementazione di origine completa per l'espressione regolare specificata a causa di una limitazione interna.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">RegexGenerator non è riuscito a generare un'implementazione di origine completa per l'espressione regolare specificata a causa di una limitazione interna.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
@@ -97,11 +97,6 @@
         <target state="translated">認識されないグループ化構成体です。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">C# LangVersion 11 以上が必要です</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">指定された正規表現が無効です。'{0}'</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">内部制限により、RegexGenerator は指定された正規表現の完全なソース実装を生成できませんでした。</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">内部制限により、RegexGenerator は指定された正規表現の完全なソース実装を生成できませんでした。</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
@@ -97,11 +97,6 @@
         <target state="translated">인식할 수 없는 그룹화 구성입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">11 이상의 C# LangVersion이 필요합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">지정한 regex가 잘못되었습니다. '{0}'</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">RegexGenerator가 내부 제한으로 인해 지정된 정규식에 대한 전체 소스 구현을 생성할 수 없습니다.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">RegexGenerator가 내부 제한으로 인해 지정된 정규식에 대한 전체 소스 구현을 생성할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Nierozpoznana konstrukcja grupowania.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">Wymagane jest wersja 11 lub nowsza języka C# LangVersion</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">Określone wyrażenie regularne jest nieprawidłowe. „{0}”</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">Narzędzie RegexGenerator nie może wygenerować pełnej implementacji źródła dla określonego wyrażenia regularnego z powodu ograniczenia wewnętrznego.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">Narzędzie RegexGenerator nie może wygenerować pełnej implementacji źródła dla określonego wyrażenia regularnego z powodu ograniczenia wewnętrznego.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Construção de agrupamento não reconhecida.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">C# LangVersion de 11 ou superior é necessária</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">O regex especificado é inválido. '{0}'</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">O RegexGenerator não pôde gerar uma implementação de origem completa para a expressão regular especificada devido a uma limitação interna.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">O RegexGenerator não pôde gerar uma implementação de origem completa para a expressão regular especificada devido a uma limitação interna.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Нераспознанная конструкция группирования.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">Требуется C# LangVersion 11 или выше</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">Указанное регулярное выражение недопустимо. "{0}"</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">RegexGenerator не удалось создать реализации источника для указанного регулярного выражения из-за внутреннего ограничения.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">RegexGenerator не удалось создать реализации источника для указанного регулярного выражения из-за внутреннего ограничения.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Tanınmayan gruplama yapısı.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">C# LangVersion 11 veya üstü gereklidir</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">Belirtilen normal ifade geçersiz. ''{0}”</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">RegexGenerator, bir iç sınırlama nedeniyle belirtilen normal ifade için tam bir kaynak uygulaması oluşturamadı.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">RegexGenerator, bir iç sınırlama nedeniyle belirtilen normal ifade için tam bir kaynak uygulaması oluşturamadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -97,11 +97,6 @@
         <target state="translated">无法识别的分组构造。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">需要 C# LangVersion 11 或更高版本</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">指定的正则表达式无效。“{0}”</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">由于内部限制，RegexGenerator 无法为指定的正则表达式生成完整的源实现。</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">由于内部限制，RegexGenerator 无法为指定的正则表达式生成完整的源实现。</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -97,11 +97,6 @@
         <target state="translated">無法識別的分組建構。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 11 or greater is required</source>
-        <target state="translated">需要 11 或更大的 C# LangVersion</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">
         <source>The specified regex is invalid. '{0}'</source>
         <target state="translated">指定的 RegEx 無效。'{0}'</target>
@@ -128,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
-        <target state="translated">由於內部限制，RegexGenerator 無法為指定的規則運算式產生完整的來源實作。</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation. See the explanation in the generated source for more details.</source>
+        <target state="needs-review-translation">由於內部限制，RegexGenerator 無法為指定的規則運算式產生完整的來源實作。</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
@@ -174,7 +174,7 @@ namespace System.Text.RegularExpressions.Tests
                         new CSharpCompilationOptions(
                             OutputKind.DynamicallyLinkedLibrary,
                             warningLevel: 9999, // docs recommend using "9999" to catch all warnings now and in the future
-                            specificDiagnosticOptions: ImmutableDictionary<string, ReportDiagnostic>.Empty.Add("SYSLIB1045", ReportDiagnostic.Hidden)) // regex with limited support
+                            specificDiagnosticOptions: ImmutableDictionary<string, ReportDiagnostic>.Empty.Add("SYSLIB1044", ReportDiagnostic.Hidden)) // regex with limited support
                             .WithNullableContextOptions(NullableContextOptions.Enable))
                             .WithParseOptions(s_previewParseOptions)
                     .AddDocument("RegexGenerator.g.cs", SourceText.From("// Empty", Encoding.UTF8)).Project;

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
@@ -206,7 +206,7 @@ namespace System.Text.RegularExpressions.Tests
         [Theory]
         [InlineData(LanguageVersion.CSharp9)]
         [InlineData(LanguageVersion.CSharp10)]
-        public async Task Diagnostic_InvalidLangVersion(LanguageVersion version)
+        public async Task Diagnostic_InvalidLangVersion_LimitedSupport(LanguageVersion version)
         {
             IReadOnlyList<Diagnostic> diagnostics = await RegexGeneratorHelper.RunGenerator(@"
                 using System.Text.RegularExpressions;
@@ -232,7 +232,37 @@ namespace System.Text.RegularExpressions.Tests
                 }
             ");
 
-            Assert.Equal("SYSLIB1045", Assert.Single(diagnostics).Id);
+            Assert.Equal("SYSLIB1044", Assert.Single(diagnostics).Id);
+        }
+
+        [Fact]
+        public async Task Diagnostic_CaseInsensitiveBackreference_LimitedSupport()
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RegexGeneratorHelper.RunGenerator(@"
+                using System.Text.RegularExpressions;
+                partial class C
+                {
+                    [RegexGenerator(@""(?i)(ab)\1"")]
+                    private static partial Regex CaseInsensitiveBackreferenceNotSupported();
+                }
+            ");
+
+            Assert.Equal("SYSLIB1044", Assert.Single(diagnostics).Id);
+        }
+
+        [Fact]
+        public async Task Diagnostic_TooMuchNesting_LimitedSupport()
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RegexGeneratorHelper.RunGenerator(@"
+                using System.Text.RegularExpressions;
+                partial class C
+                {
+                    [RegexGenerator(""" + new string('(', 100) + "a" + new string(')', 100) + @""")]
+                    private static partial Regex TooMuchNestingNotSupported();
+                }
+            ");
+
+            Assert.Equal("SYSLIB1044", Assert.Single(diagnostics).Id);
         }
 
         [Fact]

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
@@ -3,8 +3,8 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <!-- xUnit2008 is about regexes and isn't appropriate in the test project for regexes -->
     <!-- SYSLIB0036 is about obsoletion of regex members -->
-    <!-- SYSLIB1046 is for switching to RegexGenerator -->
-    <NoWarn>$(NoWarn);xUnit2008;SYSLIB0036;SYSLIB1046</NoWarn>
+    <!-- SYSLIB1045 is for switching to RegexGenerator -->
+    <NoWarn>$(NoWarn);xUnit2008;SYSLIB0036;SYSLIB1045</NoWarn>
     <TargetFrameworks>$(NetCoreAppCurrent);net48</TargetFrameworks>
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'Browser'">true</DebuggerSupport>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToRegexGeneratorAnalyzerTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToRegexGeneratorAnalyzerTests.cs
@@ -22,7 +22,7 @@ namespace System.Text.RegularExpressions.Tests
     [ActiveIssue("https://github.com/dotnet/runtime/issues/69823", TestRuntimes.Mono)]
     public class UpgradeToRegexGeneratorAnalyzerTests
     {
-        private const string UseRegexSourceGeneratorDiagnosticId = @"SYSLIB1046";
+        private const string UseRegexSourceGeneratorDiagnosticId = @"SYSLIB1045";
 
         [Fact]
         public async Task NoDiagnosticsForEmpty()


### PR DESCRIPTION
Today the RegexGenerator fails to produce any code for GeneratedRegex if the LangVersion is 10 or lower.  However, that restriction only exists because the code generated for a regex implementation contains use of language features only available in C# 11 and newer.  Rather than failing outright for 10 or lower, we can just fall back to the limited support implementation that just caches an instance of the regex.  That still provides some value and makes it easier to transition between language versions.