### PR TITLE
[WIP][Mono] Enable tests disabled by issue 36882.

### DIFF
--- a/src/libraries/System.Diagnostics.Debug/tests/DebugTestsNoListeners.cs
+++ b/src/libraries/System.Diagnostics.Debug/tests/DebugTestsNoListeners.cs
@@ -67,7 +67,6 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void Debug_WriteLineNull_IndentsEmptyStringProperly()
         {
             Debug.Indent();
@@ -209,7 +208,6 @@ namespace System.Diagnostics.Tests
         [InlineData(-1, 0)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void IndentLevel_Set_GetReturnsExpected(int indentLevel, int expectedIndentLevel)
         {
             Debug.IndentLevel = indentLevel;

--- a/src/libraries/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
+++ b/src/libraries/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
@@ -197,7 +197,6 @@ namespace System.Diagnostics.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50570", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void Trace_ClearTraceListeners_StopsWritingToDebugger()
         {
             VerifyLogged(() => Debug.Write("pizza"), "pizza");
@@ -231,7 +230,6 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void TraceWriteLineIf()
         {
             VerifyLogged(() => Trace.WriteLineIf(true, 5), "5" + Environment.NewLine);


### PR DESCRIPTION
WIP.

Re-enabled tests pass locally on iOSSimulator using Full AOT LLVM, this PR revalidates pass rate on physical devices on CI for tests disabled by issue #36882.

Fixes #36882