### PR TITLE
[eventpipe] Use MonoImage:module_name when filename is NULL

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -3784,7 +3784,7 @@ get_module_event_data (
 		if (image && image->aot_module)
 			module_data->module_flags |= MODULE_FLAGS_NATIVE_MODULE;
 
-		module_data->module_il_path = image && image->filename ? image->filename : "";
+		module_data->module_il_path = image && image->filename ? image->filename : (image->name ? image->name : "");
 		module_data->module_il_pdb_path = "";
 		module_data->module_il_pdb_age = 0;
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -3784,7 +3784,7 @@ get_module_event_data (
 		if (image && image->aot_module)
 			module_data->module_flags |= MODULE_FLAGS_NATIVE_MODULE;
 
-		module_data->module_il_path = image && image->filename ? image->filename : (image->name ? image->name : "");
+		module_data->module_il_path = image && image->filename ? image->filename : (image && image->name ? image->name : "");
 		module_data->module_il_pdb_path = "";
 		module_data->module_il_pdb_age = 0;
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -3784,7 +3784,17 @@ get_module_event_data (
 		if (image && image->aot_module)
 			module_data->module_flags |= MODULE_FLAGS_NATIVE_MODULE;
 
-		module_data->module_il_path = image && image->filename ? image->filename : (image && image->name ? image->name : "");
+		module_data->module_il_path = NULL;
+		if (image && image->filename) {
+			/* if there's a filename, use it */
+			module_data->module_il_path = image->filename;
+		} else if (image && image->module_name) {
+			/* otherwise, use the module name */
+			module_data->module_il_path = image->module_name;
+		}
+		if (!module_data->module_il_path)
+			module_data->module_il_path = "";
+
 		module_data->module_il_pdb_path = "";
 		module_data->module_il_pdb_age = 0;
 


### PR DESCRIPTION
When assemblies are bundled (for example in WASM), the filename field is set to NULL; use the module name (from the metadata Module table).

Contributes to #72481 

With this PR and with #72859 I can generate a trace and run
```
dotnet-pgo create-mibc --trace example.nettrace -r ./bin/Debug/AppBundle/managed/'*.dll' --output /tmp/out.mibc
```

and generate a .mibc file.
