### PR TITLE
increase timeout on ZeroByteRead_IssuesZeroByteReadOnUnderlyingStream test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamZeroByteReadTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamZeroByteReadTests.cs
@@ -114,14 +114,14 @@ namespace System.Net.Http.Functional.Tests
                             cert,
                             clientCertificateRequired: true,
                             enabledSslProtocols: SslProtocols.Tls12,
-                            checkCertificateRevocation: false).WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds));
+                            checkCertificateRevocation: false).WaitAsync(TestHelper.PassingTestTimeout);
                     }
                 }
 
-                await ResponseConnectedStreamConformanceTests.ReadHeadersAsync(server).WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds));
+                await ResponseConnectedStreamConformanceTests.ReadHeadersAsync(server).WaitAsync(TestHelper.PassingTestTimeout);
                 await server.WriteAsync(Encoding.ASCII.GetBytes(GetResponseHeaders()));
 
-                using HttpResponseMessage response = await clientTask.WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds));
+                using HttpResponseMessage response = await clientTask.WaitAsync(TestHelper.PassingTestTimeout);
                 using Stream clientStream = response.Content.ReadAsStream();
                 Assert.False(sawZeroByteRead.Task.IsCompleted);
 
@@ -129,14 +129,14 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(zeroByteReadTask.IsCompleted);
 
                 // The zero-byte read should block until data is actually available
-                await sawZeroByteRead.Task.WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds));
+                await sawZeroByteRead.Task.WaitAsync(TestHelper.PassingTestTimeout);
                 Assert.False(zeroByteReadTask.IsCompleted);
 
                 byte[] data = "Hello"u8.ToArray();
                 await WriteAsync(server, data);
                 await server.FlushAsync();
 
-                Assert.Equal(0, await zeroByteReadTask.WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds)));
+                Assert.Equal(0, await zeroByteReadTask.WaitAsync(TestHelper.PassingTestTimeout));
 
                 // Now that data is available, a zero-byte read should complete synchronously
                 zeroByteReadTask = StreamConformanceTests.ReadAsync(readMode, clientStream, Array.Empty<byte>(), 0, 0, CancellationToken.None);
@@ -147,7 +147,7 @@ namespace System.Net.Http.Functional.Tests
                 int read = 0;
                 while (read < data.Length)
                 {
-                    read += await StreamConformanceTests.ReadAsync(readMode, clientStream, readBuffer, read, readBuffer.Length - read, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds));
+                    read += await StreamConformanceTests.ReadAsync(readMode, clientStream, readBuffer, read, readBuffer.Length - read, CancellationToken.None).WaitAsync(TestHelper.PassingTestTimeout);
                 }
 
                 Assert.Equal(data.Length, read);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamZeroByteReadTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamZeroByteReadTests.cs
@@ -114,14 +114,14 @@ namespace System.Net.Http.Functional.Tests
                             cert,
                             clientCertificateRequired: true,
                             enabledSslProtocols: SslProtocols.Tls12,
-                            checkCertificateRevocation: false).WaitAsync(TimeSpan.FromSeconds(30));
+                            checkCertificateRevocation: false).WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds));
                     }
                 }
 
-                await ResponseConnectedStreamConformanceTests.ReadHeadersAsync(server).WaitAsync(TimeSpan.FromSeconds(30));
+                await ResponseConnectedStreamConformanceTests.ReadHeadersAsync(server).WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds));
                 await server.WriteAsync(Encoding.ASCII.GetBytes(GetResponseHeaders()));
 
-                using HttpResponseMessage response = await clientTask.WaitAsync(TimeSpan.FromSeconds(30));
+                using HttpResponseMessage response = await clientTask.WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds));
                 using Stream clientStream = response.Content.ReadAsStream();
                 Assert.False(sawZeroByteRead.Task.IsCompleted);
 
@@ -129,14 +129,14 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(zeroByteReadTask.IsCompleted);
 
                 // The zero-byte read should block until data is actually available
-                await sawZeroByteRead.Task.WaitAsync(TimeSpan.FromSeconds(30));
+                await sawZeroByteRead.Task.WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds));
                 Assert.False(zeroByteReadTask.IsCompleted);
 
                 byte[] data = "Hello"u8.ToArray();
                 await WriteAsync(server, data);
                 await server.FlushAsync();
 
-                Assert.Equal(0, await zeroByteReadTask.WaitAsync(TimeSpan.FromSeconds(30)));
+                Assert.Equal(0, await zeroByteReadTask.WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds)));
 
                 // Now that data is available, a zero-byte read should complete synchronously
                 zeroByteReadTask = StreamConformanceTests.ReadAsync(readMode, clientStream, Array.Empty<byte>(), 0, 0, CancellationToken.None);
@@ -147,7 +147,7 @@ namespace System.Net.Http.Functional.Tests
                 int read = 0;
                 while (read < data.Length)
                 {
-                    read += await StreamConformanceTests.ReadAsync(readMode, clientStream, readBuffer, read, readBuffer.Length - read, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+                    read += await StreamConformanceTests.ReadAsync(readMode, clientStream, readBuffer, read, readBuffer.Length - read, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(TestHelper.PassingTestTimeoutMilliseconds));
                 }
 
                 Assert.Equal(data.Length, read);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamZeroByteReadTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamZeroByteReadTests.cs
@@ -114,14 +114,14 @@ namespace System.Net.Http.Functional.Tests
                             cert,
                             clientCertificateRequired: true,
                             enabledSslProtocols: SslProtocols.Tls12,
-                            checkCertificateRevocation: false).WaitAsync(TimeSpan.FromSeconds(10));
+                            checkCertificateRevocation: false).WaitAsync(TimeSpan.FromSeconds(30));
                     }
                 }
 
-                await ResponseConnectedStreamConformanceTests.ReadHeadersAsync(server).WaitAsync(TimeSpan.FromSeconds(10));
+                await ResponseConnectedStreamConformanceTests.ReadHeadersAsync(server).WaitAsync(TimeSpan.FromSeconds(30));
                 await server.WriteAsync(Encoding.ASCII.GetBytes(GetResponseHeaders()));
 
-                using HttpResponseMessage response = await clientTask.WaitAsync(TimeSpan.FromSeconds(10));
+                using HttpResponseMessage response = await clientTask.WaitAsync(TimeSpan.FromSeconds(30));
                 using Stream clientStream = response.Content.ReadAsStream();
                 Assert.False(sawZeroByteRead.Task.IsCompleted);
 
@@ -129,14 +129,14 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(zeroByteReadTask.IsCompleted);
 
                 // The zero-byte read should block until data is actually available
-                await sawZeroByteRead.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                await sawZeroByteRead.Task.WaitAsync(TimeSpan.FromSeconds(30));
                 Assert.False(zeroByteReadTask.IsCompleted);
 
                 byte[] data = "Hello"u8.ToArray();
                 await WriteAsync(server, data);
                 await server.FlushAsync();
 
-                Assert.Equal(0, await zeroByteReadTask.WaitAsync(TimeSpan.FromSeconds(10)));
+                Assert.Equal(0, await zeroByteReadTask.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 // Now that data is available, a zero-byte read should complete synchronously
                 zeroByteReadTask = StreamConformanceTests.ReadAsync(readMode, clientStream, Array.Empty<byte>(), 0, 0, CancellationToken.None);


### PR DESCRIPTION
fixes #67509

I saw occasional local failures on my Win11 machine. I did not see failure since I increased the timeout. 
Not that `PassingTestTimeoutMilliseconds` is 60s for HTTP. I could possibly use that instead but the 30s is holding so far for me.