### PR TITLE
Skip assertion list look ups where unnecessary

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2001,7 +2001,8 @@ AssertionIndex Compiler::optAddAssertion(AssertionDsc* newAssertion)
     }
 #endif // DEBUG
 
-    optCanPropLclVar |= newAssertion->assertionKind == OAK_EQUAL && newAssertion->op1.kind != O1K_LCLVAR;
+    // Track the shortcircuit criterias
+    optCanPropLclVar |= newAssertion->assertionKind == OAK_EQUAL && newAssertion->op1.kind == O1K_LCLVAR;
     optCanPropEqual |= newAssertion->assertionKind == OAK_EQUAL || newAssertion->assertionKind == OAK_NOT_EQUAL;
     optCanPropNonNull |=
         newAssertion->assertionKind == OAK_NOT_EQUAL && newAssertion->op2.vn == ValueNumStore::VNForNull();

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3602,6 +3602,13 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
         return nullptr;
     }
 
+    // There are no constant assertions for structs in global propagation.
+    //
+    if (!optLocalAssertionProp && varTypeIsStruct(tree))
+    {
+        return nullptr;
+    }
+
     BitVecOps::Iter iter(apTraits, assertions);
     unsigned        index = 0;
     while (iter.NextElem(&index))

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -983,6 +983,7 @@ void Compiler::optAssertionInit(bool isLocalProp)
     optCanPropEqual        = false;
     optCanPropNonNull      = false;
     optCanPropBndsChk      = false;
+    optCanPropSubRange     = false;
 }
 
 #ifdef DEBUG
@@ -2838,7 +2839,7 @@ AssertionIndex Compiler::optFindComplementary(AssertionIndex assertIndex)
 //
 AssertionIndex Compiler::optAssertionIsSubrange(GenTree* tree, IntegralRange range, ASSERT_VALARG_TP assertions)
 {
-    if ((!optLocalAssertionProp && BitVecOps::IsEmpty(apTraits, assertions) || !optCanPropSubRange)
+    if ((!optLocalAssertionProp && BitVecOps::IsEmpty(apTraits, assertions)) || !optCanPropSubRange)
     {
         return NO_ASSERTION_INDEX;
     }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4701,7 +4701,7 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
  */
 GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
-    if (optLocalAssertionProp)
+    if (optLocalAssertionProp || !optCanPropBndsChk)
     {
         return nullptr;
     }
@@ -4738,8 +4738,6 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
         {
             continue;
         }
-
-        assert(optCanPropBndsChk);
 
         GenTreeBoundsChk* arrBndsChk = tree->AsBoundsChk();
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -6400,6 +6400,10 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE classPtr,
 
     compHasBackwardJump          = false;
     compHasBackwardJumpInHandler = false;
+    optCanPropLclVar = false;
+    optCanPropEqual = false;
+    optCanPropNonNull = false;
+    optCanPropBndsChk = false;
 
 #ifdef DEBUG
     compCurBB = nullptr;

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -6400,10 +6400,6 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE classPtr,
 
     compHasBackwardJump          = false;
     compHasBackwardJumpInHandler = false;
-    optCanPropLclVar = false;
-    optCanPropEqual = false;
-    optCanPropNonNull = false;
-    optCanPropBndsChk = false;
 
 #ifdef DEBUG
     compCurBB = nullptr;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7110,6 +7110,31 @@ public:
             return ((assertionKind == OAK_EQUAL) || (assertionKind == OAK_NOT_EQUAL)) && (op2.kind == O2K_CONST_INT);
         }
 
+        bool CanPropLclVar()
+        {
+            return assertionKind == OAK_EQUAL && op1.kind == O1K_LCLVAR;
+        }
+
+        bool CanPropEqualOrNotEqual()
+        {
+            return assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL;
+        }
+
+        bool CanPropNonNull()
+        {
+            return assertionKind == OAK_NOT_EQUAL && op2.vn == ValueNumStore::VNForNull();
+        }
+
+        bool CanPropBndsCheck()
+        {
+            return op1.kind == O1K_ARR_BND;
+        }
+
+        bool CanPropSubRange()
+        {
+            return assertionKind == OAK_SUBRANGE && op1.kind == O1K_LCLVAR;
+        }
+
         static bool SameKind(AssertionDsc* a1, AssertionDsc* a2)
         {
             return a1->assertionKind == a2->assertionKind && a1->op1.kind == a2->op1.kind &&

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7231,6 +7231,11 @@ protected:
     AssertionDsc*  optAssertionTabPrivate;      // table that holds info about value assignments
     AssertionIndex optAssertionCount;           // total number of assertions in the assertion table
     AssertionIndex optMaxAssertionCount;
+    bool optCanPropLclVar;
+    bool optCanPropEqual;
+    bool optCanPropNonNull;
+    bool optCanPropBndsChk;
+    bool optCanPropSubRange;
 
 public:
     void optVnNonNullPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7231,11 +7231,11 @@ protected:
     AssertionDsc*  optAssertionTabPrivate;      // table that holds info about value assignments
     AssertionIndex optAssertionCount;           // total number of assertions in the assertion table
     AssertionIndex optMaxAssertionCount;
-    bool optCanPropLclVar;
-    bool optCanPropEqual;
-    bool optCanPropNonNull;
-    bool optCanPropBndsChk;
-    bool optCanPropSubRange;
+    bool           optCanPropLclVar;
+    bool           optCanPropEqual;
+    bool           optCanPropNonNull;
+    bool           optCanPropBndsChk;
+    bool           optCanPropSubRange;
 
 public:
     void optVnNonNullPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);


### PR DESCRIPTION
Below is the list of metrics that I gathered before and after this change. They are based upon the instrumentation I added in https://github.com/dotnet/runtime/pull/73035.
- `*CallCount` : Number of times we go through the look-up of that assertion category.
- `*MissedCount` : Number of times we don't find any match of that assertion category.
- `*MissedIter`: Number of iterations we spend before we realize there is no match.

## Benchmarks

| Metrics | Main | PR | Diff     | Diff % |
|------------------------|---------------|--------------|----------|---------|
| NoNullCallCount:       | 199981        | 199341       | -640     | -0.32%  |
| NoNullMissedCount:     | 60178         | 59538        | -640     | -1.06%  |
| NoNullMissedIter:      | 303178        | 301984       | -1194    | -0.39%  |
| PropBndChkCallCount:   | 34049         | 34019        | -30      | -0.09%  |
| PropBndChkMissedCount: | 24860         | 24830        | -30      | -0.12%  |
| PropBndChkMissedIter:  | 199594        | 199421       | -173     | -0.09%  |
| PropLclVarCallCount:   | 2059107       | 1363307      | -695800  | -33.79% |
| PropLclVarMissedCount: | 1944506       | 1248706      | -695800  | -35.78% |
| PropLclVarMissedIter:  | 8676449       | 6027084      | -2649365 | -30.54% |
| SubRangeCallCount:     | 96002         | 24802        | -71200   | -74.17% |
| SubRangeMissedCount:   | 94776         | 23576        | -71200   | -75.12% |
| SubRangeMissedIter:    | 424824        | 102679       | -322145  | -75.83% |
| **Grand Total**             | 30072122      | 25563905     | -4508217 | -14.99% |



## Libraries

| Metrics | Main | PR | Diff     | Diff % |
|----------------------------|---------------|--------------|----------|---------|
| NoNullCallCount:           | 1310379       | 1307300      | -3079    | -0.23%  |
| NoNullMissedCount:         | 453249        | 450170       | -3079    | -0.68%  |
| NoNullMissedIter:          | 1975011       | 1969804      | -5207    | -0.26%  |
| PropBndChkCallCount:       | 63089         | 62973        | -116     | -0.18%  |
| PropBndChkMissedCount:     | 45309         | 45193        | -116     | -0.26%  |
| PropBndChkMissedIter:      | 344328        | 343546       | -782     | -0.23%  |
| PropEqualOrNotCallCount:   | 294827        | 294826       | -1       | 0.00%   |
| PropEqualOrNotMissedCount: | 275857        | 275856       | -1       | 0.00%   |
| PropEqualOrNotMissedIter:  | 1301740       | 1301739      | -1       | 0.00%   |
| PropEqualZeroCallCount:    | 741463        | 741456       | -7       | 0.00%   |
| PropEqualZeroMissedCount:  | 741052        | 741045       | -7       | 0.00%   |
| PropEqualZeroMissedIter:   | 3785718       | 3785711      | -7       | 0.00%   |
| PropLclVarCallCount:       | 8686514       | 7010713      | -1675801 | -19.29% |
| PropLclVarMissedCount:     | 8300379       | 6624578      | -1675801 | -20.19% |
| PropLclVarMissedIter:      | 35950996      | 31782991     | -4168005 | -11.59% |
| SubRangeCallCount:         | 255571        | 122810       | -132761  | -51.95% |
| SubRangeMissedCount:       | 250068        | 117307       | -132761  | -53.09% |
| SubRangeMissedIter:        | 1079732       | 433215       | -646517  | -59.88% |
| **Grand Total**                | 126889858     | 118445809    | -8444049 | -6.65%  |

## Asp

| Metrics | Main | PR | Diff     | Diff % |
|---------------------------|---------------|--------------|----------|---------|
| NoNullCallCount:          | 364032        | 362798       | -1234    | -0.34%  |
| NoNullMissedCount:        | 114676        | 113442       | -1234    | -1.08%  |
| NoNullMissedIter:         | 430855        | 428532       | -2323    | -0.54%  |
| PropBndChkCallCount:      | 16880         | 16816        | -64      | -0.38%  |
| PropBndChkMissedCount:    | 12908         | 12844        | -64      | -0.50%  |
| PropBndChkMissedIter:     | 90483         | 90192        | -291     | -0.32%  |
| PropEqualZeroCallCount:   | 241334        | 241333       | -1       | 0.00%   |
| PropEqualZeroMissedCount: | 241250        | 241249       | -1       | 0.00%   |
| PropEqualZeroMissedIter:  | 1176971       | 1176970      | -1       | 0.00%   |
| PropLclVarCallCount:      | 2005365       | 1812875      | -192490  | -9.60%  |
| PropLclVarMissedCount:    | 1911628       | 1719138      | -192490  | -10.07% |
| PropLclVarMissedIter:     | 8011006       | 7560579      | -450427  | -5.62%  |
| SubRangeCallCount:        | 71947         | 37891        | -34056   | -47.33% |
| SubRangeMissedCount:      | 69099         | 35043        | -34056   | -49.29% |
| SubRangeMissedIter:       | 277427        | 136446       | -140981  | -50.82% |
| **Grand Total**                 | 34326677      | 33276964     | -1049713 | -3.06%  |