### PR TITLE
Bump timeout for "CoreCLR Tools Unit Tests Linux x64 checked"

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -284,6 +284,7 @@ jobs:
     - Linux_x64
     jobParameters:
       testGroup: clrTools
+      timeoutInMinutes: 120
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),


### PR DESCRIPTION
We recently saw more instances of this job running into the default 60mins timeout, bump it to 120mins

A quick Kusto query shows that we started trending higher around June 10th and we started seeing jobs near the timeout:

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/1376924/181215742-e7e0a317-dbf2-45d9-bccf-9b22f1739c49.png">
