### PR TITLE
Fix duplicate reference issue

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -1241,7 +1241,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
                         if (!duplicateModuleAnalysis.TryGetValue(simpleName, out HashSet<string> candidatePaths))
                         {
-                            duplicateModuleAnalysis[simpleName] = candidatePaths = new HashSet<string>();
+                            duplicateModuleAnalysis[simpleName] = candidatePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                         }
                         candidatePaths.Add(candidateFilePath);
                     }


### PR DESCRIPTION
If you have two references that are idetentical, except for casing then
when we insert that value into the Hashset that comparison is not done
ignoring case. And since the Dictionary comparison does, this causes
multiple references that are otherwise identical to be inserted.

This fix just adds the `OrdinalIgnoreCase` comparer to the `HashSet`