### PR TITLE
Unblock tests blocked on 70012

### DIFF
--- a/src/libraries/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -398,7 +398,6 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [ClassData(typeof(CompilationTypes))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/70012", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot), nameof(PlatformDetection.IsArm64Process))]
         public static void CheckMemberAccessClassInstanceIndexerAssignNullReferenceTest(bool useInterpreter)
         {
             Expression<Func<int>> e =

--- a/src/libraries/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
@@ -29,7 +29,6 @@ namespace System.Linq.Expressions.Tests
 
         #region Test verifiers
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/70012", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot), nameof(PlatformDetection.IsArm64Process))]
         private static void VerifyUnbox(object value, Type type, bool shouldThrow, bool useInterpreter)
         {
             Expression<Func<object>> e =

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -576,9 +576,7 @@
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.IO.Compression\tests\System.IO.Compression.Tests.csproj" />
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.IO.FileSystem\tests\System.IO.FileSystem.Tests.csproj" />
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Threading\tests\System.Threading.Tests.csproj" />
-    <!-- Remove the condition after https://github.com/dotnet/runtime/issues/70012 is fixed -->
-    <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj"
-                      Condition="'$(TargetOS)' == 'windows'" />
+    <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We've seen similar failure mode in S.C.Immutable tests but that one is gone. Maybe the updated libunwind fixed it.

Fixes #70012.