### PR TITLE
Define __cpuid{ex} only when there's no builtin one

### DIFF
--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -71,7 +71,7 @@ if [[ -z "$CLR_CC" ]]; then
     # Set default versions
     if [[ -z "$majorVersion" ]]; then
         # note: gcc (all versions) and clang versions higher than 6 do not have minor version in file name, if it is zero.
-        if [[ "$compiler" == "clang" ]]; then versions=( 14 13 12 11 10 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5 )
+        if [[ "$compiler" == "clang" ]]; then versions=( 15 14 13 12 11 10 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5 )
         elif [[ "$compiler" == "gcc" ]]; then versions=( 12 11 10 9 8 7 6 5 4.9 ); fi
 
         for version in "${versions[@]}"; do

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -1200,6 +1200,7 @@ extern "C" uint64_t PalGetCurrentThreadIdForLogging()
 
 #if defined(HOST_X86) || defined(HOST_AMD64)
 
+#if !__has_builtin(__cpuid)
 REDHAWK_PALEXPORT void __cpuid(int cpuInfo[4], int function_id)
 {
     // Based on the Clang implementation provided in cpuid.h:
@@ -1210,7 +1211,9 @@ REDHAWK_PALEXPORT void __cpuid(int cpuInfo[4], int function_id)
         : "0"(function_id)
         );
 }
+#endif
 
+#if !__has_builtin(__cpuidex)
 REDHAWK_PALEXPORT void __cpuidex(int cpuInfo[4], int function_id, int subFunction_id)
 {
     // Based on the Clang implementation provided in cpuid.h:
@@ -1221,6 +1224,7 @@ REDHAWK_PALEXPORT void __cpuidex(int cpuInfo[4], int function_id, int subFunctio
         : "0"(function_id), "2"(subFunction_id)
         );
 }
+#endif
 
 REDHAWK_PALEXPORT uint32_t REDHAWK_PALAPI xmmYmmStateSupport()
 {

--- a/src/coreclr/vm/amd64/unixstubs.cpp
+++ b/src/coreclr/vm/amd64/unixstubs.cpp
@@ -10,6 +10,7 @@ extern "C"
         PORTABILITY_ASSERT("Implement for PAL");
     }
 
+#if !__has_builtin(__cpuid)
     void __cpuid(int cpuInfo[4], int function_id)
     {
         // Based on the Clang implementation provided in cpuid.h:
@@ -20,7 +21,9 @@ extern "C"
             : "0"(function_id)
         );
     }
+#endif
 
+#if !__has_builtin(__cpuidex)
     void __cpuidex(int cpuInfo[4], int function_id, int subFunction_id)
     {
         // Based on the Clang implementation provided in cpuid.h:
@@ -31,6 +34,7 @@ extern "C"
             : "0"(function_id), "2"(subFunction_id)
         );
     }
+#endif
 
     DWORD xmmYmmStateSupport()
     {


### PR DESCRIPTION
Fix clang 15 RC1 build: `error: definition of builtin function '__cpuid'`.
Also add clang 15 autodetection; upstream PR https://github.com/dotnet/arcade/pull/10199.