### PR TITLE
[wasm-mt] Fixup C exports initialization after startup.ts refactoring

### DIFF
--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -72,6 +72,10 @@ const fn_signatures: SigLine[] = [
     [true, "mono_wasm_event_pipe_enable", "bool", ["string", "number", "string", "bool", "number"]],
     [true, "mono_wasm_event_pipe_session_start_streaming", "bool", ["number"]],
     [true, "mono_wasm_event_pipe_session_disable", "bool", ["number"]],
+    [true, "mono_wasm_diagnostic_server_create_thread", "bool", ["string", "number"]],
+    [true, "mono_wasm_diagnostic_server_thread_attach_to_runtime", "void", []],
+    [true, "mono_wasm_diagnostic_server_post_resume_runtime", "void", []],
+    [true, "mono_wasm_diagnostic_server_create_stream", "number", []],
 
     //DOTNET
     [true, "mono_wasm_string_from_js", "number", ["string"]],

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -3,10 +3,11 @@
 
 import ProductVersion from "consts:productVersion";
 import Configuration from "consts:configuration";
+import MonoWasmThreads from "consts:monoWasmThreads";
 
-import { ENVIRONMENT_IS_WORKER, set_imports_exports } from "./imports";
+import { ENVIRONMENT_IS_PTHREAD, ENVIRONMENT_IS_WORKER, set_imports_exports } from "./imports";
 import { DotnetModule, is_nullish, DotnetPublicAPI, EarlyImports, EarlyExports, EarlyReplacements } from "./types";
-import { configure_emscripten_startup } from "./startup";
+import { configure_emscripten_startup, mono_wasm_pthread_worker_init } from "./startup";
 import { mono_bind_static_method } from "./net6-legacy/method-calls";
 
 import { create_weak_ref } from "./weak-ref";
@@ -123,12 +124,20 @@ function initializeImportsAndExports(
     }
     list.registerRuntime(exportedAPI);
 
-    if (ENVIRONMENT_IS_WORKER) {
-        // HACK: Emscripten's dotnet.worker.js expects the exports of dotnet.js module to be Module object
-        // until we have our own fix for dotnet.worker.js file
-        // we also skip all emscripten startup event and configuration of worker's JS state
-        // note that emscripten events are not firing either
-        return <any>exportedAPI.Module;
+    if (MonoWasmThreads && ENVIRONMENT_IS_PTHREAD) {
+        // eslint-disable-next-line no-inner-declarations
+        async function workerInit(): Promise<DotnetModule> {
+            await mono_wasm_pthread_worker_init();
+
+            // HACK: Emscripten's dotnet.worker.js expects the exports of dotnet.js module to be Module object
+            // until we have our own fix for dotnet.worker.js file
+            // we also skip all emscripten startup event and configuration of worker's JS state
+            // note that emscripten events are not firing either
+
+            return exportedAPI.Module;
+        }
+        // Emscripten pthread worker.js is ok with a Promise here.
+        return <any>workerInit();
     }
 
     configure_emscripten_startup(module, exportedAPI);

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -5,7 +5,7 @@ import ProductVersion from "consts:productVersion";
 import Configuration from "consts:configuration";
 import MonoWasmThreads from "consts:monoWasmThreads";
 
-import { ENVIRONMENT_IS_PTHREAD, ENVIRONMENT_IS_WORKER, set_imports_exports } from "./imports";
+import { ENVIRONMENT_IS_PTHREAD, set_imports_exports } from "./imports";
 import { DotnetModule, is_nullish, DotnetPublicAPI, EarlyImports, EarlyExports, EarlyReplacements } from "./types";
 import { configure_emscripten_startup, mono_wasm_pthread_worker_init } from "./startup";
 import { mono_bind_static_method } from "./net6-legacy/method-calls";

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -1,9 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import MonoWasmThreads from "consts:monoWasmThreads";
 import { mono_assert, CharPtrNull, DotnetModule, MonoConfig, wasm_type_symbol, MonoObject, MonoConfigError, LoadingResource, AssetEntry, ResourceRequest, DotnetPublicAPI } from "./types";
-import { BINDING, ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_PTHREAD, ENVIRONMENT_IS_SHELL, INTERNAL, Module, MONO, runtimeHelpers } from "./imports";
+import { BINDING, ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, INTERNAL, Module, MONO, runtimeHelpers } from "./imports";
 import cwraps, { init_c_exports } from "./cwraps";
 import { mono_wasm_raise_debug_event, mono_wasm_runtime_ready } from "./debug";
 import { mono_wasm_globalization_init, mono_wasm_load_icu_data } from "./icu";

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -928,9 +928,8 @@ export async function mono_wasm_pthread_worker_init(): Promise<void> {
     console.debug("MONO_WASM: worker initializing essential C exports and APIs");
     // FIXME: copy/pasted from mono_wasm_pre_init_essential - can we share this code? Any other global state that needs initialization?
     init_c_exports();
-    cwraps_internal(INTERNAL);
-    cwraps_mono_api(MONO);
-    cwraps_binding_api(BINDING);
+    // not initializing INTERNAL, MONO, or BINDING C wrappers here - those legacy APIs are not likely to be needed on pthread workers.
+
     // This is a good place for subsystems to attach listeners for pthreads_worker.currentWorkerThreadEvents
     pthreads_worker.currentWorkerThreadEvents.addEventListener(pthreads_worker.dotnetPthreadCreated, (ev) => {
         console.debug("MONO_WASM: pthread created", ev.pthread_self.pthread_id);


### PR DESCRIPTION
Fixup issues due to d7c8bc10ac00fe330daa633f8a2b16ba208e6e56:

1. Add back the missing diagnostic server C wraps.
2. Run `init_c_exports` lazily on pthread workers, always.  Eager initialization doesn't work because at the time that our code runs, Emscripten hasn't fully initialized `Module` yet (in particular `Module["cwraps"]` hasn't been assigned yet).
3. Call `mono_wasm_pthread_worker_init` directly from `initializeImportsAndExports` - calling it from `preInit` doesn't work because Emscripten doesn't run `preInit` in pthread workers.  Also there's a technical change here to return a `Promise<EmscriptenModule>` - Emscripten is good with this because they use `.then` in `worker.js` and it's good for us because we can do async initialization at this point (for example waiting for the channel to the main browser thread to get established)