### PR TITLE
`runtime-wasm-perf`: add support for running against forks, and branches

### DIFF
--- a/eng/pipelines/coreclr/perf-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-wasm-jobs.yml
@@ -7,6 +7,7 @@ parameters:
   onlySanityCheck: false
   downloadSpecificBuild: null # { buildId, pipeline, branchName, project }
   collectHelixLogsScript: ''
+  perfForkToUse: {} # url, branch
 
 jobs:
 
@@ -48,6 +49,7 @@ jobs:
         javascriptEngine: 'javascriptcore'
         collectHelixLogsScript: ${{ parameters.collectHelixLogsScript }}
         downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+        perfForkToUse: ${{ parameters.perfForkToUse }}
         #downloadSpecificBuild:
           #buildId: '1693181'
           #pipeline: 'perf-wasm'
@@ -74,6 +76,7 @@ jobs:
         javascriptengine: 'javascriptcore'
         collectHelixLogsScript: ${{ parameters.collectHelixLogsScript }}
         downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+        perfForkToUse: ${{ parameters.perfForkToUse }}
 
 - ${{ if eq(parameters.runProfile, 'v8') }}:
   - ${{ if eq(parameters.downloadSpecificBuild.buildId, '') }}:
@@ -116,6 +119,7 @@ jobs:
         compare: ${{ parameters.compare }}
         onlySanityCheck: ${{ parameters.onlySanityCheck }}
         downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+        perfForkToUse: ${{ parameters.perfForkToUse }}
 
   #run mono wasm aot microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -140,6 +144,7 @@ jobs:
         compare: ${{ parameters.compare }}
         onlySanityCheck: ${{ parameters.onlySanityCheck }}
         downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+        perfForkToUse: ${{ parameters.perfForkToUse }}
 
   # run mono wasm blazor perf job
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -160,3 +165,4 @@ jobs:
         #additionalSetupParameters: '--latestdotnet' - doesn't do anything, IIUC. see performance-setup.sh
         logicalmachine: 'perftiger'
         downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+        perfForkToUse: ${{ parameters.perfForkToUse }}

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -25,6 +25,7 @@ parameters:
   compare: false
   onlySanityCheck: false
   downloadSpecificBuild: null # buildId, pipeline, branchName, project
+  perfForkToUse: {} # url, branch
 
 ### Perf job
 
@@ -114,11 +115,19 @@ jobs:
     - ${{ each variable in parameters.variables }}:
       - name: ${{ variable.name }}
         value: ${{ variable.value }}
-    - name: extraSetupParametersSuffix
+
+    - name: _compareArg
       ${{ if eq(parameters.compare, 'true') }}:
         value: '--compare'
+    - name: _onlySanityCheckArg
       ${{ if eq(parameters.onlySanityCheck, 'true') }}:
         value: '--only-sanity'
+    - name: _perfForkArg
+      ${{ if ne(parameters.perfForkToUse.url, '') }}:
+        value: --perffork ${{ parameters.perfForkToUse.url }} --perfforkbranch ${{ coalesce(parameters.perfForkToUse.branch, 'main') }}
+
+    - name: extraSetupParametersSuffix
+      value: "$(_compareArg) $(_onlySanityCheckArg) $(_perfForkArg)"
 
     frameworks:
       - ${{ parameters.framework }}

--- a/eng/pipelines/runtime-wasm-perf.yml
+++ b/eng/pipelines/runtime-wasm-perf.yml
@@ -19,7 +19,10 @@ jobs:
   parameters:
     runProfile: 'v8'
     collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
-    #onlySanityCheck: false
+    onlySanityCheck: true
+    #perfForkToUse:
+      #url: https://github.com/radical/performance
+      #branch: fix-build
     #downloadSpecificBuild:
       #buildId: '1878694'
       #pipeline: 'perf-wasm'

--- a/eng/testing/performance/microbenchmarks.proj
+++ b/eng/testing/performance/microbenchmarks.proj
@@ -72,7 +72,7 @@
 
   <PropertyGroup>
     <WorkItemTimeout>2:30</WorkItemTimeout>
-    <WorkItemTimeout Condition="'$(OnlySanityCheck)' == 'true'">0:15</WorkItemTimeout>
+    <WorkItemTimeout Condition="'$(OnlySanityCheck)' == 'true'">1:30</WorkItemTimeout>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -23,6 +23,8 @@ monoaot_path=
 run_categories="Libraries Runtime"
 csproj="src\benchmarks\micro\MicroBenchmarks.csproj"
 configurations="CompliationMode=$compilation_mode RunKind=$kind"
+perf_fork=""
+perf_fork_branch="main"
 run_from_perf_repo=false
 use_core_run=true
 use_baseline_core_run=true
@@ -156,6 +158,14 @@ while (($# > 0)); do
       ;;
     --mauiversion)
       maui_version=$2
+      shift 2
+      ;;
+    --perffork)
+      perf_fork=$2
+      shift 2
+      ;;
+    --perfforkbranch)
+      perf_fork_branch=$2
       shift 2
       ;;
     --only-sanity)
@@ -306,7 +316,11 @@ if [[ "$run_from_perf_repo" == true ]]; then
     performance_directory=$workitem_directory
     setup_arguments="--perf-hash $commit_sha $common_setup_arguments"
 else
-    git clone --branch main --depth 1 --quiet https://github.com/dotnet/performance.git $performance_directory
+    if [[ -n "$perf_fork" ]]; then
+        git clone --branch $perf_fork_branch --depth 1 --quiet $perf_fork $performance_directory
+    else
+        git clone --branch main --depth 1 --quiet https://github.com/dotnet/performance.git $performance_directory
+    fi
     # uncomment to use BenchmarkDotNet sources instead of nuget packages
     # git clone https://github.com/dotnet/BenchmarkDotNet.git $benchmark_directory
 


### PR DESCRIPTION
.. of `dotnet/performance`.

This can be done by adding `perfForToUse` parameter in `runtime-wasm-perf.yml`:

```
- template: /eng/pipelines/coreclr/perf-wasm-jobs.yml
  parameters:
    ...
    perfForkToUse:
      url: https://github.com/radical/performance
      branch: fix-build
```

Also:
- change the default for the pipeline to run only sanity checks
- And increase the timeout for the helix items from 15mins to 90mins, allowing the AOT jobs to run too