### PR TITLE
Fix execution of ilverify tests in outerloop runs

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -66,6 +66,8 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
       else
         cp *.dll IL-CG2/
         rm IL-CG2/composite-r2r.dll 2>/dev/null
+        rm IL-CG2/Coreclr.TestWrapper.dll 2>/dev/null
+        rm IL-CG2/*.XUnitWrapper.dll 2>/dev/null
       fi
 
       ExtraCrossGen2Args+=" $(CrossGen2TestExtraArguments)"
@@ -186,6 +188,8 @@ if defined RunCrossGen2 (
     mkdir IL-CG2
     copy *.dll IL-CG2\
     del IL-CG2\composite-r2r.dll 2>nul
+    del IL-CG2\Coreclr.TestWrapper.dll 2>nul
+    del IL-CG2\*.XUnitWrapper.dll 2>nul
 
     if defined CompositeBuildMode (
         set ExtraCrossGen2Args=!ExtraCrossGen2Args! --composite
@@ -196,9 +200,9 @@ if defined RunCrossGen2 (
         IF NOT !CrossGen2Status!==0 goto :DoneCrossgen2Operations
     ) else (
         set ExtraCrossGen2Args=!ExtraCrossGen2Args! -r:!scriptPath!IL-CG2\*.dll
-        for %%I in (!scriptPath!\*.dll) do (
-            set __OutputFile=!scriptPath!\%%~nI.dll
-            set __InputFile=!scriptPath!IL-CG2\%%~nI.dll
+        for %%I in (!scriptPath!IL-CG2\*.dll) do (
+            set __OutputFile=!scriptPath!%%~nI.dll
+            set __InputFile=%%I
             call :CompileOneFileCrossgen2
             IF NOT !CrossGen2Status!==0 (
               IF NOT !CrossGen2Status!==2 goto :DoneCrossgen2Operations

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -16,7 +16,6 @@
     <DisabledTestDir Include="Common" />
     <DisabledTestDir Include="Tests" />
     <DisabledTestDir Include="TestWrappers" />
-    <_SkipTestDir Include="@(DisabledTestDir)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -49,23 +48,11 @@
     <Error Condition="!Exists('$(XunitTestBinBase)')"
            Text="$(XunitTestBinBase) does not exist. Please run src\tests\build / src/tests/build.sh from the repo root at least once to get the tests built." />
 
-    <ItemGroup>
-      <AllTestDirsNonCanonicalPaths Include="$([System.IO.Directory]::GetDirectories(`$(XunitTestBinBase)`))" />
-      <AllTestDirsPaths Include="@(AllTestDirsNonCanonicalPaths)" />
-      <AllTestDirsPaths Include="@(AllTestDirsNonCanonicalPaths)" >
-        <Path>$([System.IO.Path]::GetFullPath(%(Identity)))</Path>
-      </AllTestDirsPaths>
-      <SkipTestDirsPaths Include="$([System.IO.Path]::GetFullPath('$(XunitTestBinBase)%(_SkipTestDir.Identity)'))" />
-      <NonExcludedTestDirectories Include="@(AllTestDirsPaths -> '%(Path)')" Exclude="@(SkipTestDirsPaths)" />
-    </ItemGroup>
-
     <ItemGroup Condition="'@(LegacyRunnableTestPaths)' != ''">
-      <TopLevelDirectories Include="@(NonExcludedTestDirectories)" />
-      <SecondLevel Include="$([System.IO.Directory]::GetDirectories(%(TopLevelDirectories.Identity)))" />
-      <SecondLevelDirectories Include="@(SecondLevel)">
-        <Path>$([System.IO.Path]::GetFullPath(%(LegacyRunnableTestPaths.Identity)))</Path>
-      </SecondLevelDirectories>
-      <TestDirectoriesWithDup Include="@(SecondLevelDirectories -> '%(Identity)')" Condition="$([System.String]::new('%(Path)').StartsWith('%(Identity)'))" />
+      <LegacyRunnableTestPaths Separator="$([System.String]::Copy('%(LegacyRunnableTestPaths.Identity)').IndexOfAny('\\/', $(XunitTestBinBase.Length)))" />
+      <LegacyRunnableTestPaths SecondSeparator="$([System.String]::Copy('%(LegacyRunnableTestPaths.Identity)').IndexOfAny('\\/', $([MSBuild]::Add(%(LegacyRunnableTestPaths.Separator), 1))))" />
+      <LegacyRunnableTestPaths Separator="%(LegacyRunnableTestPaths.SecondSeparator)" Condition="'%(LegacyRunnableTestPaths.SecondSeparator)' != '-1'" />
+      <TestDirectoriesWithDup Include="$([System.String]::Copy('%(LegacyRunnableTestPaths.Identity)').Substring(0, %(LegacyRunnableTestPaths.Separator)))" />
     </ItemGroup>
 
     <RemoveDuplicates Inputs="@(TestDirectoriesWithDup)">
@@ -390,8 +377,10 @@
 
   <Target Name="GetListOfTestCmds">
     <ItemGroup>
+      <SkipTestDirsPaths Include="$([System.IO.Path]::GetFullPath('$(XunitTestBinBase)%(DisabledTestDir.Identity)'))" />
       <AllRunnableTestPaths Include="$(XunitTestBinBase)\**\*.$(TestScriptExtension)"/>
       <AllRunnableTestPaths Remove="$(XunitTestBinBase)\**\run-v8.sh" Condition="'$(TargetArchitecture)' == 'wasm'" />
+      <AllRunnableTestPaths Remove="%(SkipTestDirsPaths.Identity)\**\*.$(TestScriptExtension)" />
       <MergedAssemblyMarkerPaths Include="$(XunitTestBinBase)\**\*.MergedTestAssembly"/>
       <MergedAssemblyFolders Include="$([System.IO.Path]::GetDirectoryName('%(MergedAssemblyMarkerPaths.Identity)'))" />
       <MergedAssemblyParentFolders Include="$([System.IO.Path]::GetDirectoryName('%(MergedAssemblyFolders.Identity)'))" />

--- a/src/tests/xunit-wrappers.targets
+++ b/src/tests/xunit-wrappers.targets
@@ -99,10 +99,7 @@ $(_XunitEpilog)
     <!-- NOTE! semicolons must be escaped with %3B boooo -->
 
     <PropertyGroup>
-      <_CMDDIR_Parent>$([System.IO.Path]::GetDirectoryName($(_CMDDIR)))</_CMDDIR_Parent>
-      <_CMDDIR_Grandparent>$([System.IO.Path]::GetDirectoryName($(_CMDDIR_Parent)))</_CMDDIR_Grandparent>
-      <CategoryWithSlash Condition="'$(RunningOnUnix)' != 'true'" >$([System.String]::Copy('$(_CMDDIR)').Replace("$(_CMDDIR_Grandparent)\",""))</CategoryWithSlash>
-      <CategoryWithSlash Condition="'$(RunningOnUnix)' == 'true'" >$([System.String]::Copy('$(_CMDDIR)').Replace("$(_CMDDIR_Grandparent)/",""))</CategoryWithSlash>
+      <CategoryWithSlash>$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '$(_CMDDIR)'))</CategoryWithSlash>
       <Category Condition="'$(RunningOnUnix)' != 'true'" >$([System.String]::Copy('$(CategoryWithSlash)').Replace('\','.'))</Category>
       <Category Condition="'$(RunningOnUnix)' == 'true'" >$([System.String]::Copy('$(CategoryWithSlash)').Replace('/','.'))</Category>
       <XunitWrapper>$(Category).XUnitWrapper</XunitWrapper>


### PR DESCRIPTION
As @jkotas noticed in #73109, outerloop tests don't run the
ilverify/ILVerificationTests.csproj test project. This is because
the project is somewhat atypical in residing just one directory
level beneath the test binary root folder; all other tests reside
under at least two directory levels and the legacy XUnit wrapper
generator reflects it so that each wrapper corresponds to
a two-level directory subtree.

The pre-existing logic for determining active two-level test
directories was quite hacky and perf-costly; I probably accidentally
removed the support for single-subfolder tests in one of my
refactorings of the src/tests/build.proj script. This change fixes
it and makes the construction of TestDirectories much more efficient
as we no longer construct a Carthesian product of all tests
times all two-level directories.

Thanks

Tomas

/cc @dotnet/runtime-infrastructure 