### PR TITLE
Make IHostEnvironment.ApplicationName non-nullable

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Extensions.Hosting
     }
     public partial interface IHostEnvironment
     {
-        string? ApplicationName { get; set; }
+        string ApplicationName { get; set; }
         Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; }
         string ContentRootPath { get; set; }
         string EnvironmentName { get; set; }
@@ -130,7 +130,7 @@ namespace Microsoft.Extensions.Hosting
     [System.ObsoleteAttribute("IHostingEnvironment has been deprecated. Use Microsoft.Extensions.Hosting.IHostEnvironment instead.")]
     public partial interface IHostingEnvironment
     {
-        string? ApplicationName { get; set; }
+        string ApplicationName { get; set; }
         Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; }
         string ContentRootPath { get; set; }
         string EnvironmentName { get; set; }

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostEnvironment.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostEnvironment.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Hosting
         /// Gets or sets the name of the application. This property is automatically set by the host to the assembly containing
         /// the application entry point.
         /// </summary>
-        string? ApplicationName { get; set; }
+        string ApplicationName { get; set; }
 
         /// <summary>
         /// Gets or sets the absolute path to the directory that contains the application content files.

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostingEnvironment.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostingEnvironment.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Hosting
         /// Gets or sets the name of the application. This property is automatically set by the host to the assembly containing
         /// the application entry point.
         /// </summary>
-        string? ApplicationName { get; set; }
+        string ApplicationName { get; set; }
 
         /// <summary>
         /// Gets or sets the absolute path to the directory that contains the application content files.

--- a/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Extensions.Hosting.Internal
     public partial class HostingEnvironment : Microsoft.Extensions.Hosting.IHostEnvironment, Microsoft.Extensions.Hosting.IHostingEnvironment
     {
         public HostingEnvironment() { }
-        public string? ApplicationName { get { throw null; } set { } }
+        public string ApplicationName { get { throw null; } set { } }
         public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get { throw null; } set { } }
         public string ContentRootPath { get { throw null; } set { } }
         public string EnvironmentName { get { throw null; } set { } }

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
@@ -216,15 +216,20 @@ namespace Microsoft.Extensions.Hosting
         {
             var hostingEnvironment = new HostingEnvironment()
             {
-                ApplicationName = hostConfiguration[HostDefaults.ApplicationKey],
                 EnvironmentName = hostConfiguration[HostDefaults.EnvironmentKey] ?? Environments.Production,
                 ContentRootPath = ResolveContentRootPath(hostConfiguration[HostDefaults.ContentRootKey], AppContext.BaseDirectory),
             };
 
-            if (string.IsNullOrEmpty(hostingEnvironment.ApplicationName))
+            string? applicationName = hostConfiguration[HostDefaults.ApplicationKey];
+            if (string.IsNullOrEmpty(applicationName))
             {
                 // Note GetEntryAssembly returns null for the net4x console test runner.
-                hostingEnvironment.ApplicationName = Assembly.GetEntryAssembly()?.GetName().Name;
+                applicationName = Assembly.GetEntryAssembly()?.GetName().Name;
+            }
+
+            if (applicationName is not null)
+            {
+                hostingEnvironment.ApplicationName = applicationName;
             }
 
             var physicalFileProvider = new PhysicalFileProvider(hostingEnvironment.ContentRootPath);

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingEnvironment.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingEnvironment.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Hosting.Internal
     {
         public string EnvironmentName { get; set; } = null!;
 
-        public string? ApplicationName { get; set; }
+        public string ApplicationName { get; set; } = string.Empty;
 
         public string ContentRootPath { get; set; } = null!;
 

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingEnvironment.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingEnvironment.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Extensions.Hosting.Internal
     public class HostingEnvironment : IHostingEnvironment, IHostEnvironment
 #pragma warning restore CS0618 // Type or member is obsolete
     {
-        public string EnvironmentName { get; set; } = null!;
+        public string EnvironmentName { get; set; } = string.Empty;
 
         public string ApplicationName { get; set; } = string.Empty;
 
-        public string ContentRootPath { get; set; } = null!;
+        public string ContentRootPath { get; set; } = string.Empty;
 
         public IFileProvider ContentRootFileProvider { get; set; } = null!;
     }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.NotNull(builder.Environment.ApplicationName);
 #elif NETFRAMEWORK
             // Note GetEntryAssembly returns null for the net4x console test runner.
-            Assert.Null(builder.Environment.ApplicationName);
+            Assert.Equal(string.Empty, builder.Environment.ApplicationName);
 #else
 #error TFMs need to be updated
 #endif
@@ -221,7 +221,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.NotNull(env.ApplicationName);
 #elif NETFRAMEWORK
             // Note GetEntryAssembly returns null for the net4x console test runner.
-            Assert.Null(env.ApplicationName);
+            Assert.Equal(string.Empty, env.ApplicationName);
 #else
 #error TFMs need to be updated
 #endif

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                     Assert.NotNull(env.ApplicationName);
 #elif NETFRAMEWORK
                     // Note GetEntryAssembly returns null for the net4x console test runner.
-                    Assert.Null(env.ApplicationName);
+                    Assert.Equal(string.Empty, env.ApplicationName);
 #else
 #error TFMs need to be updated
 #endif
@@ -194,7 +194,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                 Assert.NotNull(env.ApplicationName);
 #elif NETFRAMEWORK
                 // Note GetEntryAssembly returns null for the net4x console test runner.
-                Assert.Null(env.ApplicationName);
+                Assert.Equal(string.Empty, env.ApplicationName);
 #else
 #error TFMs need to be updated
 #endif


### PR DESCRIPTION
It is not intended that normal execution has a null ApplicationName, so don't make callers need to check for null. When an ApplicationName is not available, it is set to string.Empty.

Fix #68512