### PR TITLE
Try to keep cache value after startup validation when current Options is default unnamed one

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/OptionsBuilderExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/OptionsBuilderExtensionsTests.cs
@@ -47,6 +47,38 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
         [Fact]
+        public async Task ValidateOnStart_ConfigureAndValidateThenCallValidateOnStart_CacheOption()
+        {
+            int configureCalledCount = 0;
+            int validateCalledCount = 0;
+
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.AddOptions<ComplexOptions>()
+                    .Configure(o =>
+                    {
+                        o.Boolean = true;
+                        configureCalledCount++;
+                    })
+                    .Validate(o =>
+                    {
+                        validateCalledCount++;
+                        return o.Boolean;
+                    })
+                    .ValidateOnStart();
+            });
+
+            using (var host = hostBuilder.Build())
+            {
+                await host.StartAsync();
+                _ = host.Services.GetRequiredService<IOptions<ComplexOptions>>().Value;
+            }
+
+            Assert.Equal(1, configureCalledCount);
+            Assert.Equal(1, validateCalledCount);
+        }
+
+        [Fact]
         public async Task ValidateOnStart_CallFirstThenConfigureAndValidate_ValidatesFailure()
         {
             var hostBuilder = CreateHostBuilder(services =>


### PR DESCRIPTION
Fix #71170.

Current code change has assumption of user expectation that `IOptions `is an helper of unchanged option, and `IOptionMonitor `is for volatile options. So if user registers unnamed options, startup validation will decide to use `IOption `to create option rather than `IOptionMonitor` so that unchanged option (IOption) can reuse its cache later. It will miss initial (before changing) cache if user code resolves `IOptionMonitor `for unnamed option (but assume users expect `IOptionMonitor `is for volatile option, again).

The code doesn't use `.Configure<IOptionMonitor, IOption>` and then diverge inside `Configure()` by `OptionsBuilder.Name`. It is because I think current code can avoid unnecessary components resolving (both IOptionMonitor and IOption) during construction of `ConfigureNamedOptions<T1, T2>` in both named and unnamed case; also it may avoid one closure in unnamed path.

Correct me if wrong, thanks !