### PR TITLE
Re-enable throwinnestedtrycatch_il_r test

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -190,9 +190,6 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/HardwareIntrinsics/**">
             <Issue>https://github.com/dotnet/runtime/issues/60154</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/eh/nested/nestedtry/throwinnestedtrycatch_il_r/*">
-            <Issue>https://github.com/dotnet/runtime/issues/66327</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Arm64 All OS -->


### PR DESCRIPTION
I don't have much information about the environment when this test failed and reported in https://github.com/dotnet/runtime/issues/66327. I will re-enable it and run outerloop to see if it still fails.

Fixes: #66327