### PR TITLE
System.Diagnostics.Tests.PerformanceCounterTests failed in CI

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
@@ -77,5 +77,25 @@ namespace System.Diagnostics.Tests
 
             return result;
         }
+
+        public static T RetryOnAllPlatformsWithClosingResources<T>(Func<T> func)
+        {
+            // Harden the tests increasing the retry count and the timeout.
+            T result = default;
+            RetryHelper.Execute(() =>
+            {
+                try
+                {
+                    result = func();
+                }
+                catch
+                {
+                    PerformanceCounter.CloseSharedResources();
+                    throw;
+                }
+            }, maxAttempts: 10, (iteration) => iteration * 300);
+
+            return result;
+        }
     }
 }

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/InstanceDataTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/InstanceDataTests.cs
@@ -124,8 +124,8 @@ namespace System.Diagnostics.Tests
 
         public static InstanceDataCollectionCollection GetInstanceDataCollectionCollection()
         {
-            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory("Processor"));
-            return Helpers.RetryOnAllPlatforms(() =>
+            PerformanceCounterCategory pcc = new PerformanceCounterCategory("Processor");
+            return Helpers.RetryOnAllPlatformsWithClosingResources(() =>
             {
                 var idcc = pcc.ReadCategory();
                 Assert.InRange(idcc.Values.Count, 1, int.MaxValue);

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterCategoryTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterCategoryTests.cs
@@ -78,16 +78,15 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60933", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public static void PerformanceCounterCategory_CategoryType_MultiInstance()
         {
             string categoryName = nameof(PerformanceCounterCategory_CategoryType_MultiInstance) + "_Category";
 
             Helpers.CreateCategory(categoryName, PerformanceCounterCategoryType.MultiInstance);
 
-            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory(categoryName));
+            PerformanceCounterCategory pcc = new PerformanceCounterCategory(categoryName);
 
-            Assert.Equal(PerformanceCounterCategoryType.MultiInstance, Helpers.RetryOnAllPlatforms(() => pcc.CategoryType));
+            Assert.Equal(PerformanceCounterCategoryType.MultiInstance, Helpers.RetryOnAllPlatformsWithClosingResources(() => pcc.CategoryType));
             PerformanceCounterCategory.Delete(categoryName);
         }
 
@@ -98,9 +97,9 @@ namespace System.Diagnostics.Tests
 
             Helpers.CreateCategory(categoryName, PerformanceCounterCategoryType.SingleInstance);
 
-            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory(categoryName));
+            PerformanceCounterCategory pcc = new PerformanceCounterCategory(categoryName);
 
-            Assert.Equal(PerformanceCounterCategoryType.SingleInstance, Helpers.RetryOnAllPlatforms(() => pcc.CategoryType));
+            Assert.Equal(PerformanceCounterCategoryType.SingleInstance, Helpers.RetryOnAllPlatformsWithClosingResources(() => pcc.CategoryType));
             PerformanceCounterCategory.Delete(categoryName);
         }
 
@@ -169,7 +168,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public static void PerformanceCounterCategory_CounterExists_InterruptsPerSec()
         {
-            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory("Processor"));
+            PerformanceCounterCategory pcc = new PerformanceCounterCategory("Processor");
 
             Assert.True(pcc.CounterExists("Interrupts/sec"));
         }
@@ -229,7 +228,7 @@ namespace System.Diagnostics.Tests
             string categoryName = nameof(PerformanceCounterCategory_GetCounters) + "_Category";
             Helpers.CreateCategory(categoryName, PerformanceCounterCategoryType.SingleInstance);
 
-            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory(categoryName));
+            PerformanceCounterCategory pcc = new PerformanceCounterCategory(categoryName);
             PerformanceCounter[] counters = pcc.GetCounters();
 
             Assert.True(counters.Length > 0);
@@ -267,12 +266,11 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60933", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public static void PerformanceCounterCategory_InstanceExists_Static()
         {
-            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory("Processor"));
+            PerformanceCounterCategory pcc = new PerformanceCounterCategory("Processor");
 
-            string[] instances = pcc.GetInstanceNames();
+            string[] instances = Helpers.RetryOnAllPlatformsWithClosingResources(() => pcc.GetInstanceNames());
             Assert.True(instances.Length > 0);
 
             foreach (string instance in instances)
@@ -291,12 +289,11 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60933", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public static void PerformanceCounterCategory_ReadCategory()
         {
-            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory("Processor"));
+            PerformanceCounterCategory pcc = new PerformanceCounterCategory("Processor");
 
-            InstanceDataCollectionCollection idColCol = pcc.ReadCategory();
+            InstanceDataCollectionCollection idColCol = Helpers.RetryOnAllPlatformsWithClosingResources(() => pcc.ReadCategory());
 
             Assert.NotNull(idColCol);
         }

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
@@ -41,12 +41,11 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60933", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public static void PerformanceCounter_CreateCounter_ProcessorCounter()
         {
-            using (PerformanceCounter counterSample = new PerformanceCounter("Processor", "Interrupts/sec", "0", "."))
+            using (PerformanceCounter counterSample = Helpers.RetryOnAllPlatformsWithClosingResources(() => new PerformanceCounter("Processor", "Interrupts/sec", "0", ".")))
             {
-                Assert.Equal(0, Helpers.RetryOnAllPlatforms(() => counterSample.NextValue()));
+                Assert.Equal(0, Helpers.RetryOnAllPlatformsWithClosingResources(() => counterSample.NextValue()));
 
                 Assert.True(counterSample.RawValue > 0);
             }
@@ -61,12 +60,12 @@ namespace System.Diagnostics.Tests
 
             Helpers.CreateCategory(categoryName, counterName, PerformanceCounterCategoryType.MultiInstance);
 
-            using (PerformanceCounter counterSample = Helpers.RetryOnAllPlatforms(() => new PerformanceCounter(categoryName, counterName, instanceName)))
+            using (PerformanceCounter counterSample = Helpers.RetryOnAllPlatformsWithClosingResources(() => new PerformanceCounter(categoryName, counterName, instanceName)))
             {
                 Assert.Equal(counterName, counterSample.CounterName);
                 Assert.Equal(categoryName, counterSample.CategoryName);
                 Assert.Equal(instanceName, counterSample.InstanceName);
-                Assert.Equal("counter description",  Helpers.RetryOnAllPlatforms(() => counterSample.CounterHelp));
+                Assert.Equal("counter description", Helpers.RetryOnAllPlatformsWithClosingResources(() => counterSample.CounterHelp));
                 Assert.True(counterSample.ReadOnly);
             }
 
@@ -81,7 +80,7 @@ namespace System.Diagnostics.Tests
 
             Helpers.CreateCategory(categoryName, PerformanceCounterCategoryType.SingleInstance);
 
-            using (PerformanceCounter counterSample = Helpers.RetryOnAllPlatforms(() => new PerformanceCounter(categoryName, counterName)))
+            using (PerformanceCounter counterSample = Helpers.RetryOnAllPlatformsWithClosingResources(() => new PerformanceCounter(categoryName, counterName)))
             {
                 counterSample.ReadOnly = false;
 
@@ -157,14 +156,14 @@ namespace System.Diagnostics.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/60403", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process), nameof(PlatformDetection.IsWindows))]
         public static void PerformanceCounter_NextValue_ProcessorCounter()
         {
-            using (PerformanceCounter counterSample = new PerformanceCounter("Processor", "Interrupts/sec", "_Total", "."))
+            using (PerformanceCounter counterSample = Helpers.RetryOnAllPlatformsWithClosingResources(() => new PerformanceCounter("Processor", "Interrupts/sec", "_Total", ".")))
             {
                 float val;
                 int counter = 0;
                 do
                 {
                     // Ensure we don't always return zero for a counter we know is not always zero
-                    val = Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
+                    val = Helpers.RetryOnAllPlatformsWithClosingResources(() => counterSample.NextValue());
                     if (val > 0f)
                     {
                         break;
@@ -181,7 +180,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public static void PerformanceCounter_BeginInit_ProcessorCounter()
         {
-            using (PerformanceCounter counterSample = new PerformanceCounter("Processor", "Interrupts/sec", "0", "."))
+            using (PerformanceCounter counterSample = Helpers.RetryOnAllPlatformsWithClosingResources(() => new PerformanceCounter("Processor", "Interrupts/sec", "0", ".")))
             {
                 counterSample.BeginInit();
 
@@ -193,7 +192,7 @@ namespace System.Diagnostics.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/60933", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public static void PerformanceCounter_BeginInitEndInit_ProcessorCounter()
         {
-            using (PerformanceCounter counterSample = new PerformanceCounter("Processor", "Interrupts/sec", "0", "."))
+            using (PerformanceCounter counterSample = Helpers.RetryOnAllPlatformsWithClosingResources(() => new PerformanceCounter("Processor", "Interrupts/sec", "0", ".")))
             {
                 counterSample.BeginInit();
                 counterSample.EndInit();
@@ -309,10 +308,10 @@ namespace System.Diagnostics.Tests
 
             Helpers.CreateCategory(categoryName, PerformanceCounterCategoryType.MultiInstance);
 
-            using (PerformanceCounter counterSample = new PerformanceCounter(categoryName, counterName, instanceName, readOnly:false))
+            using (PerformanceCounter counterSample = Helpers.RetryOnAllPlatformsWithClosingResources(() => new PerformanceCounter(categoryName, counterName, instanceName, readOnly: false)))
             {
                 counterSample.RawValue = 10;
-                Helpers.RetryOnAllPlatforms(() => counterSample.Decrement());
+                Helpers.RetryOnAllPlatformsWithClosingResources(() => counterSample.Decrement());
 
                 Assert.Equal(9, counterSample.RawValue);
             }
@@ -339,7 +338,7 @@ namespace System.Diagnostics.Tests
                 // This test ensure creating PerformanceCounter object while we are running with Globalization Invariant Mode.
                 // PerformanceCounter used to create cultures using LCID's which fail in Globalization Invariant Mode.
                 // This test ensure no failure should be encountered in this case.
-                using (PerformanceCounter counterSample = new PerformanceCounter("Processor", "Interrupts/sec", "0", "."))
+                using (PerformanceCounter counterSample = Helpers.RetryOnAllPlatformsWithClosingResources(() => new PerformanceCounter("Processor", "Interrupts/sec", "0", ".")))
                 {
                     Assert.Equal("Processor", counterSample.CategoryName);
                 }
@@ -352,7 +351,7 @@ namespace System.Diagnostics.Tests
 
             string counterName = categoryName.Replace("_Category", "_Counter");
 
-            PerformanceCounter counterSample = Helpers.RetryOnAllPlatforms(() => new PerformanceCounter(categoryName, counterName, readOnly));
+            PerformanceCounter counterSample = Helpers.RetryOnAllPlatformsWithClosingResources(() => new PerformanceCounter(categoryName, counterName, readOnly));
 
             return counterSample;
         }


### PR DESCRIPTION
Fixes #60933

I drop retries on PerformanceCounterCategory constructor calls because they seem useless. The constructor throws exception only when (categoryName null or its length = 0) or (machineName null or string empty or contains \\) (retries do not change the output)