### PR TITLE
Re-enable tests for #66421

### DIFF
--- a/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.IgnoreCycles.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.IgnoreCycles.cs
@@ -134,9 +134,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66421")]
-#endif
         public async Task IgnoreCycles_OnRecursiveDictionary()
         {
             var root = new RecursiveDictionary();
@@ -183,9 +180,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66421")]
-#endif
         public async Task IgnoreCycles_OnRecursiveList()
         {
             var root = new RecursiveList();
@@ -240,9 +234,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66421")]
-#endif
         public async Task IgnoreCycles_DoesNotSupportPreserveSemantics()
         {
             // Object
@@ -279,9 +270,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66421")]
-#endif
         public async Task IgnoreCycles_DoesNotSupportPreserveSemantics_Polymorphic()
         {
             // Object

--- a/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.cs
@@ -242,9 +242,6 @@ namespace System.Text.Json.Serialization.Tests
         public class DictionaryWithGenericCycle : Dictionary<string, DictionaryWithGenericCycle> { }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66421")]
-#endif
         public async Task DictionaryLoop()
         {
             DictionaryWithGenericCycle root = new DictionaryWithGenericCycle();
@@ -261,9 +258,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66421")]
-#endif
         public async Task DictionaryPreserveDuplicateDictionaries()
         {
             DictionaryWithGenericCycle root = new DictionaryWithGenericCycle();
@@ -298,9 +292,6 @@ namespace System.Text.Json.Serialization.Tests
         public class DictionaryWithGenericCycleWithinList : Dictionary<string, List<DictionaryWithGenericCycleWithinList>> { }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66421")]
-#endif
         public async Task DictionaryArrayLoop()
         {
             DictionaryWithGenericCycleWithinList root = new DictionaryWithGenericCycleWithinList();
@@ -316,9 +307,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66421")]
-#endif
         public async Task DictionaryPreserveDuplicateArrays()
         {
             DictionaryWithGenericCycleWithinList root = new DictionaryWithGenericCycleWithinList();
@@ -449,9 +437,6 @@ namespace System.Text.Json.Serialization.Tests
         public class ListWithGenericCycle : List<ListWithGenericCycle> { }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66421")]
-#endif
         public async Task ArrayLoop()
         {
             ListWithGenericCycle root = new ListWithGenericCycle();
@@ -518,9 +503,6 @@ namespace System.Text.Json.Serialization.Tests
         public class ListWithGenericCycleWithinDictionary : List<Dictionary<string, ListWithGenericCycleWithinDictionary>> { }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66421")]
-#endif
         public async Task ArrayDictionaryLoop()
         {
             ListWithGenericCycleWithinDictionary root = new ListWithGenericCycleWithinDictionary();
@@ -536,9 +518,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66421")]
-#endif
         public async Task ArrayPreserveDuplicateDictionaries()
         {
             ListWithGenericCycleWithinDictionary root = new ListWithGenericCycleWithinDictionary


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/66421

Seems I have already fixed this bug accidentally when doing contract customization work in https://github.com/dotnet/runtime/pull/70435

Specifically these:
https://github.com/dotnet/runtime/commit/897b2a3b8d04922e8fc7b0719aaf1fca4b1478b2#diff-b7da6b90947be2bdebc35f367d9dc2c5bb66dd3be881af8a2d6cbb9c18108a7fL529-L530

plus adjustments in JsonMetadataServices