### PR TITLE
Fix EncryptDecrypt test

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
@@ -77,7 +77,7 @@ namespace System.IO.Tests
                 RetryHelper.Execute(() =>
                 {
                     File.Decrypt(tmpFileName);
-                }, maxAttempts: 5, backoffFunc: null, retryWhen: e => e.GetType() == typeof(IOException));
+                }, maxAttempts: 30, backoffFunc: null, retryWhen: e => e.GetType() == typeof(IOException));
 
                 Assert.Equal(fileContentRead, File.ReadAllText(tmpFileName));
                 Assert.NotEqual(FileAttributes.Encrypted, (FileAttributes.Encrypted & File.GetAttributes(tmpFileName)));

--- a/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
@@ -71,7 +71,14 @@ namespace System.IO.Tests
                 Assert.Equal(fileContentRead, File.ReadAllText(tmpFileName));
                 Assert.Equal(FileAttributes.Encrypted, (FileAttributes.Encrypted & File.GetAttributes(tmpFileName)));
 
-                File.Decrypt(tmpFileName);
+                // Sometimes Decrypt will fail with, eg.,
+                // System.IO.IOException : The process cannot access the file '...' because it is being used by another process.
+                // Assumption is that it just needs a little more time
+                RetryHelper.Execute(() =>
+                {
+                    File.Decrypt(tmpFileName);
+                }, maxAttempts: 5, backoffFunc: null, retryWhen: e => e.GetType() == typeof(IOException));
+
                 Assert.Equal(fileContentRead, File.ReadAllText(tmpFileName));
                 Assert.NotEqual(FileAttributes.Encrypted, (FileAttributes.Encrypted & File.GetAttributes(tmpFileName)));
             }


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/12339

I can't reproduce this locally, but it seems reasonable to assume it just need a bit more time for the encryption to release its handle on the file; or for Defender or equivalent to do so (the file has just been written)

This will retry every 100ms up to 30 times.