### PR TITLE
Update fabricbot config per dotnet/fabricbot-config#59

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1429,10 +1429,10 @@
           }
         },
         {
-            "name": "addLabel",
-            "parameters": {
-              "label": "backlog-cleanup-candidate"
-            }
+          "name": "addLabel",
+          "parameters": {
+            "label": "backlog-cleanup-candidate"
+          }
         },
         {
           "name": "addLabel",
@@ -2931,10 +2931,10 @@
           }
         },
         {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "backlog-cleanup-candidate"
-            }
+          "name": "removeLabel",
+          "parameters": {
+            "label": "backlog-cleanup-candidate"
+          }
         }
       ],
       "eventType": "issue",
@@ -2992,10 +2992,10 @@
           }
         },
         {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "backlog-cleanup-candidate"
-            }
+          "name": "removeLabel",
+          "parameters": {
+            "label": "backlog-cleanup-candidate"
+          }
         }
       ],
       "eventType": "issue",
@@ -3028,6 +3028,12 @@
           "name": "removeLabel",
           "parameters": {
             "label": "no-recent-activity"
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "backlog-cleanup-candidate"
           }
         }
       ],
@@ -3077,6 +3083,12 @@
           "parameters": {
             "label": "no-recent-activity"
           }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "backlog-cleanup-candidate"
+          }
         }
       ],
       "eventType": "pull_request",
@@ -3113,6 +3125,12 @@
           "name": "removeLabel",
           "parameters": {
             "label": "no-recent-activity"
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "backlog-cleanup-candidate"
           }
         }
       ],
@@ -3598,10 +3616,9 @@
       "taskName": "[Area Pod: Adam / David - Issue Triage] Moved to Another Area",
       "actions": [
         {
-          "name": "addToProject",
+          "name": "removeFromProject",
           "parameters": {
             "projectName": "Area Pod: Adam / David - Issue Triage",
-            "columnName": "Triaged",
             "isOrgProject": true
           }
         }
@@ -3613,19 +3630,6 @@
       "conditions": {
         "operator": "and",
         "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Area Pod: Adam / David - Issue Triage",
-                  "columnName": "Triaged",
-                  "isOrgProject": true
-                }
-              }
-            ]
-          },
           {
             "operator": "and",
             "operands": [
@@ -5171,10 +5175,9 @@
       "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Moved to Another Area",
       "actions": [
         {
-          "name": "addToProject",
+          "name": "removeFromProject",
           "parameters": {
             "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
-            "columnName": "Triaged",
             "isOrgProject": true
           }
         }
@@ -5186,19 +5189,6 @@
       "conditions": {
         "operator": "and",
         "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
-                  "columnName": "Triaged",
-                  "isOrgProject": true
-                }
-              }
-            ]
-          },
           {
             "operator": "and",
             "operands": [
@@ -7363,10 +7353,9 @@
       "taskName": "[Area Pod: Akhil / Carlos / Viktor - Issue Triage] Moved to Another Area",
       "actions": [
         {
-          "name": "addToProject",
+          "name": "removeFromProject",
           "parameters": {
             "projectName": "Area Pod: Akhil / Carlos / Viktor - Issue Triage",
-            "columnName": "Triaged",
             "isOrgProject": true
           }
         }
@@ -7378,19 +7367,6 @@
       "conditions": {
         "operator": "and",
         "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Area Pod: Akhil / Carlos / Viktor - Issue Triage",
-                  "columnName": "Triaged",
-                  "isOrgProject": true
-                }
-              }
-            ]
-          },
           {
             "operator": "and",
             "operands": [
@@ -9345,10 +9321,9 @@
       "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Moved to Another Area",
       "actions": [
         {
-          "name": "addToProject",
+          "name": "removeFromProject",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
-            "columnName": "Triaged",
             "isOrgProject": true
           }
         }
@@ -9360,19 +9335,6 @@
       "conditions": {
         "operator": "and",
         "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
-                  "columnName": "Triaged",
-                  "isOrgProject": true
-                }
-              }
-            ]
-          },
           {
             "operator": "and",
             "operands": [
@@ -11117,10 +11079,9 @@
       "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Moved to Another Area",
       "actions": [
         {
-          "name": "addToProject",
+          "name": "removeFromProject",
           "parameters": {
             "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
-            "columnName": "Triaged",
             "isOrgProject": true
           }
         }
@@ -11132,19 +11093,6 @@
       "conditions": {
         "operator": "and",
         "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
-                  "columnName": "Triaged",
-                  "isOrgProject": true
-                }
-              }
-            ]
-          },
           {
             "operator": "and",
             "operands": [
@@ -12819,10 +12767,9 @@
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Moved to Another Area",
       "actions": [
         {
-          "name": "addToProject",
+          "name": "removeFromProject",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - Issue Triage",
-            "columnName": "Triaged",
             "isOrgProject": true
           }
         }
@@ -12834,19 +12781,6 @@
       "conditions": {
         "operator": "and",
         "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Area Pod: Eric / Jeff - Issue Triage",
-                  "columnName": "Triaged",
-                  "isOrgProject": true
-                }
-              }
-            ]
-          },
           {
             "operator": "and",
             "operands": [
@@ -14008,10 +13942,9 @@
       "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Moved to Another Area",
       "actions": [
         {
-          "name": "addToProject",
+          "name": "removeFromProject",
           "parameters": {
             "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
-            "columnName": "Triaged",
             "isOrgProject": true
           }
         }
@@ -14023,19 +13956,6 @@
       "conditions": {
         "operator": "and",
         "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
-                  "columnName": "Triaged",
-                  "isOrgProject": true
-                }
-              }
-            ]
-          },
           {
             "operator": "and",
             "operands": [
@@ -14682,162 +14602,6 @@
                 "name": "isAction",
                 "parameters": {
                   "action": "closed"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    }
-  },
-  {
-    "taskSource": "fabricbot-config",
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssuesOnlyResponder",
-    "version": "1.0",
-    "config": {
-      "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Eric Updated Issue",
-      "actions": [
-        {
-          "name": "moveToProjectColumn",
-          "parameters": {
-            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
-            "columnName": "Triage: Eric",
-            "isOrgProject": true
-          }
-        }
-      ],
-      "eventType": "issue",
-      "eventNames": [
-        "issues"
-      ],
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isInProjectColumn",
-            "parameters": {
-              "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
-              "isOrgProject": true,
-              "columnName": "Needs Triage"
-            }
-          },
-          {
-            "name": "isActivitySender",
-            "parameters": {
-              "user": "eerhardt"
-            }
-          },
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isInMilestone",
-                "parameters": {}
-              }
-            ]
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "needs-author-action"
-                }
-              }
-            ]
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "api-ready-for-review"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    }
-  },
-  {
-    "taskSource": "fabricbot-config",
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssueCommentResponder",
-    "version": "1.0",
-    "config": {
-      "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Eric Commented",
-      "actions": [
-        {
-          "name": "moveToProjectColumn",
-          "parameters": {
-            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
-            "columnName": "Triage: Eric",
-            "isOrgProject": true
-          }
-        }
-      ],
-      "eventType": "issue",
-      "eventNames": [
-        "issue_comment"
-      ],
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isInProjectColumn",
-            "parameters": {
-              "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
-              "isOrgProject": true,
-              "columnName": "Needs Triage"
-            }
-          },
-          {
-            "name": "isActivitySender",
-            "parameters": {
-              "user": "eerhardt"
-            }
-          },
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isInMilestone",
-                "parameters": {}
-              }
-            ]
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "needs-author-action"
-                }
-              }
-            ]
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "api-ready-for-review"
                 }
               }
             ]
@@ -15785,190 +15549,6 @@
     "subCapability": "PullRequestResponder",
     "version": "1.0",
     "config": {
-      "taskName": "[Area Pod: Eric / Maryam / Tarek - PRs] Eric Assigned as Champion",
-      "actions": [
-        {
-          "name": "removeFromProject",
-          "parameters": {
-            "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
-            "isOrgProject": true
-          }
-        },
-        {
-          "name": "addToProject",
-          "parameters": {
-            "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
-            "columnName": "Champion: Eric",
-            "isOrgProject": true
-          }
-        }
-      ],
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request"
-      ],
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "operator": "or",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-DependencyModel"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-Extensions-Caching"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-Extensions-Configuration"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-Extensions-DependencyInjection"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-Extensions-Hosting"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-Extensions-Logging"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-Extensions-Options"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-Extensions-Primitives"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-System.ComponentModel"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-System.ComponentModel.Composition"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-System.Composition"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-System.Diagnostics.Activity"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "area-System.Globalization"
-                }
-              }
-            ]
-          },
-          {
-            "operator": "or",
-            "operands": [
-              {
-                "name": "isAssignedToUser",
-                "parameters": {
-                  "user": "eerhardt"
-                }
-              },
-              {
-                "operator": "and",
-                "operands": [
-                  {
-                    "name": "isAction",
-                    "parameters": {
-                      "action": "opened"
-                    }
-                  },
-                  {
-                    "name": "isActivitySender",
-                    "parameters": {
-                      "user": "eerhardt"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "operator": "or",
-            "operands": [
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "isInProject",
-                    "parameters": {
-                      "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
-                      "isOrgProject": true
-                    }
-                  }
-                ]
-              },
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
-                  "columnName": "Needs Champion",
-                  "isOrgProject": true
-                }
-              },
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
-                  "columnName": "Done",
-                  "isOrgProject": true
-                }
-              }
-            ]
-          }
-        ]
-      }
-    }
-  },
-  {
-    "taskSource": "fabricbot-config",
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestResponder",
-    "version": "1.0",
-    "config": {
       "taskName": "[Area Pod: Eric / Maryam / Tarek - PRs] Maryam Assigned as Champion",
       "actions": [
         {
@@ -16340,10 +15920,9 @@
       "taskName": "[Area Pod: Jeremy / Levi - Issue Triage] Moved to Another Area",
       "actions": [
         {
-          "name": "addToProject",
+          "name": "removeFromProject",
           "parameters": {
             "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
-            "columnName": "Triaged",
             "isOrgProject": true
           }
         }
@@ -16355,19 +15934,6 @@
       "conditions": {
         "operator": "and",
         "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
-                  "columnName": "Triaged",
-                  "isOrgProject": true
-                }
-              }
-            ]
-          },
           {
             "operator": "and",
             "operands": [
@@ -17785,10 +17351,9 @@
       "taskName": "[Area Pod: Libraries Analyzers - Issue Triage] Moved to Another Area",
       "actions": [
         {
-          "name": "addToProject",
+          "name": "removeFromProject",
           "parameters": {
             "projectName": "Area Pod: Libraries Analyzers - Issue Triage",
-            "columnName": "Triaged",
             "isOrgProject": true
           }
         }
@@ -17800,19 +17365,6 @@
       "conditions": {
         "operator": "and",
         "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Area Pod: Libraries Analyzers - Issue Triage",
-                  "columnName": "Triaged",
-                  "isOrgProject": true
-                }
-              }
-            ]
-          },
           {
             "operator": "and",
             "operands": [


### PR DESCRIPTION
This PR updates the automation to reflect a few recent requests:

1. When the `no-recent-activity` label is removed in dotnet/runtime, the `backlog-cleanup-candidate` label should also be removed
    - This was manually edited in dotnet/runtime#69857, but not all events were included
2. [Remove auto-assign to eerhardt column on comments #56](https://github.com/dotnet/fabricbot-config/issues/56)
3. [Remove cards from area pod boards when moved to another area pod #58](https://github.com/dotnet/fabricbot-config/issues/58)