### PR TITLE
[release/6.0] CreateSymbolicLink PInvoke retval must be marshalled as U1

### DIFF
--- a/src/installer/tests/TestUtils/SymbolicLinking.cs
+++ b/src/installer/tests/TestUtils/SymbolicLinking.cs
@@ -64,6 +64,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         }
 
         [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.U1)]
         private static extern bool CreateSymbolicLink(
             string symbolicLinkName,
             string targetFileName,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateSymbolicLink.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateSymbolicLink.cs
@@ -21,6 +21,7 @@ internal static partial class Interop
         internal const int SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE = 0x2;
 
         [DllImport(Libraries.Kernel32, EntryPoint = "CreateSymbolicLinkW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
+        [return: MarshalAs(UnmanagedType.U1)]
         private static extern bool CreateSymbolicLinkPrivate(string lpSymlinkFileName, string lpTargetFileName, int dwFlags);
 
         /// <summary>
@@ -38,9 +39,8 @@ internal static partial class Interop
 
             int flags = 0;
 
-            bool isAtLeastWin10Build14972 =
-                Environment.OSVersion.Version.Major == 10 && Environment.OSVersion.Version.Build >= 14972 ||
-                Environment.OSVersion.Version.Major >= 11;
+            Version osVersion = Environment.OSVersion.Version;
+            bool isAtLeastWin10Build14972 = osVersion.Major >= 11 || osVersion.Major == 10 && osVersion.Build >= 14972;
 
             if (isAtLeastWin10Build14972)
             {
@@ -54,16 +54,9 @@ internal static partial class Interop
 
             bool success = CreateSymbolicLinkPrivate(symlinkFileName, targetFileName, flags);
 
-            int error;
             if (!success)
             {
                 throw Win32Marshal.GetExceptionForLastWin32Error(originalPath);
-            }
-            // In older versions we need to check GetLastWin32Error regardless of the return value of CreateSymbolicLink,
-            // e.g: if the user doesn't have enough privileges to create a symlink the method returns success which we can consider as a silent failure.
-            else if (!isAtLeastWin10Build14972 && (error = Marshal.GetLastWin32Error()) != 0)
-            {
-                throw Win32Marshal.GetExceptionForWin32Error(error, originalPath);
             }
         }
     }


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/69150

## Customer Impact

Customer reported. Customers who create Symbolic Links using the new APIs introduced in 6.0 will face silent failures when Developer mode is disabled in Windows settings. 
```cs
File.Create("my-file.txt";).Dipose();

// Having developer mode disabled on Windows, this will silently fail.
FileSystemInfo linkInfo = File.CreateSymbolicLink("my-link", "my-file.txt"); 

Console.WriteLine($"Link exsts: {linkInfo.Exists}"); // prints false when it should’ve thrown above.
```

## Testing
Customer confirmed and reported that issues is fixed, and it no longer fails silently.
The change has been in-place for months on .NET 7 with no failures involved.

## Risk
Low, changes are minimal and self-evidently correct.
