### PR TITLE
Refine wording in RequiresDynamicCode annotation in JsonStringEnumConverter.

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -978,7 +978,7 @@ namespace System.Text.Json.Serialization
         public System.Text.Json.Serialization.JsonKnownNamingPolicy PropertyNamingPolicy { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }
     }
-    [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. There is no built-in solution compatible with native AOT applications. Consider authoring a custom converter that is not a factory to work around the issue. See https://github.com/dotnet/runtime/issues/73124.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. Consider authoring a custom converter that is not a factory to work around the issue. See https://github.com/dotnet/runtime/issues/73124.")]
     public partial class JsonStringEnumConverter : System.Text.Json.Serialization.JsonConverterFactory
     {
         public JsonStringEnumConverter() { }

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -978,7 +978,7 @@ namespace System.Text.Json.Serialization
         public System.Text.Json.Serialization.JsonKnownNamingPolicy PropertyNamingPolicy { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }
     }
-    [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("Types deriving from JsonConverterFactory cannot be statically analyzed and might require runtime code generation.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. There is no built-in solution compatible with native AOT applications. Consider authoring a custom converter that is not a factory to work around the issue. See https://github.com/dotnet/runtime/issues/73124.")]
     public partial class JsonStringEnumConverter : System.Text.Json.Serialization.JsonConverterFactory
     {
         public JsonStringEnumConverter() { }

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -978,7 +978,7 @@ namespace System.Text.Json.Serialization
         public System.Text.Json.Serialization.JsonKnownNamingPolicy PropertyNamingPolicy { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }
     }
-    [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("Types deriving from JsonConverterFactory cannot be statically analyzed and might require runtime code generation.")]
     public partial class JsonStringEnumConverter : System.Text.Json.Serialization.JsonConverterFactory
     {
         public JsonStringEnumConverter() { }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -14,6 +14,8 @@ namespace System.Text.Json.Serialization
     /// </remarks>
     public abstract class JsonConverterFactory : JsonConverter
     {
+        internal const string JsonConverterFactoryRequiresDynamicCodeMessage = "Types deriving from JsonConverterFactory cannot be statically analyzed and might require runtime code generation.";
+
         /// <summary>
         /// When overridden, constructs a new <see cref="JsonConverterFactory"/> instance.
         /// </summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -14,8 +14,11 @@ namespace System.Text.Json.Serialization
     /// </remarks>
     public abstract class JsonConverterFactory : JsonConverter
     {
-        internal const string JsonConverterFactoryRequiresDynamicCodeMessage = "Types deriving from JsonConverterFactory cannot be statically analyzed and might require runtime code generation.";
-
+        private protected const string JsonStringEnumConverterRequiresDynamicCodeMessage =
+            "JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. " +
+            "There is no built-in solution compatible with native AOT applications. " +
+            "Consider authoring a custom converter that is not a factory to work around the issue. " +
+            "See https://github.com/dotnet/runtime/issues/73124.";
         /// <summary>
         /// When overridden, constructs a new <see cref="JsonConverterFactory"/> instance.
         /// </summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -14,11 +14,6 @@ namespace System.Text.Json.Serialization
     /// </remarks>
     public abstract class JsonConverterFactory : JsonConverter
     {
-        private protected const string JsonStringEnumConverterRequiresDynamicCodeMessage =
-            "JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. " +
-            "There is no built-in solution compatible with native AOT applications. " +
-            "Consider authoring a custom converter that is not a factory to work around the issue. " +
-            "See https://github.com/dotnet/runtime/issues/73124.";
         /// <summary>
         /// When overridden, constructs a new <see cref="JsonConverterFactory"/> instance.
         /// </summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization
     /// <remarks>
     /// Reading is case insensitive, writing can be customized via a <see cref="JsonNamingPolicy" />.
     /// </remarks>
-    [RequiresDynamicCode(JsonConverterFactoryRequiresDynamicCodeMessage)]
+    [RequiresDynamicCode(JsonStringEnumConverterRequiresDynamicCodeMessage)]
     public class JsonStringEnumConverter : JsonConverterFactory
     {
         private readonly JsonNamingPolicy? _namingPolicy;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization
     /// <remarks>
     /// Reading is case insensitive, writing can be customized via a <see cref="JsonNamingPolicy" />.
     /// </remarks>
-    [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+    [RequiresDynamicCode(JsonConverterFactoryRequiresDynamicCodeMessage)]
     public class JsonStringEnumConverter : JsonConverterFactory
     {
         private readonly JsonNamingPolicy? _namingPolicy;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
@@ -14,9 +14,8 @@ namespace System.Text.Json.Serialization
     /// </remarks>
     [RequiresDynamicCode(
         "JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. " +
-        "There is no built-in solution compatible with native AOT applications. " +
         "Consider authoring a custom converter that is not a factory to work around the issue. " +
-        "See https://github.com/dotnet/runtime/issues/73124." )]
+        "See https://github.com/dotnet/runtime/issues/73124.")]
     public class JsonStringEnumConverter : JsonConverterFactory
     {
         private readonly JsonNamingPolicy? _namingPolicy;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
@@ -12,7 +12,11 @@ namespace System.Text.Json.Serialization
     /// <remarks>
     /// Reading is case insensitive, writing can be customized via a <see cref="JsonNamingPolicy" />.
     /// </remarks>
-    [RequiresDynamicCode(JsonStringEnumConverterRequiresDynamicCodeMessage)]
+    [RequiresDynamicCode(
+        "JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. " +
+        "There is no built-in solution compatible with native AOT applications. " +
+        "Consider authoring a custom converter that is not a factory to work around the issue. " +
+        "See https://github.com/dotnet/runtime/issues/73124." )]
     public class JsonStringEnumConverter : JsonConverterFactory
     {
         private readonly JsonNamingPolicy? _namingPolicy;


### PR DESCRIPTION
Prompted by the discussion in #73124. Removes reference to using the source generator since `JsonConverterFactory` cannot be safely consumed in source generators.