### PR TITLE
Update the CustomMarshallerAttributeFixer to support adding missing methods for stateless marshaller shapes

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeAnalyzer.cs
@@ -662,7 +662,7 @@ namespace Microsoft.Interop.Analyzers
                                         StatelessLinearCollectionRequiresTwoParameterAllocateContainerForManagedElementsRule,
                                         MissingMemberNames.CreateDiagnosticPropertiesForMissingMembersDiagnostic(
                                             mode,
-                                            ShapeMemberNames.LinearCollection.Stateless.AllocateContainerForUnmanagedElements),
+                                            ShapeMemberNames.LinearCollection.Stateless.AllocateContainerForManagedElements),
                                         marshallerType.ToDisplayString(),
                                         mode,
                                         managedType.ToDisplayString());

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeAnalyzer.cs
@@ -424,6 +424,7 @@ namespace Microsoft.Interop.Analyzers
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(
                 MarshallerTypeMustSpecifyManagedTypeRule,
+                MarshallerTypeMustBeStaticClassOrStructRule,
                 UnmanagedTypeMustBeUnmanagedRule,
                 GetPinnableReferenceReturnTypeBlittableRule,
                 TypeMustHaveExplicitCastFromVoidPointerRule,
@@ -653,7 +654,7 @@ namespace Microsoft.Interop.Analyzers
                             if (isLinearCollectionMarshaller)
                             {
                                 // Verify that all of the following methods are present with valid shapes:
-                                // - AllocateContainerForUnmanagedElements
+                                // - AllocateContainerForManagedElements
                                 // - GetUnmanagedValuesSource
                                 // - GetManagedValuesDestination
                                 if (methods.ToManaged is null && methods.ToManagedFinally is null)

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeFixer.cs
@@ -229,6 +229,17 @@ namespace Microsoft.Interop.Analyzers
                         statements: new[] { DefaultMethodStatement(gen, editor.SemanticModel.Compilation) }));
             }
 
+            if (missingMemberNames.Contains(ShapeMemberNames.BufferSize))
+            {
+                newMembers.Add(
+                    gen.WithAccessorDeclarations(
+                        gen.PropertyDeclaration(ShapeMemberNames.BufferSize,
+                            gen.TypeExpression(editor.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Int32)),
+                            Accessibility.Public,
+                            DeclarationModifiers.Static),
+                        gen.GetAccessorDeclaration(statements: new[] { DefaultMethodStatement(gen, editor.SemanticModel.Compilation) })));
+            }
+
             editor.ReplaceNode(declaringSyntax, (declaringSyntax, gen) => gen.AddMembers(declaringSyntax, newMembers));
 
             ITypeSymbol? FindUnmanagedTypeFromExistingShape()

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CustomMarshallerAttributeFixerTests_StatelessLinearCollectionShapeValidation.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CustomMarshallerAttributeFixerTests_StatelessLinearCollectionShapeValidation.cs
@@ -35,8 +35,37 @@ namespace LibraryImportGenerator.UnitTests
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedOut, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementIn, typeof(MarshallerType<>))]
+                [ContiguousCollectionMarshaller]
+                static class MarshallerType<T>
+                {
+                    public static nint AllocateContainerForUnmanagedElements(ManagedType managed, out int numElements)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+
+                    public static System.ReadOnlySpan<nint> GetManagedValuesSource(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+
+                    public static System.Span<T> GetUnmanagedValuesDestination(nint unmanaged, int numElements)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessLinearCollectionRequiresTwoParameterAllocateContainerForUnmanagedElementsRule).WithLocation(0).WithArguments("MarshallerType<T>", MarshalMode.ManagedToUnmanagedIn, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionRequiresTwoParameterAllocateContainerForUnmanagedElementsRule).WithLocation(1).WithArguments("MarshallerType<T>", MarshalMode.UnmanagedToManagedOut, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionRequiresTwoParameterAllocateContainerForUnmanagedElementsRule).WithLocation(2).WithArguments("MarshallerType<T>", MarshalMode.ElementIn, "ManagedType"),
@@ -63,8 +92,34 @@ namespace LibraryImportGenerator.UnitTests
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedOut, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementIn, typeof(MarshallerType<>))]
+                [ContiguousCollectionMarshaller]
+                static class MarshallerType<T>
+                {
+                    public static nint AllocateContainerForUnmanagedElements(ManagedType m, out int numElements) => throw null;
+
+                    public static System.ReadOnlySpan<nint> GetManagedValuesSource(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+
+                    public static System.Span<T> GetUnmanagedValuesDestination(nint unmanaged, int numElements)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessLinearCollectionInRequiresCollectionMethodsRule).WithLocation(0).WithArguments("MarshallerType<T>", MarshalMode.ManagedToUnmanagedIn, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionInRequiresCollectionMethodsRule).WithLocation(1).WithArguments("MarshallerType<T>", MarshalMode.UnmanagedToManagedOut, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionInRequiresCollectionMethodsRule).WithLocation(2).WithArguments("MarshallerType<T>", MarshalMode.ElementIn, "ManagedType"));
@@ -87,12 +142,36 @@ namespace LibraryImportGenerator.UnitTests
                 {
                     public static nint AllocateContainerForUnmanagedElements(ManagedType m, out int numElements) => throw null;
 
-                    public static Span<byte> GetUnmanagedValuesDestination(nint unmanaged, int numElements) => default;
+                    public static Span<T> GetUnmanagedValuesDestination(nint unmanaged, int numElements) => default;
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System;
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedOut, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementIn, typeof(MarshallerType<>))]
+                [ContiguousCollectionMarshaller]
+                static class MarshallerType<T>
+                {
+                    public static nint AllocateContainerForUnmanagedElements(ManagedType m, out int numElements) => throw null;
+                
+                    public static Span<T> GetUnmanagedValuesDestination(nint unmanaged, int numElements) => default;
+                
+                    public static ReadOnlySpan<nint> GetManagedValuesSource(ManagedType managed)
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessLinearCollectionInRequiresCollectionMethodsRule).WithLocation(0).WithArguments("MarshallerType<T>", MarshalMode.ManagedToUnmanagedIn, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionInRequiresCollectionMethodsRule).WithLocation(1).WithArguments("MarshallerType<T>", MarshalMode.UnmanagedToManagedOut, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionInRequiresCollectionMethodsRule).WithLocation(2).WithArguments("MarshallerType<T>", MarshalMode.ElementIn, "ManagedType"));
@@ -115,12 +194,36 @@ namespace LibraryImportGenerator.UnitTests
                 {
                     public static nint AllocateContainerForUnmanagedElements(ManagedType m, out int numElements) => throw null;
 
-                    public static Span<byte> GetManagedValuesSource(ManagedType m) => default;
+                    public static ReadOnlySpan<byte> GetManagedValuesSource(ManagedType m) => default;
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System;
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedOut, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementIn, typeof(MarshallerType<>))]
+                [ContiguousCollectionMarshaller]
+                static class MarshallerType<T>
+                {
+                    public static nint AllocateContainerForUnmanagedElements(ManagedType m, out int numElements) => throw null;
+                
+                    public static ReadOnlySpan<byte> GetManagedValuesSource(ManagedType m) => default;
+
+                    public static Span<T> GetUnmanagedValuesDestination(nint unmanaged, int numElements)
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessLinearCollectionInRequiresCollectionMethodsRule).WithLocation(0).WithArguments("MarshallerType<T>", MarshalMode.ManagedToUnmanagedIn, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionInRequiresCollectionMethodsRule).WithLocation(1).WithArguments("MarshallerType<T>", MarshalMode.UnmanagedToManagedOut, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionInRequiresCollectionMethodsRule).WithLocation(2).WithArguments("MarshallerType<T>", MarshalMode.ElementIn, "ManagedType"));
@@ -165,9 +268,9 @@ namespace LibraryImportGenerator.UnitTests
                 
                 class ManagedType {}
                 
-                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof({|#0:MarshallerType<>|}))]
-                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedOut, typeof({|#1:MarshallerType<>|}))]
-                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementIn, typeof({|#2:MarshallerType<>|}))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedOut, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementIn, typeof(MarshallerType<>))]
                 [ContiguousCollectionMarshaller]
                 static class MarshallerType<T>
                 {
@@ -185,7 +288,7 @@ namespace LibraryImportGenerator.UnitTests
 
 
         [Fact]
-        public async Task ModeThatUsesManagedToUnmanagedShape_InvalidCollectionElementType_DoesNotReportDiagnostic()
+        public async Task ModeThatUsesManagedToUnmanagedShape_InvalidCollectionElementType_ReportsDiagnostic()
         {
             string source = """
                 using System;
@@ -231,8 +334,37 @@ namespace LibraryImportGenerator.UnitTests
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedOut, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedIn, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementOut, typeof(MarshallerType<>))]
+                [ContiguousCollectionMarshaller]
+                static class MarshallerType<T>
+                {
+                    public static ManagedType AllocateContainerForManagedElements(nint unmanaged, int numElements)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+
+                    public static System.ReadOnlySpan<T> GetUnmanagedValuesSource(nint unmanaged, int numElements)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+
+                    public static System.Span<nint> GetManagedValuesDestination(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessLinearCollectionRequiresTwoParameterAllocateContainerForManagedElementsRule).WithLocation(0).WithArguments("MarshallerType<T>", MarshalMode.ManagedToUnmanagedOut, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionRequiresTwoParameterAllocateContainerForManagedElementsRule).WithLocation(1).WithArguments("MarshallerType<T>", MarshalMode.UnmanagedToManagedIn, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionRequiresTwoParameterAllocateContainerForManagedElementsRule).WithLocation(2).WithArguments("MarshallerType<T>", MarshalMode.ElementOut, "ManagedType"),
@@ -259,8 +391,34 @@ namespace LibraryImportGenerator.UnitTests
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedOut, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedIn, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementOut, typeof(MarshallerType<>))]
+                [ContiguousCollectionMarshaller]
+                static class MarshallerType<T>
+                {
+                    public static ManagedType AllocateContainerForManagedElements(nint m, int numElements) => throw null;
+
+                    public static System.ReadOnlySpan<T> GetUnmanagedValuesSource(nint unmanaged, int numElements)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+
+                    public static System.Span<nint> GetManagedValuesDestination(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessLinearCollectionOutRequiresCollectionMethodsRule).WithLocation(0).WithArguments("MarshallerType<T>", MarshalMode.ManagedToUnmanagedOut, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionOutRequiresCollectionMethodsRule).WithLocation(1).WithArguments("MarshallerType<T>", MarshalMode.UnmanagedToManagedIn, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionOutRequiresCollectionMethodsRule).WithLocation(2).WithArguments("MarshallerType<T>", MarshalMode.ElementOut, "ManagedType"));
@@ -287,8 +445,32 @@ namespace LibraryImportGenerator.UnitTests
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System;
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedOut, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedIn, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementOut, typeof(MarshallerType<>))]
+                [ContiguousCollectionMarshaller]
+                static class MarshallerType<T>
+                {
+                    public static ManagedType AllocateContainerForManagedElements(nint m, int numElements) => throw null;
+                
+                    public static Span<byte> GetManagedValuesDestination(ManagedType m) => default;
+
+                    public static ReadOnlySpan<T> GetUnmanagedValuesSource(nint unmanaged, int numElements)
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessLinearCollectionOutRequiresCollectionMethodsRule).WithLocation(0).WithArguments("MarshallerType<T>", MarshalMode.ManagedToUnmanagedOut, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionOutRequiresCollectionMethodsRule).WithLocation(1).WithArguments("MarshallerType<T>", MarshalMode.UnmanagedToManagedIn, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionOutRequiresCollectionMethodsRule).WithLocation(2).WithArguments("MarshallerType<T>", MarshalMode.ElementOut, "ManagedType"));
@@ -309,14 +491,38 @@ namespace LibraryImportGenerator.UnitTests
                 [ContiguousCollectionMarshaller]
                 static class MarshallerType<T>
                 {
-                    public static ManagedType AllocateContainerForManagedElements(nint unmanaged, out int numElements) => throw null;
+                    public static ManagedType AllocateContainerForManagedElements(nint unmanaged, int numElements) => throw null;
 
-                    public static Span<byte> GetUnmanagedValuesSource(nint unmanaged, int numElements) => default;
+                    public static ReadOnlySpan<T> GetUnmanagedValuesSource(nint unmanaged, int numElements) => default;
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System;
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedOut, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedIn, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementOut, typeof(MarshallerType<>))]
+                [ContiguousCollectionMarshaller]
+                static class MarshallerType<T>
+                {
+                    public static ManagedType AllocateContainerForManagedElements(nint unmanaged, int numElements) => throw null;
+
+                    public static ReadOnlySpan<T> GetUnmanagedValuesSource(nint unmanaged, int numElements) => default;
+
+                    public static Span<nint> GetManagedValuesDestination(ManagedType managed)
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessLinearCollectionOutRequiresCollectionMethodsRule).WithLocation(0).WithArguments("MarshallerType<T>", MarshalMode.ManagedToUnmanagedOut, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionOutRequiresCollectionMethodsRule).WithLocation(1).WithArguments("MarshallerType<T>", MarshalMode.UnmanagedToManagedIn, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessLinearCollectionOutRequiresCollectionMethodsRule).WithLocation(2).WithArguments("MarshallerType<T>", MarshalMode.ElementOut, "ManagedType"));
@@ -361,9 +567,9 @@ namespace LibraryImportGenerator.UnitTests
                 
                 class ManagedType {}
                 
-                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedOut, typeof({|#0:MarshallerType<>|}))]
-                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedIn, typeof({|#1:MarshallerType<>|}))]
-                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementOut, typeof({|#2:MarshallerType<>|}))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedOut, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedIn, typeof(MarshallerType<>))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementOut, typeof(MarshallerType<>))]
                 [ContiguousCollectionMarshaller]
                 static class MarshallerType<T>
                 {
@@ -426,12 +632,39 @@ namespace LibraryImportGenerator.UnitTests
                 
                     public static ReadOnlySpan<int> GetManagedValuesSource(ManagedType m) => default;
                 
-                    public static Span<byte> GetUnmanagedValuesDestination(nint unmanaged, int numElements) => default;
+                    public static Span<T> GetUnmanagedValuesDestination(nint unmanaged, int numElements) => default;
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System;
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof(MarshallerType<>))]
+                [ContiguousCollectionMarshaller]
+                static class MarshallerType<T>
+                {
+                    public static nint AllocateContainerForUnmanagedElements(ManagedType m, Span<byte> b, out int numElements) => throw null;
+                
+                    public static ReadOnlySpan<int> GetManagedValuesSource(ManagedType m) => default;
+                
+                    public static Span<T> GetUnmanagedValuesDestination(nint unmanaged, int numElements) => default;
+                
+                    public static int BufferSize
+                    {
+                        get
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessLinearCollectionCallerAllocConstructorMustHaveBufferSizeRule).WithLocation(0).WithArguments("MarshallerType<T>", "byte"));
         }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CustomMarshallerAttributeFixerTests_StatelessValueShapeValidation.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CustomMarshallerAttributeFixerTests_StatelessValueShapeValidation.cs
@@ -34,8 +34,26 @@ namespace LibraryImportGenerator.UnitTests
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System.Runtime.InteropServices.Marshalling;
+
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof(MarshallerType))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedOut, typeof(MarshallerType))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementIn, typeof(MarshallerType))]
+                static class MarshallerType
+                {
+                    public static nint ConvertToUnmanaged(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessValueInRequiresConvertToUnmanagedRule).WithLocation(0).WithArguments("MarshallerType", MarshalMode.ManagedToUnmanagedIn, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessValueInRequiresConvertToUnmanagedRule).WithLocation(1).WithArguments("MarshallerType", MarshalMode.UnmanagedToManagedOut, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessValueInRequiresConvertToUnmanagedRule).WithLocation(2).WithArguments("MarshallerType", MarshalMode.ElementIn, "ManagedType"));
@@ -57,8 +75,26 @@ namespace LibraryImportGenerator.UnitTests
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System.Runtime.InteropServices.Marshalling;
+
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedOut, typeof(MarshallerType))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedIn, typeof(MarshallerType))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementOut, typeof(MarshallerType))]
+                static class MarshallerType
+                {
+                    public static ManagedType ConvertToManaged(nint unmanaged)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessRequiresConvertToManagedRule).WithLocation(0).WithArguments("MarshallerType", MarshalMode.ManagedToUnmanagedOut, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessRequiresConvertToManagedRule).WithLocation(1).WithArguments("MarshallerType", MarshalMode.UnmanagedToManagedIn, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessRequiresConvertToManagedRule).WithLocation(2).WithArguments("MarshallerType", MarshalMode.ElementOut, "ManagedType"));
@@ -80,11 +116,134 @@ namespace LibraryImportGenerator.UnitTests
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System.Runtime.InteropServices.Marshalling;
+
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedRef, typeof(MarshallerType))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedRef, typeof(MarshallerType))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementRef, typeof(MarshallerType))]
+                static class MarshallerType
+                {
+                    public static nint ConvertToUnmanaged(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                
+                    public static ManagedType ConvertToManaged(nint unmanaged)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessValueInRequiresConvertToUnmanagedRule).WithLocation(0).WithArguments("MarshallerType", MarshalMode.ManagedToUnmanagedRef, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessValueInRequiresConvertToUnmanagedRule).WithLocation(1).WithArguments("MarshallerType", MarshalMode.UnmanagedToManagedRef, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessValueInRequiresConvertToUnmanagedRule).WithLocation(2).WithArguments("MarshallerType", MarshalMode.ElementRef, "ManagedType"),
+                VerifyCS.Diagnostic(StatelessRequiresConvertToManagedRule).WithLocation(0).WithArguments("MarshallerType", MarshalMode.ManagedToUnmanagedRef, "ManagedType"),
+                VerifyCS.Diagnostic(StatelessRequiresConvertToManagedRule).WithLocation(1).WithArguments("MarshallerType", MarshalMode.UnmanagedToManagedRef, "ManagedType"),
+                VerifyCS.Diagnostic(StatelessRequiresConvertToManagedRule).WithLocation(2).WithArguments("MarshallerType", MarshalMode.ElementRef, "ManagedType"));
+        }
+
+        [Fact]
+        public async Task ModeThatUsesBidirectionalShape_Missing_ConvertToUnmanaged_AddsMethod_WithMatchingUnmanagedType()
+        {
+            string source = """
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedRef, typeof({|#0:MarshallerType|}))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedRef, typeof({|#1:MarshallerType|}))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementRef, typeof({|#2:MarshallerType|}))]
+                static class MarshallerType
+                {
+                    public static ManagedType ConvertToManaged(float unmanaged)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            string fixedSource = """
+                using System.Runtime.InteropServices.Marshalling;
+
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedRef, typeof(MarshallerType))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedRef, typeof(MarshallerType))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementRef, typeof(MarshallerType))]
+                static class MarshallerType
+                {
+                    public static ManagedType ConvertToManaged(float unmanaged)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+
+                    public static float ConvertToUnmanaged(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
+                source,
+                fixedSource,
+                VerifyCS.Diagnostic(StatelessValueInRequiresConvertToUnmanagedRule).WithLocation(0).WithArguments("MarshallerType", MarshalMode.ManagedToUnmanagedRef, "ManagedType"),
+                VerifyCS.Diagnostic(StatelessValueInRequiresConvertToUnmanagedRule).WithLocation(1).WithArguments("MarshallerType", MarshalMode.UnmanagedToManagedRef, "ManagedType"),
+                VerifyCS.Diagnostic(StatelessValueInRequiresConvertToUnmanagedRule).WithLocation(2).WithArguments("MarshallerType", MarshalMode.ElementRef, "ManagedType"));
+        }
+
+        [Fact]
+        public async Task ModeThatUsesBidirectionalShape_Missing_ConvertToManaged_AddsMethod_WithMatchingUnmanagedType()
+        {
+            string source = """
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedRef, typeof({|#0:MarshallerType|}))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedRef, typeof({|#1:MarshallerType|}))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementRef, typeof({|#2:MarshallerType|}))]
+                static class MarshallerType
+                {
+                    public static float ConvertToUnmanaged(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            string fixedSource = """
+                using System.Runtime.InteropServices.Marshalling;
+
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedRef, typeof(MarshallerType))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedRef, typeof(MarshallerType))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementRef, typeof(MarshallerType))]
+                static class MarshallerType
+                {
+                    public static float ConvertToUnmanaged(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+
+                    public static ManagedType ConvertToManaged(float unmanaged)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
+                source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessRequiresConvertToManagedRule).WithLocation(0).WithArguments("MarshallerType", MarshalMode.ManagedToUnmanagedRef, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessRequiresConvertToManagedRule).WithLocation(1).WithArguments("MarshallerType", MarshalMode.UnmanagedToManagedRef, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessRequiresConvertToManagedRule).WithLocation(2).WithArguments("MarshallerType", MarshalMode.ElementRef, "ManagedType"));
@@ -129,8 +288,29 @@ namespace LibraryImportGenerator.UnitTests
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System.Runtime.InteropServices.Marshalling;
+
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.Default, typeof(MarshallerType))]
+                static class MarshallerType
+                {
+                    public static nint ConvertToUnmanaged(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                
+                    public static ManagedType ConvertToManaged(nint unmanaged)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(StatelessValueInRequiresConvertToUnmanagedRule).WithSeverity(DiagnosticSeverity.Info).WithLocation(0).WithArguments("MarshallerType", MarshalMode.Default, "ManagedType"),
                 VerifyCS.Diagnostic(StatelessRequiresConvertToManagedRule).WithSeverity(DiagnosticSeverity.Info).WithLocation(0).WithArguments("MarshallerType", MarshalMode.Default, "ManagedType"));
         }
@@ -154,6 +334,104 @@ namespace LibraryImportGenerator.UnitTests
             await VerifyCS.VerifyAnalyzerAsync(
                 source,
                 VerifyCS.Diagnostic(CallerAllocConstructorMustHaveBufferSizeRule).WithLocation(0).WithArguments("MarshallerType", "byte"));
+        }
+
+        [Fact]
+        public async Task ModeThatUsesManagedToUnmanagedShape_Missing_ConvertToUnmanagedMethod_Marshaller_DifferentDocument_ReportsDiagnostic()
+        {
+            string entryPointTypeSource = """
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof({|SYSLIB1057:OtherMarshallerType|}))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedOut, typeof({|SYSLIB1057:OtherMarshallerType|}))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementIn, typeof({|SYSLIB1057:OtherMarshallerType|}))]
+                static class MarshallerType
+                {
+                }
+                """;
+
+            string otherMarshallerTypeOriginalSource = """
+                static class OtherMarshallerType
+                {
+                }
+                """;
+
+            string otherMarshallerTypeFixedSource = """
+                static class OtherMarshallerType
+                {
+                    public static nint ConvertToUnmanaged(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            var test = new VerifyCS.Test();
+            test.TestState.Sources.Add(entryPointTypeSource);
+            test.TestState.Sources.Add(("OtherMarshaller.cs", otherMarshallerTypeOriginalSource));
+            test.FixedState.Sources.Add(entryPointTypeSource);
+            test.FixedState.Sources.Add(("OtherMarshaller.cs", otherMarshallerTypeFixedSource));
+            test.MarkupOptions = MarkupOptions.UseFirstDescriptor;
+            test.FixedState.MarkupHandling = MarkupMode.IgnoreFixable;
+            await test.RunAsync();
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/roslyn-sdk/issues/1000")]
+        public async Task ModeThatUsesManagedToUnmanagedShape_Missing_ConvertToUnmanagedMethod_Marshaller_DifferentProject_ReportsDiagnostic()
+        {
+            string entryPointTypeSource = """
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof({|SYSLIB1057:OtherMarshallerType|}))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.UnmanagedToManagedOut, typeof({|SYSLIB1057:OtherMarshallerType|}))]
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ElementIn, typeof({|SYSLIB1057:OtherMarshallerType|}))]
+                static class MarshallerType
+                {
+                }
+                """;
+
+            string otherMarshallerTypeOriginalSource = """
+                public static class OtherMarshallerType
+                {
+                }
+                """;
+
+            string otherMarshallerTypeFixedSource = """
+                public static class OtherMarshallerType
+                {
+                    public static nint ConvertToUnmanaged(ManagedType managed)
+                    {
+                        throw new System.NotImplementedException();
+                    }
+                }
+                """;
+
+            var test = new VerifyCS.Test();
+
+            string otherProjectName = "OtherMarshallerProject";
+            ProjectState otherProjectOriginalState = new ProjectState(otherProjectName, LanguageNames.CSharp, "/1/Other", "cs");
+            otherProjectOriginalState.Sources.Add(otherMarshallerTypeOriginalSource);
+            otherProjectOriginalState.AdditionalReferences.AddRange(test.TestState.AdditionalReferences);
+
+            ProjectState otherProjectFixedState = new ProjectState(otherProjectName, LanguageNames.CSharp, "/1/Other", "cs");
+            otherProjectFixedState.Sources.Add(otherMarshallerTypeFixedSource);
+            otherProjectFixedState.AdditionalReferences.AddRange(test.TestState.AdditionalReferences);
+
+            test.TestState.Sources.Add(entryPointTypeSource);
+            test.TestState.AdditionalProjects.Add(otherProjectName, otherProjectOriginalState);
+            test.TestState.AdditionalProjectReferences.Add(otherProjectName);
+
+            test.FixedState.Sources.Add(entryPointTypeSource);
+            test.FixedState.AdditionalProjects.Add(otherProjectName, otherProjectFixedState);
+            test.FixedState.AdditionalProjectReferences.Add(otherProjectName);
+            test.MarkupOptions = MarkupOptions.UseFirstDescriptor;
+            test.FixedState.MarkupHandling = MarkupMode.IgnoreFixable;
+            await test.RunAsync();
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CustomMarshallerAttributeFixerTests_StatelessValueShapeValidation.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CustomMarshallerAttributeFixerTests_StatelessValueShapeValidation.cs
@@ -60,6 +60,27 @@ namespace LibraryImportGenerator.UnitTests
         }
 
         [Fact]
+        public async Task ModeThatUsesManagedToUnmanagedIn_OnlyCallerAllocatedBuffer_DoesNotReportDiagnostic()
+        {
+            string source = """
+                using System;
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof(MarshallerType))]
+                static class MarshallerType
+                {
+                    public static int BufferSize => 1;
+
+                    public static nint ConvertToUnmanaged(ManagedType managed, Span<byte> buffer) => default;
+                }
+                """;
+
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
         public async Task ModeThatUsesUnmanagedToManagedShape_Missing_ConvertToManagedMethod_ReportsDiagnostic()
         {
             string source = """

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CustomMarshallerAttributeFixerTests_StatelessValueShapeValidation.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CustomMarshallerAttributeFixerTests_StatelessValueShapeValidation.cs
@@ -331,8 +331,30 @@ namespace LibraryImportGenerator.UnitTests
                 }
                 """;
 
-            await VerifyCS.VerifyAnalyzerAsync(
+            string fixedSource = """
+                using System;
+                using System.Runtime.InteropServices.Marshalling;
+                
+                class ManagedType {}
+                
+                [CustomMarshaller(typeof(ManagedType), MarshalMode.ManagedToUnmanagedIn, typeof(MarshallerType))]
+                static class MarshallerType
+                {
+                    public static nint ConvertToUnmanaged(ManagedType m, Span<byte> b) => default;
+
+                    public static int BufferSize
+                    {
+                        get
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(
                 source,
+                fixedSource,
                 VerifyCS.Diagnostic(CallerAllocConstructorMustHaveBufferSizeRule).WithLocation(0).WithArguments("MarshallerType", "byte"));
         }
 


### PR DESCRIPTION
One test is disabled against a bug in the Roslyn SDK that I found.