### PR TITLE
support InfiniteTimeSpan in Select

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2155,7 +2155,7 @@ namespace System.Net.Sockets
         }
 
         /// <summary>Determines the status of the <see cref="Socket"/>.</summary>
-        /// <param name="timeout">The time to wait for a response.</param>
+        /// <param name="timeout">The time to wait for a response. <see cref="Timeout.InfiniteTimeSpan"/> indicates an infinite timeout.</param>
         /// <param name="mode">One of the <see cref="SelectMode"/> values.</param>
         /// <returns>
         /// The status of the <see cref="Socket"/> based on the polling mode value passed in the <paramref name="mode"/> parameter.
@@ -2167,7 +2167,7 @@ namespace System.Net.Sockets
         /// does not block and the connection has failed, or if OutOfBandInline is not set and out-of-band data is available.
         /// Otherwise, it returns <see langword="false"/>.
         /// </returns>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout"/> is less than -1 milliseconds or greater than <see cref="int.MaxValue"/> milliseconds.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout"/> was negative or greater thanTimeSpan.FromMicroseconds(int.MaxValue).</exception>
         /// <exception cref="SocketException">An error occurred when attempting to access the socket.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="Socket"/> has been closed.</exception>
         public bool Poll(TimeSpan timeout, SelectMode mode) =>
@@ -2217,10 +2217,10 @@ namespace System.Net.Sockets
         /// <param name="checkRead">An <see cref="IList"/> of <see cref="Socket"/> instances to check for readability.</param>
         /// <param name="checkWrite">An <see cref="IList"/> of <see cref="Socket"/> instances to check for writability.</param>
         /// <param name="checkError">An <see cref="IList"/> of <see cref="Socket"/> instances to check for errors.</param>
-        /// <param name="timeout">The timeout value. A value equal to -1 microseconds indicates an infinite timeout.</param>
+        /// <param name="timeout">The timeout value. A value equal to <see cref="Timeout.InfiniteTimeSpan"/> microseconds indicates an infinite timeout.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="checkRead"/>, <paramref name="checkWrite"/>, or <paramref name="checkError"/> parameter is <see langword="null"/> or empty.</exception>
         /// <exception cref="ArgumentOutOfRangeException">The <paramref name="checkRead"/>, <paramref name="checkWrite"/>, or <paramref name="checkError"/> parameter contains too many sockets.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">The <paramref name="timeout"/> was less than -1 microseconds or greater than <see cref="int.MaxValue"/> microseconds</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The <paramref name="timeout"/> was negative or greater than TimeSpan.FromMicroseconds(int.MaxValue).</exception>
         /// <exception cref="SocketException">An error occurred when attempting to access the socket.</exception>
         /// <exception cref="ObjectDisposedException">One or more sockets was disposed.</exception>
         public static void Select(IList? checkRead, IList? checkWrite, IList? checkError, TimeSpan timeout) =>
@@ -2233,8 +2233,13 @@ namespace System.Net.Sockets
                 return -1;
             }
 
+            if (timeout < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeout));
+            }
             long totalMicroseconds = (long)timeout.TotalMicroseconds;
-            if (totalMicroseconds < -1 || totalMicroseconds > int.MaxValue)
+
+            if (totalMicroseconds > int.MaxValue)
             {
                 throw new ArgumentOutOfRangeException(nameof(timeout));
             }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2167,7 +2167,7 @@ namespace System.Net.Sockets
         /// does not block and the connection has failed, or if OutOfBandInline is not set and out-of-band data is available.
         /// Otherwise, it returns <see langword="false"/>.
         /// </returns>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout"/> was negative or greater thanTimeSpan.FromMicroseconds(int.MaxValue).</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout"/> was negative or greater than TimeSpan.FromMicroseconds(int.MaxValue).</exception>
         /// <exception cref="SocketException">An error occurred when attempting to access the socket.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="Socket"/> has been closed.</exception>
         public bool Poll(TimeSpan timeout, SelectMode mode) =>
@@ -2217,7 +2217,7 @@ namespace System.Net.Sockets
         /// <param name="checkRead">An <see cref="IList"/> of <see cref="Socket"/> instances to check for readability.</param>
         /// <param name="checkWrite">An <see cref="IList"/> of <see cref="Socket"/> instances to check for writability.</param>
         /// <param name="checkError">An <see cref="IList"/> of <see cref="Socket"/> instances to check for errors.</param>
-        /// <param name="timeout">The timeout value. A value equal to <see cref="Timeout.InfiniteTimeSpan"/> microseconds indicates an infinite timeout.</param>
+        /// <param name="timeout">The timeout value. A value equal to <see cref="Timeout.InfiniteTimeSpan"/> indicates an infinite timeout.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="checkRead"/>, <paramref name="checkWrite"/>, or <paramref name="checkError"/> parameter is <see langword="null"/> or empty.</exception>
         /// <exception cref="ArgumentOutOfRangeException">The <paramref name="checkRead"/>, <paramref name="checkWrite"/>, or <paramref name="checkError"/> parameter contains too many sockets.</exception>
         /// <exception cref="ArgumentOutOfRangeException">The <paramref name="timeout"/> was negative or greater than TimeSpan.FromMicroseconds(int.MaxValue).</exception>

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2228,6 +2228,11 @@ namespace System.Net.Sockets
 
         private static int ToTimeoutMicroseconds(TimeSpan timeout)
         {
+            if (timeout == Timeout.InfiniteTimeSpan)
+            {
+                return -1;
+            }
+
             long totalMicroseconds = (long)timeout.TotalMicroseconds;
             if (totalMicroseconds < -1 || totalMicroseconds > int.MaxValue)
             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -374,10 +374,24 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void Select_InfiniteTimeSpan_Ok()
         {
-             var list = new List<Socket>();
-             list.Add(GetSocket());
-             Socket.Select(list, null, null, Timeout.InfiniteTimeSpan);
-             Socket.Select(list, null, null, -1);
+            using (Socket host = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                host.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                host.Listen(1);
+                Task accept = host.AcceptAsync();
+
+                using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    s.Connect(new IPEndPoint(IPAddress.Loopback, ((IPEndPoint)host.LocalEndPoint).Port));
+
+                    var list = new List<Socket>();
+                    list.Add(s);
+
+                    // should be writable
+                    Socket.Select(null, list, null, Timeout.InfiniteTimeSpan);
+                    Socket.Select(null, list, null, -1);
+                }
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -372,6 +372,15 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        public void Select_InfiniteTimeSpan_Ok()
+        {
+             var list = new List<Socket>();
+             list.Add(GetSocket());
+             Socket.Select(list, null, null, Timeout.InfiniteTimeSpan);
+             Socket.Select(list, null, null, -1);
+        }
+
+        [Fact]
         public void Select_LargeList_Throws_ArgumentOutOfRange()
         {
             var largeList = new LargeList();


### PR DESCRIPTION
This change adds special handling for `Timeout.InfiniteTimeSpan` so it can be passed to Select without throwing. 
fixes #72458

