### PR TITLE
Add localloc empty stack verification

### DIFF
--- a/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
+++ b/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
@@ -2582,7 +2582,7 @@ namespace Internal.IL
 
             var size = Pop();
 
-            FatalCheck(_stackTop == 0, VerifierError.LocallocStackNotEmpty);
+            Check(_stackTop == 0, VerifierError.LocallocStackNotEmpty);
 
             CheckIsInteger(size);
 

--- a/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
+++ b/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
@@ -2582,6 +2582,8 @@ namespace Internal.IL
 
             var size = Pop();
 
+            FatalCheck(_stackTop == 0, VerifierError.LocallocStackNotEmpty);
+
             CheckIsInteger(size);
 
             Push(StackValue.CreatePrimitive(StackValueKind.NativeInt));

--- a/src/coreclr/tools/ILVerification/Strings.resx
+++ b/src/coreclr/tools/ILVerification/Strings.resx
@@ -447,4 +447,7 @@
   <data name="InterfaceMethodNotImplemented" xml:space="preserve">
     <value>Class implements interface but not method, Class: '{0}' Interface: '{1}' Missing method: '{2}'.</value>
   </data>
+  <data name="LocallocStackNotEmpty" xml:space="preserve">
+    <value>Evaluation stack should contain single element - size.</value>
+  </data>
 </root>

--- a/src/coreclr/tools/ILVerification/Strings.resx
+++ b/src/coreclr/tools/ILVerification/Strings.resx
@@ -448,6 +448,6 @@
     <value>Class implements interface but not method, Class: '{0}' Interface: '{1}' Missing method: '{2}'.</value>
   </data>
   <data name="LocallocStackNotEmpty" xml:space="preserve">
-    <value>Stack must contain only the size item.</value>
+    <value>Stack must be empty before localloc, except for the size item.</value>
   </data>
 </root>

--- a/src/coreclr/tools/ILVerification/Strings.resx
+++ b/src/coreclr/tools/ILVerification/Strings.resx
@@ -448,6 +448,6 @@
     <value>Class implements interface but not method, Class: '{0}' Interface: '{1}' Missing method: '{2}'.</value>
   </data>
   <data name="LocallocStackNotEmpty" xml:space="preserve">
-    <value>Evaluation stack should contain single element - size.</value>
+    <value>Stack must contain only the size item.</value>
   </data>
 </root>

--- a/src/coreclr/tools/ILVerification/VerifierError.cs
+++ b/src/coreclr/tools/ILVerification/VerifierError.cs
@@ -190,6 +190,7 @@ namespace ILVerify
         //IDS_E_GLOBAL         "<GlobalFunction>"
         //IDS_E_MDTOKEN        "[mdToken=0x%x]"
         InterfaceImplHasDuplicate,            // InterfaceImpl has a duplicate
-        InterfaceMethodNotImplemented         // Class implements interface but not method
+        InterfaceMethodNotImplemented,         // Class implements interface but not method
+        LocallocStackNotEmpty, // localloc requires that stack must be empty, except for 'size' argument
     }
 }

--- a/src/tests/ilverify/ILTests/DefaultInterfaceMethod.il
+++ b/src/tests/ilverify/ILTests/DefaultInterfaceMethod.il
@@ -107,7 +107,7 @@
 	}
 }
 
-.class public auto ansi beforefieldinit ChildClassInheritsFromInterfaceWithDefaultImplementationWhereChildInterfaceReabstractsInterfaceMethod_InvalidType_InterfaceMethodNotImplemented
+.class public auto ansi beforefieldinit ChildClassInheritsFromInterfaceWithDefaultImplementationWhereChildInterfaceReabstractsInterfaceMethod_InvalidType_InterfaceMethodNotImplemented@InterfaceMethodNotImplemented
 	extends [System.Runtime]System.Object
 	implements IReabstractDefaultImplementation, IInheritedDefaultImplInterface, IInterface
 {

--- a/src/tests/ilverify/ILTests/LocalAllocTests.il
+++ b/src/tests/ilverify/ILTests/LocalAllocTests.il
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Runtime
+{
+}
+
+.assembly extern LocalAllocTestsFriend
+{
+}
+
+.assembly LocalAllocTests
+{
+}
+
+.class public auto ansi beforefieldinit LocAllocTests
+        extends [System.Runtime]System.Object
+{
+    .method private hidebysig instance void Load.LocAllocShouldFailWhenStackNotEmpty_Invalid_LocallocStackNotEmpty(class SimpleClass c) cil managed
+    {
+        ldnull // pretend there's meaningfull value on stack
+        ldc.i4.2 // size parameter for localloc
+        localloc
+        pop // pop localloc pointer
+        pop // pop ldnull
+        ret
+    }
+}

--- a/src/tests/ilverify/ILTests/LocalAllocTests.il
+++ b/src/tests/ilverify/ILTests/LocalAllocTests.il
@@ -16,7 +16,7 @@
 .class public auto ansi beforefieldinit LocAllocTests
         extends [System.Runtime]System.Object
 {
-    .method private hidebysig instance void Load.LocAllocShouldFailWhenStackNotEmpty_Invalid_LocallocStackNotEmpty() cil managed
+    .method private hidebysig instance void Load.LocAllocShouldFailWhenStackNotEmpty_Invalid_Unverifiable.LocallocStackNotEmpty() cil managed
     {
         ldnull // pretend there's meaningfull value on stack
         ldc.i4.2 // size parameter for localloc
@@ -26,14 +26,14 @@
         ret
     }
 
-    .method private hidebysig instance void Load.LocAllocShouldFailWhenSizeIsAbsent_Invalid_StackUnderflow() cil managed
+    .method private hidebysig instance void Load.LocAllocShouldFailWhenSizeIsAbsent_Invalid_Unverifiable.StackUnderflow() cil managed
     {
         localloc
         pop // pop localloc pointer
         ret
     }
 
-    .method private hidebysig instance void Load.LocAllocShouldSuccesWhenSizeIsPresent_Valid() cil managed
+    .method private hidebysig instance void Load.LocAllocShouldSuccesWhenSizeIsPresent_Invalid_Unverifiable() cil managed
     {
         ldc.i4.2 // size parameter for localloc
         localloc

--- a/src/tests/ilverify/ILTests/LocalAllocTests.il
+++ b/src/tests/ilverify/ILTests/LocalAllocTests.il
@@ -16,7 +16,7 @@
 .class public auto ansi beforefieldinit LocAllocTests
         extends [System.Runtime]System.Object
 {
-    .method private hidebysig instance void Load.LocAllocShouldFailWhenStackNotEmpty_Invalid_LocallocStackNotEmpty(class SimpleClass c) cil managed
+    .method private hidebysig instance void Load.LocAllocShouldFailWhenStackNotEmpty_Invalid_LocallocStackNotEmpty() cil managed
     {
         ldnull // pretend there's meaningfull value on stack
         ldc.i4.2 // size parameter for localloc

--- a/src/tests/ilverify/ILTests/LocalAllocTests.il
+++ b/src/tests/ilverify/ILTests/LocalAllocTests.il
@@ -25,4 +25,19 @@
         pop // pop ldnull
         ret
     }
+
+    .method private hidebysig instance void Load.LocAllocShouldFailWhenSizeIsAbsent_Invalid_StackUnderflow() cil managed
+    {
+        localloc
+        pop // pop localloc pointer
+        ret
+    }
+
+    .method private hidebysig instance void Load.LocAllocShouldSuccesWhenSizeIsPresent_Valid() cil managed
+    {
+        ldc.i4.2 // size parameter for localloc
+        localloc
+        pop // pop localloc pointer
+        ret
+    }
 }

--- a/src/tests/ilverify/ILTests/LocalAllocTests.ilproj
+++ b/src/tests/ilverify/ILTests/LocalAllocTests.ilproj
@@ -1,0 +1,3 @@
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="ILTests.targets" />
+</Project>


### PR DESCRIPTION
According to III.3.47 stack must be empty before `localloc` instruction