### PR TITLE
Optimize Enumerable.Chunk

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Chunk.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Chunk.cs
@@ -57,14 +57,10 @@ namespace System.Linq
             // Before allocating anything, make sure there's at least one element.
             if (e.MoveNext())
             {
-                if (!source.TryGetNonEnumeratedCount(out int count))
-                {
-                    // Now that we know we have at least one item, allocate an initial storage array. This is not
-                    // the array we'll yield.  It starts out small in order to avoid significantly overallocating
-                    // when the source has many fewer elements than the chunk size.
-                    count = 4;
-                }
-                int arraySize = Math.Min(size, count);
+                // Now that we know we have at least one item, allocate an initial storage array. This is not
+                // the array we'll yield.  It starts out small in order to avoid significantly overallocating
+                // when the source has many fewer elements than the chunk size.
+                int arraySize = Math.Min(size, 4);
                 int i;
                 do
                 {


### PR DESCRIPTION
- Avoid copying the array if the array already has the desired size
``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1806 (21H2)
Intel Core i5-4670K CPU 3.40GHz (Haswell), 1 CPU, 4 logical and 4 physical cores
.NET SDK=7.0.100-preview.6.22352.1
  [Host]     : .NET 7.0.0 (7.0.22.32404), X64 RyuJIT
  DefaultJob : .NET 7.0.0 (7.0.22.32404), X64 RyuJIT


```
|   Method | chunkSize |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
|--------- |---------- |---------:|----------:|----------:|------:|--------:|-------:|----------:|
| **ChunkOld** |        **10** | **8.060 μs** | **0.0359 μs** | **0.0299 μs** |  **1.00** |    **0.00** | **2.1210** |      **7 KB** |
| ChunkNew |        10 | 7.716 μs | 0.1376 μs | 0.1287 μs |  0.96 |    0.02 | 2.1057 |      6 KB |
|          |           |          |           |           |       |         |        |           |
| **ChunkOld** |       **100** | **7.191 μs** | **0.0645 μs** | **0.0603 μs** |  **1.00** |    **0.00** | **1.7166** |      **5 KB** |
| ChunkNew |       100 | 7.143 μs | 0.0956 μs | 0.0894 μs |  0.99 |    0.01 | 1.5793 |      5 KB |
|          |           |          |           |           |       |         |        |           |
| **ChunkOld** |       **200** | **7.269 μs** | **0.0994 μs** | **0.0930 μs** |  **1.00** |    **0.00** | **1.9836** |      **6 KB** |
| ChunkNew |       200 | 6.971 μs | 0.0320 μs | 0.0284 μs |  0.96 |    0.01 | 1.7166 |      5 KB |
|          |           |          |           |           |       |         |        |           |
| **ChunkOld** |       **400** | **7.913 μs** | **0.1500 μs** | **0.1667 μs** |  **1.00** |    **0.00** | **2.5482** |      **8 KB** |
| ChunkNew |       400 | 7.172 μs | 0.0475 μs | 0.0445 μs |  0.90 |    0.02 | 2.5482 |      8 KB |
|          |           |          |           |           |       |         |        |           |
| **ChunkOld** |      **1000** | **8.581 μs** | **0.1460 μs** | **0.1366 μs** |  **1.00** |    **0.00** | **3.9673** |     **12 KB** |
| ChunkNew |      1000 | 7.848 μs | 0.1373 μs | 0.1284 μs |  0.91 |    0.02 | 2.6703 |      8 KB |

I am not quite sure if i am missing something, I've expected to cut the allocations in half but the savings are way smaller than that.
<hr>

~~- Add a fast path for when we can get a non enumerated count~~
``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1806 (21H2)
Intel Core i5-4670K CPU 3.40GHz (Haswell), 1 CPU, 4 logical and 4 physical cores
.NET SDK=7.0.100-preview.6.22352.1
  [Host]     : .NET 7.0.0 (7.0.22.32404), X64 RyuJIT
  DefaultJob : .NET 7.0.0 (7.0.22.32404), X64 RyuJIT


```
|   Method | chunkSize |       Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
|--------- |---------- |-----------:|----------:|----------:|------:|--------:|-------:|----------:|
| **ChunkOld** |        **10** | **6,145.9 ns** |  **67.05 ns** |  **62.72 ns** |  **1.00** |    **0.00** | **2.1210** |      **7 KB** |
| ChunkNew |        10 | 5,302.2 ns |  38.75 ns |  34.35 ns |  0.86 |    0.01 | 2.0676 |      6 KB |
|          |           |            |           |           |       |         |        |           |
| **ChunkOld** |       **100** | **5,167.2 ns** |  **91.75 ns** |  **85.83 ns** |  **1.00** |    **0.00** | **1.7166** |      **5 KB** |
| ChunkNew |       100 | 4,506.2 ns |  43.61 ns |  36.42 ns |  0.87 |    0.01 | 1.3809 |      4 KB |
|          |           |            |           |           |       |         |        |           |
| **ChunkOld** |       **200** | **5,370.0 ns** | **105.67 ns** | **141.07 ns** |  **1.00** |    **0.00** | **1.9760** |      **6 KB** |
| ChunkNew |       200 | 4,600.2 ns |  58.30 ns |  54.54 ns |  0.86 |    0.03 | 1.3428 |      4 KB |
|          |           |            |           |           |       |         |        |           |
| **ChunkOld** |       **400** | **5,498.5 ns** |  **62.59 ns** |  **55.48 ns** |  **1.00** |    **0.00** | **2.5482** |      **8 KB** |
| ChunkNew |       400 | 4,509.8 ns |  26.56 ns |  24.85 ns |  0.82 |    0.01 | 1.3275 |      4 KB |
|          |           |            |           |           |       |         |        |           |
| **ChunkOld** |      **1000** | **6,124.1 ns** |  **53.78 ns** |  **44.91 ns** |  **1.00** |    **0.00** | **3.9597** |     **12 KB** |
| ChunkNew |      1000 |   405.1 ns |   5.89 ns |   6.78 ns |  0.07 |    0.00 | 1.3051 |      4 KB |

`ToArray()` appears to be much faster than what we're doing here but from my reading, it boils down to calling `ICollection.CopyTo` which unfortunately can't work for this case it seems.

Was inspired to work on this after seeing #72811
cc @stephentoub