### PR TITLE
Move System.ValueType.s_seed into System.Runtime.CompilerServices.RuntimeHelpers

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -123,7 +123,7 @@ namespace System
 
         public override int GetHashCode()
         {
-            return ValueType.GetHashCodeOfPtr(ArgCookie);
+            return RuntimeHelpers.GetHashCodeOfPtr(ArgCookie);
         }
 
         // Inherited from object

--- a/src/coreclr/System.Private.CoreLib/src/System/MulticastDelegate.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/MulticastDelegate.cs
@@ -460,7 +460,7 @@ namespace System
         public sealed override int GetHashCode()
         {
             if (IsUnmanagedFunctionPtr())
-                return ValueType.GetHashCodeOfPtr(_methodPtr) ^ ValueType.GetHashCodeOfPtr(_methodPtrAux);
+                return RuntimeHelpers.GetHashCodeOfPtr(_methodPtr) ^ RuntimeHelpers.GetHashCodeOfPtr(_methodPtrAux);
 
             if (_invocationCount != (IntPtr)0)
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -206,7 +206,7 @@ namespace System.Reflection
 
         public override int GetHashCode()
         {
-            return ValueType.GetHashCodeOfPtr(m_metadataImport2);
+            return RuntimeHelpers.GetHashCodeOfPtr(m_metadataImport2);
         }
 
         public override bool Equals(object? obj)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
@@ -161,7 +161,7 @@ namespace System.Reflection
         {
             // See RuntimeMethodInfo.Equals() below.
             if (IsGenericMethod)
-                return ValueType.GetHashCodeOfPtr(m_handle);
+                return RuntimeHelpers.GetHashCodeOfPtr(m_handle);
             else
                 return base.GetHashCode();
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -8,11 +8,14 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Runtime.Versioning;
+using System.Threading;
 
 namespace System.Runtime.CompilerServices
 {
     public static partial class RuntimeHelpers
     {
+        private static int s_pointerHashSeed;
+
         [Intrinsic]
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void InitializeArray(Array array, RuntimeFieldHandle fldHandle);
@@ -397,6 +400,31 @@ namespace System.Runtime.CompilerServices
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern unsafe void UnregisterForGCReporting(GCFrameRegistration* pRegistration);
+
+        internal static int GetHashCodeOfPtr(IntPtr ptr)
+        {
+            int hashCode = (int)ptr;
+
+            if (hashCode == 0)
+            {
+                return 0;
+            }
+
+            int seed = s_pointerHashSeed;
+
+            // Initialize s_pointerHashSeed lazily
+            if (seed == 0)
+            {
+                // We use the first non-0 pointer as the seed, all hashcodes will be based off that.
+                // This is to make sure that we only reveal relative memory addresses and never absolute ones.
+                seed = hashCode;
+                Interlocked.CompareExchange(ref s_pointerHashSeed, seed, 0);
+                seed = s_pointerHashSeed;
+            }
+
+            Debug.Assert(s_pointerHashSeed != 0);
+            return hashCode - seed;
+        }
     }
     // Helper class to assist with unsafe pinning of arbitrary objects.
     // It's used by VM code.

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -873,7 +873,7 @@ namespace System
 
         public override int GetHashCode()
         {
-            return ValueType.GetHashCodeOfPtr(Value);
+            return RuntimeHelpers.GetHashCodeOfPtr(Value);
         }
 
         public override bool Equals(object? obj)
@@ -1226,7 +1226,7 @@ namespace System
 
         public override int GetHashCode()
         {
-            return ValueType.GetHashCodeOfPtr(Value);
+            return RuntimeHelpers.GetHashCodeOfPtr(Value);
         }
 
         public override bool Equals(object? obj)

--- a/src/coreclr/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/ValueType.cs
@@ -10,11 +10,9 @@
 **
 ===========================================================*/
 
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace System
 {
@@ -83,33 +81,6 @@ namespace System
         ==============================================================================*/
         [MethodImpl(MethodImplOptions.InternalCall)]
         public extern override int GetHashCode();
-
-        private static int s_seed;
-
-        internal static int GetHashCodeOfPtr(IntPtr ptr)
-        {
-            int hashCode = (int)ptr;
-
-            if (hashCode == 0)
-            {
-                return 0;
-            }
-
-            int seed = s_seed;
-
-            // Initialize s_seed lazily
-            if (seed == 0)
-            {
-                // We use the first non-0 pointer as the seed, all hashcodes will be based off that.
-                // This is to make sure that we only reveal relative memory addresses and never absolute ones.
-                seed = hashCode;
-                Interlocked.CompareExchange(ref s_seed, seed, 0);
-                seed = s_seed;
-            }
-
-            Debug.Assert(s_seed != 0);
-            return hashCode - seed;
-        }
 
         public override string? ToString()
         {


### PR DESCRIPTION
PR https://github.com/dotnet/runtime/pull/69723 added a 's_seed' field to System.ValueType. This causes the debugger to show all structs as having static members. 

![image](https://user-images.githubusercontent.com/11078489/181826298-f8d2104d-23e9-430d-abe7-e3df6718b36d.png)

This PR moves the field and the function that used it into RuntimeHelpers.