### PR TITLE
JIT: have jit tail call stress avoid creating loops in some cases

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -2220,6 +2220,7 @@ void Compiler::fgAdjustForAddressExposedOrWrittenThis()
     // Optionally enable adjustment during stress.
     if (compStressCompile(STRESS_GENERIC_VARN, 15))
     {
+        JITDUMP("JitStress: creating modifiable `this`\n");
         thisVarDsc->lvHasILStoreOp = true;
     }
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -2215,7 +2215,13 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
 
 void Compiler::fgAdjustForAddressExposedOrWrittenThis()
 {
-    LclVarDsc* const thisVarDsc = lvaGetDesc(info.compThisArg);
+    LclVarDsc* thisVarDsc = lvaGetDesc(info.compThisArg);
+
+    // Optionally enable adjustment during stress.
+    if (compStressCompile(STRESS_GENERIC_VARN, 15))
+    {
+        thisVarDsc->lvHasILStoreOp = true;
+    }
 
     // If this is exposed or written to, create a temp for the modifiable this
     if (thisVarDsc->IsAddressExposed() || thisVarDsc->lvHasILStoreOp)

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -2215,13 +2215,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
 
 void Compiler::fgAdjustForAddressExposedOrWrittenThis()
 {
-    LclVarDsc* thisVarDsc = lvaGetDesc(info.compThisArg);
-
-    // Optionally enable adjustment during stress.
-    if (compStressCompile(STRESS_GENERIC_VARN, 15))
-    {
-        thisVarDsc->lvHasILStoreOp = true;
-    }
+    LclVarDsc* const thisVarDsc = lvaGetDesc(info.compThisArg);
 
     // If this is exposed or written to, create a temp for the modifiable this
     if (thisVarDsc->IsAddressExposed() || thisVarDsc->lvHasILStoreOp)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -15665,7 +15665,13 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                                                            constraintCall ? &constrainedResolvedToken : nullptr,
                                                            returnFalseIfInvalid);
 
-                            if (passedConstraintCheck)
+                            // Avoid setting compHasBackwardsJump = true via tail call stress if the method cannot have
+                            // patchpoints.
+                            //
+                            const bool mayHavePatchpoints = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0) &&
+                                                            (JitConfig.TC_OnStackReplacement() > 0) &&
+                                                            compCanHavePatchpoints();
+                            if (passedConstraintCheck && (mayHavePatchpoints || compHasBackwardJump))
                             {
                                 // Now check with the runtime
                                 CORINFO_METHOD_HANDLE declaredCalleeHnd = callInfo.hMethod;

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -529,6 +529,14 @@ void Compiler::lvaInitThisPtr(InitVarDscInfo* varDscInfo)
         varDscInfo->varNum++;
         varDscInfo->varDsc++;
     }
+
+    // Under stress, optionally force the jit to act as if `this` is modifable.
+    //
+    if (compStressCompile(STRESS_GENERIC_VARN, 15))
+    {
+        JITDUMP("JITSTRESS: creating modifiable `this`\n");
+        varDsc->lvHasILStoreOp = true;
+    }
 }
 
 /*****************************************************************************/

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -529,14 +529,6 @@ void Compiler::lvaInitThisPtr(InitVarDscInfo* varDscInfo)
         varDscInfo->varNum++;
         varDscInfo->varDsc++;
     }
-
-    // Under stress, optionally force the jit to act as if `this` is modifable.
-    //
-    if (compStressCompile(STRESS_GENERIC_VARN, 15))
-    {
-        JITDUMP("JITSTRESS: creating modifiable `this`\n");
-        varDsc->lvHasILStoreOp = true;
-    }
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Don't create a loop via tail call stress if the method didn't already have a loop and could have patchpoints.

Fixes #73090.