### PR TITLE
Disable tests that wait for compaction

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72912")]
         public async Task DoNotAddIfSizeOverflows()
         {
             var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = long.MaxValue });
@@ -142,6 +143,7 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72912")]
         public async Task ExceedsCapacityCompacts()
         {
             var cache = new MemoryCache(new MemoryCacheOptions
@@ -235,6 +237,7 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72912")]
         public async Task AddingReplacementWhenTotalSizeExceedsCapacityDoesNotUpdateRemovesOldEntryAndTriggersCompaction()
         {
             var cache = new MemoryCache(new MemoryCacheOptions
@@ -305,6 +308,7 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72912")]
         public async Task ExpiringEntryDecreasesCacheSize()
         {
             var cache = new MemoryCache(new MemoryCacheOptions
@@ -375,6 +379,7 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/72912")]
         public async Task CompactsToLessThanLowWatermarkUsingLRUWhenHighWatermarkExceeded()
         {
             var testClock = new TestClock();


### PR DESCRIPTION
Relates to https://github.com/dotnet/runtime/issues/72912

Yet more tests that were fragile in other ways after I fixed the original problem. 