### PR TITLE
Fix assert in NativeAOT when handling data flow on compiler generated…

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -927,6 +927,11 @@ namespace ILCompiler
                 methodILDefinition = FlowAnnotations.ILProvider.GetMethodIL(userMethod);
             }
 
+            // Data-flow (reflection scanning) for compiler-generated methods will happen as part of the
+            // data-flow scan of the user-defined method which uses this compiler-generated method.
+            if (CompilerGeneratedState.IsNestedFunctionOrStateMachineMember(methodILDefinition.OwningMethod))
+                return;
+
             dependencies = dependencies ?? new DependencyList();
             dependencies.Add(factory.DataflowAnalyzedMethod(methodILDefinition), reason);
         }


### PR DESCRIPTION
… code.

The problem occurs when an entire type/assembly is preserved through explicit rooting (command line, rd.xml, ...). If such type contains a local function (for example) which is only called from a branch which is going to be removed by constant-prop/branch removal the internal tracking of compiler generated methods will see this local function as orphaned (not belonging to any user method). This leads to a case where we will try to run data flow on the local function - but that should never happen for compiler generated methods directly -> assert.

The fix is (just like in the linker), to never run data flow on compiler generated methods directly - they should only run data flow as part of their respective user method.

Fixes https://github.com/dotnet/runtime/issues/73027