### PR TITLE
JIT: Disqualify methods with modifiable `this` from OSR.

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -6677,8 +6677,7 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE classPtr,
 
         if (compHasBackwardJump && (reason == nullptr) && (JitConfig.TC_OnStackReplacement() > 0))
         {
-            const char* noPatchpointReason = nullptr;
-            bool        canEscapeViaOSR    = compCanHavePatchpoints(&reason);
+            bool canEscapeViaOSR = compCanHavePatchpoints(&reason);
 
 #ifdef DEBUG
             if (canEscapeViaOSR)
@@ -6703,7 +6702,7 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE classPtr,
             }
             else
             {
-                JITDUMP("\nOSR disabled for this method: %s\n", noPatchpointReason);
+                JITDUMP("\nOSR disabled for this method: %s\n", reason);
                 assert(reason != nullptr);
             }
         }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5360,6 +5360,23 @@ void Compiler::generatePatchpointInfo()
             }
         }
 
+        // If the this pointer can be modified, the patchpoint should record
+        // the location for the modifiable this.
+        //
+        // The Tier0 method's scratch BB will have code (see `fgAddInternal`) that
+        // ensures this location always includes an appropriate `this` (either original
+        // or modified) so we don't need to worry about the relative timing of
+        // the potential modification by Tier0 vis-a-vis the timing of any OSR transition.
+        //
+        // Note when the orginal `this` must be kept alive (for say generics context
+        // reporting) its location is conveyed by a separate field in the patchpoint info.
+        // The OSR method will not need to refer to the original Tier0 `this` in codegen.
+        //
+        if ((lclNum == 0) && !info.compIsStatic && !lvaIsOriginalThisReadOnly())
+        {
+            varNum = lvaArg0Var;
+        }
+
         LclVarDsc* const varDsc = lvaGetDesc(varNum);
 
         // We expect all these to have stack homes, and be FP relative

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5360,23 +5360,6 @@ void Compiler::generatePatchpointInfo()
             }
         }
 
-        // If the this pointer can be modified, the patchpoint should record
-        // the location for the modifiable this.
-        //
-        // The Tier0 method's scratch BB will have code (see `fgAddInternal`) that
-        // ensures this location always includes an appropriate `this` (either original
-        // or modified) so we don't need to worry about the relative timing of
-        // the potential modification by Tier0 vis-a-vis the timing of any OSR transition.
-        //
-        // Note when the orginal `this` must be kept alive (for say generics context
-        // reporting) its location is conveyed by a separate field in the patchpoint info.
-        // The OSR method will not need to refer to the original Tier0 `this` in codegen.
-        //
-        if ((lclNum == 0) && !info.compIsStatic && !lvaIsOriginalThisReadOnly())
-        {
-            varNum = lvaArg0Var;
-        }
-
         LclVarDsc* const varDsc = lvaGetDesc(varNum);
 
         // We expect all these to have stack homes, and be FP relative

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4703,6 +4703,10 @@ inline bool Compiler::compCanHavePatchpoints(const char** reason)
     {
         whyNot = "OSR can't handle reverse pinvoke";
     }
+    else if (!info.compIsStatic && !lvaIsOriginalThisReadOnly())
+    {
+        whyNot = "OSR can't handle modifiable this";
+    }
 #else
     whyNot = "OSR feature not defined in build";
 #endif

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72845/Runtime_72845.fs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72845/Runtime_72845.fs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// OSR method with modifiable this
+
+[<EntryPoint>]
+let main _ =
+    let l1 = [0 .. 100000]
+    let l2 = [0 .. 100000]
+    let eq = l1 = l2
+    printfn $"Lists equal: {eq}"
+    if eq then 100 else -1

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72845/Runtime_72845.fsproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72845/Runtime_72845.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NoStandardLib>True</NoStandardLib>
+    <Noconfig>True</Noconfig>
+    <Optimize>True</Optimize>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Runtime_72845.fs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1823,7 +1823,7 @@
             <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/tailcall/mutual_recursion/**">
-            <Issue>needs triage</Issue>
+            <Issue>FSharp Test</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/newarr/newarr/**">
             <Issue>needs triage</Issue>
@@ -1965,6 +1965,9 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_72265/**">
             <Issue>https://github.com/dotnet/runtime/issues/72016</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_72485/**">
+            <Issue>FSharp Test</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/VS-ia64-JIT/V1.2-M02/b10828/**">
             <Issue>needs triage</Issue>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1966,7 +1966,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_72265/**">
             <Issue>https://github.com/dotnet/runtime/issues/72016</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_72485/**">
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_72845/**">
             <Issue>FSharp Test</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/VS-ia64-JIT/V1.2-M02/b10828/**">


### PR DESCRIPTION
Disqualify methods with modifiable `this` from OSR.

Closes #72845.