### PR TITLE
[RateLimiting] Update TranslateKey to allow disposal of wrapped limiter

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
+++ b/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
@@ -79,7 +79,7 @@ namespace System.Threading.RateLimiting
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public abstract int GetAvailablePermits(TResource resource);
-        public System.Threading.RateLimiting.PartitionedRateLimiter<TOuter> TranslateKey<TOuter>(System.Func<TOuter, TResource> keyAdapter) { throw null; }
+        public System.Threading.RateLimiting.PartitionedRateLimiter<TOuter> WithTranslatedKey<TOuter>(System.Func<TOuter, TResource> keyAdapter, bool leaveOpen) { throw null; }
     }
     public enum QueueProcessingOrder
     {

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
@@ -127,15 +127,16 @@ namespace System.Threading.RateLimiting
         /// <typeparam name="TOuter">The type to translate into <typeparamref name="TResource"/>.</typeparam>
         /// <param name="keyAdapter">The function to be called every time a <typeparamref name="TOuter"/> is passed to
         /// PartitionedRateLimiter&lt;TOuter&gt;.Acquire(TOuter, int) or PartitionedRateLimiter&lt;TOuter&gt;.WaitAsync(TOuter, int, CancellationToken).</param>
+        /// <param name="leaveOpen">Specifies whether the returned <see cref="PartitionedRateLimiter{TOuter}"/> will dispose the wrapped <see cref="PartitionedRateLimiter{TResource}"/>.</param>
         /// <remarks><see cref="PartitionedRateLimiter{TResource}.Dispose()"/> or <see cref="PartitionedRateLimiter{TResource}.DisposeAsync()"/> does not dispose the wrapped <see cref="PartitionedRateLimiter{TResource}"/>.</remarks>
         /// <returns>A new PartitionedRateLimiter&lt;TOuter&gt; that translates <typeparamref name="TOuter"/>
         /// to <typeparamref name="TResource"/> and calls the inner <see cref="PartitionedRateLimiter{TResource}"/>.</returns>
-        public PartitionedRateLimiter<TOuter> TranslateKey<TOuter>(Func<TOuter, TResource> keyAdapter)
+        public PartitionedRateLimiter<TOuter> WithTranslatedKey<TOuter>(Func<TOuter, TResource> keyAdapter, bool leaveOpen)
         {
             // REVIEW: Do we want to have an option to dispose the inner limiter?
             // Should the default be to dispose the inner limiter and have an option to not dispose it?
             // See Stream wrappers like SslStream for prior-art
-            return new TranslatingLimiter<TResource, TOuter>(this, keyAdapter);
+            return new TranslatingLimiter<TResource, TOuter>(this, keyAdapter, leaveOpen);
         }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TranslatingLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TranslatingLimiter.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace System.Threading.RateLimiting
@@ -13,13 +9,15 @@ namespace System.Threading.RateLimiting
     {
         private readonly PartitionedRateLimiter<TInner> _innerRateLimiter;
         private readonly Func<TResource, TInner> _keyAdapter;
+        private readonly bool _disposeInnerLimiter;
 
-        private bool _disposed;
+        private int _disposed;
 
-        public TranslatingLimiter(PartitionedRateLimiter<TInner> inner, Func<TResource, TInner> keyAdapter)
+        public TranslatingLimiter(PartitionedRateLimiter<TInner> inner, Func<TResource, TInner> keyAdapter, bool leaveOpen)
         {
             _innerRateLimiter = inner;
             _keyAdapter = keyAdapter;
+            _disposeInnerLimiter = !leaveOpen;
         }
 
         public override int GetAvailablePermits(TResource resource)
@@ -45,21 +43,32 @@ namespace System.Threading.RateLimiting
 
         protected override void Dispose(bool disposing)
         {
-            _disposed = true;
-            base.Dispose(disposing);
+            if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
+            {
+                if (_disposeInnerLimiter)
+                {
+                    _innerRateLimiter.Dispose();
+                }
+            }
         }
 
         protected override ValueTask DisposeAsyncCore()
         {
-            _disposed = true;
-            return base.DisposeAsyncCore();
+            if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
+            {
+                if (_disposeInnerLimiter)
+                {
+                    return _innerRateLimiter.DisposeAsync();
+                }
+            }
+            return default(ValueTask);
         }
 
         private void ThrowIfDispose()
         {
-            if (_disposed)
+            if (_disposed == 1)
             {
-                throw new ObjectDisposedException(nameof(PartitionedRateLimiter));
+                throw new ObjectDisposedException(nameof(PartitionedRateLimiter<TResource>));
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/72551