### PR TITLE
[release/6.0] Remove 1024 character limit on ODBC connection strings

### DIFF
--- a/src/libraries/System.Data.Odbc/src/Resources/Strings.resx
+++ b/src/libraries/System.Data.Odbc/src/Resources/Strings.resx
@@ -392,9 +392,6 @@
   <data name="ADP_OdbcNoTypesFromProvider" xml:space="preserve">
     <value>The ODBC provider did not return results from SQLGETTYPEINFO.</value>
   </data>
-  <data name="OdbcConnection_ConnectionStringTooLong" xml:space="preserve">
-    <value>Connection string exceeds maximum allowed length of {0}.</value>
-  </data>
   <data name="Odbc_UnknownSQLType" xml:space="preserve">
     <value>Unknown SQL type - {0}.</value>
   </data>

--- a/src/libraries/System.Data.Odbc/src/System.Data.Odbc.csproj
+++ b/src/libraries/System.Data.Odbc/src/System.Data.Odbc.csproj
@@ -5,6 +5,8 @@
     <NoWarn>$(NoWarn);CA2249;CA1838</NoWarn>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
     <PackageDescription>Provides a collection of classes used to access an ODBC data source in the managed space
 
 Commonly Used Types:

--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/Odbc32.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/Odbc32.cs
@@ -24,18 +24,17 @@ namespace System.Data.Odbc
         {
             return ADP.Argument(SR.GetString(SR.Odbc_UnknownSQLType, sqltype.ToString()));
         }
-        internal static Exception ConnectionStringTooLong()
-        {
-            return ADP.Argument(SR.GetString(SR.OdbcConnection_ConnectionStringTooLong, ODBC32.MAX_CONNECTION_STRING_LENGTH));
-        }
+
         internal static ArgumentException GetSchemaRestrictionRequired()
         {
             return ADP.Argument(SR.GetString(SR.ODBC_GetSchemaRestrictionRequired));
         }
+
         internal static ArgumentOutOfRangeException NotSupportedEnumerationValue(Type type, int value)
         {
             return ADP.ArgumentOutOfRange(SR.GetString(SR.ODBC_NotSupportedEnumerationValue, type.Name, value.ToString(System.Globalization.CultureInfo.InvariantCulture)), type.Name);
         }
+
         internal static ArgumentOutOfRangeException NotSupportedCommandType(CommandType value)
         {
 #if DEBUG
@@ -663,12 +662,6 @@ namespace System.Data.Odbc
             PROMPT = 2,
             COMPLETE_REQUIRED = 3,
         }
-
-        // todo:move
-        // internal const. not odbc specific
-        //
-        // Connection string max length
-        internal const int MAX_CONNECTION_STRING_LENGTH = 1024;
 
         // Column set for SQLPrimaryKeys
         internal enum SQL_PRIMARYKEYS : short

--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcConnectionString.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcConnectionString.cs
@@ -22,14 +22,6 @@ namespace System.Data.Odbc
                 int position = 0;
                 _expandedConnectionString = ExpandDataDirectories(ref filename, ref position);
             }
-            if (validate || (null == _expandedConnectionString))
-            {
-                // do not check string length if it was expanded because the final result may be shorter than the original
-                if ((null != connectionString) && (ODBC32.MAX_CONNECTION_STRING_LENGTH < connectionString.Length))
-                { // MDAC 83536
-                    throw ODBC.ConnectionStringTooLong();
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Backport of #73149

### Description

System.Data.Odbc currently validates that connection strings are a most 1024 characters long; this removes that restriction.

### Customer impact

The 1024-char restriction prevents some ODBC providers from being used in certain scenarios. Specifically, in modern cloud environments, a rotating authentication token is frequently used instead of a password, and it's sometimes quite long. The 1024-char restriction makes it impossible to use System.Data.Odbc in those scenarios..

### How found

Reported by multiple users, both in #63630 and in internal channels

### Regression

No.

### Testing

Manual and verified by one customer.

### Risk

Very low - this removes a check in the code, so that long connection strings don't cause an exception to be thrown.

Fixes #63630

/cc @ajcvickers