### PR TITLE
[wasm][debugger] Fix insert a breakpoint in sources with same prefix.

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -1506,7 +1506,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
         }
 
-        public IEnumerable<SourceFile> AllSources() => assemblies.SelectMany(a => a.Sources);
+        public IEnumerable<SourceFile> AllSources() => assemblies.SelectMany(a => a.Sources).OrderBy(source => source.Url);
 
         public SourceFile GetFileById(SourceId id) => AllSources().SingleOrDefault(f => f.SourceId.Equals(id));
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -899,5 +899,18 @@ namespace DebuggerTests
                 "DefaultInterfaceMethod." + methodName
             );
         }
+
+        [ConditionalTheory(nameof(RunningOnChrome))]
+        [InlineData(".*debugger-test.cs.sameprefix", "TestBreakpointUsingUrlRegex", "debugger-test.cs.sameprefix")]
+        [InlineData(".*debugger-test.cs.sameprefix2", "TestBreakpointUsingUrlRegex2", "debugger-test.cs.sameprefix2")]
+        public async Task SetBreakpointUsingUrlRegexWithSourceWithSamePrefix(string regex, string klassName, string fileName)
+        {
+            var bp1_res = await SetBreakpoint(regex, 8, 8, use_regex: true);
+            await EvaluateAndCheck(
+                "window.setTimeout(function() { invoke_static_method('[debugger-test] " + klassName + ":Run'); }, 1);",
+                $"dotnet://debugger-test.dll/{fileName}", 8, 8,
+                $"{klassName}.Run"
+            );
+        }
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs.sameprefix
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs.sameprefix
@@ -1,0 +1,11 @@
+
+using System;
+
+public class TestBreakpointUsingUrlRegex
+{
+    public int i = 0;
+    public static void Run()
+    {
+        Console.WriteLine("break here");
+    } 
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs.sameprefix2
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs.sameprefix2
@@ -1,0 +1,11 @@
+
+using System;
+
+public class TestBreakpointUsingUrlRegex2
+{
+    public int i = 0;
+    public static void Run()
+    {
+        Console.WriteLine("break here");
+    } 
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -11,6 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="debugger-test.cs.sameprefix2" />
+    <Compile Include="debugger-test.cs.sameprefix" />
+
     <WasmExtraFilesToDeploy Include="debugger-driver.html" />
     <WasmExtraFilesToDeploy Include="non-wasm-page.html" />
     <WasmExtraFilesToDeploy Include="wasm-page-without-assets.html" />


### PR DESCRIPTION
If we have two files, for example: Counter.razor and Counter.razor.cs. We receive a setBreakpoint like this:

```json
{
   "level" : 0,
   "metadata" : {
      "connectionId" : 0,
      "message" : {
         "id" : 1041,
         "method" : "Debugger.setBreakpointByUrl",
         "params" : {
            "columnNumber" : 1,
            "lineNumber" : 11,
            "urlRegex" : "[fF][iI][lL][eE]:\\/\\/\\/[tT]:\\/[tT][hH][aA][yY][sS]\\/[sS][oO][uU][rR][cC][eE]\\/[rR][eE][pP][oO][sS]\\/[bB][lL][aA][zZ][oO][rR][aA][pP][pP]101\\/[bB][lL][aA][zZ][oO][rR][aA][pP][pP]101\\/[pP][aA][gG][eE][sS]\\/[cC][oO][uU][nN][tT][eE][rR]\\.[rR][aA][zZ][oO][rR]|[tT]:\\\\[tT][hH][aA][yY][sS]\\\\[sS][oO][uU][rR][cC][eE]\\\\[rR][eE][pP][oO][sS]\\\\[bB][lL][aA][zZ][oO][rR][aA][pP][pP]101\\\\[bB][lL][aA][zZ][oO][rR][aA][pP][pP]101\\\\[pP][aA][gG][eE][sS]\\\\[cC][oO][uU][nN][tT][eE][rR]\\.[rR][aA][zZ][oO][rR]"
         },
         "sessionId" : "0CE5589DF6F17AD04C004678DDD3870E"
      }
   },
   "tag" : "cdp.send",
   "timestamp" : 1659368431903
}
```

And we were looking in a list where we had Counter.razor.cs first and Counter.razor second.
So when we do a `regex.Match` using `Counter.razor` as regex, `Counter.razor.cs` is a match and we were trying to insert the breakpoint in the wrong source file.

Ordering the source list fixes that. But maybe this is not good for performance, and we should create a cache for it. Or another list ordered by URL.

Fixes #56029 