### PR TITLE
[wasm] Wasm.Build.Tests: Use Chrome on windows, instead of V8

### DIFF
--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildPublishTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildPublishTests.cs
@@ -21,8 +21,8 @@ namespace Wasm.Build.Tests
         }
 
         [Theory]
-        [BuildAndRun(host: RunHost.V8, aot: false, config: "Release")]
-        [BuildAndRun(host: RunHost.V8, aot: false, config: "Debug")]
+        [BuildAndRun(host: RunHost.Chrome, aot: false, config: "Release")]
+        [BuildAndRun(host: RunHost.Chrome, aot: false, config: "Debug")]
         public void BuildThenPublishNoAOT(BuildArgs buildArgs, RunHost host, string id)
         {
             string projectName = $"build_publish_{buildArgs.Config}";
@@ -70,8 +70,8 @@ namespace Wasm.Build.Tests
         }
 
         [Theory]
-        [BuildAndRun(host: RunHost.V8, aot: true, config: "Release")]
-        [BuildAndRun(host: RunHost.V8, aot: true, config: "Debug")]
+        [BuildAndRun(host: RunHost.Chrome, aot: true, config: "Release")]
+        [BuildAndRun(host: RunHost.Chrome, aot: true, config: "Debug")]
         public void BuildThenPublishWithAOT(BuildArgs buildArgs, RunHost host, string id)
         {
             string projectName = $"build_publish_{buildArgs.Config}";

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildPublishTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildPublishTests.cs
@@ -108,7 +108,6 @@ namespace Wasm.Build.Tests
             File.Move(product!.LogFile, Path.ChangeExtension(product.LogFile!, ".first.binlog"));
 
             _testOutput.WriteLine($"{Environment.NewLine}Publishing with no changes ..{Environment.NewLine}");
-            //_testOutput.WriteLine($"{Environment.NewLine}Publishing with no changes ..{Environment.NewLine}");
 
             // relink by default for Release+publish
             (_, output) = BuildProject(buildArgs,

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -154,6 +154,8 @@ namespace Wasm.Build.Tests
             }
 
             bundleDir ??= Path.Combine(GetBinDir(baseDir: buildDir, config: buildArgs.Config, targetFramework: targetFramework), "AppBundle");
+            if (host is RunHost.V8 && OperatingSystem.IsWindows())
+                throw new InvalidOperationException("Running tests with V8 on windows isn't supported");
 
             // Use wasm-console.log to get the xharness output for non-browser cases
             (string testCommand, string extraXHarnessArgs, bool useWasmConsoleOutput) = host switch

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/HelperExtensions.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/HelperExtensions.cs
@@ -70,6 +70,12 @@ namespace Wasm.Build.Tests
                 if (value == RunHost.None)
                     continue;
 
+                if (value == RunHost.V8 && OperatingSystem.IsWindows())
+                {
+                    // Don't run tests with V8 on windows
+                    continue;
+                }
+
                 // Ignore any combos like RunHost.All from Enum.GetValues
                 // by ignoring any @value that has more than 1 bit set
                 if (((int)value & ((int)value - 1)) != 0)

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeRebuildTests/FlagsChangeRebuildTest.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeRebuildTests/FlagsChangeRebuildTest.cs
@@ -25,7 +25,7 @@ namespace Wasm.Build.NativeRebuild.Tests
                         new object[] { /*cflags*/ "/p:EmccExtraCFlags=-g", /*ldflags*/ "" },
                         new object[] { /*cflags*/ "",                      /*ldflags*/ "/p:EmccExtraLDFlags=-g" },
                         new object[] { /*cflags*/ "/p:EmccExtraCFlags=-g", /*ldflags*/ "/p:EmccExtraLDFlags=-g" }
-            ).WithRunHosts(RunHost.V8).UnwrapItemsAsArrays();
+            ).WithRunHosts(RunHost.Chrome).UnwrapItemsAsArrays();
 
         [Theory]
         [MemberData(nameof(FlagsChangesForNativeRelinkingData), parameters: /*aot*/ false)]
@@ -71,7 +71,7 @@ namespace Wasm.Build.NativeRebuild.Tests
             => ConfigWithAOTData(aot, config: "Release").Multiply(
                         new object[] { /*cflags*/ "/p:EmccCompileOptimizationFlag=-O1", /*ldflags*/ "" },
                         new object[] { /*cflags*/ "",                                   /*ldflags*/ "/p:EmccLinkOptimizationFlag=-O0" }
-            ).WithRunHosts(RunHost.V8).UnwrapItemsAsArrays();
+            ).WithRunHosts(RunHost.Chrome).UnwrapItemsAsArrays();
 
         [Theory]
         [MemberData(nameof(FlagsOnlyChangeData), parameters: /*aot*/ false)]

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeRebuildTests/NativeRebuildTestsBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeRebuildTests/NativeRebuildTestsBase.cs
@@ -40,7 +40,7 @@ namespace Wasm.Build.NativeRebuild.Tests
             IEnumerable<object?[]> GetData(bool aot, bool nativeRelinking, bool invariant)
                 => ConfigWithAOTData(aot)
                         .Multiply(new object[] { nativeRelinking, invariant })
-                        .WithRunHosts(RunHost.V8)
+                        .WithRunHosts(RunHost.Chrome)
                         .UnwrapItemsAsArrays().ToList();
         }
 
@@ -55,7 +55,7 @@ namespace Wasm.Build.NativeRebuild.Tests
                                 HasIcudt: !invariant,
                                 CreateProject: true));
 
-            RunAndTestWasmApp(buildArgs, buildDir: _projectDir, expectedExitCode: 42, host: RunHost.V8, id: id);
+            RunAndTestWasmApp(buildArgs, buildDir: _projectDir, expectedExitCode: 42, host: RunHost.Chrome, id: id);
             return (buildArgs, GetBuildPaths(buildArgs));
         }
 

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -18,7 +18,7 @@ namespace Wasm.Build.Tests
         }
 
         [Theory]
-        [BuildAndRun(host: RunHost.V8)]
+        [BuildAndRun(host: RunHost.Chrome)]
         public void NativeLibraryWithVariadicFunctions(BuildArgs buildArgs, RunHost host, string id)
         {
             string code = @"
@@ -55,7 +55,7 @@ namespace Wasm.Build.Tests
         }
 
         [Theory]
-        [BuildAndRun(host: RunHost.V8)]
+        [BuildAndRun(host: RunHost.Chrome)]
         public void DllImportWithFunctionPointersCompilesWithWarning(BuildArgs buildArgs, RunHost host, string id)
         {
             string code = @"
@@ -87,7 +87,7 @@ namespace Wasm.Build.Tests
         }
 
         [Theory]
-        [BuildAndRun(host: RunHost.V8)]
+        [BuildAndRun(host: RunHost.Chrome)]
         public void DllImportWithFunctionPointers_ForVariadicFunction_CompilesWithWarning(BuildArgs buildArgs, RunHost host, string id)
         {
             string code = @"
@@ -116,7 +116,7 @@ namespace Wasm.Build.Tests
         }
 
         [Theory]
-        [BuildAndRun(host: RunHost.V8, parameters: new object[] { "tr_TR.UTF-8" })]
+        [BuildAndRun(host: RunHost.Chrome, parameters: new object[] { "tr_TR.UTF-8" })]
         public void BuildNativeInNonEnglishCulture(BuildArgs buildArgs, string culture, RunHost host, string id)
         {
             // Check that we can generate interp tables in non-english cultures

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/RebuildTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/RebuildTests.cs
@@ -22,7 +22,7 @@ namespace Wasm.Build.Tests
 
         public static IEnumerable<object?[]> NonNativeDebugRebuildData()
             => ConfigWithAOTData(aot: false, config: "Debug")
-                    .WithRunHosts(RunHost.V8)
+                    .WithRunHosts(RunHost.Chrome)
                     .UnwrapItemsAsArrays().ToList();
 
         [Theory]


### PR DESCRIPTION
V8 has issues running on windows, and that's not really something we support anyway. So, switch to using Chrome for running Wasm.Build.Tests, same as we do for library tests.

Fixes https://github.com/dotnet/runtime/issues/72880 .