### PR TITLE
try to port ASCIIUtility.NarrowUtf16ToAscii to x-plat intrinsics

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -1380,44 +1380,10 @@ namespace System.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool VectorContainsNonAsciiChar(Vector128<ushort> utf16Vector)
         {
-            if (Sse2.IsSupported)
-            {
-                if (Sse41.IsSupported)
-                {
-                    Vector128<ushort> asciiMaskForTestZ = Vector128.Create((ushort)0xFF80);
-                    // If a non-ASCII bit is set in any WORD of the vector, we have seen non-ASCII data.
-                    if (!Sse41.TestZ(utf16Vector.AsInt16(), asciiMaskForTestZ.AsInt16()))
-                    {
-                        return true;
-                    }
-                }
-                else
-                {
-                    Vector128<ushort> asciiMaskForAddSaturate = Vector128.Create((ushort)0x7F80);
-                    // The operation below forces the 0x8000 bit of each WORD to be set iff the WORD element
-                    // has value >= 0x0800 (non-ASCII). Then we'll treat the vector as a BYTE vector in order
-                    // to extract the mask. Reminder: the 0x0080 bit of each WORD should be ignored.
-                    if ((Sse2.MoveMask(Sse2.AddSaturate(utf16Vector, asciiMaskForAddSaturate).AsByte()) & 0b_1010_1010_1010_1010) != 0)
-                    {
-                        return true;
-                    }
-                }
-            }
-            else if (AdvSimd.Arm64.IsSupported)
-            {
-                // First we pick four chars, a larger one from all four pairs of adjecent chars in the vector.
-                // If any of those four chars has a non-ASCII bit set, we have seen non-ASCII data.
-                Vector128<ushort> maxChars = AdvSimd.Arm64.MaxPairwise(utf16Vector, utf16Vector);
-                if ((maxChars.AsUInt64().ToScalar() & 0xFF80FF80FF80FF80) != 0)
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                throw new PlatformNotSupportedException();
-            }
-            return false;
+            const ushort asciiMask = ushort.MaxValue - 127; // 0x7F80
+            Vector128<ushort> zeroIsAscii = utf16Vector & Vector128.Create(asciiMask);
+            // If a non-ASCII bit is set in any WORD of the vector, we have seen non-ASCII data.
+            return !Vector128.EqualsAll(zeroIsAscii, Vector128<ushort>.Zero);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
For both x64 and ARM64 I am observing 10-15% regression.

### x64

<details>

```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=Windows 11 (10.0.22000.795/21H2)
AMD Ryzen Threadripper PRO 3945WX 12-Cores, 1 CPU, 24 logical and 12 physical cores
.NET SDK=7.0.100-preview.6.22352.1
  [Host]     : .NET 7.0.0 (7.0.22.32404), X64 RyuJIT AVX2
  
Method=GetBytes
```

|              Type |  Job | size | encName |              Input |          Mean | Ratio |
|------------------ |----- |----- |-------- |------------------- |--------------:|------:|
|     Perf_Encoding |   PR |   16 |   ascii |                  ? |      18.22 ns |  1.00 |
|     Perf_Encoding | main |   16 |   ascii |                  ? |      18.20 ns |  1.00 |
|                   |      |      |         |                    |               |       |
|     Perf_Encoding |   PR |   16 |   utf-8 |                  ? |      17.81 ns |  1.09 |
|     Perf_Encoding | main |   16 |   utf-8 |                  ? |      16.63 ns |  1.00 |
|                   |      |      |         |                    |               |       |
|     Perf_Encoding |   PR |  512 |   ascii |                  ? |      50.45 ns |  1.12 |
|     Perf_Encoding | main |  512 |   ascii |                  ? |      44.88 ns |  1.00 |
|                   |      |      |         |                    |               |       |
|     Perf_Encoding |   PR |  512 |   utf-8 |                  ? |      74.30 ns |  1.16 |
|     Perf_Encoding | main |  512 |   utf-8 |                  ? |      64.30 ns |  1.00 |
|                   |      |      |         |                    |               |       |
| Perf_Utf8Encoding |   PR |    ? |       ? |    EnglishAllAscii |  17,846.09 ns |  1.08 |
| Perf_Utf8Encoding | main |    ? |       ? |    EnglishAllAscii |  16,454.56 ns |  1.00 |
|                   |      |      |         |                    |               |       |
| Perf_Utf8Encoding |   PR |    ? |       ? | EnglishMostlyAscii |  79,019.77 ns |  0.97 |
| Perf_Utf8Encoding | main |    ? |       ? | EnglishMostlyAscii |  81,128.97 ns |  1.00 |
|                   |      |      |         |                    |               |       |
| Perf_Utf8Encoding |   PR |    ? |       ? |            Chinese |  82,925.92 ns |  0.99 |
| Perf_Utf8Encoding | main |    ? |       ? |            Chinese |  83,539.51 ns |  1.00 |
|                   |      |      |         |                    |               |       |
| Perf_Utf8Encoding |   PR |    ? |       ? |           Cyrillic |  97,716.52 ns |  0.98 |
| Perf_Utf8Encoding | main |    ? |       ? |           Cyrillic |  99,311.72 ns |  1.00 |
|                   |      |      |         |                    |               |       |
| Perf_Utf8Encoding |   PR |    ? |       ? |              Greek | 151,446.91 ns |  0.96 |
| Perf_Utf8Encoding | main |    ? |       ? |              Greek | 157,171.66 ns |  1.00 |

</details>

Here I was able to use VTune (I also tried uProf but it leaves a lot to desire):

<img width="1770" alt="vectors_vtune" src="https://user-images.githubusercontent.com/6011991/181774953-f20454dc-9316-4641-ad72-2810a8331657.PNG">

From what I can see the regression comes from additional 3 `vpand` instructions:

![image](https://user-images.githubusercontent.com/6011991/181775208-4451b09b-a874-40b1-a18d-5ee9f4edca0d.png)

It seems that the first one comes from the new `VectorContainsNonAsciiChar` implementation (this is expected). But the other two from `Vector128.Narrow`? @tannergooding is that expected?

### ARM64

<details>

```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=ubuntu 20.04
Unknown processor
.NET SDK=7.0.100-rc.1.22379.1
  [Host]     : .NET 7.0.0 (7.0.22.37802), Arm64 RyuJIT AdvSIMD

Method=GetBytes
```

|              Type |  Job | size | encName |              Input |          Mean | Ratio |
|------------------ |----- |----- |-------- |------------------- |--------------:|------:|
|     Perf_Encoding |   PR |   16 |   ascii |                  ? |      67.68 ns |  0.98 |
|     Perf_Encoding | main |   16 |   ascii |                  ? |      68.75 ns |  1.00 |
|                   |      |      |         |                    |               |       |
|     Perf_Encoding |   PR |   16 |   utf-8 |                  ? |      75.34 ns |  1.00 |
|     Perf_Encoding | main |   16 |   utf-8 |                  ? |      75.26 ns |  1.00 |
|                   |      |      |         |                    |               |       |
|     Perf_Encoding |   PR |  512 |   ascii |                  ? |     202.77 ns |  1.12 |
|     Perf_Encoding | main |  512 |   ascii |                  ? |     180.61 ns |  1.00 |
|                   |      |      |         |                    |               |       |
|     Perf_Encoding |   PR |  512 |   utf-8 |                  ? |     269.92 ns |  1.13 |
|     Perf_Encoding | main |  512 |   utf-8 |                  ? |     239.16 ns |  1.00 |
|                   |      |      |         |                    |               |       |
| Perf_Utf8Encoding |   PR |    ? |       ? |    EnglishAllAscii |  79,699.39 ns |  1.15 |
| Perf_Utf8Encoding | main |    ? |       ? |    EnglishAllAscii |  69,283.09 ns |  1.00 |
|                   |      |      |         |                    |               |       |
| Perf_Utf8Encoding |   PR |    ? |       ? | EnglishMostlyAscii | 285,553.35 ns |  1.00 |
| Perf_Utf8Encoding | main |    ? |       ? | EnglishMostlyAscii | 285,896.31 ns |  1.00 |
|                   |      |      |         |                    |               |       |
| Perf_Utf8Encoding |   PR |    ? |       ? |            Chinese | 308,349.96 ns |  1.00 |
| Perf_Utf8Encoding | main |    ? |       ? |            Chinese | 307,750.04 ns |  1.00 |
|                   |      |      |         |                    |               |       |
| Perf_Utf8Encoding |   PR |    ? |       ? |           Cyrillic | 217,887.57 ns |  1.00 |
| Perf_Utf8Encoding | main |    ? |       ? |           Cyrillic | 217,912.29 ns |  1.00 |
|                   |      |      |         |                    |               |       |
| Perf_Utf8Encoding |   PR |    ? |       ? |              Greek | 312,137.16 ns |  1.00 |
| Perf_Utf8Encoding | main |    ? |       ? |              Greek | 311,067.67 ns |  1.00 |

</details>