### PR TITLE
Fix xxHash64 handling of large (> 4GB) inputs

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
@@ -90,7 +90,7 @@ namespace System.IO.Hashing
                 return acc;
             }
 
-            internal readonly ulong Complete(int length, ReadOnlySpan<byte> remaining)
+            internal readonly ulong Complete(long length, ReadOnlySpan<byte> remaining)
             {
                 ulong acc = _hadFullStripe ? Converge() : _smallAcc;
 

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
@@ -19,7 +19,7 @@ namespace System.IO.Hashing
         private readonly ulong _seed;
         private State _state;
         private byte[]? _holdback;
-        private int _length;
+        private long _length;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="XxHash64"/> class.
@@ -67,7 +67,7 @@ namespace System.IO.Hashing
             // Data that isn't perfectly mod-32 gets stored in a holdback
             // buffer.
 
-            int held = _length & 0x1F;
+            int held = (int)_length & 0x1F;
 
             if (held != 0)
             {
@@ -110,7 +110,7 @@ namespace System.IO.Hashing
         /// </summary>
         protected override void GetCurrentHashCore(Span<byte> destination)
         {
-            int remainingLength = _length & 0x1F;
+            int remainingLength = (int)_length & 0x1F;
             ReadOnlySpan<byte> remaining = ReadOnlySpan<byte>.Empty;
 
             if (remainingLength > 0)
@@ -225,7 +225,7 @@ namespace System.IO.Hashing
                 source = source.Slice(StripeSize);
             }
 
-            ulong val = state.Complete(totalLength, source);
+            ulong val = state.Complete((uint)totalLength, source);
             BinaryPrimitives.WriteUInt64BigEndian(destination, val);
             return HashSize;
         }

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
@@ -109,7 +109,7 @@ namespace System.IO.Hashing.Tests
         protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
             new[]
             {
-                //https://asecuritysite.com/encryption/xxHash, Example 1
+                // Manually run against the xxHash32 reference implementation.
                 new LargeTestCase(
                     "EEEEE... (10GB)",
                     (byte)'E',

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
@@ -92,6 +92,31 @@ namespace System.IO.Hashing.Tests
                     "FC23CD03"),
             };
 
+        public static IEnumerable<object[]> LargeTestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (LargeTestCase testCase in LargeTestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
+            new[]
+            {
+                //https://asecuritysite.com/encryption/xxHash, Example 1
+                new LargeTestCase(
+                    "EEEEE...",
+                    (byte)'E',
+                    10L * 1024 * 1024 * 1024, // 10 GB
+                    "1C44F650"),
+            };
+
         protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash32(Seed);
 
         protected override byte[] StaticOneShot(byte[] source) => XxHash32.Hash(source, Seed);
@@ -123,6 +148,14 @@ namespace System.IO.Hashing.Tests
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
         {
             InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(LargeTestCases))]
+        [OuterLoop]
+        public void InstanceMultiAppendLargeInput(LargeTestCase testCase)
+        {
+            InstanceMultiAppendLargeInputDriver(testCase);
         }
 
         [Theory]

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
@@ -111,7 +111,7 @@ namespace System.IO.Hashing.Tests
             {
                 //https://asecuritysite.com/encryption/xxHash, Example 1
                 new LargeTestCase(
-                    "EEEEE...",
+                    "EEEEE... (10GB)",
                     (byte)'E',
                     10L * 1024 * 1024 * 1024, // 10 GB
                     "1C44F650"),

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
@@ -123,7 +123,7 @@ namespace System.IO.Hashing.Tests
         protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
             new[]
             {
-                //https://asecuritysite.com/encryption/xxHash, Example 1
+                // Manually run against the xxHash32 reference implementation.
                 new LargeTestCase(
                     "EEEEE... (10GB)",
                     (byte)'E',

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
@@ -106,6 +106,31 @@ namespace System.IO.Hashing.Tests
                     "5DF7D6C0"),
             };
 
+        public static IEnumerable<object[]> LargeTestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (LargeTestCase testCase in LargeTestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
+            new[]
+            {
+                //https://asecuritysite.com/encryption/xxHash, Example 1
+                new LargeTestCase(
+                    "EEEEE...",
+                    (byte)'E',
+                    10L * 1024 * 1024 * 1024, // 10 GB
+                    "22CBC3AA"),
+            };
+
         protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash32();
 
         protected override byte[] StaticOneShot(byte[] source) => XxHash32.Hash(source);
@@ -137,6 +162,14 @@ namespace System.IO.Hashing.Tests
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
         {
             InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(LargeTestCases))]
+        [OuterLoop]
+        public void InstanceMultiAppendLargeInput(LargeTestCase testCase)
+        {
+            InstanceMultiAppendLargeInputDriver(testCase);
         }
 
         [Theory]

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
@@ -125,7 +125,7 @@ namespace System.IO.Hashing.Tests
             {
                 //https://asecuritysite.com/encryption/xxHash, Example 1
                 new LargeTestCase(
-                    "EEEEE...",
+                    "EEEEE... (10GB)",
                     (byte)'E',
                     10L * 1024 * 1024 * 1024, // 10 GB
                     "22CBC3AA"),

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
@@ -109,7 +109,7 @@ namespace System.IO.Hashing.Tests
         protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
             new[]
             {
-                //https://asecuritysite.com/encryption/xxHash, Example 1
+                // Manually run against the xxHash32 reference implementation.
                 new LargeTestCase(
                     "EEEEE... (10GB)",
                     (byte)'E',

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
@@ -111,7 +111,7 @@ namespace System.IO.Hashing.Tests
             {
                 //https://asecuritysite.com/encryption/xxHash, Example 1
                 new LargeTestCase(
-                    "EEEEE...",
+                    "EEEEE... (10GB)",
                     (byte)'E',
                     10L * 1024 * 1024 * 1024, // 10 GB
                     "B19FAE15"),

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
@@ -92,6 +92,31 @@ namespace System.IO.Hashing.Tests
                     "C7A3D1CB"),
             };
 
+        public static IEnumerable<object[]> LargeTestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (LargeTestCase testCase in LargeTestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
+            new[]
+            {
+                //https://asecuritysite.com/encryption/xxHash, Example 1
+                new LargeTestCase(
+                    "EEEEE...",
+                    (byte)'E',
+                    10L * 1024 * 1024 * 1024, // 10 GB
+                    "B19FAE15"),
+            };
+
         protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash32(Seed);
 
         protected override byte[] StaticOneShot(byte[] source) => XxHash32.Hash(source, Seed);
@@ -123,6 +148,14 @@ namespace System.IO.Hashing.Tests
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
         {
             InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(LargeTestCases))]
+        [OuterLoop]
+        public void InstanceMultiAppendLargeInput(LargeTestCase testCase)
+        {
+            InstanceMultiAppendLargeInputDriver(testCase);
         }
 
         [Theory]

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
@@ -131,7 +131,7 @@ namespace System.IO.Hashing.Tests
         protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
             new[]
             {
-                //https://asecuritysite.com/encryption/xxHash, Example 1
+                // Manually run against the xxHash64 reference implementation.
                 new LargeTestCase(
                     "EEEEE... (10GB)",
                     (byte)'E',

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
@@ -114,6 +114,31 @@ namespace System.IO.Hashing.Tests
         protected override bool TryStaticOneShot(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten) =>
             XxHash64.TryHash(source, destination, out bytesWritten, Seed);
 
+        public static IEnumerable<object[]> LargeTestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (LargeTestCase testCase in LargeTestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
+            new[]
+            {
+                //https://asecuritysite.com/encryption/xxHash, Example 1
+                new LargeTestCase(
+                    "EEEEE...",
+                    (byte)'E',
+                    10L * 1024 * 1024 * 1024, // 10 GB
+                    "DFBE10B17366232C"),
+            };
+
         [Theory]
         [MemberData(nameof(TestCases))]
         public void InstanceAppendAllocate(TestCase testCase)
@@ -133,6 +158,14 @@ namespace System.IO.Hashing.Tests
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
         {
             InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(LargeTestCases))]
+        [OuterLoop]
+        public void InstanceMultiAppendLargeInput(LargeTestCase testCase)
+        {
+            InstanceMultiAppendLargeInputDriver(testCase);
         }
 
         [Theory]

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
@@ -133,7 +133,7 @@ namespace System.IO.Hashing.Tests
             {
                 //https://asecuritysite.com/encryption/xxHash, Example 1
                 new LargeTestCase(
-                    "EEEEE...",
+                    "EEEEE... (10GB)",
                     (byte)'E',
                     10L * 1024 * 1024 * 1024, // 10 GB
                     "DFBE10B17366232C"),

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
@@ -136,7 +136,7 @@ namespace System.IO.Hashing.Tests
         protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
             new[]
             {
-                //https://asecuritysite.com/encryption/xxHash, Example 1
+                // Manually run against the xxHash64 reference implementation.
                 new LargeTestCase(
                     "EEEEE... (10GB)",
                     (byte)'E',

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
@@ -138,7 +138,7 @@ namespace System.IO.Hashing.Tests
             {
                 //https://asecuritysite.com/encryption/xxHash, Example 1
                 new LargeTestCase(
-                    "EEEEE...",
+                    "EEEEE... (10GB)",
                     (byte)'E',
                     10L * 1024 * 1024 * 1024, // 10 GB
                     "F3CB8D45A8B695EF"),

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
@@ -119,6 +119,31 @@ namespace System.IO.Hashing.Tests
                     "BDD40F0FAC166EAA"),
             };
 
+        public static IEnumerable<object[]> LargeTestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (LargeTestCase testCase in LargeTestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
+            new[]
+            {
+                //https://asecuritysite.com/encryption/xxHash, Example 1
+                new LargeTestCase(
+                    "EEEEE...",
+                    (byte)'E',
+                    10L * 1024 * 1024 * 1024, // 10 GB
+                    "F3CB8D45A8B695EF"),
+            };
+
         protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash64();
 
         protected override byte[] StaticOneShot(byte[] source) => XxHash64.Hash(source);
@@ -150,6 +175,14 @@ namespace System.IO.Hashing.Tests
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
         {
             InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(LargeTestCases))]
+        [OuterLoop]
+        public void InstanceMultiAppendLargeInput(LargeTestCase testCase)
+        {
+            InstanceMultiAppendLargeInputDriver(testCase);
         }
 
         [Theory]

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
@@ -119,7 +119,7 @@ namespace System.IO.Hashing.Tests
         protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
             new[]
             {
-                //https://asecuritysite.com/encryption/xxHash, Example 1
+                // Manually run against the xxHash64 reference implementation.
                 new LargeTestCase(
                     "EEEEE... (10GB)",
                     (byte)'E',

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
@@ -121,7 +121,7 @@ namespace System.IO.Hashing.Tests
             {
                 //https://asecuritysite.com/encryption/xxHash, Example 1
                 new LargeTestCase(
-                    "EEEEE...",
+                    "EEEEE... (10GB)",
                     (byte)'E',
                     10L * 1024 * 1024 * 1024, // 10 GB
                     "CD7B3A954E199AE8"),

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
@@ -102,6 +102,31 @@ namespace System.IO.Hashing.Tests
                     "C9B96062B49FEC42"),
             };
 
+        public static IEnumerable<object[]> LargeTestCases
+        {
+            get
+            {
+                object[] arr = new object[1];
+
+                foreach (LargeTestCase testCase in LargeTestCaseDefinitions)
+                {
+                    arr[0] = testCase;
+                    yield return arr;
+                }
+            }
+        }
+
+        protected static IEnumerable<LargeTestCase> LargeTestCaseDefinitions { get; } =
+            new[]
+            {
+                //https://asecuritysite.com/encryption/xxHash, Example 1
+                new LargeTestCase(
+                    "EEEEE...",
+                    (byte)'E',
+                    10L * 1024 * 1024 * 1024, // 10 GB
+                    "CD7B3A954E199AE8"),
+            };
+
         protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash64(Seed);
 
         protected override byte[] StaticOneShot(byte[] source) => XxHash64.Hash(source, Seed);
@@ -133,6 +158,14 @@ namespace System.IO.Hashing.Tests
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)
         {
             InstanceMultiAppendGetCurrentHashDriver(testCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(LargeTestCases))]
+        [OuterLoop]
+        public void InstanceMultiAppendLargeInput(LargeTestCase testCase)
+        {
+            InstanceMultiAppendLargeInputDriver(testCase);
         }
 
         [Theory]


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/69184.

Our implementation of xxHash64 stored the length as a 32-bit integer internally. This meant that we're producing incorrect hashes when handling inputs greater than 4GB, as we're losing some of the length bits that should be folded into the final digest.

I couldn't find any real test cases for this scenario, so I ran 10GB worth of "EEEEEE..." through the reference implementation and observed its outputs given the various seeds we use in our test infrastructure. After changing our length handling to be 64-bit, our outputs match the reference implementation.