### PR TITLE
Implement new API GetEnumValuesAsUnderlyingType

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -111,6 +111,14 @@ namespace System
             return result;
         }
 
+        public sealed override Array GetEnumValuesAsUnderlyingType()
+        {
+            if (!IsActualEnum)
+                throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
+
+            return (Array)Enum.GetEnumInfo(this).ValuesAsUnderlyingType.Clone();
+        }
+
         internal bool IsActualEnum
             => TryGetEEType(out EETypePtr eeType) && eeType.IsEnum;
     }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
@@ -62,7 +62,7 @@ namespace System.ComponentModel
         /// </summary>
         protected virtual IComparer Comparer => InvariantComparer.Default;
 
-        private static long GetEnumValue(bool isUnderlyingTypeUInt64, Enum enumVal, CultureInfo? culture)
+        private static long GetEnumValue(bool isUnderlyingTypeUInt64, object enumVal, CultureInfo? culture)
         {
             return isUnderlyingTypeUInt64 ?
                 unchecked((long)Convert.ToUInt64(enumVal, culture)) :
@@ -85,7 +85,7 @@ namespace System.ComponentModel
                         string[] values = strValue.Split(',');
                         foreach (string v in values)
                         {
-                            convertedValue |= GetEnumValue(isUnderlyingTypeUInt64, (Enum)Enum.Parse(EnumType, v, true), culture);
+                            convertedValue |= GetEnumValue(isUnderlyingTypeUInt64, Enum.Parse(EnumType, v, true), culture);
                         }
                         return Enum.ToObject(EnumType, convertedValue);
                     }
@@ -175,11 +175,10 @@ namespace System.ComponentModel
                     long[] ulValues = new long[objValues.Length];
                     for (int idx = 0; idx < objValues.Length; idx++)
                     {
-                        ulValues[idx] = isUnderlyingTypeUInt64 ? unchecked((long)Convert.ToUInt64(objValues.GetValue(idx), culture)) :
-                            Convert.ToInt64(objValues.GetValue(idx), culture);
+                        ulValues[idx] = GetEnumValue(isUnderlyingTypeUInt64, objValues.GetValue(idx)!, culture);
                     }
 
-                    long longValue = GetEnumValue(isUnderlyingTypeUInt64, (Enum)value, culture);
+                    long longValue = GetEnumValue(isUnderlyingTypeUInt64, value, culture);
                     bool valueFound = true;
                     while (valueFound)
                     {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
@@ -171,11 +171,12 @@ namespace System.ComponentModel
                     bool isUnderlyingTypeUInt64 = Enum.GetUnderlyingType(EnumType) == typeof(ulong);
                     List<Enum> flagValues = new List<Enum>();
 
-                    Array objValues = Enum.GetValues(EnumType);
+                    Array objValues = Enum.GetValuesAsUnderlyingType(EnumType);
                     long[] ulValues = new long[objValues.Length];
                     for (int idx = 0; idx < objValues.Length; idx++)
                     {
-                        ulValues[idx] = GetEnumValue(isUnderlyingTypeUInt64, (Enum)objValues.GetValue(idx)!, culture);
+                        ulValues[idx] = isUnderlyingTypeUInt64 ? unchecked((long)Convert.ToUInt64(objValues.GetValue(idx), culture)) :
+                            Convert.ToInt64(objValues.GetValue(idx), culture);
                     }
 
                     long longValue = GetEnumValue(isUnderlyingTypeUInt64, (Enum)value, culture);

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -323,7 +323,7 @@ namespace System
         }
 
         public static Array GetValuesAsUnderlyingType<TEnum>() where TEnum : struct, Enum =>
-            GetValuesAsUnderlyingType(typeof(TEnum));
+            typeof(TEnum).GetEnumValuesAsUnderlyingType();
 
         public static Array GetValuesAsUnderlyingType(Type enumType)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -323,28 +323,31 @@ namespace System
         }
 
         /// <summary>
-        /// Gets an array of values of the underlying type of the Enum.
+        /// Retrieves an array of the values of the underlying type constants in a specified enumeration type.
         /// </summary>
-        /// <typeparam name="TEnum">Enum type</typeparam>
+        /// <typeparam name="TEnum">An enumeration type.</typeparam>
         /// /// <remarks>
-        /// This method can be used to get enum values when creating an Array of Enum is challenging
-        /// For example, reflection-only context or on a platform where runtime codegen is not available.
+        /// This method can be used to get enumeration values when creating an array of the enumeration type is challenging.
+        /// For example, <see cref="T:System.Reflection.MetadataLoadContext" /> or on a platform where runtime codegen is not available.
         /// </remarks>
-        /// <returns>Array of values containing the underlying type of the Enum</returns>
+        /// <returns>An array that contains the values of the underlying type constants in enumType.</returns>
         public static Array GetValuesAsUnderlyingType<TEnum>() where TEnum : struct, Enum =>
             typeof(TEnum).GetEnumValuesAsUnderlyingType();
 
         /// <summary>
-        /// Gets an array of values of the underlying type of the Enum.
+        /// Retrieves an array of the values of the underlying type constants in a specified enumeration.
         /// </summary>
-        /// <param name="enumType">Enum type</param>
+        /// <param name="enumType">An enumeration type.</param>
         /// <remarks>
-        /// This method can be used to get enum values when creating an Array of Enum is challenging
-        /// For example, in reflection-only context or on a platform where runtime codegen is not available.
+        /// This method can be used to get enumeration values when creating an array of the enumeration type is challenging.
+        /// For example, <see cref="T:System.Reflection.MetadataLoadContext" /> or on a platform where runtime codegen is not available.
         /// </remarks>
-        /// <returns>Array of values containing the underlying type of the Enum</returns>
+        /// <returns>An array that contains the values of the underlying type constants in  <paramref name="enumType" />.</returns>
         /// <exception cref="ArgumentNullException">
-        /// Thrown when the enum type is null
+        /// Thrown when the enumeration type is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the type is not an enumeration type.
         /// </exception>
         public static Array GetValuesAsUnderlyingType(Type enumType)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -322,9 +322,30 @@ namespace System
             return enumType.GetEnumValues();
         }
 
+        /// <summary>
+        /// Gets an array of values of the underlying type of the Enum.
+        /// </summary>
+        /// <typeparam name="TEnum">Enum type</typeparam>
+        /// /// <remarks>
+        /// This method can be used to get enum values when creating an Array of Enum is challenging
+        /// For example, reflection-only context or on a platform where runtime codegen is not available.
+        /// </remarks>
+        /// <returns>Array of values containing the underlying type of the Enum</returns>
         public static Array GetValuesAsUnderlyingType<TEnum>() where TEnum : struct, Enum =>
             typeof(TEnum).GetEnumValuesAsUnderlyingType();
 
+        /// <summary>
+        /// Gets an array of values of the underlying type of the Enum.
+        /// </summary>
+        /// <param name="enumType">Enum type</param>
+        /// <remarks>
+        /// This method can be used to get enum values when creating an Array of Enum is challenging
+        /// For example, in reflection-only context or on a platform where runtime codegen is not available.
+        /// </remarks>
+        /// <returns>Array of values containing the underlying type of the Enum</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when the enum type is null
+        /// </exception>
         public static Array GetValuesAsUnderlyingType(Type enumType)
         {
             ArgumentNullException.ThrowIfNull(enumType);

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -315,7 +315,7 @@ namespace System
             (TEnum[])GetValues(typeof(TEnum));
 #endif
 
-        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload instead.")]
+        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload or the GetValuesAsUnderlyingType method instead.")]
         public static Array GetValues(Type enumType)
         {
             ArgumentNullException.ThrowIfNull(enumType);

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -322,6 +322,15 @@ namespace System
             return enumType.GetEnumValues();
         }
 
+        public static Array GetValuesAsUnderlyingType<TEnum>() where TEnum : struct, Enum =>
+            GetValuesAsUnderlyingType(typeof(TEnum));
+
+        public static Array GetValuesAsUnderlyingType(Type enumType)
+        {
+            ArgumentNullException.ThrowIfNull(enumType);
+            return enumType.GetEnumValuesAsUnderlyingType();
+        }
+
         [Intrinsic]
         public bool HasFlag(Enum flag)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureType.cs
@@ -99,7 +99,7 @@ namespace System.Reflection
         public sealed override string GetEnumName(object value) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override string[] GetEnumNames() => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override Type GetEnumUnderlyingType() => throw new NotSupportedException(SR.NotSupported_SignatureType);
-        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use Enum.GetValues<TEnum> instead.")]
+        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetEnumValues<TEnum> overload or the GetEnumValuesAsUnderlyingType method instead.")]
         public sealed override Array GetEnumValues() => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override Guid GUID => throw new NotSupportedException(SR.NotSupported_SignatureType);
         protected sealed override TypeCode GetTypeCodeImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -158,7 +158,7 @@ namespace System
             // Get all of the values
             ulong[] values = Enum.InternalGetValues(this);
 
-            switch (RuntimeTypeHandle.GetCorElementType(Enum.InternalGetUnderlyingType(this)))
+            switch (RuntimeTypeHandle.GetCorElementType(this))
             {
                 case CorElementType.ELEMENT_TYPE_U1:
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -126,7 +126,7 @@ namespace System
             if (!IsActualEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
 
-            // Get all of tkhe values
+            // Get all of the values
             ulong[] values = Enum.InternalGetValues(this);
 
             // Create a generic Array

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -158,9 +158,18 @@ namespace System
             // Get all of the values
             ulong[] values = Enum.InternalGetValues(this);
 
+#if MONO
+            switch (GetTypeCode(Enum.GetUnderlyingType(this)))
+#else
             switch (RuntimeTypeHandle.GetCorElementType(this))
+#endif
             {
+
+#if MONO
+                case TypeCode.Byte:
+#else
                 case CorElementType.ELEMENT_TYPE_U1:
+#endif
                     {
                         var ret = new byte[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -170,7 +179,11 @@ namespace System
                         return ret;
                     }
 
+#if MONO
+                case TypeCode.UInt16:
+#else
                 case CorElementType.ELEMENT_TYPE_U2:
+#endif
                     {
                         var ret = new ushort[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -180,7 +193,11 @@ namespace System
                         return ret;
                     }
 
+#if MONO
+                case TypeCode.UInt32:
+#else
                 case CorElementType.ELEMENT_TYPE_U4:
+#endif
                     {
                         var ret = new uint[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -190,12 +207,20 @@ namespace System
                         return ret;
                     }
 
+#if MONO
+                case TypeCode.UInt64:
+#else
                 case CorElementType.ELEMENT_TYPE_U8:
+#endif
                     {
                         return (Array)values.Clone();
                     }
 
+#if MONO
+                case TypeCode.SByte:
+#else
                 case CorElementType.ELEMENT_TYPE_I1:
+#endif
                     {
                         var ret = new sbyte[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -205,7 +230,11 @@ namespace System
                         return ret;
                     }
 
+#if MONO
+                case TypeCode.Int16:
+#else
                 case CorElementType.ELEMENT_TYPE_I2:
+#endif
                     {
                         var ret = new short[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -215,7 +244,11 @@ namespace System
                         return ret;
                     }
 
+#if MONO
+                case TypeCode.Int32:
+#else
                 case CorElementType.ELEMENT_TYPE_I4:
+#endif
                     {
                         var ret = new int[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -225,7 +258,11 @@ namespace System
                         return ret;
                     }
 
+#if MONO
+                case TypeCode.Int64:
+#else
                 case CorElementType.ELEMENT_TYPE_I8:
+#endif
                     {
                         var ret = new long[values.Length];
                         for (int i = 0; i < values.Length; i++)

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -158,18 +158,10 @@ namespace System
             // Get all of the values
             ulong[] values = Enum.InternalGetValues(this);
 
-#if MONO
             switch (RuntimeTypeHandle.GetCorElementType(Enum.InternalGetUnderlyingType(this)))
-#else
-            switch (RuntimeTypeHandle.GetCorElementType(this))
-#endif
             {
 
-#if MONO
-                case TypeCode.Byte:
-#else
                 case CorElementType.ELEMENT_TYPE_U1:
-#endif
                     {
                         var ret = new byte[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -179,11 +171,7 @@ namespace System
                         return ret;
                     }
 
-#if MONO
-                case TypeCode.UInt16:
-#else
                 case CorElementType.ELEMENT_TYPE_U2:
-#endif
                     {
                         var ret = new ushort[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -193,11 +181,7 @@ namespace System
                         return ret;
                     }
 
-#if MONO
-                case TypeCode.UInt32:
-#else
                 case CorElementType.ELEMENT_TYPE_U4:
-#endif
                     {
                         var ret = new uint[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -207,20 +191,12 @@ namespace System
                         return ret;
                     }
 
-#if MONO
-                case TypeCode.UInt64:
-#else
                 case CorElementType.ELEMENT_TYPE_U8:
-#endif
                     {
                         return (Array)values.Clone();
                     }
 
-#if MONO
-                case TypeCode.SByte:
-#else
                 case CorElementType.ELEMENT_TYPE_I1:
-#endif
                     {
                         var ret = new sbyte[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -230,11 +206,7 @@ namespace System
                         return ret;
                     }
 
-#if MONO
-                case TypeCode.Int16:
-#else
                 case CorElementType.ELEMENT_TYPE_I2:
-#endif
                     {
                         var ret = new short[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -244,11 +216,7 @@ namespace System
                         return ret;
                     }
 
-#if MONO
-                case TypeCode.Int32:
-#else
                 case CorElementType.ELEMENT_TYPE_I4:
-#endif
                     {
                         var ret = new int[values.Length];
                         for (int i = 0; i < values.Length; i++)
@@ -258,11 +226,7 @@ namespace System
                         return ret;
                     }
 
-#if MONO
-                case TypeCode.Int64:
-#else
                 case CorElementType.ELEMENT_TYPE_I8:
-#endif
                     {
                         var ret = new long[values.Length];
                         for (int i = 0; i < values.Length; i++)

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -235,7 +235,7 @@ namespace System
                         return ret;
                     }
                 default:
-                    throw new NotImplementedException("Not Implemented");
+                    throw new InvalidOperationException(SR.InvalidOperation_UnknownEnumType);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -7,8 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
-using Internal;
 
 namespace System
 {

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -7,6 +7,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Internal;
 
 namespace System
 {
@@ -124,11 +126,30 @@ namespace System
             if (!IsActualEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
 
-            // Get all of the values
+            // Get all of tkhe values
             ulong[] values = Enum.InternalGetValues(this);
 
             // Create a generic Array
             Array ret = Array.CreateInstance(this, values.Length);
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                object val = Enum.ToObject(this, values[i]);
+                ret.SetValue(val, i);
+            }
+
+            return ret;
+        }
+
+        public override Array GetEnumValuesAsUnderlyingType()
+        {
+            if (!IsActualEnum)
+                throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
+
+            // Get all of the values
+            ulong[] values = Enum.InternalGetValues(this);
+
+            Array ret = Array.CreateInstance(Enum.InternalGetUnderlyingType(this), values.Length);
 
             for (int i = 0; i < values.Length; i++)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -139,6 +139,17 @@ namespace System
             return ret;
         }
 
+        /// <summary>
+        /// Gets an array of values of the underlying type of the Enum.
+        /// </summary>
+        /// <remarks>
+        /// This method can be used to get enum values when creating an Array of Enum is challenging
+        /// For example, in reflection-only context or on a platform where runtime codegen is not available.
+        /// </remarks>
+        /// <returns>Array of values containing the underlying type of the Enum</returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the type is not Enum
+        /// </exception>
         public override Array GetEnumValuesAsUnderlyingType()
         {
             if (!IsActualEnum)
@@ -147,15 +158,85 @@ namespace System
             // Get all of the values
             ulong[] values = Enum.InternalGetValues(this);
 
-            Array ret = Array.CreateInstance(Enum.InternalGetUnderlyingType(this), values.Length);
-
-            for (int i = 0; i < values.Length; i++)
+            switch (RuntimeTypeHandle.GetCorElementType(Enum.InternalGetUnderlyingType(this)))
             {
-                object val = Enum.ToObject(this, values[i]);
-                ret.SetValue(val, i);
-            }
+                case CorElementType.ELEMENT_TYPE_U1:
+                    {
+                        var ret = new byte[values.Length];
+                        for (int i = 0; i < values.Length; i++)
+                        {
+                            ret[i] = (byte)values[i];
+                        }
+                        return ret;
+                    }
 
-            return ret;
+                case CorElementType.ELEMENT_TYPE_U2:
+                    {
+                        var ret = new ushort[values.Length];
+                        for (int i = 0; i < values.Length; i++)
+                        {
+                            ret[i] = (ushort)values[i];
+                        }
+                        return ret;
+                    }
+
+                case CorElementType.ELEMENT_TYPE_U4:
+                    {
+                        var ret = new uint[values.Length];
+                        for (int i = 0; i < values.Length; i++)
+                        {
+                            ret[i] = (uint)values[i];
+                        }
+                        return ret;
+                    }
+
+                case CorElementType.ELEMENT_TYPE_U8:
+                    {
+                        return (Array)values.Clone();
+                    }
+
+                case CorElementType.ELEMENT_TYPE_I1:
+                    {
+                        var ret = new sbyte[values.Length];
+                        for (int i = 0; i < values.Length; i++)
+                        {
+                            ret[i] = (sbyte)values[i];
+                        }
+                        return ret;
+                    }
+
+                case CorElementType.ELEMENT_TYPE_I2:
+                    {
+                        var ret = new short[values.Length];
+                        for (int i = 0; i < values.Length; i++)
+                        {
+                            ret[i] = (short)values[i];
+                        }
+                        return ret;
+                    }
+
+                case CorElementType.ELEMENT_TYPE_I4:
+                    {
+                        var ret = new int[values.Length];
+                        for (int i = 0; i < values.Length; i++)
+                        {
+                            ret[i] = (int)values[i];
+                        }
+                        return ret;
+                    }
+
+                case CorElementType.ELEMENT_TYPE_I8:
+                    {
+                        var ret = new long[values.Length];
+                        for (int i = 0; i < values.Length; i++)
+                        {
+                            ret[i] = (long)values[i];
+                        }
+                        return ret;
+                    }
+                default:
+                    throw new NotImplementedException("Not Implemented");
+            }
         }
 
         public override Type GetEnumUnderlyingType()

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -120,7 +120,7 @@ namespace System
             return new ReadOnlySpan<string>(ret).ToArray();
         }
 
-        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload instead.")]
+        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetEnumValues<TEnum> overload or the GetEnumValuesAsUnderlyingType method instead.")]
         public override Array GetEnumValues()
         {
             if (!IsActualEnum)

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -159,7 +159,7 @@ namespace System
             ulong[] values = Enum.InternalGetValues(this);
 
 #if MONO
-            switch (GetTypeCode(Enum.GetUnderlyingType(this)))
+            switch (RuntimeTypeHandle.GetCorElementType(Enum.InternalGetUnderlyingType(this)))
 #else
             switch (RuntimeTypeHandle.GetCorElementType(this))
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -140,13 +140,13 @@ namespace System
         }
 
         /// <summary>
-        /// Gets an array of values of the underlying type of the Enum.
+        /// Retrieves an array of the values of the underlying type constants in a specified enumeration type.
         /// </summary>
         /// <remarks>
-        /// This method can be used to get enum values when creating an Array of Enum is challenging
-        /// For example, in reflection-only context or on a platform where runtime codegen is not available.
+        /// This method can be used to get enumeration values when creating an array of the enumeration type is challenging.
+        /// For example, <see cref="T:System.Reflection.MetadataLoadContext" /> or on a platform where runtime codegen is not available.
         /// </remarks>
-        /// <returns>Array of values containing the underlying type of the Enum</returns>
+        /// <returns>An array that contains the values of the underlying type constants in enumType.</returns>
         /// <exception cref="ArgumentException">
         /// Thrown when the type is not Enum
         /// </exception>

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -527,15 +527,15 @@ namespace System
         }
 
         /// <summary>
-        /// Gets an array of values of the underlying type of the Enum.
+        /// Retrieves an array of the values of the underlying type constants in a specified enumeration type.
         /// </summary>
         /// <remarks>
-        /// This method can be used to get enum values when creating an Array of Enum is challenging
-        /// For example, in reflection-only context or on a platform where runtime codegen is not available.
+        /// This method can be used to get enumeration values when creating an array of the enumeration type is challenging.
+        /// For example, <see cref="T:System.Reflection.MetadataLoadContext" /> or on a platform where runtime codegen is not available.
         /// </remarks>
-        /// <returns>Array of values containing the underlying type of the Enum</returns>
+        /// <returns>An array that contains the values of the underlying type constants in enumType.</returns>
         /// <exception cref="ArgumentException">
-        /// Thrown when the type is not Enum
+        /// Thrown when the type is not an enumeration type.
         /// </exception>
         public virtual Array GetEnumValuesAsUnderlyingType() => throw new NotSupportedException(SR.NotSupported_SubclassOverride);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -515,7 +515,7 @@ namespace System
             return fields[0].FieldType;
         }
 
-        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use Enum.GetValues<TEnum> instead.")]
+        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetEnumValues<TEnum> overload or the GetEnumValuesAsUnderlyingType method instead.")]
         public virtual Array GetEnumValues()
         {
             if (!IsEnum)

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -526,18 +526,7 @@ namespace System
             throw NotImplemented.ByDesign;
         }
 
-        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-            Justification = "The runtime overrides this method with AOT compatible implementation")]
-        public virtual Array GetEnumValuesAsUnderlyingType()
-        {
-            if (!IsEnum)
-                throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
-
-            Array enumValues = GetEnumValues();
-            Array ret = Array.CreateInstance(GetEnumUnderlyingType(), enumValues.Length);
-            Array.Copy(enumValues, ret, enumValues.Length);
-            return ret;
-        }
+        public virtual Array GetEnumValuesAsUnderlyingType() => throw new NotSupportedException(SR.NotSupported_SubclassOverride);
 
         [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         public virtual Type MakeArrayType() => throw new NotSupportedException();

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -526,6 +526,17 @@ namespace System
             throw NotImplemented.ByDesign;
         }
 
+        /// <summary>
+        /// Gets an array of values of the underlying type of the Enum.
+        /// </summary>
+        /// <remarks>
+        /// This method can be used to get enum values when creating an Array of Enum is challenging
+        /// For example, in reflection-only context or on a platform where runtime codegen is not available.
+        /// </remarks>
+        /// <returns>Array of values containing the underlying type of the Enum</returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the type is not Enum
+        /// </exception>
         public virtual Array GetEnumValuesAsUnderlyingType() => throw new NotSupportedException(SR.NotSupported_SubclassOverride);
 
         [RequiresDynamicCode("The code for an array of the specified type might not be available.")]

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -526,6 +526,19 @@ namespace System
             throw NotImplemented.ByDesign;
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "The runtime overrides this method with AOT compatible implementation")]
+        public virtual Array GetEnumValuesAsUnderlyingType()
+        {
+            if (!IsEnum)
+                throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
+
+            Array enumValues = GetEnumValues();
+            Array ret = Array.CreateInstance(GetEnumUnderlyingType(), enumValues.Length);
+            Array.Copy(enumValues, ret, enumValues.Length);
+            return ret;
+        }
+
         [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         public virtual Type MakeArrayType() => throw new NotSupportedException();
         [RequiresDynamicCode("The code for an array of the specified type might not be available.")]

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.cs
@@ -296,7 +296,7 @@ namespace System.Reflection.TypeLoading
             if (!IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
 
-            FieldInfo[] enumFields = this.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            FieldInfo[] enumFields = GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
             int numValues = enumFields.Length;
             Array ret = Type.GetTypeCode(GetEnumUnderlyingType()) switch
             {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.cs
@@ -288,6 +288,7 @@ namespace System.Reflection.TypeLoading
         private volatile RoType? _lazyUnderlyingEnumType;
         public sealed override Array GetEnumValues() => throw new InvalidOperationException(SR.Arg_InvalidOperation_Reflection);
 
+#if NET7_0_OR_GREATER
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Enum Types are not trimmed.")]
         public override Array GetEnumValuesAsUnderlyingType()
@@ -317,6 +318,7 @@ namespace System.Reflection.TypeLoading
 
             return ret;
         }
+#endif
 
         // No trust environment to apply these to.
         public sealed override bool IsSecurityCritical => throw new InvalidOperationException(SR.InvalidOperation_IsSecurity);

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.cs
@@ -288,6 +288,36 @@ namespace System.Reflection.TypeLoading
         private volatile RoType? _lazyUnderlyingEnumType;
         public sealed override Array GetEnumValues() => throw new InvalidOperationException(SR.Arg_InvalidOperation_Reflection);
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
+            Justification = "Enum Types are not trimmed.")]
+        public override Array GetEnumValuesAsUnderlyingType()
+        {
+            if (!IsEnum)
+                throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
+
+            FieldInfo[] enumFields = this.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            int numValues = enumFields.Length;
+            Array ret = Type.GetTypeCode(GetEnumUnderlyingType()) switch
+            {
+                TypeCode.Byte => new byte[numValues],
+                TypeCode.SByte => new sbyte[numValues],
+                TypeCode.UInt16 => new ushort[numValues],
+                TypeCode.Int16 => new short[numValues],
+                TypeCode.UInt32 => new uint[numValues],
+                TypeCode.Int32 => new int[numValues],
+                TypeCode.UInt64 => new ulong[numValues],
+                TypeCode.Int64 => new long[numValues],
+                _ => throw new NotSupportedException(),
+            };
+
+            for (int i = 0; i < numValues; i++)
+            {
+                ret.SetValue(enumFields[i].GetRawConstantValue(), i);
+            }
+
+            return ret;
+        }
+
         // No trust environment to apply these to.
         public sealed override bool IsSecurityCritical => throw new InvalidOperationException(SR.InvalidOperation_IsSecurity);
         public sealed override bool IsSecuritySafeCritical => throw new InvalidOperationException(SR.InvalidOperation_IsSecurity);

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/SampleMetadata/SampleMetadata.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/SampleMetadata/SampleMetadata.cs
@@ -84,6 +84,9 @@ namespace SampleMetadata
     public enum EU8 : ulong { }
     public enum EI8 : long { }
 
+    public enum E_2_I4 : int { min=int.MinValue, zero=0, one=1, max=int.MaxValue}
+    public enum E_2_U4 : uint { min = uint.MinValue, zero = 0, one = 1, max = uint.MaxValue }
+
     public class GenericEnumContainer<T>
     {
         public enum GenericEnum : short { }

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
@@ -365,6 +365,7 @@ namespace System.Reflection.Tests
             }
         }
 
+#if NET7_0_OR_GREATER
         [Fact]
         public static void GetEnumValuesAsUnderlyingType()
         {
@@ -386,6 +387,7 @@ namespace System.Reflection.Tests
                 Assert.Equal(Type.GetTypeCode(expectesUIntValues[i].GetType()), Type.GetTypeCode(uintArr.GetValue(i).GetType()));
             }
         }
+#endif        
 
         [Theory]
         [MemberData(nameof(GetTypeCodeTheoryData))]

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
@@ -365,6 +365,28 @@ namespace System.Reflection.Tests
             }
         }
 
+        [Fact]
+        public static void GetEnumValuesAsUnderlyingType()
+        {
+            var intEnumType = typeof(E_2_I4).Project();
+            int[] expectedIntValues = { int.MinValue, 0, 1, int.MaxValue };
+            Array intArr = intEnumType.GetEnumValuesAsUnderlyingType();
+            for (int i = 0; i < intArr.Length; i++)
+            {
+                Assert.Equal(expectedIntValues[i], intArr.GetValue(i));
+                Assert.Equal(Type.GetTypeCode(expectedIntValues[i].GetType()), Type.GetTypeCode(intArr.GetValue(i).GetType()));
+            }
+
+            var uintEnumType = typeof(E_2_U4).Project();
+            uint[] expectesUIntValues = { uint.MinValue, 0, 1, uint.MaxValue };
+            Array uintArr = uintEnumType.GetEnumValuesAsUnderlyingType();
+            for (int i = 0; i < uintArr.Length; i++)
+            {
+                Assert.Equal(expectesUIntValues[i], uintArr.GetValue(i));
+                Assert.Equal(Type.GetTypeCode(expectesUIntValues[i].GetType()), Type.GetTypeCode(uintArr.GetValue(i).GetType()));
+            }
+        }
+
         [Theory]
         [MemberData(nameof(GetTypeCodeTheoryData))]
         public static void GettypeCode(TypeWrapper tw, TypeCode expectedTypeCode)

--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -458,6 +458,24 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        public static void GetEnumValuesAsUnderlyingType_Int()
+        {
+            GetEnumValuesAsUnderlyingType(typeof(IntEnum), new int[] { 1, 2, 10, 18, 45 });
+        }
+
+        [Fact]
+        public static void GetEnumValuesAsUnderlyingType_UInt()
+        {
+            GetEnumValues(typeof(UIntEnum), new uint[] { 1, 10 });
+        }
+
+        private static void GetEnumValuesAsUnderlyingType(Type enumType, Array expected)
+        {
+            Assert.Equal(expected, enumType.GetTypeInfo().GetEnumValuesAsUnderlyingType());
+        }
+
+
+        [Fact]
         public void GetEnumValues_TypeNotEnum_ThrowsArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>("enumType", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().GetEnumUnderlyingType());

--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -466,7 +466,7 @@ namespace System.Reflection.Tests
         [Fact]
         public static void GetEnumValuesAsUnderlyingType_UInt()
         {
-            GetEnumValues(typeof(UIntEnum), new uint[] { 1, 10 });
+            GetEnumValuesAsUnderlyingType(typeof(UIntEnum), new uint[] { 1, 10 });
         }
 
         private static void GetEnumValuesAsUnderlyingType(Type enumType, Array expected)

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2315,6 +2315,8 @@ namespace System
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload instead.")]
         public static System.Array GetValues(System.Type enumType) { throw null; }
         public static TEnum[] GetValues<TEnum>() where TEnum : struct, System.Enum { throw null; }
+        public static System.Array GetValuesAsUnderlyingType(System.Type enumType) { throw null; }
+        public static System.Array GetValuesAsUnderlyingType<TEnum>() where TEnum : struct, System.Enum { throw null; }
         public bool HasFlag(System.Enum flag) { throw null; }
         public static bool IsDefined(System.Type enumType, object value) { throw null; }
         public static bool IsDefined<TEnum>(TEnum value) where TEnum : struct, System.Enum { throw null; }
@@ -5862,6 +5864,7 @@ namespace System
         public virtual System.Type GetEnumUnderlyingType() { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use Enum.GetValues<TEnum> instead.")]
         public virtual System.Array GetEnumValues() { throw null; }
+        public virtual System.Array GetEnumValuesAsUnderlyingType() { throw null; }
         [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]
         public System.Reflection.EventInfo? GetEvent(string name) { throw null; }
         [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicEvents | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2312,7 +2312,7 @@ namespace System
         public static string[] GetNames<TEnum>() where TEnum: struct, System.Enum { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
         public static System.Type GetUnderlyingType(System.Type enumType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload instead.")]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload or the GetValuesAsUnderlyingType method instead.")]
         public static System.Array GetValues(System.Type enumType) { throw null; }
         public static TEnum[] GetValues<TEnum>() where TEnum : struct, System.Enum { throw null; }
         public static System.Array GetValuesAsUnderlyingType(System.Type enumType) { throw null; }
@@ -5862,7 +5862,7 @@ namespace System
         public virtual string? GetEnumName(object value) { throw null; }
         public virtual string[] GetEnumNames() { throw null; }
         public virtual System.Type GetEnumUnderlyingType() { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use Enum.GetValues<TEnum> instead.")]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetEnumValues<TEnum> overload or the GetEnumValuesAsUnderlyingType method instead.")]
         public virtual System.Array GetEnumValues() { throw null; }
         public virtual System.Array GetEnumValuesAsUnderlyingType() { throw null; }
         [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]

--- a/src/libraries/System.Runtime/tests/System/EnumTests.cs
+++ b/src/libraries/System.Runtime/tests/System/EnumTests.cs
@@ -1589,6 +1589,76 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentNullException>("enumType", () => Enum.GetValues(null));
         }
 
+        [Fact]
+        public void GetValuesAsUnderlyingType_InvokeSByteEnum_ReturnsExpected()
+        {
+            Array expected = new sbyte[] { 1, 2, sbyte.MaxValue, sbyte.MinValue };
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType(typeof(SByteEnum)));
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType<SByteEnum>());
+        }
+
+        [Fact]
+        public void GetValuesAsUnderlyingType_InvokeByteEnum_ReturnsExpected()
+        {
+            Array expected = new byte[] { byte.MinValue, 1, 2, byte.MaxValue };
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType(typeof(ByteEnum)));
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType<ByteEnum>());
+        }
+
+        [Fact]
+        public void GetValuesAsUnderlyingType_InvokeInt16Enum_ReturnsExpected()
+        {
+            Array expected = new short[] { 1, 2, short.MaxValue, short.MinValue };
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType(typeof(Int16Enum)));
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType<Int16Enum>());
+        }
+
+        [Fact]
+        public void GetValuesAsUnderlyingType_InvokeUInt16Enum_ReturnsExpected()
+        {
+            Array expected = new ushort[] { ushort.MinValue, 1, 2, ushort.MaxValue };
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType(typeof(UInt16Enum)));
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType<UInt16Enum>());
+        }
+
+        [Fact]
+        public void GetValuesAsUnderlyingType_InvokeInt32Enum_ReturnsExpected()
+        {
+            Array expected = new int[] { 1, 2, int.MaxValue, int.MinValue };
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType(typeof(Int32Enum)));
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType<Int32Enum>());
+        }
+
+        [Fact]
+        public void GetValuesAsUnderlyingType_InvokeUInt32Enum_ReturnsExpected()
+        {
+            Array expected = new uint[] { uint.MinValue, 1, 2, uint.MaxValue };
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType(typeof(UInt32Enum)));
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType<UInt32Enum>());
+        }
+
+        [Fact]
+        public void GetValuesAsUnderlyingType_InvokeInt64Enum_ReturnsExpected()
+        {
+            Array expected = new long[] { 1, 2, long.MaxValue, long.MinValue };
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType(typeof(Int64Enum)));
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType<Int64Enum>());
+        }
+
+        [Fact]
+        public void GetValuesAsUnderlyingType_InvokeUInt64Enum_ReturnsExpected()
+        {
+            Array expected = new ulong[] { ulong.MinValue, 1, 2, ulong.MaxValue };
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType(typeof(UInt64Enum)));
+            Assert.Equal(expected, Enum.GetValuesAsUnderlyingType<UInt64Enum>());
+        }
+
+        [Fact]
+        public static void GetValuesAsUnderlyingType_NullEnumType_ThrowsArgumentNullException()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("enumType", () => Enum.GetValuesAsUnderlyingType(null));
+        }
+
         [Theory]
         [InlineData(typeof(object))]
         [InlineData(typeof(int))]

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -1436,7 +1436,7 @@ internal static class ReflectionTest
 
             Console.WriteLine("Enum.GetEnumValuesAsUnderlyingType");
             {
-                if (Enum.GetEnumValuesAsUnderlyingType(typeof(Mine)) is not int[])
+                if (Enum.GetEnumValuesAsUnderlyingType(typeof(Mine)).GetType() != typeof(int[]))
                     throw new Exception("GetEnumValuesAsUnderlyingType");
             }
 

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -1434,6 +1434,12 @@ internal static class ReflectionTest
                     throw new Exception("GetValues");
             }
 
+            Console.WriteLine("Enum.GetEnumValuesAsUnderlyingType");
+            {
+                if (Enum.GetEnumValuesAsUnderlyingType(typeof(Mine)) is not int[])
+                    throw new Exception("GetEnumValuesAsUnderlyingType");
+            }
+
             Console.WriteLine("Pattern in LINQ expressions");
             {
                 Type objType = typeof(object);

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -1436,7 +1436,7 @@ internal static class ReflectionTest
 
             Console.WriteLine("Enum.GetEnumValuesAsUnderlyingType");
             {
-                if (Enum.GetEnumValuesAsUnderlyingType(typeof(Mine)).GetType() != typeof(int[]))
+                if (Enum.GetValuesAsUnderlyingType(typeof(Mine)).GetType() != typeof(int[]))
                     throw new Exception("GetEnumValuesAsUnderlyingType");
             }
 

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -1434,10 +1434,10 @@ internal static class ReflectionTest
                     throw new Exception("GetValues");
             }
 
-            Console.WriteLine("Enum.GetEnumValuesAsUnderlyingType");
+            Console.WriteLine("Enum.GetValuesAsUnderlyingType");
             {
                 if (Enum.GetValuesAsUnderlyingType(typeof(Mine)).GetType() != typeof(int[]))
-                    throw new Exception("GetEnumValuesAsUnderlyingType");
+                    throw new Exception("Enum.GetValuesAsUnderlyingType");
             }
 
             Console.WriteLine("Pattern in LINQ expressions");


### PR DESCRIPTION
Fixes #72498,

- Implemented the new API in Type and the two static API's in Enum calling the Type implementation. The abstract Type implementation throws with the expectation that a derived runtime Type will provide its own implementation.
- `CoreCLR/Mono` has an override implementation and `NativeAOT` has its own implementation that mirrors the original PR #72236.
- Also added an override in `MetadataAssemblyLoadContext `that is reflection friendly
- Added some test scenarios with the most on `EnumTests`