### PR TITLE
Add memory fences to ByRefAssignRef on Unix ARM64

### DIFF
--- a/src/coreclr/nativeaot/Runtime/arm/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/arm/WriteBarriers.S
@@ -323,15 +323,7 @@ LEAF_END RhpCheckedXchg, _TEXT
 //      r2, r3: trashed
 //
 LEAF_ENTRY RhpByRefAssignRef, _TEXT
-          // Use the GC write barrier as a convenient place to implement the managed memory model for ARM. The
-          // intent is that writes to the target object ($REFREG) will be visible across all CPUs before the
-          // write to the destination ($DESTREG). This covers most of the common scenarios where the programmer
-          // might assume strongly ordered accessess, namely where the preceding writes are used to initialize
-          // the object and the final write, made by this barrier in the instruction following the DMB,
-          // publishes that object for other threads/cpus to see.
-          //
-          // Note that none of this is relevant for single cpu machines. We may choose to implement a
-          // uniprocessor specific version of this barrier if uni-proc becomes a significant scenario again.
+          // See comment in RhpAssignRef
           dmb
 
           ldr          r2, [r1]

--- a/src/coreclr/nativeaot/Runtime/arm/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/arm/WriteBarriers.S
@@ -323,6 +323,17 @@ LEAF_END RhpCheckedXchg, _TEXT
 //      r2, r3: trashed
 //
 LEAF_ENTRY RhpByRefAssignRef, _TEXT
+          // Use the GC write barrier as a convenient place to implement the managed memory model for ARM. The
+          // intent is that writes to the target object ($REFREG) will be visible across all CPUs before the
+          // write to the destination ($DESTREG). This covers most of the common scenarios where the programmer
+          // might assume strongly ordered accessess, namely where the preceding writes are used to initialize
+          // the object and the final write, made by this barrier in the instruction following the DMB,
+          // publishes that object for other threads/cpus to see.
+          //
+          // Note that none of this is relevant for single cpu machines. We may choose to implement a
+          // uniprocessor specific version of this barrier if uni-proc becomes a significant scenario again.
+          dmb
+
           ldr          r2, [r1]
           str          r2, [r0]
 

--- a/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
@@ -361,13 +361,13 @@ LEAF_END RhpCheckedAssignRefArm64, _TEXT
 //   x17  : trashed (ip1) if FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 //
 LEAF_ENTRY RhpByRefAssignRefArm64, _TEXT
-    ldr x15, [x13]
-    str x15, [x14]
+    ldr     x15, [x13]
+    stlr    x15, [x14]
 
     INSERT_CHECKED_WRITE_BARRIER_CORE x14, x15, 12, X15
 
-    add X13, x13, #8
-    add x14, x14, #8
+    add     X13, x13, #8
+    add     x14, x14, #8
 
     ret
 LEAF_END RhpByRefAssignRefArm64, _TEXT


### PR DESCRIPTION
Fixes dotnet/runtimelab#639.

Would be nice if this did something for #72831. I'll revalidate once we have an official installer build with this since I'm not set up to do ARM64 Linux dev work locally.