### PR TITLE
[mono][debugger] Fix infinite recursion and null pointer access while debugging

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -4069,7 +4069,7 @@ jit_end (MonoProfiler *prof, MonoMethod *method, MonoJitInfo *jinfo)
 
 	// only send typeload from AOTed classes if has .cctor when .cctor emits jit_end
 	// to avoid deadlock while trying to set a breakpoint in a class that was not fully initialized
-	if (jinfo->from_aot && m_class_has_cctor(method->klass) && (!(method->flags & METHOD_ATTRIBUTE_SPECIAL_NAME) || strcmp (method->name, ".cctor")))
+	if (jinfo && jinfo->from_aot && m_class_has_cctor(method->klass) && (!(method->flags & METHOD_ATTRIBUTE_SPECIAL_NAME) || strcmp (method->name, ".cctor")))
 	{
 		return;
 	}
@@ -5185,6 +5185,8 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 				continue;
 			if (mono_field_is_deleted (f))
 				continue;
+			if (mono_vtype_get_field_addr (addr, f) == addr)
+				continue;
 			nfields ++;
 		}
 		buffer_add_int (buf, nfields);
@@ -5194,6 +5196,8 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 			if (f->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
 			if (mono_field_is_deleted (f))
+				continue;
+			if (mono_vtype_get_field_addr (addr, f) == addr)
 				continue;
 			buffer_add_value_full (buf, f->type, mono_vtype_get_field_addr (addr, f), domain, FALSE, parent_vtypes, len_fixed_array != 1 ? len_fixed_array : isFixedSizeArray(f));
 		}

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -5281,8 +5281,6 @@ decode_vtype (MonoType *t, MonoDomain *domain, gpointer void_addr, gpointer void
 			continue;
 		if (mono_field_is_deleted (f))
 			continue;
-		if (mono_vtype_get_field_addr (addr, f) == addr)
-			continue;
 		err = decode_value (f->type, domain, mono_vtype_get_field_addr (addr, f), buf, &buf, limit, check_field_datatype);
 		if (err != ERR_NONE)
 			return err;

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -1030,11 +1030,12 @@ namespace DebuggerTests
 
             await EvaluateAndCheck(
                 "window.setTimeout(function() {" + expression + "; }, 1);",
-                "dotnet://debugger-test.dll/debugger-test.cs", 1254, 8,
+                "dotnet://debugger-test.dll/debugger-test.cs", 1256, 8,
                 $"InspectIntPtr.Run",
                 locals_fn: async (locals) =>
                 {
                     await CheckValueType(locals, "myInt", "System.IntPtr");
+                    await CheckValueType(locals, "myInt2", "System.IntPtr");
                 }
             );
         }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -1022,5 +1022,21 @@ namespace DebuggerTests
                 method_name_call_stack
             );
         }
+
+        [Fact]
+        public async Task InspectLocalRecursiveFieldValue()
+        {
+            var expression = $"{{ invoke_static_method('[debugger-test] InspectIntPtr:Run'); }}";
+
+            await EvaluateAndCheck(
+                "window.setTimeout(function() {" + expression + "; }, 1);",
+                "dotnet://debugger-test.dll/debugger-test.cs", 1254, 8,
+                $"InspectIntPtr.Run",
+                locals_fn: async (locals) =>
+                {
+                    await CheckValueType(locals, "myInt", "System.IntPtr");
+                }
+            );
+        }
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1247,3 +1247,11 @@ public class AsyncGeneric
     }
 }
 
+public class InspectIntPtr
+{
+    public static void Run()
+    {
+        IntPtr myInt = default;
+        System.Diagnostics.Debugger.Break();
+    }
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1252,6 +1252,8 @@ public class InspectIntPtr
     public static void Run()
     {
         IntPtr myInt = default;
+        IntPtr myInt2 = new IntPtr(1);
+
         System.Diagnostics.Debugger.Break();
     }
 }


### PR DESCRIPTION
- `IntPtr` class in .net7 has a field called `_value` which points to itself so it was generating a recursive call.
- Protect when jit_done is called from jit_failed because jinfo is NULL.


This is how we see IntPtr in the locals window:
![image](https://user-images.githubusercontent.com/4503299/181669329-f9bd564c-84be-41c7-b4be-6a5f0ebc0f84.png)
