### PR TITLE
[wasm][debugger] Fix "command is not pending"

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -58,7 +58,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public override bool Equals(object obj) => obj is MessageId other && Equals(other);
 
-        public bool Equals(MessageId other) => other.sessionId == sessionId && other.id == id;
+        public bool Equals(MessageId other) => other.id == id;
     }
 
     internal sealed class DotnetObjectId

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -54,7 +54,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public override string ToString() => $"msg-{sessionId}:::{id}";
 
-        public override int GetHashCode() => (sessionId?.GetHashCode() ?? 0) ^ id.GetHashCode();
+        public override int GetHashCode() => id;
 
         public override bool Equals(object obj) => obj is MessageId other && Equals(other);
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -297,6 +297,12 @@ namespace Microsoft.WebAssembly.Diagnostics
                     {
                         Result resp = await SendCommand(id, method, args, token);
 
+                        if (!resp.IsOk)
+                        {
+                            SendResponse(id, resp, token);
+                            return true;
+                        }
+
                         context.DebugId = resp.Value["DebugId"]?.ToString();
 
                         if (await IsRuntimeAlreadyReadyAlready(id, token))


### PR DESCRIPTION
Session id can be different if there is a redirect, but the message id is kept.

I mean, even if the sessionID number is changed the sequential number that answers the message is the same, so we only need to compare the sequential number.
For example:
We send -> messageID = 1 to sessionID = aaa
We receive -> messageID = 1 sessionID = bbb because there was a redirect
So it was not finding in the dictionary because we were expecting SessionID and MessageId to be the same.
`other.sessionId == sessionId && other.id == id;`

I have no idea how to create a test case for it.

Fix https://github.com/aspnet/AspNetCore-ManualTests/issues/1456