### PR TITLE
Avoid promoting in sweep_in_plan when we already decided not to promote

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -30685,7 +30685,7 @@ bool gc_heap::should_sweep_in_plan (heap_segment* region)
             sip_p = true;
         }
 
-        if (new_gen_num < max_generation)
+        if (settings.promotion && (new_gen_num < max_generation))
         {
             int old_card_surv_ratio =
                 (int)(((double)heap_segment_old_card_survived (region) * 100.0) / (double)basic_region_size);


### PR DESCRIPTION
Fixes #70262 

If we happened to be in a case such that:

1. `settings.promote == 0`,
2. All gen1 regions satisfy the condition `surv_ratio >= sip_surv_ratio_th`, and
3. All gen1 regions satisfy the condition `old_card_surv_ratio >= sip_old_card_surv_ratio_th`.

Note that when `settings.promote == 0`, `new_gen_num` computed by `get_plan_gen_num` for a gen 1 region will be 1, so the following condition is satisfied.

`(new_gen_num < max_generation) && (sip_maxgen_regions_per_gen[gen_num] == regions_per_gen[gen_num])` 

But then `gen_num == 1`, now we will hit the assertion.

Note that we shouldn't be promoting regions if `settings.promote == 0`, if we make the change as in the PR to avoid promoting regions due to old card survival, we will never increase `sip_maxgen_regions_per_gen` and therefore we will not enter the branch leading to the assertion.
