### PR TITLE
[GC] Handle objects from frozen segments in GCHeap::IsEphemeral

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -44691,7 +44691,7 @@ bool GCHeap::IsEphemeral (Object* object)
 {
     uint8_t* o = (uint8_t*)object;
 #if defined(FEATURE_BASICFREEZE) && defined(USE_REGIONS)
-    if (!is_in_heap_range(o))
+    if (!is_in_heap_range (o))
     {
         // Objects in frozen segments are not ephemeral
         return FALSE;

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -44690,6 +44690,13 @@ unsigned int GCHeap::GetGenerationWithRange (Object* object, uint8_t** ppStart, 
 bool GCHeap::IsEphemeral (Object* object)
 {
     uint8_t* o = (uint8_t*)object;
+#if defined(FEATURE_BASICFREEZE) && defined(USE_REGIONS)
+    if (!is_in_heap_range(o))
+    {
+        // Objects in frozen segments are not ephemeral
+        return FALSE;
+    }
+#endif
     gc_heap* hp = gc_heap::heap_of (o);
     return !!hp->ephemeral_pointer_p (o);
 }


### PR DESCRIPTION
Fixes an assert I hit in https://github.com/dotnet/runtime/pull/49576#issuecomment-1199995582
Hopefully, helps NativeAOT https://github.com/dotnet/runtime/issues/72645#issuecomment-1200049039