### PR TITLE
[wasm][debugger] Fix assert when passing an invalid array to runtime.

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -9466,6 +9466,9 @@ array_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 	if (err != ERR_NONE)
 		return err;
 
+	if (m_class_get_rank (arr->obj.vtable->klass) == 0)
+		return ERR_INVALID_OBJECT;
+
 	switch (command) {
 	case CMD_ARRAY_REF_GET_TYPE: {
 			buffer_add_byte(buf, m_class_get_byval_arg (m_class_get_element_class (arr->obj.vtable->klass))->type);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/ArrayTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/ArrayTests.cs
@@ -564,8 +564,6 @@ namespace DebuggerTests
         }
 
         [ConditionalFact(nameof(RunningOnChrome))]
-        [Trait("Category", "windows-failing")] // https://github.com/dotnet/runtime/issues/65742
-        [Trait("Category", "linux-failing")] // https://github.com/dotnet/runtime/issues/65742
         public async Task InvalidArrayId() => await CheckInspectLocalsAtBreakpointSite(
             "DebuggerTests.Container", "PlaceholderMethod", 1, "DebuggerTests.Container.PlaceholderMethod",
             "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.ArrayTestsClass:ObjectArrayMembers'); }, 1);",


### PR DESCRIPTION
Check if it's an array before calling the array functions.

Fix https://github.com/dotnet/runtime/issues/65742