### PR TITLE
Clarify the purpose of the official discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For other issues, please use the following repos:
 * [API Reference docs](https://docs.microsoft.com/dotnet/api)
 * [.NET API Catalog](https://apisof.net) (incl. APIs from daily builds and API usage info)
 * [API docs writing guidelines](https://github.com/dotnet/dotnet-api-docs/wiki) - useful when writing /// comments
-* [.NET Discord Server](https://aka.ms/dotnet-discord) - a place to talk and hang out with .NET community
+* [.NET Discord Server](https://aka.ms/dotnet-discord) - a place to discuss the development of .NET and its ecosystem
 
 ## .NET Foundation
 


### PR DESCRIPTION
Clarifies that the official .NET discord is for people contributing to it, not for general community talks, as the #rules also state so:
```
The main audience of this server are contributors to the .NET platform and ecosystem. For general .NET/C# questions please use the C# Discord (https://aka.ms/csharp-discord) or Stack Overflow.
```