### PR TITLE
Use the common path for lowering single-reg SIMD returns

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3599,13 +3599,6 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
             else
             {
                 assert(comp->info.compRetNativeType == ret->TypeGet());
-                GenTree* retVal = ret->gtGetOp1();
-                if (retVal->TypeGet() != ret->TypeGet())
-                {
-                    assert(retVal->OperIs(GT_LCL_VAR));
-                    LowerRetSingleRegStructLclVar(ret);
-                }
-                return;
             }
         }
     }
@@ -3721,7 +3714,6 @@ void Lowering::LowerRetSingleRegStructLclVar(GenTreeUnOp* ret)
     if (varDsc->lvDoNotEnregister)
     {
         lclVar->ChangeOper(GT_LCL_FLD);
-        lclVar->AsLclFld()->SetLclOffs(0);
 
         // We are returning as a primitive type and the lcl is of struct type.
         assert(comp->info.compRetNativeType != TYP_STRUCT);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3619,10 +3619,6 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
 
     switch (retVal->OperGet())
     {
-        case GT_CALL:
-            assert(retVal->TypeIs(genActualType(nativeReturnType))); // Type should be changed during call processing.
-            break;
-
         case GT_CNS_INT:
             // When we promote LCL_VAR single fields into return we could have all type of constans here.
             if (varTypeUsesFloatReg(nativeReturnType))
@@ -3657,26 +3653,6 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
         case GT_LCL_FLD:
             retVal->ChangeType(nativeReturnType);
             break;
-
-#if defined(FEATURE_SIMD) || defined(FEATURE_HW_INTRINSICS)
-#ifdef FEATURE_SIMD
-        case GT_SIMD:
-#endif // FEATURE_SIMD
-#ifdef FEATURE_HW_INTRINSICS
-        case GT_HWINTRINSIC:
-#endif // FEATURE_HW_INTRINSICS
-        {
-            assert(!retVal->TypeIs(TYP_STRUCT));
-            if (varTypeUsesFloatReg(ret) != varTypeUsesFloatReg(retVal))
-            {
-                GenTree* bitcast = comp->gtNewBitCastNode(ret->TypeGet(), retVal);
-                ret->gtOp1       = bitcast;
-                BlockRange().InsertBefore(ret, bitcast);
-                ContainCheckBitCast(bitcast);
-            }
-        }
-        break;
-#endif // FEATURE_SIMD || FEATURE_HW_INTRINSICS
 
         default:
             assert(varTypeIsEnregisterable(retVal));

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3644,13 +3644,7 @@ int LinearScan::BuildReturn(GenTree* tree)
 #ifdef TARGET_ARM64
         if (varTypeIsSIMD(tree) && !op1->IsMultiRegLclVar())
         {
-            useCandidates = allSIMDRegs();
-            if (op1->OperGet() == GT_LCL_VAR)
-            {
-                assert(op1->TypeGet() != TYP_SIMD32);
-                useCandidates = RBM_DOUBLERET;
-            }
-            BuildUse(op1, useCandidates);
+            BuildUse(op1, RBM_DOUBLERET);
             return 1;
         }
 #endif // TARGET_ARM64

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.cs
@@ -25,6 +25,10 @@ public unsafe class Runtime_72926
         {
             return 104;
         }
+        if (CallForStructWithLongAsStructWithDouble().Dbl != 0)
+        {
+            return 105;
+        }
 
         return 100;
     }
@@ -55,5 +59,28 @@ public unsafe class Runtime_72926
     {
         double value = BitConverter.Int64BitsToDouble(-1);
         return *(Vector64<double>*)&value;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static StructWithDouble CallForStructWithLongAsStructWithDouble()
+    {
+        StructWithLong lng = GetStructWithLong();
+        return *(StructWithDouble*)&lng;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static StructWithLong GetStructWithLong()
+    {
+        return default;
+    }
+
+    struct StructWithDouble
+    {
+        public double Dbl;
+    }
+
+    struct StructWithLong
+    {
+        public long Lng;
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Intrinsics;
+using System.Runtime.CompilerServices;
+
+public unsafe class Runtime_72926
+{
+    public static int Main()
+    {
+        if (CallForLongAsVector64() != Vector64<double>.Zero)
+        {
+            return 101;
+        }
+        if (CallForDoubleAsVector64() != Vector64<double>.Zero)
+        {
+            return 102;
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<double> CallForLongAsVector64()
+    {
+        long value = 0;
+        return *(Vector64<double>*)&value;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<double> CallForDoubleAsVector64()
+    {
+        double value = 0;
+        return *(Vector64<double>*)&value;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Runtime.Intrinsics;
 using System.Runtime.CompilerServices;
 
@@ -8,29 +9,51 @@ public unsafe class Runtime_72926
 {
     public static int Main()
     {
-        if (CallForLongAsVector64() != Vector64<double>.Zero)
+        if (CallForLongAsVector64_Zero() != Vector64<double>.Zero)
         {
             return 101;
         }
-        if (CallForDoubleAsVector64() != Vector64<double>.Zero)
+        if (CallForLongAsVector64_AllBitsSet().AsInt64() != Vector64<long>.AllBitsSet)
         {
             return 102;
+        }
+        if (CallForDoubleAsVector64_Zero() != Vector64<double>.Zero)
+        {
+            return 103;
+        }
+        if (CallForDoubleAsVector64_AllBitsSet().AsInt64() != Vector64<long>.AllBitsSet)
+        {
+            return 104;
         }
 
         return 100;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static Vector64<double> CallForLongAsVector64()
+    private static Vector64<double> CallForLongAsVector64_Zero()
     {
         long value = 0;
         return *(Vector64<double>*)&value;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static Vector64<double> CallForDoubleAsVector64()
+    private static Vector64<double> CallForLongAsVector64_AllBitsSet()
+    {
+        long value = -1;
+        return *(Vector64<double>*)&value;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<double> CallForDoubleAsVector64_Zero()
     {
         double value = 0;
+        return *(Vector64<double>*)&value;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<double> CallForDoubleAsVector64_AllBitsSet()
+    {
+        double value = BitConverter.Int64BitsToDouble(-1);
         return *(Vector64<double>*)&value;
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.csproj
@@ -3,6 +3,14 @@
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_JitNoStructPromotion=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_JitNoStructPromotion=1
+]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
The code was assuming the only cases where we could have a type mismatch for SIMD types was with a local node, which is not true, it could also arise from a constant propagated into one.

Fall through to the general handling instead of using bespoke logic.

A number of positive [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1908781&view=ms.vss-build-web.run-extensions-tab) due to the second commit, which was required to avoid some regressions.

Fixes #72926.