### PR TITLE
[NativeAOT] Fix assert in Thread.SpinWait(0)

### DIFF
--- a/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
@@ -48,6 +48,9 @@ COOP_PINVOKE_HELPER(void, RhDebugBreak, ())
 // Busy spin for the given number of iterations.
 EXTERN_C NATIVEAOT_API void __cdecl RhSpinWait(int32_t iterations)
 {
+    // limit the spin count in coop mode.
+    ASSERT(iterations > 0 && iterations <= 10000);
+
     YieldProcessorNormalizationInfo normalizationInfo;
     YieldProcessorNormalizedForPreSkylakeCount(normalizationInfo, iterations);
 }

--- a/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
@@ -48,8 +48,11 @@ COOP_PINVOKE_HELPER(void, RhDebugBreak, ())
 // Busy spin for the given number of iterations.
 EXTERN_C NATIVEAOT_API void __cdecl RhSpinWait(int32_t iterations)
 {
+    ASSERT(iterations > 0);
+
     // limit the spin count in coop mode.
-    ASSERT(iterations > 0 && iterations <= 10000);
+    ASSERT_MSG(iterations <= 10000 || !ThreadStore::GetCurrentThread()->IsCurrentThreadInCooperativeMode(),
+        "This is too long wait for coop mode. You must p/invoke with GC transition.");
 
     YieldProcessorNormalizationInfo normalizationInfo;
     YieldProcessorNormalizedForPreSkylakeCount(normalizationInfo, iterations);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -388,6 +388,11 @@ namespace System.Runtime
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
         internal static partial void RhSpinWait(int iterations);
 
+        // Call RhSpinWait with a GC transition
+        [LibraryImport(RuntimeLibrary, EntryPoint = "RhSpinWait")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static partial void RhLongSpinWait(int iterations);
+
         // Yield the cpu to another thread ready to process, if one is available.
         [LibraryImport(RuntimeLibrary, EntryPoint = "RhYield")]
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
@@ -324,17 +324,18 @@ namespace System.Threading
 
         public static void SpinWait(int iterations)
         {
-            // Max iterations to be done in one call to RhSpinWait.
+            if (iterations <= 0)
+                return;
+
+            // Max iterations to be done in RhSpinWait.
             // RhSpinWait does not switch GC modes and we want to avoid native spinning in coop mode for too long.
-            const int spinWaitBatch = 10000;
+            const int spinWaitCoopThreshold = 10000;
 
-            while (iterations > spinWaitBatch)
+            if (iterations > spinWaitCoopThreshold)
             {
-                RuntimeImports.RhSpinWait(spinWaitBatch);
-                iterations -= spinWaitBatch;
+                RuntimeImports.RhLongSpinWait(iterations);
             }
-
-            if (iterations > 0)
+            else
             {
                 RuntimeImports.RhSpinWait(iterations);
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
@@ -322,7 +322,23 @@ namespace System.Threading
         /// </summary>
         internal const int OptimalMaxSpinWaitsPerSpinIteration = 64;
 
-        public static void SpinWait(int iterations) => RuntimeImports.RhSpinWait(iterations);
+        public static void SpinWait(int iterations)
+        {
+            // Max iterations to be done in one call to RhSpinWait.
+            // RhSpinWait does not switch GC modes and we want to avoid native spinning in coop mode for too long.
+            const int spinWaitBatch = 10000;
+
+            while (iterations > spinWaitBatch)
+            {
+                RuntimeImports.RhSpinWait(spinWaitBatch);
+                iterations -= spinWaitBatch;
+            }
+
+            if (iterations > 0)
+            {
+                RuntimeImports.RhSpinWait(iterations);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.NoInlining)] // Slow path method. Make sure that the caller frame does not pay for PInvoke overhead.
         public static bool Yield() => RuntimeImports.RhYield();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
@@ -322,6 +322,12 @@ namespace System.Threading
         /// </summary>
         internal const int OptimalMaxSpinWaitsPerSpinIteration = 64;
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void LongSpinWait(int iterations)
+        {
+            RuntimeImports.RhLongSpinWait(iterations);
+        }
+
         public static void SpinWait(int iterations)
         {
             if (iterations <= 0)
@@ -333,7 +339,7 @@ namespace System.Threading
 
             if (iterations > spinWaitCoopThreshold)
             {
-                RuntimeImports.RhLongSpinWait(iterations);
+                LongSpinWait(iterations);
             }
             else
             {


### PR DESCRIPTION
The underlying `YieldProcessorNormalizedForPreSkylakeCount` asserts that `_ASSERTE(preSkylakeCount != 0)`
We passed the number of iterations unchanged and that caused asserts in scenarios like `Thread.SpinWait(0)`, when running libraries tests on Chk runtime.

Also made the implementation to do multiple calls to `RhSpinWait` if the number of iterations is high. 
Spinning for too long in native code while in coop mode may cause GC latency problems.