### PR TITLE
Do not embed result type in VN for scalar hw intrinsics

### DIFF
--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -210,10 +210,17 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, Co
 //
 /* static */ bool Compiler::vnEncodesResultTypeForHWIntrinsic(NamedIntrinsic hwIntrinsicID)
 {
+    // No extra type information is needed for scalar HW Intrinsic.
+    //
+    if (HWIntrinsicInfo::lookupCategory(hwIntrinsicID) == HW_Category_Scalar)
+    {
+        return false;
+    }
+
     int numArgs = HWIntrinsicInfo::lookupNumArgs(hwIntrinsicID);
 
     // HW Intrinsic's with -1 for numArgs have a varying number of args, so we currently
-    // give themm a unique value number them, and don't add an extra argument.
+    // give them a unique value number, and don't add an extra argument.
     //
     if (numArgs == -1)
     {

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -212,7 +212,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, Co
 {
     // No extra type information is needed for scalar/special HW Intrinsic.
     //
-    unsigned simdSize = 100;
+    unsigned simdSize = 0;
     if (HWIntrinsicInfo::tryLookupSimdSize(hwIntrinsicID, &simdSize) && (simdSize == 0))
     {
         return false;

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -210,9 +210,10 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, Co
 //
 /* static */ bool Compiler::vnEncodesResultTypeForHWIntrinsic(NamedIntrinsic hwIntrinsicID)
 {
-    // No extra type information is needed for scalar HW Intrinsic.
+    // No extra type information is needed for scalar/special HW Intrinsic.
     //
-    if (HWIntrinsicInfo::lookupCategory(hwIntrinsicID) == HW_Category_Scalar)
+    unsigned simdSize = 100;
+    if (HWIntrinsicInfo::tryLookupSimdSize(hwIntrinsicID, &simdSize) && (simdSize == 0))
     {
         return false;
     }


### PR DESCRIPTION
For scalar hw intrinsics, we were creating `VNForSimdType` and it was manifesting in `vnDumpSimdType()`.

Fixes: https://github.com/dotnet/runtime/issues/69551