### PR TITLE
[mono] Skip .mibc profile methods when not found

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -13359,7 +13359,6 @@ add_mibc_group_method_methods (MonoAotCompile *acfg, MonoMethod *mibcGroupMethod
 		ERROR_DECL(method_entry_error);
 		MonoMethod *methodEntry = mono_get_method_checked (image, mibcGroupMethodEntryToken, mibcModuleClass, context, method_entry_error);
 		if (!is_ok (method_entry_error)) {
-			g_warning ("Method not found for method token '%x' from mibc image '%s'.\n", mibcGroupMethodEntryToken, image->name);
 			mono_error_cleanup (method_entry_error);
 			continue;
 		}

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -13352,19 +13352,17 @@ add_mibc_group_method_methods (MonoAotCompile *acfg, MonoMethod *mibcGroupMethod
 
 		g_assert (cur + 4 < end); // Assert that there is atleast a 32 bit token before the end
 		guint32 mibcGroupMethodEntryToken = read32 (cur + 1);
-		g_assertf ((mono_metadata_token_table (mibcGroupMethodEntryToken) == MONO_TABLE_MEMBERREF || mono_metadata_token_table (mibcGroupMethodEntryToken) == MONO_TABLE_METHODSPEC), "token %x is not MemberRef or MethodSpec.\n", mibcGroupMethodEntryToken);
+		g_assertf ((mono_metadata_token_table (mibcGroupMethodEntryToken) == MONO_TABLE_MEMBERREF || mono_metadata_token_table (mibcGroupMethodEntryToken) == MONO_TABLE_METHODSPEC), "token '%x' is not MemberRef or MethodSpec.\n", mibcGroupMethodEntryToken);
 		cur += op_size;
 
-		MonoMethod *methodEntry = mono_get_method_checked (image, mibcGroupMethodEntryToken, mibcModuleClass, context, error);
-		mono_error_assert_ok (error);
-
-		MonoClass *method_class = mono_method_get_class (methodEntry);
-		if (!method_class)
+		// Skip methods in the profile that are not found
+		ERROR_DECL(method_entry_error);
+		MonoMethod *methodEntry = mono_get_method_checked (image, mibcGroupMethodEntryToken, mibcModuleClass, context, method_entry_error);
+		if (!is_ok (method_entry_error)) {
+			g_warning ("Method not found for method token '%x' from mibc image '%s'.\n", mibcGroupMethodEntryToken, image->name);
+			mono_error_cleanup (method_entry_error);
 			continue;
-
-		MonoImage *method_image = mono_class_get_image (method_class);
-		if (!method_image)
-			continue;
+		}
 
 		count += add_single_profile_method (acfg, methodEntry);
 	}


### PR DESCRIPTION
This PR allows the MonoAOTCompiler to skip compiling methods from a .mibc profile that can not be found. This case can occur when one uses a .mibc profile based on a different app.

/cc: @jonathanpeppers 